### PR TITLE
Display a specific message when no changelog available from a Github Release

### DIFF
--- a/pkg/plugins/github/changelog.go
+++ b/pkg/plugins/github/changelog.go
@@ -65,10 +65,20 @@ func (g *Github) Changelog(name string) (string, error) {
 		return "", err
 	}
 
-	changelog := fmt.Sprintf("\nRelease published on the %v at the url %v\n%v\n",
-		query.Repository.Release.PublishedAt.String(),
-		query.Repository.Release.Url,
-		query.Repository.Release.Description)
+	changelog := ""
+
+	if len(query.Repository.Release.Url) == 0 {
+		changelog = fmt.Sprintf("No Github Release found for %s on https://github.com/%s/%s",
+			name,
+			g.Owner,
+			g.Repository)
+	} else {
+		changelog = fmt.Sprintf("\nRelease published on the %v at the url %v\n\n%v\n",
+			query.Repository.Release.PublishedAt.String(),
+			query.Repository.Release.Url,
+			query.Repository.Release.Description)
+
+	}
 
 	return changelog, nil
 }

--- a/pkg/plugins/github/main.go
+++ b/pkg/plugins/github/main.go
@@ -52,7 +52,7 @@ func (g *Github) Check() (bool, error) {
 	}
 
 	if len(required) > 0 {
-		err := fmt.Errorf("\u2717 Github parameter(s) required: [%v]", strings.Join(required, ","))
+		err := fmt.Errorf("github parameter(s) required: [%v]", strings.Join(required, ","))
 		return false, err
 	}
 


### PR DESCRIPTION
Display a specific message when no changelog available from a Github Release

Signed-off-by: Olivier Vernin <olivier@vernin.me>