### PR TITLE
Fix Docker Build/Push

### DIFF
--- a/.github/workflows/publish-docker-image.yaml
+++ b/.github/workflows/publish-docker-image.yaml
@@ -3,6 +3,7 @@ on:
   workflow_dispatch:
   release:
     types: [published]
+  pull_request:
 jobs:
   push_to_registries:
     name: Push Docker image to multiple registries

--- a/.github/workflows/publish-docker-image.yaml
+++ b/.github/workflows/publish-docker-image.yaml
@@ -82,6 +82,8 @@ jobs:
           platforms: linux/amd64 #,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.prep.outputs.tags }}
+          build-args: |
+            MAKE_TARGET=${{ fromJSON('["build.all", "build"]')[github.event_name == 'pull_request'] }}
           labels: |
             org.opencontainers.image.title=${{ fromJson(steps.repo.outputs.result).name }}
             org.opencontainers.image.description=${{ fromJson(steps.repo.outputs.result).description }}

--- a/.github/workflows/publish-docker-image.yaml
+++ b/.github/workflows/publish-docker-image.yaml
@@ -57,12 +57,16 @@ jobs:
         uses: docker/setup-buildx-action@v1
 
       - name: Login to DockerHub
+        # Secrets and credentials are not available in pull requests to avoid leaking
+        if: ${{ github.event_name != 'pull_request' }}
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Login to GitHub Docker Registry
+        # Secrets and credentials are not available in pull requests to avoid leaking
+        if: ${{ github.event_name != 'pull_request' }}
         uses: docker/login-action@v1
         with:
           registry: ghcr.io

--- a/.github/workflows/publish-docker-image.yaml
+++ b/.github/workflows/publish-docker-image.yaml
@@ -79,7 +79,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64 #,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.prep.outputs.tags }}
           labels: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM golang:1.15 as builder
 
-# RUN go get -d -v ./...
-
 ARG GORELEASER_VERSION=0.156.2
 RUN curl --silent --show-error --location --output "/tmp/goreleaser.tgz" \
   "https://github.com/goreleaser/goreleaser/releases/download/v${GORELEASER_VERSION}/goreleaser_Linux_x86_64.tar.gz" \
@@ -12,7 +10,10 @@ RUN curl --silent --show-error --location --output "/tmp/goreleaser.tgz" \
 WORKDIR /go/src/app
 
 COPY . .
-RUN make build.all
+
+# Default make build is a "dirty/snapshot" build
+ARG MAKE_TARGET=build
+RUN make "${MAKE_TARGET}"
 
 ###
 

--- a/Makefile
+++ b/Makefile
@@ -10,12 +10,12 @@ export DOCKER_BUILDKIT
 local_bin=./dist/updatecli_$(shell go env GOHOSTOS)_$(shell go env GOHOSTARCH)/updatecli
 
 .PHONY: build
-build: ## Build updatecli for the host OS and architecture
+build: ## Build updatecli as a "dirty snapshot" (no tag, no release, but all OS/arch combinations)
 	echo $(VERSION)
 	goreleaser build --snapshot --rm-dist
 
 .PHONY: build.all
-build.all: ## Build updatecli for all supported OSes and architectures
+build.all: ## Build updatecli for "release" (tag or release and all OS/arch combinations)
 	goreleaser --rm-dist --skip-publish
 
 .PHONY: diff


### PR DESCRIPTION
The last release [`v0.1.0`](https://github.com/updatecli/updatecli/releases/tag/v0.1.0) failed to build the Docker image: https://github.com/updatecli/updatecli/runs/2014386430?check_suite_focus=true.

This PR aims at fixing these issues, following the work done in #188 .

It introduces the following changes:

* Introduce a build arg to the docker image to specify the make target to use in the "builder" image. It defaults to `build` on a PR, but should be `build.all` on a tagged build (need to be tested with a tag build)
* Build the Docker images even on Pull Requests to catch build errors earlier (the condition of "push image if not a pull request is already present)
* Disable the arm build which was failing the release: the goal would be to improve the build process in the future and re-enable arm