### PR TITLE
Add transformer definition

### DIFF
--- a/examples/updateCli.generic/transformers/jenkins.tpl
+++ b/examples/updateCli.generic/transformers/jenkins.tpl
@@ -2,10 +2,10 @@ source:
   name: "Get latest jenkins weekly version"
   kind: jenkins
   transformers:
-    - prefix: "alpha-"
-    - suffix: "-jdk11"
+    - addPrefix: "alpha-"
+    - addSuffix: "-jdk11"
     - trimSuffix: "-jdk11"
-    - suffix: "-jdk11"
+    - addSuffix: "-jdk11"
     - replacer:
         from: "-jdk11"
         to: "-jdk15"

--- a/examples/updateCli.generic/transformers/jenkins.tpl
+++ b/examples/updateCli.generic/transformers/jenkins.tpl
@@ -1,0 +1,22 @@
+source:
+  name: "Get latest jenkins weekly version"
+  kind: jenkins
+  transformers:
+    - prefix: "alpha-"
+    - suffix: "-jdk11"
+    - trimSuffix: "-jdk11"
+    - suffix: "-jdk11"
+    - replacer:
+        from: "-jdk11"
+        to: "-jdk15"
+    - replacers:
+        - from: "-jdk15"
+          to: "-jdk17"
+  spec:
+    release: weekly
+targets:
+  targetID:
+    name: "Update file file"
+    kind: file
+    spec:
+      file: TODO

--- a/pkg/core/engine/condition/main.go
+++ b/pkg/core/engine/condition/main.go
@@ -53,12 +53,12 @@ func (c *Condition) Run(source string) (ok bool, err error) {
 
 	// Announce deprecation on 2021/01/31
 	if len(c.Prefix) > 0 {
-		logrus.Warnf("Key 'prefix' deprecated in favor of 'transformers', it will be delete in a futur release")
+		logrus.Warnf("Key 'prefix' deprecated in favor of 'transformers', it will be delete in a future release")
 	}
 
 	// Announce deprecation on 2021/01/31
 	if len(c.Postfix) > 0 {
-		logrus.Warnf("Key 'postfix' deprecated in favor of 'transformers', it will be delete in a futur release")
+		logrus.Warnf("Key 'postfix' deprecated in favor of 'transformers', it will be delete in a future release")
 	}
 
 	// If scm is defined then clone the repository

--- a/pkg/core/engine/source/main.go
+++ b/pkg/core/engine/source/main.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/mitchellh/mapstructure"
 	"github.com/olblak/updateCli/pkg/core/scm"
+	"github.com/olblak/updateCli/pkg/core/transformer"
 	"github.com/olblak/updateCli/pkg/plugins/docker"
 	"github.com/olblak/updateCli/pkg/plugins/file"
 	"github.com/olblak/updateCli/pkg/plugins/github"
@@ -20,16 +21,17 @@ import (
 
 // Source defines how a value is retrieved from a specific source
 type Source struct {
-	Name      string
-	Kind      string
-	Changelog string
-	Output    string
-	Prefix    string
-	Postfix   string
-	Replaces  Replacers
-	Spec      interface{}
-	Scm       map[string]interface{}
-	Result    string `yaml:"-"` // Ignore this key field when unmarshalling yaml file
+	Name         string
+	Kind         string
+	Changelog    string
+	Output       string
+	Prefix       string // Deprecated in favor of Transformers on 2021/01/3
+	Postfix      string // Deprecated in favor of Transformers on 2021/01/3
+	Transformers transformer.Transformers
+	Replaces     Replacers // Deprecated in favor of Transformers on 2021/01/3
+	Spec         interface{}
+	Scm          map[string]interface{}
+	Result       string `yaml:"-"` // Ignore this key field when unmarshalling yaml file
 }
 
 // Spec source is an interface to handle source spec
@@ -93,6 +95,23 @@ func (s *Source) Execute() error {
 
 	output, err = spec.Source(workingDir)
 
+	if len(s.Transformers) > 0 {
+		output, err = s.Transformers.Apply(output)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Announce deprecation on 2021/01/31
+	if len(s.Prefix) > 0 {
+		logrus.Warnf("Key 'prefix' deprecated in favor of 'transformers', it will be delete in a futur release")
+	}
+
+	// Announce deprecation on 2021/01/31
+	if len(s.Postfix) > 0 {
+		logrus.Warnf("Key 'postfix' deprecated in favor of 'transformers', it will be delete in a futur release")
+	}
+
 	if err != nil {
 		return err
 	}
@@ -108,6 +127,7 @@ func (s *Source) Execute() error {
 		return fmt.Errorf("Something weird happened while setting changelog")
 	}
 
+	// Deprecated in favor of Transformers on 2021/01/3
 	if len(s.Replaces) > 0 {
 		args := s.Replaces.Unmarshal()
 

--- a/pkg/core/engine/source/main.go
+++ b/pkg/core/engine/source/main.go
@@ -104,12 +104,12 @@ func (s *Source) Execute() error {
 
 	// Announce deprecation on 2021/01/31
 	if len(s.Prefix) > 0 {
-		logrus.Warnf("Key 'prefix' deprecated in favor of 'transformers', it will be delete in a futur release")
+		logrus.Warnf("Key 'prefix' deprecated in favor of 'transformers', it will be delete in a future release\n")
 	}
 
 	// Announce deprecation on 2021/01/31
 	if len(s.Postfix) > 0 {
-		logrus.Warnf("Key 'postfix' deprecated in favor of 'transformers', it will be delete in a futur release")
+		logrus.Warnf("Key 'postfix' deprecated in favor of 'transformers', it will be delete in a future release\n")
 	}
 
 	if err != nil {

--- a/pkg/core/engine/source/replacer.go
+++ b/pkg/core/engine/source/replacer.go
@@ -1,7 +1,7 @@
 package source
 
 // 2021/01/31
-// Deprecated in favor of Transformer, need to be deleted in a futur release
+// Deprecated in favor of Transformer, need to be deleted in a future release
 
 // Replacer is struct used to feed strings.Replacer
 type Replacer struct {

--- a/pkg/core/engine/source/replacer_test.go
+++ b/pkg/core/engine/source/replacer_test.go
@@ -1,7 +1,7 @@
 package source
 
 // 2021/01/31
-// Deprecated in favor of Transformer, need to be deleted in a futur release
+// Deprecated in favor of Transformer, need to be deleted in a future release
 
 import (
 	"reflect"

--- a/pkg/core/engine/target/main.go
+++ b/pkg/core/engine/target/main.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/mitchellh/mapstructure"
 	"github.com/olblak/updateCli/pkg/core/scm"
+	"github.com/olblak/updateCli/pkg/core/transformer"
 	"github.com/olblak/updateCli/pkg/plugins/docker/dockerfile"
 	"github.com/olblak/updateCli/pkg/plugins/file"
 	"github.com/olblak/updateCli/pkg/plugins/yaml"
@@ -15,14 +16,15 @@ import (
 
 // Target defines which file needs to be updated based on source output
 type Target struct {
-	Name      string
-	Kind      string
-	Changelog string `yaml:"-"`
-	Prefix    string
-	Postfix   string
-	Spec      interface{}
-	Scm       map[string]interface{}
-	Result    string `yaml:"-"`
+	Name         string
+	Kind         string
+	Changelog    string `yaml:"-"`
+	Prefix       string // Deprecated in favor of Transformers on 2021/01/3
+	Postfix      string // Deprecated in favor of Transformers on 2021/01/3
+	Transformers transformer.Transformers
+	Spec         interface{}
+	Scm          map[string]interface{}
+	Result       string `yaml:"-"`
 }
 
 // Spec is an interface which offers common function to manipulate targets.
@@ -94,6 +96,23 @@ func Unmarshal(target *Target) (spec Spec, err error) {
 
 // Run applies a specific target configuration
 func (t *Target) Run(source string, o *Options) (changed bool, err error) {
+
+	if len(t.Transformers) > 0 {
+		source, err = t.Transformers.Apply(source)
+		if err != nil {
+			return false, err
+		}
+	}
+
+	// Announce deprecation on 2021/01/31
+	if len(t.Prefix) > 0 {
+		logrus.Warnf("Key 'prefix' deprecated in favor of 'transformers', it will be delete in a futur release")
+	}
+
+	// Announce deprecation on 2021/01/31
+	if len(t.Postfix) > 0 {
+		logrus.Warnf("Key 'postfix' deprecated in favor of 'transformers', it will be delete in a futur release")
+	}
 
 	if o.DryRun {
 

--- a/pkg/core/engine/target/main.go
+++ b/pkg/core/engine/target/main.go
@@ -106,12 +106,12 @@ func (t *Target) Run(source string, o *Options) (changed bool, err error) {
 
 	// Announce deprecation on 2021/01/31
 	if len(t.Prefix) > 0 {
-		logrus.Warnf("Key 'prefix' deprecated in favor of 'transformers', it will be delete in a futur release")
+		logrus.Warnf("Key 'prefix' deprecated in favor of 'transformers', it will be delete in a future release")
 	}
 
 	// Announce deprecation on 2021/01/31
 	if len(t.Postfix) > 0 {
-		logrus.Warnf("Key 'postfix' deprecated in favor of 'transformers', it will be delete in a futur release")
+		logrus.Warnf("Key 'postfix' deprecated in favor of 'transformers', it will be delete in a future release")
 	}
 
 	if o.DryRun {

--- a/pkg/core/transformer/main.go
+++ b/pkg/core/transformer/main.go
@@ -23,10 +23,10 @@ func (t *Transformer) Apply(input string) (output string, err error) {
 	for key, value := range *t {
 		switch key {
 
-		case "prefix":
+		case "addPrefix":
 			output = fmt.Sprintf("%s%s", value, input)
 
-		case "suffix":
+		case "addSuffix":
 			output = fmt.Sprintf("%s%s", input, value)
 
 		case "trimPrefix":

--- a/pkg/core/transformer/main.go
+++ b/pkg/core/transformer/main.go
@@ -46,9 +46,23 @@ func (t *Transformer) Apply(input string) (output string, err error) {
 
 			output = strings.TrimSuffix(output, val)
 
-		case "replacer":
+		case "replacers":
 
 			r := Replacers{}
+
+			err := mapstructure.Decode(value, &r)
+			if err != nil {
+				return "", err
+			}
+
+			args := r.Unmarshal()
+
+			replacer := strings.NewReplacer(args...)
+
+			output = (replacer.Replace(output))
+		case "replacer":
+
+			r := Replacer{}
 
 			err := mapstructure.Decode(value, &r)
 			if err != nil {

--- a/pkg/core/transformer/main.go
+++ b/pkg/core/transformer/main.go
@@ -2,6 +2,7 @@ package transformer
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/mitchellh/mapstructure"
@@ -74,6 +75,23 @@ func (t *Transformer) Apply(input string) (output string, err error) {
 			replacer := strings.NewReplacer(args...)
 
 			output = (replacer.Replace(output))
+
+		case "find":
+
+			val, ok := value.(string)
+
+			if !ok {
+				return "", fmt.Errorf("unknown value for find: %v", val)
+			}
+
+			re, err := regexp.Compile(val)
+			if err != nil {
+				return "", err
+			}
+
+			found := re.FindString(output)
+
+			output = found
 
 		default:
 			return "", fmt.Errorf("key '%v' not supported", key)

--- a/pkg/core/transformer/main.go
+++ b/pkg/core/transformer/main.go
@@ -1,0 +1,85 @@
+package transformer
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/mitchellh/mapstructure"
+	"github.com/sirupsen/logrus"
+)
+
+//Transformer holds a tranformer rule
+type Transformer map[string]interface{}
+
+//Transformers holds a list of transformer
+type Transformers []Transformer
+
+// Apply applies a single transformation based on a key
+func (t *Transformer) Apply(input string) (output string, err error) {
+
+	output = input
+
+	for key, value := range *t {
+		switch key {
+
+		case "prefix":
+			output = fmt.Sprintf("%s%s", value, input)
+
+		case "suffix":
+			output = fmt.Sprintf("%s%s", input, value)
+
+		case "trimPrefix":
+			val, ok := value.(string)
+
+			if !ok {
+				return "", fmt.Errorf("unknown value for trimPrefix: %v", val)
+			}
+
+			output = strings.TrimPrefix(input, val)
+
+		case "trimSuffix":
+			val, ok := value.(string)
+
+			if !ok {
+				return "", fmt.Errorf("unknown value for trimSuffix: %v", val)
+			}
+
+			output = strings.TrimSuffix(output, val)
+
+		case "replacer":
+
+			r := Replacers{}
+
+			err := mapstructure.Decode(value, &r)
+			if err != nil {
+				return "", err
+			}
+
+			args := r.Unmarshal()
+
+			replacer := strings.NewReplacer(args...)
+
+			output = (replacer.Replace(output))
+
+		default:
+			return "", fmt.Errorf("key '%v' not supported", key)
+		}
+
+	}
+
+	return output, nil
+}
+
+// Apply applies a list of transformers
+func (t *Transformers) Apply(input string) (output string, err error) {
+	output = input
+	for _, transformer := range *t {
+		output, err = transformer.Apply(output)
+
+		if err != nil {
+			logrus.Error(err)
+			return "", err
+		}
+	}
+	return output, nil
+}

--- a/pkg/core/transformer/main_test.go
+++ b/pkg/core/transformer/main_test.go
@@ -95,6 +95,36 @@ var (
 			expectedOutput: "beta-2.263",
 			expectedErr:    nil,
 		},
+		Data{
+			input: "4b7f2b878a9854652493b2c94ac586586f2ab53f93e3baa55fc2199ccd5a042d  terraform_0.14.5_freebsd_amd64.zip",
+			rules: Transformers{
+				Transformer{
+					"find": "terraform_(.*)$",
+				},
+			},
+			expectedOutput: "terraform_0.14.5_freebsd_amd64.zip",
+			expectedErr:    nil,
+		},
+		Data{
+			input: "4b7f2b878a9854652493b2c94ac586586f2ab53f93e3baa55fc2199ccd5a042d  terraform_0.14.5_freebsd_amd64.zip",
+			rules: Transformers{
+				Transformer{
+					"find": `^\S*`,
+				},
+			},
+			expectedOutput: "4b7f2b878a9854652493b2c94ac586586f2ab53f93e3baa55fc2199ccd5a042d",
+			expectedErr:    nil,
+		},
+		Data{
+			input: "4b7f2b878a9854652493b2c94ac586586f2ab53f93e3baa55fc2199ccd5a042d  terraform_0.14.5_freebsd_amd64.zip",
+			rules: Transformers{
+				Transformer{
+					"find": `\S*$`,
+				},
+			},
+			expectedOutput: "terraform_0.14.5_freebsd_amd64.zip",
+			expectedErr:    nil,
+		},
 	}
 )
 

--- a/pkg/core/transformer/main_test.go
+++ b/pkg/core/transformer/main_test.go
@@ -1,0 +1,100 @@
+package transformer
+
+import (
+	"testing"
+)
+
+type Data struct {
+	input          string
+	rules          Transformers
+	expectedOutput string
+	expectedErr    error
+}
+
+type DataSet []Data
+
+var (
+	dataSet = DataSet{
+		Data{
+			input: "2.263",
+			rules: Transformers{
+				Transformer{
+					"prefix": "alpha-",
+				},
+			},
+			expectedOutput: "alpha-2.263",
+		},
+		Data{
+			input: "2.263",
+			rules: Transformers{
+				Transformer{
+					"suffix": "-jdk11",
+				},
+			},
+			expectedOutput: "2.263-jdk11",
+			expectedErr:    nil,
+		},
+		Data{
+			input: "alpha-2.263",
+			rules: Transformers{
+				Transformer{
+					"trimPrefix": "alpha-",
+				},
+			},
+			expectedOutput: "2.263",
+			expectedErr:    nil,
+		},
+		Data{
+			input: "2.263-jdk11",
+			rules: Transformers{
+				Transformer{
+					"trimSuffix": "-jdk11",
+				},
+			},
+			expectedOutput: "2.263",
+			expectedErr:    nil,
+		},
+		Data{
+			input: "alpha-2.263",
+			rules: Transformers{
+				Transformer{
+					"trimPrefix": "alpha-",
+				},
+				Transformer{
+					"trimPrefix": "2.",
+				},
+			},
+			expectedOutput: "263",
+			expectedErr:    nil,
+		},
+		Data{
+			input: "alpha-2.263",
+			rules: Transformers{
+				Transformer{
+					"replacer": Replacers{
+						Replacer{
+							From: "alpha",
+							To:   "beta",
+						},
+					},
+				},
+			},
+			expectedOutput: "beta-2.263",
+			expectedErr:    nil,
+		},
+	}
+)
+
+func TestApply(t *testing.T) {
+	for _, d := range dataSet {
+		got, err := d.rules.Apply(d.input)
+		if err != nil {
+			t.Errorf("%v\n", err)
+		}
+
+		if got != d.expectedOutput {
+			t.Errorf("Expected Output '%v', got '%v'", d.expectedOutput, got)
+		}
+
+	}
+}

--- a/pkg/core/transformer/main_test.go
+++ b/pkg/core/transformer/main_test.go
@@ -19,7 +19,7 @@ var (
 			input: "2.263",
 			rules: Transformers{
 				Transformer{
-					"prefix": "alpha-",
+					"addPrefix": "alpha-",
 				},
 			},
 			expectedOutput: "alpha-2.263",
@@ -28,7 +28,7 @@ var (
 			input: "2.263",
 			rules: Transformers{
 				Transformer{
-					"suffix": "-jdk11",
+					"addSuffix": "-jdk11",
 				},
 			},
 			expectedOutput: "2.263-jdk11",

--- a/pkg/core/transformer/main_test.go
+++ b/pkg/core/transformer/main_test.go
@@ -71,11 +71,24 @@ var (
 			input: "alpha-2.263",
 			rules: Transformers{
 				Transformer{
-					"replacer": Replacers{
+					"replacers": Replacers{
 						Replacer{
 							From: "alpha",
 							To:   "beta",
 						},
+					},
+				},
+			},
+			expectedOutput: "beta-2.263",
+			expectedErr:    nil,
+		},
+		Data{
+			input: "alpha-2.263",
+			rules: Transformers{
+				Transformer{
+					"replacer": Replacer{
+						From: "alpha",
+						To:   "beta",
 					},
 				},
 			},

--- a/pkg/core/transformer/replacer.go
+++ b/pkg/core/transformer/replacer.go
@@ -18,3 +18,12 @@ func (replacers Replacers) Unmarshal() (result []string) {
 	}
 	return result
 }
+
+// Unmarshal read a struct of Replacer then return a slice of string
+func (r Replacer) Unmarshal() (result []string) {
+
+	result = append(result, r.From)
+	result = append(result, r.To)
+
+	return result
+}

--- a/pkg/core/transformer/replacer.go
+++ b/pkg/core/transformer/replacer.go
@@ -1,7 +1,4 @@
-package source
-
-// 2021/01/31
-// Deprecated in favor of Transformer, need to be deleted in a futur release
+package transformer
 
 // Replacer is struct used to feed strings.Replacer
 type Replacer struct {

--- a/pkg/core/transformer/replacer_test.go
+++ b/pkg/core/transformer/replacer_test.go
@@ -1,7 +1,4 @@
-package source
-
-// 2021/01/31
-// Deprecated in favor of Transformer, need to be deleted in a futur release
+package transformer
 
 import (
 	"reflect"


### PR DESCRIPTION
Fix #160 
Fix #152 

Add the parameter `transformers` for every stage definitions, "source", "condition", and "target".
A "transformers" contains a list of transformer rule which are applied successively to the source value.
Each transformer applies a different rule

We also deprecated string manipulation like prefix/postfix/replacer defined outside a transformers definition

## transformer

* `prefix`, add a prefix to the source value
* `suffix`, add a suffix to the source value
* `trimPrefix`, remove the source value prefix
* `trimSuffix`, remove the source value suffix
* `replacer`, replace a substring by another one in the source value
* `find`, return the first occurrence that matches the regex

```
source:
  name: "Get latest jenkins weekly version"
  kind: jenkins
  transformers:
    - prefix: "alpha-"
    - suffix: "-jdk11"
    - trimSuffix: "-jdk11"
    - suffix: "-jdk11"
    - replacer:
        from: "-jdk11"
        to: "-jdk15"
    - replacers:
        - from: "-jdk15"
          to: "-jdk17"
  spec:
    release: weekly
targets:
  targetID:
    name: "Update file file"
    kind: file
    spec:
      file: TODO
```

This rule should generate the value "alpha-2.277-jdk11"

Signed-off-by: Olivier Vernin <olivier@vernin.me>