### PR TITLE
[WIP] Allows reinjecting configuration value into a different places

### DIFF
--- a/pkg/core/config/main.go
+++ b/pkg/core/config/main.go
@@ -1,9 +1,14 @@
 package config
 
 import (
+	"bytes"
+	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
+	"text/template"
 
 	"github.com/mitchellh/hashstructure"
 	"github.com/sirupsen/logrus"
@@ -11,8 +16,21 @@ import (
 	"github.com/olblak/updateCli/pkg/core/engine/condition"
 	"github.com/olblak/updateCli/pkg/core/engine/source"
 	"github.com/olblak/updateCli/pkg/core/engine/target"
-	"github.com/spf13/viper"
 	"gopkg.in/yaml.v3"
+)
+
+var (
+	// ErrConfigFileTypeNotSupported is returned when updatecli try to read
+	// an unsupported file type.
+	ErrConfigFileTypeNotSupported = errors.New("file extension not supported")
+
+	// ErrNoEnvironmentVariableSet is returned when during the templating process,
+	// it tries to access en environment variable not set.
+	ErrNoEnvironmentVariableSet = errors.New("Environment variable doesn't exist")
+
+	// ErrNoKeyDefined is returned when during the templating process, it tries to
+	// retrieve a key value which is not defined in the configuration
+	ErrNoKeyDefined = errors.New("key not defined in configuration")
 )
 
 // Config contains cli configuration
@@ -26,61 +44,40 @@ type Config struct {
 
 // Reset reset configuration
 func (config *Config) Reset() {
-	config.Source = source.Source{}
-	config.Conditions = map[string]condition.Condition{}
-	config.Targets = map[string]target.Target{}
+	*config = Config{}
 }
 
-// ReadFile reads the updatecli configuration file
-func (config *Config) ReadFile(cfgFile, valuesFile string) (err error) {
+// New reads an updatecli configuration file
+func New(cfgFile, valuesFile string) (config Config, err error) {
 
 	config.Reset()
 
 	dirname, basename := filepath.Split(cfgFile)
 
 	switch extension := filepath.Ext(basename); extension {
-	case ".tpl", ".tmpl":
+	case ".tpl", ".tmpl", ".yaml", ".yml":
 		t := Template{
 			CfgFile:    filepath.Join(dirname, basename),
 			ValuesFile: valuesFile,
 		}
 
-		err := t.Unmarshal(config)
+		err := t.Init(&config)
 		if err != nil {
-			return err
+			return config, err
 		}
 
-	case ".yaml", ".yml":
-		v := viper.New()
-
-		v.SetEnvPrefix("updatecli")
-		v.AutomaticEnv()
-		v.SetConfigName(strings.TrimSuffix(basename, filepath.Ext(basename))) // name of config file (without extension)
-		v.SetConfigType(strings.Replace(filepath.Ext(basename), ".", "", -1)) // REQUIRED if the config file does not have the extension in the name
-		v.AddConfigPath(dirname)                                              // optionally look for config in the working directory
-		v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
-
-		if err := v.ReadInConfig(); err != nil {
-			if _, ok := err.(viper.ConfigFileNotFoundError); ok {
-				return fmt.Errorf("Config file not found")
-			}
-
-			return err
-		}
-		err := v.Unmarshal(&config)
-		if err != nil {
-			return fmt.Errorf("unable to decode into struct, %v", err)
-		}
 	default:
-		return fmt.Errorf("file extension not supported: %v", extension)
+		logrus.Debugf("file extension '%s' not supported for file '%s'", extension, filepath.Join(dirname, basename))
+		return config, ErrConfigFileTypeNotSupported
+	}
+
+	if len(config.Name) == 0 {
+		config.Name = strings.ToTitle(basename)
 	}
 
 	err = config.Validate()
-	if err != nil {
-		return err
-	}
 
-	return nil
+	return config, err
 
 }
 
@@ -109,4 +106,122 @@ func (config *Config) Validate() error {
 	}
 
 	return nil
+}
+
+// Update updates its own configuration file
+// It uses when the configuration expected a value that
+// hasn't been set yet like a source output
+func (config *Config) Update() (err error) {
+	funcMap := template.FuncMap{
+		"requiredEnv": func(s string) (string, error) {
+			/*
+				Retrieve value from environment variable, return error if not found
+			*/
+			value := os.Getenv(s)
+			if value == "" {
+				logrus.Debugf("%s", fmt.Sprintf("no value found for environment variable "+s))
+				return "", ErrNoEnvironmentVariableSet
+			}
+			return value, nil
+		},
+		"pipeline": func(s string) (string, error) {
+			/*
+				Retrieve the value of a third location key from
+				the updatecli configuration.
+				It returns an error if a key doesn't exist
+				It returns {{ pipeline "<key>" }} if a key exist but still set to zero value,
+				then we assume that the value will be set later in the run.
+				Otherwise it returns the value.
+				This func is design to constantly reevaluate if a configuration changed
+			*/
+
+			var field func(interface{}, []string) (string, error)
+
+			field = func(conf interface{}, query []string) (value string, err error) {
+				ValueIface := reflect.ValueOf(conf)
+
+				Field := reflect.Value{}
+
+				switch ValueIface.Kind() {
+				case reflect.Ptr:
+					// Check if the passed interface is a pointer
+					// Create a new type of Iface's Type, so we have a pointer to work with
+					// 'dereference' with Elem() and get the field by name
+					Field = ValueIface.Elem().FieldByName(query[0])
+				case reflect.Map:
+					Field = ValueIface.MapIndex(reflect.ValueOf(query[0]))
+				case reflect.Struct:
+					Field = ValueIface.FieldByName(query[0])
+				}
+
+				if !Field.IsValid() {
+					logrus.Debugf(
+						"Configuration `%s` does not have the field `%s`",
+						ValueIface.Type(),
+						query[0])
+					return "", ErrNoKeyDefined
+				}
+
+				if len(query) > 1 {
+					value, err = field(Field.Interface(), query[1:])
+					if err != nil {
+						return "", err
+					}
+
+				} else if len(query) == 1 {
+					return Field.String(), nil
+				}
+
+				return value, nil
+
+			}
+
+			val, err := field(config, strings.Split(s, "."))
+
+			if err != nil {
+				return "", err
+			}
+
+			if len(val) > 0 {
+				return val, nil
+			}
+			// If we couldn't find a value, then we return the function so we can retry
+			// later on.
+			return fmt.Sprintf("\"{{ pipeline \"%s\" }}\"", s), nil
+
+		},
+	}
+
+	data := *config
+
+	content, err := yaml.Marshal(config)
+
+	if err != nil {
+		return err
+	}
+
+	tmpl, err := template.New("cfg").Funcs(funcMap).Parse(string(content))
+
+	if err != nil {
+		return err
+	}
+
+	b := bytes.Buffer{}
+
+	if err := tmpl.Execute(&b, &data); err != nil {
+		return err
+	}
+
+	err = yaml.Unmarshal(b.Bytes(), &config)
+	if err != nil {
+		return err
+	}
+
+	err = config.Validate()
+	if err != nil {
+		return err
+	}
+
+	return err
+
 }

--- a/pkg/core/config/main_test.go
+++ b/pkg/core/config/main_test.go
@@ -1,0 +1,117 @@
+package config
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/olblak/updateCli/pkg/core/engine/source"
+)
+
+type Data struct {
+	Config         Config
+	ExpectedConfig Config
+	ExpectedErr    error
+}
+type DataSet []Data
+
+var (
+	dataSet DataSet = DataSet{
+		{
+			Config: Config{
+				Name: "{{ pipeline \"Source.Kind\" }}",
+				Source: source.Source{
+					Name: "Get Version",
+					Kind: "jenkins",
+				},
+			},
+			ExpectedConfig: Config{
+				Name: "jenkins",
+				Source: source.Source{
+					Name: "Get Version",
+					Kind: "jenkins",
+				},
+			},
+			ExpectedErr: nil,
+		},
+		{
+			Config: Config{
+				Name: `{{ pipeline "Source.Output" }}`,
+				Source: source.Source{
+					Name: "Get Version",
+					Kind: "jenkins",
+				},
+			},
+			ExpectedConfig: Config{
+				Name: `"{{ pipeline "Source.Output" }}"`,
+				Source: source.Source{
+					Name: "Get Version",
+					Kind: "jenkins",
+				},
+			},
+			ExpectedErr: nil,
+		},
+		{
+			Config: Config{
+				Name: `{{ pipeline "Source.kind" }}`,
+				Source: source.Source{
+					Name: "Get Version",
+					Kind: "jenkins",
+				},
+			},
+			ExpectedConfig: Config{},
+			ExpectedErr:    ErrNoKeyDefined,
+		},
+		{
+			Config: Config{
+				Name: `{{ pipeline Source.kind }}`,
+				Source: source.Source{
+					Name: "Get Version",
+					Kind: "jenkins",
+				},
+			},
+			ExpectedConfig: Config{},
+			ExpectedErr:    fmt.Errorf(`function "Source" not defined`),
+		},
+		{
+			Config: Config{
+				Name: `{{ requiredEnv "XXX" }}`,
+				Source: source.Source{
+					Name: "Get Version",
+					Kind: "jenkins",
+				},
+			},
+			ExpectedConfig: Config{},
+			ExpectedErr:    ErrNoEnvironmentVariableSet,
+		},
+	}
+)
+
+func TestUpdate(t *testing.T) {
+	for _, data := range dataSet {
+		err := data.Config.Update()
+		if err != nil && !strings.Contains(err.Error(), data.ExpectedErr.Error()) {
+			t.Errorf("Expected error:\n%v\ngot\n%v\n", data.ExpectedErr, err)
+		} else if err != nil && data.ExpectedErr == err {
+			continue
+		} else if err == nil {
+			if strings.Compare(data.Config.Name, data.ExpectedConfig.Name) != 0 {
+				t.Errorf("\n\nWrong output, expect: \n`%v`\n\ngot\n\n`%v`\n", data.ExpectedConfig.Name, data.Config.Name)
+			}
+		}
+	}
+}
+
+func TestReset(t *testing.T) {
+	for _, data := range dataSet {
+		data.Config.Reset()
+
+		c := Config{}
+
+		if !reflect.DeepEqual(data.Config, c) {
+
+			t.Errorf("\n\nWrong output, expect: \n`%v`\n\ngot\n\n`%v`\n", c, data.Config)
+		}
+	}
+}

--- a/pkg/core/config/template.go
+++ b/pkg/core/config/template.go
@@ -3,6 +3,7 @@ package config
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"text/template"
@@ -17,16 +18,19 @@ type Template struct {
 	CfgFile    string
 }
 
-// Unmarshal parse golang templates then return its config struct
-func (t *Template) Unmarshal(config *Config) error {
+// Init parse golang templates then return its config struct
+func (t *Template) Init(config *Config) error {
 	funcMap := template.FuncMap{
 		// Retrieve value from environment variable, return error if not found
-		"requiredEnv": func(env string) (string, error) {
-			value := os.Getenv(env)
+		"requiredEnv": func(s string) (string, error) {
+			value := os.Getenv(s)
 			if value == "" {
-				return "", errors.New("no value found for environment variable " + env)
+				return "", errors.New("no value found for environment variable " + s)
 			}
 			return value, nil
+		},
+		"pipeline": func(s string) (string, error) {
+			return fmt.Sprintf(`"{{ pipeline \"%s\" }}"`, s), nil
 		},
 	}
 

--- a/pkg/core/engine/main.go
+++ b/pkg/core/engine/main.go
@@ -163,18 +163,15 @@ func (e *Engine) ReadConfigurations() error {
 	// Read every strategy files
 	for _, cfgFile := range GetFiles(e.Options.File) {
 
-		c := config.Config{}
+		c, err := config.New(cfgFile, e.Options.ValuesFile)
 
-		_, basename := filepath.Split(cfgFile)
-		cfgFileName := strings.TrimSuffix(basename, filepath.Ext(basename))
-
-		c.Name = strings.ToTitle(cfgFileName)
-
-		err := c.ReadFile(cfgFile, e.Options.ValuesFile)
-		if err != nil {
-			logrus.Errorf("%s - %s\n\n", basename, err)
+		if err != nil && err != config.ErrConfigFileTypeNotSupported {
+			logrus.Errorf("%s\n\n", err)
+			continue
+		} else if err == config.ErrConfigFileTypeNotSupported {
 			continue
 		}
+
 		e.configurations = append(e.configurations, c)
 	}
 	return nil
@@ -252,6 +249,11 @@ func (e *Engine) Run() (err error) {
 		conf.Source.Result = result.SUCCESS
 		report.Source.Result = result.SUCCESS
 
+		err := conf.Update()
+		if err != nil {
+			return err
+		}
+
 		if len(conf.Conditions) > 0 {
 			c := conf
 			ok, err := RunConditions(&c)
@@ -262,6 +264,11 @@ func (e *Engine) Run() (err error) {
 				conditionsStageReport[i].Result = c.Result
 				report.Conditions[i].Result = c.Result
 				i++
+				// Update config if some templating value need to be apply
+				err := conf.Update()
+				if err != nil {
+					return err
+				}
 			}
 
 			if err != nil || !ok {
@@ -289,7 +296,12 @@ func (e *Engine) Run() (err error) {
 			for _, t := range conf.Targets {
 				targetsStageReport[i].Result = t.Result
 				report.Targets[i].Result = t.Result
+				// Update config if some templating value need to be apply
 				i++
+				err := conf.Update()
+				if err != nil {
+					return err
+				}
 			}
 		}
 


### PR DESCRIPTION
This PR is an attempt to partially fix #158

It allows reinjecting configuration value into a different places.
The function "pipeline" accept one parameter where the value correspond to an updatecli configuration key, value where the key must start with a capital letter. 

which can be defined like: 
```
title: {{ pipeline "Source.Output" }}
source:
  name: Get Latest helm release version
  kind: githubRelease
  spec:
    owner: "helm"
    repository: "helm"
    token: {{ requiredEnv .github.token }}
    username: olblak
    version: latest
```
The configuration is updated after each stage, if it finds a function configuration value set to `pipeline "updatecli_config"`, then it tries to replace with a value but only if the value exists otherwise it keeps `pipeline "updatecli_config"` for the next run .

This pull request also remove the constraint to only use go template with files extension .tpl

Once the multiple sources is implemented, I'll add a new template function named Source which will accept as a parameter a source id. The purpose will be to have a simpler way to retrieve a source output

```
title: {{ source "Id" }}
sources:
  id:
    name: Get Latest helm release version
    kind: githubRelease
    spec:
      owner: "helm"
      repository: "helm"
      token: {{ requiredEnv .github.token }}
      username: olblak
      version: latest
```


Signed-off-by: Olivier Vernin <olivier@vernin.me>