### PR TITLE
Add version pattern for Github Source and correctly handle github tags

### DIFF
--- a/examples/updateCli.generic/githubRelease.tpl
+++ b/examples/updateCli.generic/githubRelease.tpl
@@ -53,6 +53,8 @@ sources:
       token: "{{ requiredEnv .github.token }}"
       username: "olblak"
       version: "~1.10"
+      versioning:
+        kind: semver
     transformers:
       - addPrefix: "v"
 conditions:

--- a/examples/updateCli.generic/githubRelease.tpl
+++ b/examples/updateCli.generic/githubRelease.tpl
@@ -37,8 +37,14 @@ source:
     repository: "jenkins-wiki-exporter"
     token: "{{ requiredEnv .github.token }}"
     username: "olblak"
-    version: "latest"
-    constraint: "~1.10"
+    #version: "latest"
+    version: "~1.10"
+    #version: "~9.10"
+    #version: "v1.10"
+    #versiontype: string
+    #versiontype: random
+  transformers:
+    - addPrefix: "v"
 conditions:
   docker:
     name: "Docker Image Published on Registry"

--- a/examples/updateCli.generic/githubRelease.tpl
+++ b/examples/updateCli.generic/githubRelease.tpl
@@ -38,6 +38,7 @@ source:
     token: "{{ requiredEnv .github.token }}"
     username: "olblak"
     version: "latest"
+    constraint: "~1.10"
 conditions:
   docker:
     name: "Docker Image Published on Registry"

--- a/examples/updateCli.generic/githubRelease.tpl
+++ b/examples/updateCli.generic/githubRelease.tpl
@@ -41,7 +41,8 @@ sources:
       #version: 'kubernetes-1.(\d*).(\d*)$' # return latest publish version starting with kubernetes-1.20
       #version: latest
       version: v0.20
-      versionType: text
+      versioning:
+        kind: text
     transformers:
       - trimPrefix: "kubernetes-"
   jenkins-wiki-exporter:

--- a/examples/updateCli.generic/githubRelease.tpl
+++ b/examples/updateCli.generic/githubRelease.tpl
@@ -30,28 +30,39 @@
 #
 ###
 
-source:
-  kind: githubRelease
-  spec:
-    owner: "jenkins-infra"
-    repository: "jenkins-wiki-exporter"
-    token: "{{ requiredEnv .github.token }}"
-    username: "olblak"
-    #version: "latest"
-    version: "~1.10"
-    #version: "~9.10"
-    #version: "v1.10"
-    #versiontype: string
-    #versiontype: random
-  transformers:
-    - addPrefix: "v"
+sources:
+  kubectl:
+    kind: githubRelease
+    spec:
+      owner: "kubernetes"
+      repository: "kubectl"
+      token: "{{ requiredEnv .github.token }}"
+      username: "olblak"
+      #version: 'kubernetes-1.(\d*).(\d*)$' # return latest publish version starting with kubernetes-1.20
+      #version: latest
+      version: v0.20
+      versionType: text
+    transformers:
+      - trimPrefix: "kubernetes-"
+  jenkins-wiki-exporter:
+    kind: githubRelease
+    spec:
+      owner: "jenkins-infra"
+      repository: "jenkins-wiki-exporter"
+      token: "{{ requiredEnv .github.token }}"
+      username: "olblak"
+      version: "~1.10"
+    transformers:
+      - addPrefix: "v"
 conditions:
   docker:
+    sourceID: jenkins-wiki-exporter
     name: "Docker Image Published on Registry"
     kind: dockerImage
     spec:
       image: "jenkinsciinfra/jenkins-wiki-exporter"
   imageName:
+    sourceID: jenkins-wiki-exporter
     name: "jenkinsci/jenkins Helm Chart used"
     kind: yaml
     spec:
@@ -69,6 +80,7 @@ conditions:
         branch: "{{ .github.branch }}"
 targets:
   chartVersion:
+    sourceID: jenkins-wiki-exporter
     name: "jenkinsci/jenkins Helm Chart"
     kind: yaml
     spec:

--- a/pkg/plugins/github/changelog.go
+++ b/pkg/plugins/github/changelog.go
@@ -19,9 +19,13 @@ type Changelog struct {
 
 // Changelog returns a changelog description based on a release name
 func (g *Github) Changelog(name string) (string, error) {
-	_, err := g.Check()
-	if err != nil {
-		return "", err
+
+	errs := g.Check()
+	if len(errs) > 0 {
+		for _, e := range errs {
+			logrus.Errorf("%s\n", e)
+		}
+		return "", fmt.Errorf("wrong github configuration")
 	}
 
 	/*
@@ -61,7 +65,7 @@ func (g *Github) Changelog(name string) (string, error) {
 		"tagName":    githubv4.String(name),
 	}
 
-	err = client.Query(context.Background(), &query, variables)
+	err := client.Query(context.Background(), &query, variables)
 
 	if err != nil {
 		logrus.Warnf("\t %s", err)

--- a/pkg/plugins/github/main.go
+++ b/pkg/plugins/github/main.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	// TEXTVERSIONTYPE stores the version as a simple string
-	TEXTVERSIONTYPE string = "string"
+	TEXTVERSIONTYPE string = "text"
 	// SEMVERVERSIONTYPE stores the semantic versionning type
 	SEMVERVERSIONTYPE string = "semver"
 )

--- a/pkg/plugins/github/main.go
+++ b/pkg/plugins/github/main.go
@@ -57,10 +57,6 @@ func (g *Github) Check() (errs []error) {
 		g.Versioning.Pattern = g.Version
 	}
 
-	if len(g.Versioning.Kind) == 0 {
-		g.Versioning.Kind = version.TEXTVERSIONKIND
-	}
-
 	if err := g.Versioning.Validate(); err != nil {
 		errs = append(errs, err)
 	}

--- a/pkg/plugins/github/main.go
+++ b/pkg/plugins/github/main.go
@@ -24,8 +24,8 @@ type Github struct {
 	Username               string
 	Token                  string
 	URL                    string
-	Version                string          // **Deprecated** Field depecated in favor of `versionFilter.pattern`, this field will be removed in a futur version
-	versionFilter          version.Version //Versioning provides parameters to specify version pattern and its type like regex, semver, or just latest.
+	Version                string         // **Deprecated** Field depecated in favor of `versionFilter.pattern`, this field will be removed in a futur version
+	versionFilter          version.Filter //Versioning provides parameters to specify version pattern and its type like regex, semver, or just latest.
 	Directory              string
 	Branch                 string
 	remoteBranch           string
@@ -39,10 +39,6 @@ func (g *Github) Check() (errs []error) {
 
 	if g.Token == "" {
 		required = append(required, "token")
-	}
-
-	if g.Username == "" {
-		required = append(required, "username")
 	}
 
 	if g.Owner == "" {

--- a/pkg/plugins/github/main.go
+++ b/pkg/plugins/github/main.go
@@ -10,15 +10,9 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/olblak/updateCli/pkg/core/tmp"
+	"github.com/olblak/updateCli/pkg/plugins/version"
 	"github.com/shurcooL/githubv4"
 	"golang.org/x/oauth2"
-)
-
-const (
-	// TEXTVERSIONTYPE stores the version as a simple string
-	TEXTVERSIONTYPE string = "text"
-	// SEMVERVERSIONTYPE stores the semantic versionning type
-	SEMVERVERSIONTYPE string = "semver"
 )
 
 // Github contains settings to interact with Github
@@ -31,7 +25,7 @@ type Github struct {
 	Token                  string
 	URL                    string
 	Version                string
-	VersionType            string //VersionType defines the type of version, semver, default,etc...
+	Versioning             version.Version //Versioning provide parameters to clarify the type of version, simple text, semantic versioning,etc.
 	Directory              string
 	Branch                 string
 	remoteBranch           string
@@ -59,15 +53,16 @@ func (g *Github) Check() (errs []error) {
 		required = append(required, "repository")
 	}
 
-	if len(g.VersionType) == 0 {
-		g.VersionType = SEMVERVERSIONTYPE
+	if len(g.Versioning.Pattern) == 0 {
+		g.Versioning.Pattern = g.Version
 	}
 
-	if g.VersionType != TEXTVERSIONTYPE &&
-		g.VersionType != SEMVERVERSIONTYPE &&
-		g.VersionType != "" {
-		errs = append(errs, fmt.Errorf("wrong versionType %q, only accepted values [%q,%q]", g.VersionType, TEXTVERSIONTYPE, SEMVERVERSIONTYPE))
+	if len(g.Versioning.Kind) == 0 {
+		g.Versioning.Kind = version.SEMVERVERSIONKIND
+	}
 
+	if err := g.Versioning.Validate(); err != nil {
+		errs = append(errs, err)
 	}
 
 	if len(required) > 0 {

--- a/pkg/plugins/github/main.go
+++ b/pkg/plugins/github/main.go
@@ -24,8 +24,8 @@ type Github struct {
 	Username               string
 	Token                  string
 	URL                    string
-	Version                string
-	Versioning             version.Version //Versioning provide parameters to clarify the type of version, simple text, semantic versioning,etc.
+	Version                string          // **Deprecated** Field depecated in favor of `versionFilter.pattern`, this field will be removed in a futur version
+	versionFilter          version.Version //Versioning provides parameters to specify version pattern and its type like regex, semver, or just latest.
 	Directory              string
 	Branch                 string
 	remoteBranch           string
@@ -53,12 +53,16 @@ func (g *Github) Check() (errs []error) {
 		required = append(required, "repository")
 	}
 
-	if len(g.Versioning.Pattern) == 0 {
-		g.Versioning.Pattern = g.Version
+	if len(g.versionFilter.Pattern) == 0 {
+		g.versionFilter.Pattern = g.Version
 	}
 
-	if err := g.Versioning.Validate(); err != nil {
+	if err := g.versionFilter.Validate(); err != nil {
 		errs = append(errs, err)
+	}
+
+	if len(g.Version) > 0 {
+		logrus.Warningln("**Deprecated** Field deprecated in favor of `versionFilter.pattern`, this field will be removed in the next major version")
 	}
 
 	if len(required) > 0 {

--- a/pkg/plugins/github/main.go
+++ b/pkg/plugins/github/main.go
@@ -15,8 +15,8 @@ import (
 )
 
 const (
-	// STRINGVERSIONTYPE stores the version as a simple string
-	STRINGVERSIONTYPE string = "string"
+	// TEXTVERSIONTYPE stores the version as a simple string
+	TEXTVERSIONTYPE string = "string"
 	// SEMVERVERSIONTYPE stores the semantic versionning type
 	SEMVERVERSIONTYPE string = "semver"
 )
@@ -63,10 +63,10 @@ func (g *Github) Check() (errs []error) {
 		g.VersionType = SEMVERVERSIONTYPE
 	}
 
-	if g.VersionType != STRINGVERSIONTYPE &&
+	if g.VersionType != TEXTVERSIONTYPE &&
 		g.VersionType != SEMVERVERSIONTYPE &&
 		g.VersionType != "" {
-		errs = append(errs, fmt.Errorf("wrong versionType %q, only accepted values [%q,%q]", g.VersionType, STRINGVERSIONTYPE, SEMVERVERSIONTYPE))
+		errs = append(errs, fmt.Errorf("wrong versionType %q, only accepted values [%q,%q]", g.VersionType, TEXTVERSIONTYPE, SEMVERVERSIONTYPE))
 
 	}
 

--- a/pkg/plugins/github/main.go
+++ b/pkg/plugins/github/main.go
@@ -58,7 +58,7 @@ func (g *Github) Check() (errs []error) {
 	}
 
 	if len(g.Versioning.Kind) == 0 {
-		g.Versioning.Kind = version.SEMVERVERSIONKIND
+		g.Versioning.Kind = version.TEXTVERSIONKIND
 	}
 
 	if err := g.Versioning.Validate(); err != nil {

--- a/pkg/plugins/github/main.go
+++ b/pkg/plugins/github/main.go
@@ -29,6 +29,7 @@ type Github struct {
 	remoteBranch           string
 	User                   string
 	Email                  string
+	Constraint             string // Specify version constraint
 }
 
 // Check verifies if mandatory Github parameters are provided and return false if not.

--- a/pkg/plugins/github/main.go
+++ b/pkg/plugins/github/main.go
@@ -14,6 +14,13 @@ import (
 	"golang.org/x/oauth2"
 )
 
+const (
+	// STRINGVERSIONTYPE stores the version as a simple string
+	STRINGVERSIONTYPE string = "string"
+	// SEMVERVERSIONTYPE stores the semantic versionning type
+	SEMVERVERSIONTYPE string = "semver"
+)
+
 // Github contains settings to interact with Github
 type Github struct {
 	Owner                  string
@@ -24,16 +31,16 @@ type Github struct {
 	Token                  string
 	URL                    string
 	Version                string
+	VersionType            string //VersionType defines the type of version, semver, default,etc...
 	Directory              string
 	Branch                 string
 	remoteBranch           string
 	User                   string
 	Email                  string
-	Constraint             string // Specify version constraint
 }
 
 // Check verifies if mandatory Github parameters are provided and return false if not.
-func (g *Github) Check() (bool, error) {
+func (g *Github) Check() (errs []error) {
 	required := []string{}
 
 	if g.Token == "" {
@@ -52,12 +59,22 @@ func (g *Github) Check() (bool, error) {
 		required = append(required, "repository")
 	}
 
-	if len(required) > 0 {
-		err := fmt.Errorf("github parameter(s) required: [%v]", strings.Join(required, ","))
-		return false, err
+	if len(g.VersionType) == 0 {
+		g.VersionType = SEMVERVERSIONTYPE
 	}
 
-	return true, nil
+	if g.VersionType != STRINGVERSIONTYPE &&
+		g.VersionType != SEMVERVERSIONTYPE &&
+		g.VersionType != "" {
+		errs = append(errs, fmt.Errorf("wrong versionType %q, only accepted values [%q,%q]", g.VersionType, STRINGVERSIONTYPE, SEMVERVERSIONTYPE))
+
+	}
+
+	if len(required) > 0 {
+		errs = append(errs, fmt.Errorf("github parameter(s) required: [%v]", strings.Join(required, ",")))
+	}
+
+	return errs
 }
 
 func (g *Github) setDirectory() {

--- a/pkg/plugins/github/pageInfo.go
+++ b/pkg/plugins/github/pageInfo.go
@@ -1,0 +1,9 @@
+package github
+
+// PageInfo is used for Graphql queries to iterate over pagination
+type PageInfo struct {
+	HasNextPage     bool
+	HasPreviousPage bool
+	EndCursor       string
+	StartCursor     string
+}

--- a/pkg/plugins/github/rateLimit.go
+++ b/pkg/plugins/github/rateLimit.go
@@ -1,0 +1,21 @@
+package github
+
+import "github.com/sirupsen/logrus"
+
+// RateLimit is a struct that contains Github Api limit information
+type RateLimit struct {
+	Cost      int
+	Remaining int
+	ResetAt   string
+}
+
+// Show display Github Api limit usage
+func (a *RateLimit) Show() {
+	if (a.Cost * 2) > a.Remaining {
+		logrus.Warningf("Running out of Github Api resource, currently used %d remaining %d (reset at %s)",
+			a.Cost, a.Remaining, a.ResetAt)
+	} else {
+		logrus.Debugf("GitHub Api credit used used %d, remaining %d (reset at %s)",
+			a.Cost, a.Remaining, a.ResetAt)
+	}
+}

--- a/pkg/plugins/github/scm.go
+++ b/pkg/plugins/github/scm.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	git "github.com/olblak/updateCli/pkg/plugins/git/generic"
+	"github.com/sirupsen/logrus"
 )
 
 // Init set default Github parameters if not set.
@@ -13,8 +14,12 @@ func (g *Github) Init(source string, pipelineID string) error {
 	g.remoteBranch = git.SanitizeBranchName(fmt.Sprintf("updatecli_%v", pipelineID))
 	g.setDirectory()
 
-	if ok, err := g.Check(); !ok {
-		return err
+	errs := g.Check()
+	if len(errs) > 0 {
+		for _, e := range errs {
+			logrus.Errorf("%s\n", e)
+		}
+		return fmt.Errorf("wrong github configuration")
 	}
 	return nil
 }

--- a/pkg/plugins/github/source.go
+++ b/pkg/plugins/github/source.go
@@ -40,7 +40,7 @@ func (g *Github) Source(workingDir string) (value string, err error) {
 		}
 	}
 
-	value, err = g.Versioning.Search(versions)
+	value, err = g.versionFilter.Search(versions)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/plugins/github/source.go
+++ b/pkg/plugins/github/source.go
@@ -88,7 +88,7 @@ func (g *Github) Source(workingDir string) (string, error) {
 	}
 
 	switch g.VersionType {
-	case STRINGVERSIONTYPE:
+	case TEXTVERSIONTYPE:
 		if g.Version == "latest" {
 			value = versions[0]
 		} else {

--- a/pkg/plugins/github/source.go
+++ b/pkg/plugins/github/source.go
@@ -3,7 +3,7 @@ package github
 import (
 	"context"
 	"fmt"
-	"strings"
+	"regexp"
 
 	"github.com/olblak/updateCli/pkg/plugins/version/semver"
 	"github.com/sirupsen/logrus"
@@ -12,116 +12,80 @@ import (
 )
 
 // Source retrieves a specific version tag from Github Releases.
-func (g *Github) Source(workingDir string) (string, error) {
+func (g *Github) Source(workingDir string) (value string, err error) {
 
 	errs := g.Check()
 	if len(errs) > 0 {
 		for _, e := range errs {
 			logrus.Errorf("%s\n", e)
 		}
-		return "", fmt.Errorf("wrong github configuration")
+		return value, fmt.Errorf("wrong github configuration")
 	}
 
-	/*
-			https://developer.github.com/v4/explorer/
-		# Query
-		query getLatestRelease($owner: String!, $repository: String!){
-			repository(owner: $owner, name: $repository){
-				releases(first:10, orderBy:$orderBy){
-					nodes{
-						name
-						tagName
-						isDraft
-						isPrerelease
-					}
-				}
-			}
-		}
-		# Variables
-		{
-			"owner": "olblak",
-			"repository": "charts",
-		}
-	*/
-
-	client := g.NewClient()
-
-	type release struct {
-		Name         string
-		TagName      string
-		IsDraft      bool
-		IsPrerelease bool
-	}
-
-	var query struct {
-		Repository struct {
-			Releases struct {
-				Nodes []release
-			} `graphql:"releases(first: 100, orderBy: $orderBy)"`
-		} `graphql:"repository(owner: $owner, name: $repository)"`
-	}
-
-	variables := map[string]interface{}{
-		"owner":      githubv4.String(g.Owner),
-		"repository": githubv4.String(g.Repository),
-		"orderBy": githubv4.ReleaseOrder{
-			Field:     "CREATED_AT",
-			Direction: "DESC",
-		},
-	}
-
-	err := client.Query(context.Background(), &query, variables)
+	versions, err := g.SearchReleases()
 
 	if err != nil {
-		logrus.Errorf("\u2717 Couldn't find a valid github release version")
-		logrus.Errorf("\t %s", err)
-		return "", err
+		logrus.Error(err)
+		return value, err
 	}
 
-	value := ""
-	versions := []string{}
-
-	for _, release := range query.Repository.Releases.Nodes {
-		if !release.IsDraft && !release.IsPrerelease {
-			versions = append(versions, release.TagName)
+	if len(versions) == 0 {
+		logrus.Infof("\u26A0 No GitHub Release found. As fallback Looking at published git tags")
+		versions, err = g.SearchTags()
+		if err != nil {
+			logrus.Errorf("%s", err)
+			return "", err
+		}
+		if len(versions) == 0 {
+			logrus.Infof("\t=> No release neither git tags founded, exiting")
+			return "", fmt.Errorf("No release or git tags founded, exiting")
 		}
 	}
 
 	switch g.VersionType {
 	case TEXTVERSIONTYPE:
+		logrus.Infof("Searching for version %s", g.Version)
 		if g.Version == "latest" {
-			value = versions[0]
+			value = versions[len(versions)-1]
 		} else {
-			for _, version := range versions {
-				if strings.HasPrefix(version, g.Version) {
+			re, err := regexp.Compile(g.Version)
+			if err != nil {
+				return "", err
+			}
+
+			// Parse version in by date publishing
+			for i := len(versions) - 1; i >= 0; i-- {
+				version := versions[i]
+				if re.Match([]byte(version)) {
 					value = version
 					break
 				}
 			}
 		}
 	case SEMVERVERSIONTYPE:
+		logrus.Info("Searching for version respecting semantic versioning %q", g.Version)
 		sv := semver.Semver{
 			Constraint: g.Version,
 		}
 		err = sv.Init(versions)
 
 		if err != nil {
+			logrus.Errorf("%s", err)
 			return value, err
 		}
 
 		value, err = sv.GetLatestVersion()
 		if err != nil {
+			logrus.Errorf("%s", err)
 			return value, err
 		}
 	default:
 		return value, fmt.Errorf("Something went wrong while decoding version %q for version pattern %q", g.Version, g.VersionType)
 	}
 
-	logrus.Debugf("%d version returned from Github", len(query.Repository.Releases.Nodes))
-	logrus.Debugf("%s", versions)
-
 	if len(value) == 0 {
 		logrus.Infof("\u2717 No Github Release version founded matching pattern %q", g.Version)
+		return value, fmt.Errorf("no Github Release version founded matching pattern %q", g.Version)
 	} else if len(value) > 0 {
 		logrus.Infof("\u2714 Github Release version %q founded matching pattern %q", value, g.Version)
 	} else {
@@ -129,4 +93,209 @@ func (g *Github) Source(workingDir string) (string, error) {
 	}
 
 	return value, nil
+}
+
+// SearchTags return every tags from the github api return in reverse order of commit tags.
+func (g *Github) SearchTags() (tags []string, err error) {
+
+	client := g.NewClient()
+
+	//var query struct {
+	//	RateLimit  RateLimit
+	//	Repository struct {
+	//		Refs struct {
+	//			TotalCount string
+	//			Nodes      []struct {
+	//				Name string
+	//			}
+	//		} `graphql:"refs(refPrefix: $refPrefix, last: 100,orderBy: $orderBy)"`
+	//	} `graphql:"repository(owner: $owner, name: $repository)"`
+	//}
+	//		{
+	//	  rateLimit {
+	//	    cost
+	//	    remaining
+	//	    resetAt
+	//	  }
+	//	  repository(owner: "kubernetes", name: "kubectl") {
+	//	    refs(refPrefix: "refs/tags/", first: 100, after: $cursor, orderBy: {field: TAG_COMMIT_DATE, direction: DESC}) {
+	//	      totalCount
+	//	      pageInfo {
+	//	        hasNextPage
+	//	        endCursor
+	//	      }
+	//	      edges {
+	//	        node {
+	//	            name
+	//	        }
+	//	        cursor
+	//	      }
+	//	    }
+	//	  }
+	//	}
+
+	var query struct {
+		RateLimit  RateLimit
+		Repository struct {
+			Refs struct {
+				TotalCount int
+				PageInfo   PageInfo
+				Edges      []struct {
+					Cursor string
+					Node   struct {
+						Name string
+					}
+				}
+			} `graphql:"refs(refPrefix: $refPrefix, last: 100, before: $before,orderBy: $orderBy)"`
+		} `graphql:"repository(owner: $owner, name: $repository)"`
+	}
+
+	variables := map[string]interface{}{
+		"owner":      githubv4.String(g.Owner),
+		"repository": githubv4.String(g.Repository),
+		"refPrefix":  githubv4.String("refs/tags/"),
+		"before":     (*githubv4.String)(nil),
+		"orderBy": githubv4.RefOrder{
+			Field:     "TAG_COMMIT_DATE",
+			Direction: "DESC",
+		},
+	}
+
+	expectedFound := 0
+	tagCounter := 0
+	for {
+		err = client.Query(context.Background(), &query, variables)
+		if err != nil {
+			logrus.Error(err)
+			return nil, err
+		}
+
+		expectedFound = query.Repository.Refs.TotalCount
+
+		query.RateLimit.Show()
+
+		for i := len(query.Repository.Refs.Edges) - 1; i >= 0; i-- {
+			tagCounter++
+			node := query.Repository.Refs.Edges[i]
+			tags = append(tags, node.Node.Name)
+		}
+
+		if !query.Repository.Refs.PageInfo.HasPreviousPage {
+			break
+		}
+		variables["before"] = githubv4.NewString(githubv4.String(query.Repository.Refs.PageInfo.StartCursor))
+	}
+
+	if expectedFound != tagCounter {
+		return tags, fmt.Errorf("Something went wrong, find %d, expected %d", tagCounter, expectedFound)
+	}
+
+	logrus.Debugf("%d tags found", len(tags))
+
+	return tags, err
+}
+
+// SearchReleases return every releases from the github api returned in reverse order of created time.
+func (g *Github) SearchReleases() (releases []string, err error) {
+	/*
+			https://developer.github.com/v4/explorer/
+		# Query
+		query getLatestRelease($owner: String!, $repository: String!){
+			rateLimit {
+				cost
+				remaining
+				resetAt
+			}
+			repository(owner: $owner, name: $repository){
+				releases(last:100, before: $before, orderBy:$orderBy){
+		    		totalCount
+		    		pageInfo {
+		    		  hasNextPage
+		    		  endCursor
+		    		}
+		    		edges {
+		    		  node {
+		    		      	name
+				  			tagName
+							isDraft
+							isPrerelease
+		    		  }
+		    		  cursor
+		    		}
+				}
+			}
+		}
+		# Variables
+		{
+			"owner": "olblak",
+			"repository": "charts"
+		}
+	*/
+
+	client := g.NewClient()
+
+	variables := map[string]interface{}{
+		"owner":      githubv4.String(g.Owner),
+		"repository": githubv4.String(g.Repository),
+		"before":     (*githubv4.String)(nil),
+		"orderBy": githubv4.ReleaseOrder{
+			Field:     "CREATED_AT",
+			Direction: "DESC",
+		},
+	}
+
+	var query struct {
+		RateLimit  RateLimit
+		Repository struct {
+			Releases struct {
+				TotalCount int
+				PageInfo   PageInfo
+				Edges      []struct {
+					Cursor string
+					Node   struct {
+						Name         string
+						TagName      string
+						IsDraft      bool
+						IsPrerelease bool
+					}
+				}
+			} `graphql:"releases(last: 100, before: $before, orderBy: $orderBy)"`
+		} `graphql:"repository(owner: $owner, name: $repository)"`
+	}
+
+	expectedFound := 0
+	releaseCounter := 0
+
+	for {
+		err := client.Query(context.Background(), &query, variables)
+
+		if err != nil {
+			logrus.Errorf("\t%s", err)
+			return releases, err
+		}
+
+		query.RateLimit.Show()
+
+		for i := len(query.Repository.Releases.Edges) - 1; i >= 0; i-- {
+			releaseCounter++
+			node := query.Repository.Releases.Edges[i]
+			releases = append(releases, node.Node.Name)
+		}
+
+		expectedFound = query.Repository.Releases.TotalCount
+
+		if !query.Repository.Releases.PageInfo.HasPreviousPage {
+			break
+		}
+
+		variables["before"] = githubv4.NewString(githubv4.String(query.Repository.Releases.PageInfo.StartCursor))
+	}
+
+	if expectedFound != releaseCounter {
+		return releases, fmt.Errorf("Something went wrong, found %d releases, expected %d", releaseCounter, expectedFound)
+	}
+
+	logrus.Debugf("%d releases found", len(releases))
+	return releases, nil
+
 }

--- a/pkg/plugins/github/source.go
+++ b/pkg/plugins/github/source.go
@@ -104,10 +104,25 @@ func (g *Github) Source(workingDir string) (string, error) {
 		}
 	}
 
-	if len(g.Constraint) > 0 {
+	versions := []string{}
+	for _, release := range query.Repository.Releases.Nodes {
+		versions = append(versions, release.TagName)
+	}
+
+	if len(g.Constraint) > 0 && len(value) > 0 {
 		logrus.Infof("\u2714 %q github release version matching constraint %q, founded: %q", g.Version, g.Constraint, value)
-	} else {
+	} else if len(g.Constraint) == 0 && len(value) > 0 {
 		logrus.Infof("\u2714 %q github release version founded: %q", g.Version, value)
+	} else if len(value) == 0 && len(g.Constraint) == 0 {
+		logrus.Infof("\u2714 No %q github release version founded", g.Version)
+		logrus.Debugf("%d version returned from Github", len(query.Repository.Releases.Nodes))
+		logrus.Debugf("%s", versions)
+	} else if len(value) == 0 && len(g.Constraint) >= 0 {
+		logrus.Infof("\u2714 No %q github release version founded matching constraint %q", g.Version, g.Constraint)
+		logrus.Debugf("%d version returned from Github", len(query.Repository.Releases.Nodes))
+		logrus.Debugf("%s", versions)
+	} else {
+		logrus.Errorf("Something unexpected happened in Github source")
 	}
 	return value, nil
 }

--- a/pkg/plugins/github/source.go
+++ b/pkg/plugins/github/source.go
@@ -103,7 +103,12 @@ func (g *Github) Source(workingDir string) (string, error) {
 		sv := semver.Semver{
 			Constraint: g.Version,
 		}
-		sv.Init(versions)
+		err = sv.Init(versions)
+
+		if err != nil {
+			return value, err
+		}
+
 		value, err = sv.GetLatestVersion()
 		if err != nil {
 			return value, err

--- a/pkg/plugins/github/source_test.go
+++ b/pkg/plugins/github/source_test.go
@@ -2,31 +2,69 @@ package github
 
 import (
 	"os"
-	"path/filepath"
+	"strings"
 	"testing"
+)
+
+type DataSet struct {
+	github           Github
+	expectedTags     []string
+	expectedReleases []string
+	expectedSource   string
+}
+
+var (
+	dataSet = DataSet{
+		github: Github{
+			Owner:      "olblak",
+			Repository: "nocode",
+			Token:      os.Getenv("GITHUB_TOKEN"),
+		},
+		expectedTags:     []string{"1.0.0"},
+		expectedReleases: []string{"1.0.0"},
+		expectedSource:   "1.0.0",
+	}
 )
 
 func TestGetTags(t *testing.T) {
 
-	g := Github{
-		Owner:      "updatecli",
-		Repository: "updatecli",
-		Token:      os.Getenv("GITHUB_TOKEN"),
-		Directory:  filepath.Join(os.TempDir(), "tests", "updatecli"),
-	}
-
-	_, err := g.Clone()
-	if err != nil {
-		t.Errorf("Something went wrong when running git clone: %q", err)
-	}
-
-	tags, err := g.SearchTags()
+	tags, err := dataSet.github.SearchTags()
 
 	if err != nil {
 		t.Errorf("Something went wrong when retrieving tags: %q", err)
 	}
 
-	if len(tags) == 0 {
-		t.Errorf("No tags found: %q", tags)
+	for id, tag := range tags {
+		if strings.Compare(tag, dataSet.expectedTags[id]) != 0 {
+			t.Errorf("At position %d, expected tag %q, got %q", id, tag, dataSet.expectedTags[id])
+		}
+	}
+}
+
+func TestSource(t *testing.T) {
+
+	got, err := dataSet.github.Source("")
+
+	if err != nil {
+		t.Errorf("Something went wrong when retrieving tags: %q", err)
+	}
+
+	if strings.Compare(got, dataSet.expectedSource) != 0 {
+		t.Errorf("Expected source value %q, got %q", dataSet.expectedSource, got)
+	}
+}
+
+func TestSearchReleases(t *testing.T) {
+
+	releases, err := dataSet.github.SearchReleases()
+
+	if err != nil {
+		t.Errorf("Something went wrong when retrieving tags: %q", err)
+	}
+
+	for id, release := range releases {
+		if strings.Compare(release, dataSet.expectedReleases[id]) != 0 {
+			t.Errorf("At position %d, expected tag %q, got %q", id, release, dataSet.expectedReleases[id])
+		}
 	}
 }

--- a/pkg/plugins/github/source_test.go
+++ b/pkg/plugins/github/source_test.go
@@ -27,6 +27,6 @@ func TestGetTags(t *testing.T) {
 	}
 
 	if len(tags) == 0 {
-		t.Errorf("No tags founded: %q", tags)
+		t.Errorf("No tags found: %q", tags)
 	}
 }

--- a/pkg/plugins/github/source_test.go
+++ b/pkg/plugins/github/source_test.go
@@ -1,0 +1,32 @@
+package github
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestGetTags(t *testing.T) {
+
+	g := Github{
+		Owner:      "updatecli",
+		Repository: "updatecli",
+		Token:      os.Getenv("GITHUB_TOKEN"),
+		Directory:  filepath.Join(os.TempDir(), "tests", "updatecli"),
+	}
+
+	_, err := g.Clone()
+	if err != nil {
+		t.Errorf("Something went wrong when running git clone: %q", err)
+	}
+
+	tags, err := g.SearchTags()
+
+	if err != nil {
+		t.Errorf("Something went wrong when retrieving tags: %q", err)
+	}
+
+	if len(tags) == 0 {
+		t.Errorf("No tags founded: %q", tags)
+	}
+}

--- a/pkg/plugins/helm/chart/source.go
+++ b/pkg/plugins/helm/chart/source.go
@@ -46,7 +46,7 @@ func (c *Chart) Source(workingDir string) (string, error) {
 	}
 
 	if e.Version != "" {
-		logrus.Infof("\u2714 Helm Chart '%s' version '%v' is founded from repository %s",
+		logrus.Infof("\u2714 Helm Chart '%s' version '%v' is found from repository %s",
 			c.Name,
 			e.Version,
 			c.URL)

--- a/pkg/plugins/version/main.go
+++ b/pkg/plugins/version/main.go
@@ -1,0 +1,88 @@
+package version
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/olblak/updateCli/pkg/plugins/version/semver"
+	"github.com/sirupsen/logrus"
+)
+
+// Version hold version information
+type Version struct {
+	Kind    string
+	Pattern string
+}
+
+const (
+	// TEXTVERSIONKIND represent versions as a simple string
+	TEXTVERSIONKIND string = "text"
+	// SEMVERVERSIONKIND represent versions as a semantic versionning type
+	SEMVERVERSIONKIND string = "semver"
+)
+
+var (
+	// SupportedKind holds a list of supported version kind
+	SupportedKind []string = []string{
+		TEXTVERSIONKIND,
+		SEMVERVERSIONKIND,
+	}
+)
+
+// Validate tests if we are analysing a valid version type
+func (v *Version) Validate() error {
+	ok := false
+	for id := range SupportedKind {
+		if SupportedKind[id] == v.Kind {
+			ok = true
+			break
+		}
+	}
+	if !ok {
+		return fmt.Errorf("Unsupported version kind %q", v.Kind)
+	}
+	return nil
+}
+
+// Search returns a value matching pattern
+func (v *Version) Search(versions []string) (version string, err error) {
+
+	logrus.Infof("Searching for version matching pattern %q", v.Pattern)
+
+	switch v.Kind {
+	case TEXTVERSIONKIND:
+		if v.Pattern == "latest" {
+			version = versions[len(versions)-1]
+		} else {
+			re, err := regexp.Compile(v.Pattern)
+			if err != nil {
+				return "", err
+			}
+
+			// Parse version in by date publishing
+			// Oldest version appears first in array
+			for i := len(versions) - 1; i >= 0; i-- {
+				v := versions[i]
+				if re.Match([]byte(v)) {
+					version = v
+					break
+				}
+			}
+		}
+	case SEMVERVERSIONKIND:
+		s := semver.Semver{
+			Constraint: v.Pattern,
+		}
+
+		version, err = s.Searcher(versions)
+		if err != nil {
+			logrus.Error(err)
+			return version, err
+		}
+	default:
+		return version, fmt.Errorf("Unsupported version kind %q with pattern %q", v.Kind, v.Pattern)
+
+	}
+
+	return version, err
+}

--- a/pkg/plugins/version/main.go
+++ b/pkg/plugins/version/main.go
@@ -31,6 +31,11 @@ var (
 
 // Validate tests if we are analysing a valid version type
 func (v *Version) Validate() error {
+
+	if len(v.Kind) == 0 {
+		v.Kind = TEXTVERSIONKIND
+	}
+
 	ok := false
 	for id := range SupportedKind {
 		if SupportedKind[id] == v.Kind {

--- a/pkg/plugins/version/main_test.go
+++ b/pkg/plugins/version/main_test.go
@@ -1,0 +1,149 @@
+package version
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+type SearchDataSet struct {
+	Filter         Filter
+	Versions       []string
+	ExpectedResult string
+	ExpectedError  error
+}
+
+type ValidateDataSet struct {
+	Filter Filter
+	Err    error
+}
+
+var (
+	searchDataSet []SearchDataSet = []SearchDataSet{
+		{
+			Filter: Filter{
+				Kind:    "latest",
+				Pattern: "latest",
+			},
+			Versions:       []string{"1.0", "2.0", "3.0"},
+			ExpectedResult: "3.0",
+			ExpectedError:  nil,
+		},
+		{
+			Filter: Filter{
+				Kind: "latest",
+			},
+			Versions:       []string{"1.0", "2.0", "3.0"},
+			ExpectedResult: "3.0",
+			ExpectedError:  nil,
+		},
+		{
+			Filter:         Filter{},
+			Versions:       []string{"1.0", "2.0", "3.0"},
+			ExpectedResult: "3.0",
+			ExpectedError:  nil,
+		},
+		{
+			Filter: Filter{
+				Kind:    "semver",
+				Pattern: "~2",
+			},
+			Versions:       []string{"1.0", "2.0", "3.0"},
+			ExpectedResult: "2.0.0",
+			ExpectedError:  nil,
+		},
+		{
+			Filter: Filter{
+				Kind: "semver",
+			},
+			Versions:       []string{"1.0", "2.0", "3.0"},
+			ExpectedResult: "3.0.0",
+			ExpectedError:  nil,
+		},
+		{
+			Filter: Filter{
+				Kind:    "regex",
+				Pattern: "^updatecli-2.(\\d*)$",
+			},
+			Versions:       []string{"updatecli-1.0", "updatecli-2.0", "updatecli-3.0"},
+			ExpectedResult: "updatecli-2.0",
+			ExpectedError:  nil,
+		},
+		{
+			Filter: Filter{
+				Kind: "regex",
+			},
+			Versions:       []string{"updatecli-1.0", "updatecli-2.0", "updatecli-3.0"},
+			ExpectedResult: "updatecli-3.0",
+			ExpectedError:  nil,
+		},
+		{
+			Filter: Filter{
+				Kind:    "semver",
+				Pattern: "~2",
+			},
+			Versions:       []string{"updatecli-1.0", "updatecli-2.0", "updatecli-3.0"},
+			ExpectedResult: "",
+			ExpectedError:  errors.New("No valid semantic version found"),
+		},
+	}
+
+	validateDataSet []ValidateDataSet = []ValidateDataSet{
+		{
+			Filter: Filter{
+				Kind:    "semver",
+				Pattern: "~2",
+			},
+			Err: nil,
+		},
+		{
+			Filter: Filter{
+				Kind:    "regex",
+				Pattern: "~2",
+			},
+			Err: nil,
+		},
+		{
+			Filter: Filter{
+				Kind:    "noExist",
+				Pattern: "~2",
+			},
+			Err: errors.New(`Unsupported version kind "noExist"`),
+		},
+	}
+)
+
+func TestSearch(t *testing.T) {
+
+	for _, d := range searchDataSet {
+		err := d.Filter.Validate()
+		if err != nil {
+			t.Errorf("Unexpected err %q", err.Error())
+		}
+		got, err := d.Filter.Search(d.Versions)
+		if err != nil && d.ExpectedError != nil {
+			if strings.Compare(err.Error(), d.ExpectedError.Error()) != 0 {
+				t.Errorf("Expected %q, got %q", d.ExpectedError.Error(), err.Error())
+			}
+		} else if err != nil {
+			t.Errorf("Unexpected err %q", err.Error())
+		}
+		if got != d.ExpectedResult {
+			t.Errorf("Expected version %q, got %q", d.ExpectedResult, got)
+		}
+	}
+
+}
+
+func TestValidate(t *testing.T) {
+	for _, v := range validateDataSet {
+		err := v.Filter.Validate()
+		if err != nil && v.Err != nil {
+			if strings.Compare(err.Error(), v.Err.Error()) != 0 {
+				t.Errorf("Expected Error %q, got %q", v.Err, err)
+			}
+		} else if err != nil {
+			t.Errorf("Unexpected err %q", err.Error())
+		}
+	}
+}

--- a/pkg/plugins/version/semver/main.go
+++ b/pkg/plugins/version/semver/main.go
@@ -1,0 +1,61 @@
+package semver
+
+import (
+	"fmt"
+	"sort"
+
+	sv "github.com/Masterminds/semver/v3"
+)
+
+// Semver is an interface in front the masterminds/semver used across the updatecli project
+type Semver struct {
+	Constraint string
+	versions   []*sv.Version
+}
+
+// Init creates a new semver object
+func (s *Semver) Init(versions []string) error {
+
+	vs := make([]*sv.Version, len(versions))
+	for i, version := range versions {
+		v, err := sv.NewVersion(version)
+		if err != nil {
+			return fmt.Errorf("Error parsing version: %s", err)
+		}
+
+		vs[i] = v
+	}
+
+	s.versions = vs
+
+	return nil
+}
+
+// Sort re-order a list of versions with the newest first
+func (s *Semver) Sort() {
+	sort.Sort(sort.Reverse(sv.Collection(s.versions)))
+}
+
+// GetLatestVersion return the latest version matching pattern from a sorted list.
+func (s *Semver) GetLatestVersion() (version string, err error) {
+	s.Sort()
+
+	if len(s.Constraint) == 0 {
+		return s.versions[0].String(), err
+	}
+
+	c, err := sv.NewConstraint(s.Constraint)
+	if err != nil {
+		return version, err
+	}
+
+	for _, v := range s.versions {
+
+		if c.Check(v) {
+			version = v.String()
+			return version, err
+		}
+	}
+
+	return version, err
+}

--- a/pkg/plugins/version/semver/main.go
+++ b/pkg/plugins/version/semver/main.go
@@ -33,16 +33,22 @@ func (s *Semver) Init(versions []string) error {
 	return fmt.Errorf("No valid semantic version found")
 }
 
-// Sort re-order a list of versions with the newest first
+// Sort re-order a list of versions with the newest version first
 func (s *Semver) Sort() {
 	sort.Sort(sort.Reverse(sv.Collection(s.versions)))
 }
 
-// GetLatestVersion return the latest version matching pattern from a sorted list.
-func (s *Semver) GetLatestVersion() (version string, err error) {
+// Searcher returns the version matching pattern from a sorted list.
+func (s *Semver) Searcher(versions []string) (version string, err error) {
 	// We need to be sure that at least one version exist
-	if len(s.versions) == 0 {
+	if len(versions) == 0 {
 		return "", fmt.Errorf("empty list of versions")
+
+	}
+	err = s.Init(versions)
+	if err != nil {
+		logrus.Error(err)
+		return version, err
 	}
 
 	s.Sort()

--- a/pkg/plugins/version/semver/main.go
+++ b/pkg/plugins/version/semver/main.go
@@ -1,6 +1,7 @@
 package semver
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 
@@ -13,6 +14,13 @@ type Semver struct {
 	Constraint string
 	versions   []*sv.Version
 }
+
+var (
+	// ErrNoVersionFound return a error when no version couldn't be found
+	ErrNoVersionFound error = errors.New("No version found")
+	// ErrNoVersionsFound return a error when the versions list is empty
+	ErrNoVersionsFound error = errors.New("Versions list empty")
+)
 
 // Init creates a new semver object
 func (s *Semver) Init(versions []string) error {
@@ -38,11 +46,11 @@ func (s *Semver) Sort() {
 	sort.Sort(sort.Reverse(sv.Collection(s.versions)))
 }
 
-// Searcher returns the version matching pattern from a sorted list.
-func (s *Semver) Searcher(versions []string) (version string, err error) {
+// Search returns the version matching pattern from a sorted list.
+func (s *Semver) Search(versions []string) (version string, err error) {
 	// We need to be sure that at least one version exist
 	if len(versions) == 0 {
-		return "", fmt.Errorf("empty list of versions")
+		return "", ErrNoVersionsFound
 
 	}
 	err = s.Init(versions)
@@ -66,8 +74,11 @@ func (s *Semver) Searcher(versions []string) (version string, err error) {
 
 		if c.Check(v) {
 			version = v.String()
-			return version, err
+			break
 		}
+	}
+	if len(version) == 0 {
+		return "", ErrNoVersionFound
 	}
 
 	return version, err

--- a/pkg/plugins/version/semver/main_test.go
+++ b/pkg/plugins/version/semver/main_test.go
@@ -1,0 +1,144 @@
+package semver
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+type DataSet struct {
+	Semver            Semver
+	Versions          []string
+	SortedVersions    []string
+	ExpectedInitErr   error
+	ExpectedVersion   string
+	ExpectedSearchErr error
+}
+
+var (
+	dataset []DataSet = []DataSet{
+		{
+			Versions:          []string{"1.0", "2.0", "4.0", "3.0", "6.0", "5.0"},
+			SortedVersions:    []string{"6.0.0", "5.0.0", "4.0.0", "3.0.0", "2.0.0", "1.0.0"},
+			ExpectedInitErr:   nil,
+			ExpectedSearchErr: nil,
+			ExpectedVersion:   "6.0.0",
+		},
+		{
+			Versions:          []string{"1.0.0", "2.0.0", "4.0.0", "3.0.0", "6.0.0", "5.0.0"},
+			SortedVersions:    []string{"6.0.0", "5.0.0", "4.0.0", "3.0.0", "2.0.0", "1.0.0"},
+			ExpectedInitErr:   nil,
+			ExpectedSearchErr: nil,
+			ExpectedVersion:   "6.0.0",
+		},
+		{
+			Versions:          []string{},
+			SortedVersions:    []string{},
+			ExpectedInitErr:   errors.New("No valid semantic version found"),
+			ExpectedSearchErr: ErrNoVersionsFound,
+			ExpectedVersion:   "",
+		},
+		{
+			Semver: Semver{
+				Constraint: "~5",
+			},
+			Versions:          []string{"1.0.0", "2.0.0", "4.0.0", "3.0.0", "6.0.0", "5.0.0"},
+			SortedVersions:    []string{"6.0.0", "5.0.0", "4.0.0", "3.0.0", "2.0.0", "1.0.0"},
+			ExpectedInitErr:   nil,
+			ExpectedSearchErr: nil,
+			ExpectedVersion:   "5.0.0",
+		},
+		{
+			Semver: Semver{
+				Constraint: "~9",
+			},
+			Versions:          []string{"1.0.0", "2.0.0", "4.0.0", "3.0.0", "6.0.0", "5.0.0"},
+			SortedVersions:    []string{"6.0.0", "5.0.0", "4.0.0", "3.0.0", "2.0.0", "1.0.0"},
+			ExpectedInitErr:   nil,
+			ExpectedSearchErr: ErrNoVersionFound,
+			ExpectedVersion:   "",
+		},
+		{
+			Semver: Semver{
+				Constraint: "xyz",
+			},
+			Versions:          []string{"1.0.0", "2.0.0", "4.0.0", "3.0.0", "6.0.0", "5.0.0"},
+			SortedVersions:    []string{"6.0.0", "5.0.0", "4.0.0", "3.0.0", "2.0.0", "1.0.0"},
+			ExpectedInitErr:   nil,
+			ExpectedSearchErr: fmt.Errorf("improper constraint: xyz"),
+			ExpectedVersion:   "",
+		},
+		{
+			Versions:          []string{"updatecli-1.0", "updatecli-2.0", "updatecli-3.0"},
+			SortedVersions:    []string{},
+			ExpectedInitErr:   errors.New("No valid semantic version found"),
+			ExpectedSearchErr: errors.New("No valid semantic version found"),
+			ExpectedVersion:   "",
+		},
+	}
+)
+
+func TestInit(t *testing.T) {
+	for id, d := range dataset {
+		t.Logf("Dataset position %d", id)
+		err := d.Semver.Init(d.Versions)
+		if err != nil && d.ExpectedInitErr != nil {
+			if strings.Compare(err.Error(), d.ExpectedInitErr.Error()) != 0 {
+				t.Errorf("Unexpected error %q, got %q", err.Error(), d.ExpectedInitErr)
+			}
+		} else if err != nil {
+			t.Errorf("Unexpected error %q", err)
+		}
+	}
+}
+
+func TestSort(t *testing.T) {
+	for id, d := range dataset {
+		t.Logf("Dataset position %d", id)
+		err := d.Semver.Init(d.Versions)
+		if err != nil && d.ExpectedInitErr != nil {
+			if strings.Compare(err.Error(), d.ExpectedInitErr.Error()) != 0 {
+				t.Errorf("Unexpected error %q, got %q", err.Error(), d.ExpectedInitErr)
+			}
+		} else if err != nil {
+			t.Errorf("Unexpected error %q", err)
+		}
+
+		d.Semver.Sort()
+
+		for id, version := range d.Semver.versions {
+			if version.String() != d.SortedVersions[id] {
+				t.Errorf("At position %d, version should be %q instead of %q", id, version, d.SortedVersions[id])
+			}
+		}
+	}
+}
+
+func TestSearch(t *testing.T) {
+	for id, d := range dataset {
+		t.Logf("Dataset position %d", id)
+		err := d.Semver.Init(d.Versions)
+		if err != nil && d.ExpectedInitErr != nil {
+			if strings.Compare(err.Error(), d.ExpectedInitErr.Error()) != 0 {
+				t.Errorf("Unexpected error %q, got %q", err.Error(), d.ExpectedInitErr)
+			}
+		} else if err != nil {
+			t.Errorf("Unexpected error %q", err)
+		}
+
+		d.Semver.Sort()
+		got, err := d.Semver.Search(d.Versions)
+		if err != nil && d.ExpectedSearchErr != nil {
+			if strings.Compare(err.Error(), d.ExpectedSearchErr.Error()) != 0 {
+				t.Errorf("Unexpected error %q, got %q", err.Error(), d.ExpectedSearchErr)
+			}
+		} else if err != nil {
+			t.Errorf("Unexpected error %q", err)
+		}
+
+		if got != d.ExpectedVersion {
+			t.Errorf("Expected version %q, got %q", d.ExpectedVersion, got)
+		}
+	}
+}


### PR DESCRIPTION
Fix #175 
Fix #182 

Add a new parameter `versiontype` which allows defining the kind of version we are fetching.
this new parameter accepts one of the two following values "semver" or "text". Default is set to semver
The parameter github.version can handle version pattern as explained in the following example

*semver*
If semver is used then it means we are looking for a version following the semantic versioning rules. we can provide a version pattern in the Github `version` and any rule explained here [here](https://github.com/Masterminds/semver#checking-version-constraints) can be used.
It's important to notice that in the process we drop any character not compliant with the semantic versioning like if a version starts with v, so this value must be added using `transformers` like in the example

*text*
If text is specified we can apply a simple string pattern where Github version will match the latest version returned by Github starting with the pattern

```
source:
  kind: githubRelease
  spec:
    owner: "jenkins-infra"
    repository: "jenkins-wiki-exporter"
    token: "{{ requiredEnv .github.token }}" 
    username: "john"
    #version: "latest"
    version: "~1.10"
    #version: "~9.10"
    #version: "v1.10"
    #versiontype: string
  transformers:
    - addPrefix: "v"
```

Add a new optional Github parameter "constraint".
"Constraint" can specify version constraint as explained 
 
Signed-off-by: Olivier Vernin <olivier@vernin.me>