### PR TITLE
Remove occurences of 'master'

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,10 +2,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [master, ]
+    branches: [main, ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [master]
+    branches: [main]
   schedule:
     - cron: '0 5 * * 0'
 

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -2,10 +2,10 @@ name: Go
 on:
   push:
     branches:
-    - master
+    - main
   pull_request:
     branches:
-    - master
+    - main
 
 jobs:
 

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -5,7 +5,7 @@ on:
   push:
     # branches to consider in the event; optional, defaults to all
     branches:
-      - master
+      - main
 
 jobs:
   update_release_draft:

--- a/README.adoc
+++ b/README.adoc
@@ -60,7 +60,7 @@ targets:
     kind: yaml
     spec:
       file: "charts/jenkins/values.yaml"
-      key: "jenkins.master.imageTag"
+      key: "jenkins.controller.imageTag"
     scm:
       github:
         user: olblak

--- a/README.adoc
+++ b/README.adoc
@@ -1,6 +1,6 @@
 = Updatecli
 
-link:https://github.com/olblak/updatecli/blob/master/LICENSE[image:https://img.shields.io/github/license/olblak/updatecli[GitHub]]
+link:https://github.com/olblak/updatecli/blob/main/LICENSE[image:https://img.shields.io/github/license/olblak/updatecli[GitHub]]
 link:https://goreportcard.com/report/github.com/olblak/updatecli[image:https://goreportcard.com/badge/github.com/olblak/updatecli[Go Report Card]]
 link:https://hub.docker.com/r/olblak/updatecli[image:https://img.shields.io/docker/pulls/olblak/updatecli?label=olblak%2Fupdatecli&logo=docker&logoColor=white[Docker Pulls]]
 link:https://github.com/olblak/updatecli/releases[image:https://img.shields.io/github/downloads/olblak/updatecli/latest/total[GitHub Releases]]
@@ -69,7 +69,7 @@ targets:
         repository: "charts"
         token: mySecretTokenWhichShouldNeverUsedThisWay
         username: olblak
-        branch: "master"
+        branch: "main"
 ```
 
 |What it says:
@@ -85,16 +85,16 @@ Is there a docker image "jenkins/jenkins" from Dockerhub with the tag "2.264-jdk
 => Yes then proceed otherwise abort +
 
 . Targets: +
-Do we have to update the key "jenkins.master.imageTag" from file "./charts/jenkins/values.yaml" located on the Github repository olblak/charts to "2.264-jdk11"? +
-=> If yes then open a Github pull request to the branch "master" 
+Do we have to update the key "jenkins.controller.imageTag" from file "./charts/jenkins/values.yaml" located on the Github repository olblak/charts to "2.264-jdk11"? +
+=> If yes then open a Github pull request to the branch "main"
 
 |===
 
 
 [cols="4*","header"]
 |===
-|link:https://github.com/olblak/updatecli/blob/master/LICENSE[LICENSE]
-|link:https://github.com/olblak/updatecli/blob/master/doc/CONTRIBUTING.adoc[CONTRIBUTING]
-|link:https://github.com/olblak/updatecli/blob/master/doc/README.adoc[DOCUMENTATION]
-|link:https://github.com/olblak/updatecli/blob/master/doc/ADOPTERS.md[ADOPTERS]
+|link:https://github.com/olblak/updatecli/blob/main/LICENSE[LICENSE]
+|link:https://github.com/olblak/updatecli/blob/main/doc/CONTRIBUTING.adoc[CONTRIBUTING]
+|link:https://github.com/olblak/updatecli/blob/main/doc/README.adoc[DOCUMENTATION]
+|link:https://github.com/olblak/updatecli/blob/main/doc/ADOPTERS.md[ADOPTERS]
 |===

--- a/doc/README.adoc
+++ b/doc/README.adoc
@@ -469,7 +469,7 @@ targets:
         repository: "charts"
         token: {{ requiredEnv "GITHUB_TOKEN" }}
         username: "updatecli"
-        branch: "master"
+        branch: "main"
 ```
 
 == Continuous Update

--- a/doc/README.adoc
+++ b/doc/README.adoc
@@ -460,7 +460,7 @@ targets:
     postfix: "-jdk11"
     spec:
       file: "charts/jenkins/values.yaml"
-      key: "jenkins.master.imageTag"
+      key: "jenkins.controller.imageTag"
     scm:
       github:
         user: "updatecli"

--- a/doc/README.adoc
+++ b/doc/README.adoc
@@ -61,7 +61,7 @@ source:
 conditions:
   conditionID:
     kind: <conditionType>
-    spec: 
+    spec:
       <conditionTypeSpec>
 targets:
   target1:
@@ -70,7 +70,7 @@ targets:
       <targetTypeSpec>
 ```
 
-**YAML** 
+**YAML**
 
 Accepted extensions: ".yaml",".yml"
 
@@ -80,7 +80,7 @@ A YAML configuration can be specified using `--config <yaml_file>`, it accepts e
 
 Accepted extensions: ".tpl",".tmpl"
 
-Another way to use this tool is by using go template files in place of YAML. 
+Another way to use this tool is by using go template files in place of YAML.
 Using go templates allow us to specify generic values in a different yaml file then reference those values from each go templates.
 We also provide a custom function called requireEnv to inject any environment variable in the template example, `{{ requiredEnv "PATH" }}`.
 
@@ -113,8 +113,8 @@ A Dockerfile retrieves information from a Dockerfile. To identify which informat
 * "x", reference a specific instruction position where x is replaced by any integer starting from 0. So "0" means the first instruction of type `INSTRUCTION`, "1" means the second, etc
 * "y", reference a specific argument element for the `INSTRUCTION[x]` where "y" is replaced by any integer starting from 0. So "0" means the first argument, "1" means the second, etc
 
-The library uses to manipulate Dockerfile, split each INSTRUCTION into arrays so the line 
-`LABEL key1=value2 key2=value2` becomes `["key1","value2","key2","value2"]` 
+The library uses to manipulate Dockerfile, split each INSTRUCTION into arrays so the line
+`LABEL key1=value2 key2=value2` becomes `["key1","value2","key2","value2"]`
 
 * `LABEL[0][0]` equal `key1`
 * `LABEL[0][1]` equal `value2`
@@ -239,8 +239,8 @@ A Dockerfile validate information from a Dockerfile. It uses the field "Value" t
 * "x", reference a specific instruction position where x is replaced by any integer starting from 0. So "0" means the first instruction of type `INSTRUCTION`, "1" means the second, etc
 * "y", reference a specific argument element for the `INSTRUCTION[x]` where "y" is replaced by any integer starting from 0. So "0" means the first argument, "1" means the second, etc
 
-The library uses to manipulate Dockerfile, split each INSTRUCTION into arrays so the line 
-`LABEL key1=value2 key2=value2` becomes `["key1","value2","key2","value2"]` 
+The library uses to manipulate Dockerfile, split each INSTRUCTION into arrays so the line
+`LABEL key1=value2 key2=value2` becomes `["key1","value2","key2","value2"]`
 
 * `LABEL[0][0]` equal `key1`
 * `LABEL[0][1]` equal `value2`
@@ -252,7 +252,7 @@ For instance, based on the previous example, `LABEL` means "key1"
 
 ```
 conditions:
-  id: 
+  id:
     kind: dockerfile
     spec:
       file: docker/Dockerfile
@@ -351,8 +351,8 @@ A Dockerfile target, updates a Dockerfile based on information retrieved from so
 * "x", reference a specific instruction position where x is replaced by any integer starting from 0. So "0" means the first instruction of type `INSTRUCTION`, "1" means the second, etc
 * "y", reference a specific argument element for the `INSTRUCTION[x]` where "y" is replaced by any integer starting from 0. So "0" means the first argument, "1" means the second, etc
 
-The library uses to manipulate Dockerfile, split each INSTRUCTION into arrays so the line 
-`LABEL key1=value2 key2=value2` becomes `["key1","value2","key2","value2"]` 
+The library uses to manipulate Dockerfile, split each INSTRUCTION into arrays so the line
+`LABEL key1=value2 key2=value2` becomes `["key1","value2","key2","value2"]`
 
 * `LABEL[0][0]` equal `key1`
 * `LABEL[0][1]` equal `value2`
@@ -367,7 +367,7 @@ TIP: It's a good idea to test that a LABEL key exist before updating its value
 
 ```
 targets:
-  taskId 
+  taskId
     kind: dockerfile
     spec:
       file: docker/Dockerfile

--- a/doc/scenarios/docker-compose.adoc
+++ b/doc/scenarios/docker-compose.adoc
@@ -157,7 +157,7 @@ targets:
         repository: "charts"
         token: "{{ requiredEnv GITHUB_TOKEN }}"
         username: "johnDoe"
-        branch: "master"
+        branch: "main"
 
 ```
 

--- a/doc/scenarios/docker-compose.adoc
+++ b/doc/scenarios/docker-compose.adoc
@@ -12,7 +12,7 @@ This means that a docker image tag can't be considered as a source of truth.
 
 *Digest*
 
-The second method to identify a docker image version is by using its digest like in `nginx@sha256:8269a7352a7dad1f8b3dc83284f195bac72027dd50279422d363d49311ab7d9b` where `8269a7352a7dad1f8b3dc83284f195bac72027dd50279422d363d49311ab7d9b` is the digest. A digest is a hash referencing a specific version of a docker image tag like in this case `nginx:1.17`. A digest is immutable, we can always rollblack to a specific digest if need. But we must admit that it's not convenient to identify which version we are referencing to without having to dig into it. 
+The second method to identify a docker image version is by using its digest like in `nginx@sha256:8269a7352a7dad1f8b3dc83284f195bac72027dd50279422d363d49311ab7d9b` where `8269a7352a7dad1f8b3dc83284f195bac72027dd50279422d363d49311ab7d9b` is the digest. A digest is a hash referencing a specific version of a docker image tag like in this case `nginx:1.17`. A digest is immutable, we can always rollblack to a specific digest if need. But we must admit that it's not convenient to identify which version we are referencing to without having to dig into it.
 
 
 The problem here could be resumed by "Do we want to only use well-defined docker image by using digests but with the cost of losing readability?" or "Are we ok to take the risk of running an unwanted version by using image tags?".
@@ -171,4 +171,4 @@ And now you can use the same command than before
 
 In this scenario, we saw how to automatically update docker-compose file using custom strategies by using updatecli. Updatecli is a small tool that can be used from your favorite CI environment.
 
-Now we can replace our docker-compose file by any other YAML file to automate YAML update. 
+Now we can replace our docker-compose file by any other YAML file to automate YAML update.

--- a/examples/updateCli.d/dockerfile.tpl
+++ b/examples/updateCli.d/dockerfile.tpl
@@ -24,7 +24,7 @@ conditions:
         repository: "charts"
         token: {{ requiredEnv "GITHUB_TOKEN" }}
         username: "olblak"
-        branch: "master"
+        branch: "main"
 targets:
   updateENVHELMVERSION:
     name: Update HELM_VERSION
@@ -40,4 +40,4 @@ targets:
         repository: "charts"
         token: {{ requiredEnv "GITHUB_TOKEN" }}
         username: "olblak"
-        branch: "master"
+        branch: "main"

--- a/examples/updateCli.d/jenkins.tpl
+++ b/examples/updateCli.d/jenkins.tpl
@@ -22,7 +22,7 @@ targets:
     #postfix: "-jdk13"
     spec:
       file: "charts/jenkins/values.yaml"
-      key: "jenkins.master.imageTag"
+      key: "jenkins.controller.imageTag"
     scm:
       github:
         user: "{{ .github.user }}"

--- a/examples/updateCli.d/jenkins.yaml
+++ b/examples/updateCli.d/jenkins.yaml
@@ -20,7 +20,7 @@ targets:
     kind: yaml
     spec:
       file: "charts/jenkins/values.yaml"
-      key: "jenkins.master.imageTag"
+      key: "jenkins.controller.imageTag"
     scm:
       github:
         user: "updatecli"

--- a/examples/updateCli.d/jenkins.yaml
+++ b/examples/updateCli.d/jenkins.yaml
@@ -29,4 +29,4 @@ targets:
         repository: "charts"
         token: ""
         username: "olblak"
-        branch: "master"
+        branch: "main"

--- a/examples/updateCli.d/nginx.yaml
+++ b/examples/updateCli.d/nginx.yaml
@@ -19,4 +19,4 @@ targets:
         repository: "charts"
         token: ""
         username: "olblak"
-        branch: "master"
+        branch: "main"

--- a/examples/updateCli.d/updateCli.tpl
+++ b/examples/updateCli.d/updateCli.tpl
@@ -26,7 +26,7 @@ conditions:
         repository: "updatecli"
         token: {{ requiredEnv "GITHUB_TOKEN" }}
         username: "olblak"
-        branch: master
+        branch: main
 targets:
   dockerFile:
     name: "isDockerfileCorrect"
@@ -42,5 +42,5 @@ targets:
         repository: "updatecli"
         token: {{ requiredEnv "GITHUB_TOKEN" }}
         username: "olblak"
-        branch: master
+        branch: main
         email: "update-bot@olblak.com"

--- a/examples/updateCli.generic/dockerfile.tpl
+++ b/examples/updateCli.generic/dockerfile.tpl
@@ -12,8 +12,8 @@
 #  ===========
 #
 #  Then it will test one condition:
-#  If the dockerfile 'docker/Dockerfile' is located on the git repository https://github.com/olblak/charts 
-#  has the instruction ENV[1][0] set to "HELM_VERSION". ENV[1][0] is a custom syntax to represent 
+#  If the dockerfile 'docker/Dockerfile' is located on the git repository https://github.com/olblak/charts
+#  has the instruction ENV[1][0] set to "HELM_VERSION". ENV[1][0] is a custom syntax to represent
 #  a two-dimensional array where the first element represents a specific Dockerfile instruction identifier
 #  starting from "0" at the beginning of the document, so we are looking for the second INSTRUCTION "ENV".
 #  The second element represents an instruction argument position. In this case, we want to check that ENV key
@@ -22,7 +22,7 @@
 #  Targets:
 #  ========
 #
-#  If the condition is met, which is to be sure that the ENV key set to "HELM_VERSION" exist, then we'll 
+#  If the condition is met, which is to be sure that the ENV key set to "HELM_VERSION" exist, then we'll
 #  are going to update its value if needed based on the version retrieved from the source.
 #  The syntax is the same for the condition excepted that this time we are looking for ENV[1][1]
 #  which means that the second argument of the second ENV instruction.

--- a/examples/updateCli.generic/dockerfile.tpl
+++ b/examples/updateCli.generic/dockerfile.tpl
@@ -55,7 +55,7 @@ conditions:
         repository: "charts"
         token: {{ requiredEnv "GITHUB_TOKEN" }}
         username: "olblak"
-        branch: "master"
+        branch: "main"
 targets:
   updateENVHELMVERSION:
     name: Update HELM_VERSION
@@ -71,4 +71,4 @@ targets:
         repository: "charts"
         token: {{ requiredEnv "GITHUB_TOKEN" }}
         username: "olblak"
-        branch: "master"
+        branch: "main"

--- a/examples/updateCli.generic/githubRelease.tpl
+++ b/examples/updateCli.generic/githubRelease.tpl
@@ -35,7 +35,7 @@ source:
   spec:
     owner: "jenkins-infra"
     repository: "jenkins-wiki-exporter"
-    token: "{{ requiredEnv .github.token }}" 
+    token: "{{ requiredEnv .github.token }}"
     username: "olblak"
     version: "latest"
 conditions:

--- a/examples/updateCli.generic/githubRelease.tpl
+++ b/examples/updateCli.generic/githubRelease.tpl
@@ -23,7 +23,7 @@
 #  If conditions are all met, then updatecli will update (if needed) the key
 #  "image.tag" to "1.10.3" for the file "charts/jenkins-wiki-exporter/values.yaml"
 #  from the github repository olblak/chart then commit the change to a temporary branch then open
-#  a pull request targeting master
+#  a pull request targeting main
 #
 # Remark: The specificity in this example is that we are using a go template
 # so we could reuse information accross the yaml file or use environment variable which contains the github token

--- a/examples/updateCli.generic/helmRelease.tpl
+++ b/examples/updateCli.generic/helmRelease.tpl
@@ -23,7 +23,7 @@
 #  If conditions are all met, then updatecli will update (if needed) the first element of the key
 #  "dependencies" to "2.7.1" for the file "charts/jenkins/requirements.yaml"
 #  from the github repository olblak/chart then commit the change to a temporary branch then open
-#  a pull request targeting master
+#  a pull request targeting main
 #
 # Remark: The specificity in this example is that we are using a go template
 # so we could reuse information accross the yaml file or use environment variable which contains the github token

--- a/examples/updateCli.generic/maven.yaml
+++ b/examples/updateCli.generic/maven.yaml
@@ -19,9 +19,9 @@
 #   1 - Test a dockerImage condition, "Do we have a docker image published on Dockerhub"
 #       for the "jenkins/jenkins" using the tag "2.264-jdk11"
 #         => Yes, proceed, No then abort
-#   2 - Test a yaml condition, "Do we have a docker image set?" 
-#       Test if the key jenkins.master.image is set to the value "jenkins/jenkins" 
-#       from the file "charts/jenkins/values.yaml" located on the git repository 
+#   2 - Test a yaml condition, "Do we have a docker image set?"
+#       Test if the key jenkins.controller.image is set to the value "jenkins/jenkins"
+#       from the file "charts/jenkins/values.yaml" located on the git repository
 #       "tgit@github.com:olblak/charts.git"
 #         => Yes, proceed, No then abort
 #
@@ -57,7 +57,7 @@ conditions:
     kind: yaml
     spec:
       file: "charts/jenkins/values.yaml"
-      key: "jenkins.master.image"
+      key: "jenkins.controller.image"
       value: "jenkins/jenkins"
     scm:
       git:

--- a/examples/updateCli.generic/maven.yaml
+++ b/examples/updateCli.generic/maven.yaml
@@ -29,9 +29,9 @@
 #  ========
 #
 #  If conditions are all met, then updatecli will update (if needed) the key
-#  "jenkins.master.imageTag" to "2.264-jdk11" for the file "charts/jenkins/values.yaml"
-#  from the git repository "git@github.com:olblak/charts.git" then commit the change to the 
-#  branch master
+#  "jenkins.controller.imageTag" to "2.264-jdk11" for the file "charts/jenkins/values.yaml"
+#  from the git repository "git@github.com:olblak/charts.git" then commit the change to the
+#  branch main
 #
 #
 ###
@@ -62,7 +62,7 @@ conditions:
     scm:
       git:
         url: "git@github.com:olblak/charts.git"
-        branch: "master"
+        branch: "main"
         user: "olblak"
         email: "me@olblak.com"
 targets:
@@ -71,12 +71,11 @@ targets:
     kind: yaml
     spec:
       file: "charts/jenkins/values.yaml"
-      key: "jenkins.master.imageTag"
+      key: "jenkins.controller.imageTag"
     scm:
       git:
         url: "git@github.com:olblak/charts.git"
-        branch: master
+        branch: main
         user: olblak
         email: me@olblak.com
         directory: "/home/olblak/Project/Jenkins-infra/charts"
-

--- a/examples/values.yaml
+++ b/examples/values.yaml
@@ -6,4 +6,4 @@ github:
   #token: "UPDATECLI_GITHUB_TOKEN"
   token: "GITHUB_TOKEN"
   username: olblak
-  branch: master
+  branch: main


### PR DESCRIPTION
Closes #93 .

After renaming the principal branch to `main`, some elements have to be changed to fix documentation's links, example, CI process, etc.

This PR is split in 3 commits:

- MUST HAVE: Replacing occurrences of `master` by `main` in git context (to fix dead links, example and CI)
- NICE TO HAVE: Replacing occurrences of `master` by `controller` in Jenkins context
- NICE TO HAVE: My editor auto-removed some trailing blank characters