### PR TITLE
Throw away local changes from git repository

### DIFF
--- a/pkg/plugins/git/generic/main.go
+++ b/pkg/plugins/git/generic/main.go
@@ -58,6 +58,7 @@ func Checkout(branch, remoteBranch, workingDir string) error {
 		Branch: plumbing.NewRemoteReferenceName("origin", remoteBranch),
 		Create: false,
 		Keep:   false,
+		Force:  true,
 	})
 
 	if err == plumbing.ErrReferenceNotFound {
@@ -66,6 +67,7 @@ func Checkout(branch, remoteBranch, workingDir string) error {
 			Branch: plumbing.NewBranchReferenceName(branch),
 			Create: false,
 			Keep:   false,
+			Force:  true,
 		})
 
 		if err != nil {
@@ -78,6 +80,7 @@ func Checkout(branch, remoteBranch, workingDir string) error {
 			Branch: plumbing.NewBranchReferenceName(remoteBranch),
 			Create: false,
 			Keep:   false,
+			Force:  true,
 		})
 
 		// Branch doesn't exist locally
@@ -88,6 +91,7 @@ func Checkout(branch, remoteBranch, workingDir string) error {
 				Branch: plumbing.NewBranchReferenceName(remoteBranch),
 				Create: true,
 				Keep:   false,
+				Force:  true,
 			})
 
 			if err != nil &&


### PR DESCRIPTION
If a git repository contains local changes, then updatecli won't remove them.
This PR will ensure that behavior

```
✔ Helm Chart 'keycloak' is available on https://codecentric.github.io/helm-charts for version '9.9.0'
✗ worktree contains unstaged changes
```
Signed-off-by: Olivier Vernin <olivier@vernin.me>