### PR TITLE
Better Handle errors

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -1,9 +1,10 @@
 package cmd
 
 import (
-	"github.com/sirupsen/logrus"
 	"os"
 	"strings"
+
+	"github.com/sirupsen/logrus"
 
 	"github.com/spf13/cobra"
 )
@@ -29,7 +30,7 @@ var (
 
 			err := run("apply")
 			if err != nil {
-				logrus.Errorf("command failed: %s", err)
+				logrus.Errorf("command failed")
 				os.Exit(1)
 			}
 		},

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -1,9 +1,10 @@
 package cmd
 
 import (
-	"github.com/sirupsen/logrus"
 	"os"
 	"strings"
+
+	"github.com/sirupsen/logrus"
 
 	"github.com/spf13/cobra"
 )
@@ -27,7 +28,7 @@ var (
 
 			err := run("diff")
 			if err != nil {
-				logrus.Errorf("command failed: %s", err)
+				logrus.Errorf("command failed")
 				os.Exit(1)
 			}
 		},

--- a/cmd/prepare.go
+++ b/cmd/prepare.go
@@ -1,9 +1,10 @@
 package cmd
 
 import (
-	"github.com/sirupsen/logrus"
 	"os"
 	"strings"
+
+	"github.com/sirupsen/logrus"
 
 	"github.com/spf13/cobra"
 )
@@ -24,7 +25,7 @@ var (
 
 			err := run("prepare")
 			if err != nil {
-				logrus.Errorf("command failed: %s", err)
+				logrus.Errorf("command failed")
 				os.Exit(1)
 			}
 		},

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,9 +1,10 @@
 package cmd
 
 import (
+	"os"
+
 	"github.com/olblak/updateCli/pkg/core/log"
 	"github.com/sirupsen/logrus"
-	"os"
 
 	"github.com/olblak/updateCli/pkg/core/engine"
 	"github.com/olblak/updateCli/pkg/core/result"
@@ -14,10 +15,10 @@ import (
 var (
 	cfgFile    string
 	valuesFile string
-	e engine.Engine
-    verbose bool
+	e          engine.Engine
+	verbose    bool
 
-rootCmd = &cobra.Command{
+	rootCmd = &cobra.Command{
 		Use:   "updateCli",
 		Short: "Updatecli is a tool used to define and apply file update strategies. ",
 		Long: `
@@ -61,12 +62,6 @@ func run(command string) error {
 
 	switch command {
 	case "apply":
-		err := e.Prepare()
-		if err != nil {
-			logrus.Errorf("%s %s", result.FAILURE, err)
-			return err
-		}
-
 		if applyClean {
 			defer func() {
 				if err := e.Clean(); err != nil {
@@ -75,24 +70,30 @@ func run(command string) error {
 			}()
 		}
 
+		err := e.Prepare()
+		if err != nil {
+			logrus.Errorf("%s %s", result.FAILURE, err)
+			logrus.Errorln("Continuing and trying to go as far as possible")
+		}
+
 		err = e.Run()
 		if err != nil {
 			logrus.Errorf("%s %s", result.FAILURE, err)
 			return err
 		}
 	case "diff":
-		err := e.Prepare()
-		if err != nil {
-			logrus.Errorf("%s %s", result.FAILURE, err)
-			return err
-		}
-
 		if diffClean {
 			defer func() {
 				if err := e.Clean(); err != nil {
 					logrus.Errorf("error in diff clean - %s", err)
 				}
 			}()
+		}
+
+		err := e.Prepare()
+		if err != nil {
+			logrus.Errorf("%s %s", result.FAILURE, err)
+			logrus.Errorln("Continuing and trying to go as far as possible")
 		}
 
 		err = e.Run()
@@ -108,6 +109,12 @@ func run(command string) error {
 				}
 			}()
 		}
+
+		err := e.Prepare()
+		if err != nil {
+			logrus.Errorf("%s %s", result.FAILURE, err)
+		}
+
 	case "show":
 		err := e.Show()
 		if err != nil {

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -1,9 +1,10 @@
 package cmd
 
 import (
-	"github.com/sirupsen/logrus"
 	"os"
 	"strings"
+
+	"github.com/sirupsen/logrus"
 
 	"github.com/spf13/cobra"
 )
@@ -20,7 +21,7 @@ var (
 
 			err := run("show")
 			if err != nil {
-				logrus.Errorf("command failed: %s", err)
+				logrus.Errorf("command failed")
 				os.Exit(1)
 			}
 		},

--- a/pkg/core/config/template.go
+++ b/pkg/core/config/template.go
@@ -67,7 +67,11 @@ func (t *Template) Unmarshal(config *Config) error {
 		return err
 	}
 
-	tmpl := template.Must(template.New("cfg").Funcs(funcMap).Parse(string(content)))
+	tmpl, err := template.New("cfg").Funcs(funcMap).Parse(string(content))
+
+	if err != nil {
+		return err
+	}
 
 	b := bytes.Buffer{}
 

--- a/pkg/core/reports/main.go
+++ b/pkg/core/reports/main.go
@@ -2,9 +2,10 @@ package reports
 
 import (
 	"bytes"
-	"errors"
-	"github.com/sirupsen/logrus"
+	"fmt"
 	"text/template"
+
+	"github.com/sirupsen/logrus"
 
 	"github.com/olblak/updateCli/pkg/core/result"
 )
@@ -92,7 +93,10 @@ func (r *Reports) Summary() (int, int, int, error) {
 	logrus.Infof("%d job applied changes", changedCounter)
 
 	if failedCounter > 0 {
-		return successCounter, changedCounter, failedCounter, errors.New("a job has failed")
+		return successCounter,
+			changedCounter,
+			failedCounter,
+			fmt.Errorf("%d/%d job(s) failed", failedCounter, counter)
 	}
 
 	return successCounter, changedCounter, failedCounter, nil

--- a/pkg/plugins/git/generic/main.go
+++ b/pkg/plugins/git/generic/main.go
@@ -3,10 +3,11 @@ package generic
 import (
 	"bytes"
 	"fmt"
-	"github.com/sirupsen/logrus"
 	"os"
 	"strings"
 	"time"
+
+	"github.com/sirupsen/logrus"
 
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"
@@ -203,12 +204,16 @@ func Clone(username, password, URL, workingDir string) error {
 		})
 
 		logrus.Infof(b.String())
+
 		b.Reset()
-		if err != nil {
+
+		if err != nil &&
+			err != git.NoErrAlreadyUpToDate {
 			return err
 		}
 
-	} else if err != nil {
+	} else if err != nil &&
+		err != git.NoErrAlreadyUpToDate {
 		return err
 	}
 
@@ -224,7 +229,8 @@ func Clone(username, password, URL, workingDir string) error {
 		err := r.Fetch(&git.FetchOptions{Progress: &b})
 		logrus.Infof(b.String())
 		b.Reset()
-		if err != nil {
+		if err != nil &&
+			err != git.NoErrAlreadyUpToDate {
 			return err
 		}
 	}


### PR DESCRIPTION
Now that better catch errors during run some of them prevent updatecli to finish a run.
This PR handle some of them
* Don't panic but return errors during config templating, we still want to apply valid update strategies
* Don't exist if something went wrong during the prepare stage but instead try to apply strategies that can be apply