### PR TITLE
Add multi sources support

### DIFF
--- a/examples/updateCli.d/sources/dockerfile_sources.tpl
+++ b/examples/updateCli.d/sources/dockerfile_sources.tpl
@@ -1,0 +1,71 @@
+---
+title: Bump jenkinsciinfra/helmfile image
+sources:
+  helm:
+    name: Get Latest helm release version
+    kind: githubRelease
+    spec:
+      owner: "helm"
+      repository: "helm"
+      token: {{ requiredEnv .github.token }}
+      username: olblak
+      version: latest
+  checksum:
+    name: Get Latest kubectl release version
+    kind: file
+    transformers:
+      - find: '^\S*'
+    spec:
+      # For some reason helm must start with lower case
+      file: https://get.helm.sh/helm-{{ pipeline "Sources.helm.Output" }}-linux-amd64.tar.gz.sha256sum
+conditions:
+  isENVSet:
+    sourceID: helm
+    name: Is the 2nd ENV instruction having a "keyword" set to "HELM_VERSION"
+    kind: dockerfile
+    spec:
+      file: docker/Dockerfile
+      Instruction: "ENV[1][0]"
+      Value: "HELM_VERSION"
+    scm:
+      github:
+        user: "updatecli"
+        email: "updatecli@olblak.com"
+        owner: "olblak"
+        repository: "charts"
+        token: {{ requiredEnv "GITHUB_TOKEN" }}
+        username: "olblak"
+        branch: "master"
+targets:
+  updateHelm:
+    name: Update the 2nd element of the 2nd ENV instruction to the source value
+    sourceID: helm
+    kind: dockerfile
+    spec:
+      file: docker/Dockerfile
+      Instruction: ENV[1][1]
+    scm:
+      github:
+        user: "updatecli"
+        email: "updatecli@olblak.com"
+        owner: "olblak"
+        repository: "charts"
+        token: {{ requiredEnv "GITHUB_TOKEN" }}
+        username: "olblak"
+        branch: "master"
+  updateChecksum:
+    name: Update Helm checksum
+    sourceID: checksum
+    kind: dockerfile
+    spec:
+      file: docker/Dockerfile
+      Instruction: ENV[5][1]
+    scm:
+      github:
+        user: "updatecli"
+        email: "updatecli@olblak.com"
+        owner: "olblak"
+        repository: "charts"
+        token: {{ requiredEnv "GITHUB_TOKEN" }}
+        username: "olblak"
+        branch: "master"

--- a/examples/updateCli.d/sources/dockerfile_sources.tpl
+++ b/examples/updateCli.d/sources/dockerfile_sources.tpl
@@ -1,7 +1,7 @@
 ---
 title: Bump jenkinsciinfra/helmfile image
 sources:
-  helm:
+  helm1:
     name: Get Latest helm release version
     kind: githubRelease
     spec:
@@ -10,14 +10,15 @@ sources:
       token: {{ requiredEnv .github.token }}
       username: olblak
       version: latest
-  checksum:
-    name: Get Latest kubectl release version
-    kind: file
-    transformers:
-      - find: '^\S*'
+  helm2:
+    name: Get Latest helm release version
+    kind: githubRelease
     spec:
-      # For some reason helm must start with lower case
-      file: https://get.helm.sh/helm-{{ pipeline "Sources.helm.Output" }}-linux-amd64.tar.gz.sha256sum
+      owner: "helm"
+      repository: "helm"
+      token: {{ requiredEnv .github.token }}
+      username: olblak
+      version: latest
 conditions:
   isENVSet:
     sourceID: helm

--- a/pkg/core/config/main.go
+++ b/pkg/core/config/main.go
@@ -121,7 +121,7 @@ func (config *Config) Validate() error {
 
 	} else if config.Source.Kind != "" && len(config.Sources) == 0 {
 
-		logrus.Warning("**Deprecated** 2021/02/18 Is replaced by Sources, this parameter will be deleted in a future release")
+		logrus.Warning("Since version 1.2.0, the single source definition is **Deprecated**  and replaced by Sources. This parameter will be deleted in a future release")
 
 		config.Sources = make(map[string]source.Source)
 		config.Sources[defaultSourceID] = config.Source

--- a/pkg/core/config/template.go
+++ b/pkg/core/config/template.go
@@ -3,7 +3,6 @@ package config
 import (
 	"bytes"
 	"errors"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"text/template"
@@ -28,9 +27,6 @@ func (t *Template) Init(config *Config) error {
 				return "", errors.New("no value found for environment variable " + s)
 			}
 			return value, nil
-		},
-		"pipeline": func(s string) (string, error) {
-			return fmt.Sprintf(`{{ pipeline %q }}`, s), nil
 		},
 	}
 

--- a/pkg/core/config/template.go
+++ b/pkg/core/config/template.go
@@ -3,6 +3,7 @@ package config
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"text/template"
@@ -17,16 +18,19 @@ type Template struct {
 	CfgFile    string
 }
 
-// Unmarshal parse golang templates then return its config struct
-func (t *Template) Unmarshal(config *Config) error {
+// Init parse golang templates then return its config struct
+func (t *Template) Init(config *Config) error {
 	funcMap := template.FuncMap{
 		// Retrieve value from environment variable, return error if not found
-		"requiredEnv": func(env string) (string, error) {
-			value := os.Getenv(env)
+		"requiredEnv": func(s string) (string, error) {
+			value := os.Getenv(s)
 			if value == "" {
-				return "", errors.New("no value found for environment variable " + env)
+				return "", errors.New("no value found for environment variable " + s)
 			}
 			return value, nil
+		},
+		"pipeline": func(s string) (string, error) {
+			return fmt.Sprintf(`"{{ pipeline \"%s\" }}"`, s), nil
 		},
 	}
 

--- a/pkg/core/config/template.go
+++ b/pkg/core/config/template.go
@@ -30,7 +30,7 @@ func (t *Template) Init(config *Config) error {
 			return value, nil
 		},
 		"pipeline": func(s string) (string, error) {
-			return fmt.Sprintf(`"{{ pipeline \"%s\" }}"`, s), nil
+			return fmt.Sprintf(`{{ pipeline %q }}`, s), nil
 		},
 	}
 

--- a/pkg/core/engine/condition/main.go
+++ b/pkg/core/engine/condition/main.go
@@ -27,6 +27,7 @@ type Condition struct {
 	Spec         interface{}
 	Scm          map[string]interface{}
 	Result       string `yaml:"-"` // Ignore this field when unmarshal YAML
+	SourceID     string `yaml:"sourceID"`
 }
 
 // Spec is an interface that test if condition is met

--- a/pkg/core/engine/main.go
+++ b/pkg/core/engine/main.go
@@ -163,18 +163,15 @@ func (e *Engine) ReadConfigurations() error {
 	// Read every strategy files
 	for _, cfgFile := range GetFiles(e.Options.File) {
 
-		c := config.Config{}
+		c, err := config.New(cfgFile, e.Options.ValuesFile)
 
-		_, basename := filepath.Split(cfgFile)
-		cfgFileName := strings.TrimSuffix(basename, filepath.Ext(basename))
-
-		c.Name = strings.ToTitle(cfgFileName)
-
-		err := c.ReadFile(cfgFile, e.Options.ValuesFile)
-		if err != nil {
-			logrus.Errorf("%s - %s\n\n", basename, err)
+		if err != nil && err != config.ErrConfigFileTypeNotSupported {
+			logrus.Errorf("%s\n\n", err)
+			continue
+		} else if err == config.ErrConfigFileTypeNotSupported {
 			continue
 		}
+
 		e.configurations = append(e.configurations, c)
 	}
 	return nil

--- a/pkg/core/engine/main.go
+++ b/pkg/core/engine/main.go
@@ -354,7 +354,6 @@ func RunConditions(conf *config.Config) (bool, error) {
 			return false, err
 		}
 
-
 		if !ok {
 			c.Result = result.FAILURE
 			conf.Conditions[k] = c

--- a/pkg/core/engine/main.go
+++ b/pkg/core/engine/main.go
@@ -63,10 +63,13 @@ func (e *Engine) InitSCM() (err error) {
 	defer wg.Wait()
 
 	for _, conf := range e.configurations {
-		if len(conf.Source.Scm) > 0 {
-			err = Clone(&conf.Source.Scm, &hashes, channel, &wg)
-			if err != nil {
-				return err
+		for _, source := range conf.Sources {
+
+			if len(source.Scm) > 0 {
+				err = Clone(&source.Scm, &hashes, channel, &wg)
+				if err != nil {
+					return err
+				}
 			}
 		}
 		for _, condition := range conf.Conditions {
@@ -196,8 +199,18 @@ func (e *Engine) Run() (err error) {
 			logrus.Infof("%s\n\n", strings.Repeat("#", len(conf.Name)+4))
 		}
 
+		sourcesStageReport := []reports.Stage{}
 		conditionsStageReport := []reports.Stage{}
 		targetsStageReport := []reports.Stage{}
+
+		for _, s := range conf.Sources {
+			s := reports.Stage{
+				Name:   s.Name,
+				Kind:   s.Kind,
+				Result: result.FAILURE,
+			}
+			sourcesStageReport = append(sourcesStageReport, s)
+		}
 
 		for _, c := range conf.Conditions {
 			s := reports.Stage{
@@ -219,35 +232,38 @@ func (e *Engine) Run() (err error) {
 
 		report := reports.Init(
 			conf.Name,
-			reports.Stage{
-				Name:   conf.Source.Name,
-				Kind:   conf.Source.Kind,
-				Result: result.FAILURE,
-			},
+			sourcesStageReport,
 			conditionsStageReport,
 			targetsStageReport,
 		)
 
 		report.Name = strings.ToTitle(conf.Name)
 
-		err = conf.Source.Execute()
+		i := 0
+		for id, s := range conf.Sources {
+			err = s.Execute()
 
-		if err != nil {
-			logrus.Errorf("%s %v\n", result.FAILURE, err)
-			e.Reports = append(e.Reports, report)
-			continue
+			if err != nil {
+				logrus.Errorf("%s %v\n", result.FAILURE, err)
+				e.Reports = append(e.Reports, report)
+				continue
+			}
+
+			if s.Output == "" {
+				s.Result = result.FAILURE
+				logrus.Infof("\n%s Something went wrong no value returned from Source", result.FAILURE)
+				e.Reports = append(e.Reports, report)
+				continue
+			}
+
+			s.Result = result.SUCCESS
+			report.Sources[i].Result = result.SUCCESS
+
+			i++
+
+			conf.Sources[id] = s
+
 		}
-
-		if conf.Source.Output == "" {
-			conf.Source.Result = result.FAILURE
-			report.Source.Result = result.FAILURE
-			logrus.Infof("\n%s Something went wrong no value returned from Source", result.FAILURE)
-			e.Reports = append(e.Reports, report)
-			continue
-		}
-
-		conf.Source.Result = result.SUCCESS
-		report.Source.Result = result.SUCCESS
 
 		if len(conf.Conditions) > 0 {
 			c := conf
@@ -284,10 +300,13 @@ func (e *Engine) Run() (err error) {
 
 			i := 0
 			for _, t := range conf.Targets {
-				targetsStageReport[i].Result = t.Result
+
 				report.Targets[i].Result = t.Result
+
+				targetsStageReport[i].Result = t.Result
 				i++
 			}
+
 		}
 
 		if err != nil {
@@ -327,10 +346,14 @@ func RunConditions(conf *config.Config) (bool, error) {
 		c.Result = result.FAILURE
 
 		conf.Conditions[k] = c
-		ok, err := c.Run(conf.Source.Prefix + conf.Source.Output + conf.Source.Postfix)
+		ok, err := c.Run(
+			conf.Sources[c.SourceID].Prefix +
+				conf.Sources[c.SourceID].Output +
+				conf.Sources[c.SourceID].Postfix)
 		if err != nil {
 			return false, err
 		}
+
 
 		if !ok {
 			c.Result = result.FAILURE
@@ -353,7 +376,7 @@ func RunTargets(config *config.Config, options *target.Options, report *reports.
 	logrus.Infof("\n\n%s:\n", strings.ToTitle("Targets"))
 	logrus.Infof("%s\n\n", strings.Repeat("=", len("Targets")+1))
 
-	sourceReport, err := report.String("source")
+	sourceReport, err := report.String("sources")
 
 	if err != nil {
 		logrus.Errorf("err - %s", err)
@@ -367,7 +390,7 @@ func RunTargets(config *config.Config, options *target.Options, report *reports.
 	for id, t := range config.Targets {
 		targetChanged := false
 
-		t.Changelog = config.Source.Changelog
+		t.Changelog = config.Sources[t.SourceID].Changelog
 
 		if _, ok := t.Scm["github"]; ok {
 			var g github.Github
@@ -395,37 +418,40 @@ func RunTargets(config *config.Config, options *target.Options, report *reports.
 				// I am still thinking to a better solution.
 				logrus.Warning("**Fallback** Please add a title to you configuration using the field 'title: <your pipeline>'")
 				g.PullRequestDescription.Title = fmt.Sprintf("[updatecli][%s] Bump version to %s",
-					config.Source.Kind,
-					config.Source.Output)
+					config.Sources[t.SourceID].Kind,
+					config.Sources[t.SourceID].Output)
 			}
 
 			t.Scm["github"] = g
 
 		}
 
-		if t.Prefix == "" && config.Source.Prefix != "" {
-			t.Prefix = config.Source.Prefix
+		if t.Prefix == "" && config.Sources[t.SourceID].Prefix != "" {
+			t.Prefix = config.Sources[t.SourceID].Prefix
 		}
 
-		if t.Postfix == "" && config.Source.Postfix != "" {
-			t.Postfix = config.Source.Postfix
+		if t.Postfix == "" && config.Sources[t.SourceID].Postfix != "" {
+			t.Postfix = config.Sources[t.SourceID].Postfix
 		}
 
-		targetChanged, err = t.Run(config.Source.Output, options)
+		targetChanged, err = t.Run(config.Sources[t.SourceID].Output, options)
 
 		if err != nil {
 			logrus.Errorf("Something went wrong in target \"%v\" :\n", id)
 			logrus.Errorf("%v\n\n", err)
 			t.Result = result.FAILURE
 			return targetChanged, err
-		} else if targetChanged {
+		}
+
+		if !targetChanged {
+			t.Result = result.SUCCESS
+		} else {
 			t.Result = result.CHANGED
 			targetsChanged = true
-		} else {
-			t.Result = result.SUCCESS
 		}
 
 		config.Targets[id] = t
+
 	}
 	return targetsChanged, nil
 }

--- a/pkg/core/engine/target/main.go
+++ b/pkg/core/engine/target/main.go
@@ -27,6 +27,7 @@ type Target struct {
 	Spec         interface{}
 	Scm          map[string]interface{}
 	Result       string `yaml:"-"`
+	SourceID     string `yaml:"sourceID"`
 }
 
 // Spec is an interface which offers common function to manipulate targets.

--- a/pkg/core/reports/main.go
+++ b/pkg/core/reports/main.go
@@ -21,18 +21,20 @@ REPORTS:
 {{ "\t"}}Error: {{ .Err}}
 {{ else }}
 {{- .Result }} {{ .Name -}}{{"\n"}}
-{{- "\t"}}Source:
-{{ "\t"}}{{"\t"}}{{- .Source.Result }}  {{ .Source.Name -}}({{- .Source.Kind -}}){{"\n"}}
+{{- "\t"}}Sources:
+{{ range .Sources }}
+{{- "\t" }}{{"\t"}}{{- .Result }}  {{ .Name -}}({{- .Kind -}}){{"\n"}}
+{{- end }}
 
 {{- if .Conditions -}}
 {{- "\t" }}Condition:
-{{ range .Conditions }} 
+{{ range .Conditions }}
 {{- "\t" }}{{"\t"}}{{- .Result }}  {{ .Name -}}({{- .Kind -}}){{"\n"}}
 {{- end -}}
 {{- end -}}
 
 {{- "\t" -}}Target:
-{{ range .Targets }} 
+{{ range .Targets }}
 {{- "\t" }}{{"\t"}}{{- .Result }}  {{ .Name -}}({{- .Kind -}}){{"\n"}}
 {{- end }}
 {{ end }}

--- a/pkg/core/reports/report.go
+++ b/pkg/core/reports/report.go
@@ -27,7 +27,9 @@ const (
 	// SOURCEREPORTTEMPLATE ...
 	SOURCEREPORTTEMPLATE string = `
 {{- "\t"}}Source:
-{{ "\t"}}{{"\t"}}{{- .Source.Result }}  {{ .Source.Name -}}({{- .Source.Kind -}}){{"\n"}}
+{{ range .Sources }}
+{{- "\t" }}{{"\t"}}{{- .Result }}  {{ .Name -}}({{- .Kind -}}){{"\n"}}
+{{- end }}
 `
 
 	// REPORTTEMPLATE ...
@@ -42,7 +44,9 @@ REPORTS:
 {{ else }}
 {{- .Result }} {{ .Name -}}{{"\n"}}
 {{- "\t"}}Source:
-{{ "\t"}}{{"\t"}}{{- .Source.Result }}  {{ .Source.Name -}}({{- .Source.Kind -}}){{"\n"}}
+{{ range .Sources }}
+{{- "\t" }}{{"\t"}}{{- .Result }}  {{ .Name -}}({{- .Kind -}}){{"\n"}}
+{{- end }}
 
 {{- if .Conditions -}}
 {{- "\t" }}Condition:
@@ -64,7 +68,7 @@ type Report struct {
 	Name       string
 	Err        string
 	Result     string
-	Source     Stage
+	Sources    []Stage
 	Conditions []Stage
 	Targets    []Stage
 }
@@ -73,7 +77,7 @@ type Report struct {
 //func (config *Config) InitReport() (report *Report) {
 func Init(
 	name string,
-	source Stage,
+	sources []Stage,
 	conditions []Stage,
 	targets []Stage,
 ) (report Report) {
@@ -81,10 +85,12 @@ func Init(
 	report.Name = name
 	report.Result = result.FAILURE
 
-	report.Source = Stage{
-		Name:   source.Name,
-		Kind:   source.Kind,
-		Result: result.FAILURE,
+	for _, source := range sources {
+		report.Sources = append(report.Sources, Stage{
+			Name:   source.Name,
+			Kind:   source.Kind,
+			Result: result.FAILURE,
+		})
 	}
 
 	for _, condition := range conditions {
@@ -113,7 +119,7 @@ func (r *Report) String(mode string) (report string, err error) {
 	switch mode {
 	case "conditions":
 		t = template.Must(template.New("reports").Parse(CONDITIONREPORTTEMPLATE))
-	case "source":
+	case "sources":
 		t = template.Must(template.New("reports").Parse(SOURCEREPORTTEMPLATE))
 	case "targets":
 		t = template.Must(template.New("reports").Parse(TARGETREPORTTEMPLATE))


### PR DESCRIPTION
This PR comes hand in hand with #181  to solve #158 
While keeping backward compatibility, I am switching from one source to a map of sources.
Now for each condition/target, we must specify the `sourceID` parameter to specify which source a condition/target depends on, 
it mainly used to get default values for those stages.  

An example of this change
```
---
title: Bump jenkinsciinfra/helmfile image
sources:
  helm:
    name: Get Latest helm release version
    kind: githubRelease
    spec:
      owner: "helm"
      repository: "helm"
      token: {{ requiredEnv .github.token }}
      username: olblak
      version: latest
  helm2:
    name: Get Latest helm release version
    kind: githubRelease
    spec:
      owner: "helm"
      repository: "helm"
      token: {{ requiredEnv .github.token }}
      username: olblak
      version: latest
conditions:
  isENVSet:

```