### PR TITLE
First get changelog information before applying transformers to the source value

### DIFF
--- a/pkg/core/engine/source/main.go
+++ b/pkg/core/engine/source/main.go
@@ -95,6 +95,19 @@ func (s *Source) Execute() error {
 
 	output, err = spec.Source(workingDir)
 
+	// Retrieve changelog using default source output before
+	// modifying its value with the transformer
+	if changelog != nil && s.Changelog == "" {
+		s.Changelog, err = changelog.Changelog(output)
+		if err != nil {
+			return err
+		}
+	} else if changelog == nil && s.Changelog == "" {
+		s.Changelog = "We couldn't identify a way to automatically retrieve changelog information"
+	} else {
+		return fmt.Errorf("Something weird happened while setting changelog")
+	}
+
 	if len(s.Transformers) > 0 {
 		output, err = s.Transformers.Apply(output)
 		if err != nil {
@@ -114,17 +127,6 @@ func (s *Source) Execute() error {
 
 	if err != nil {
 		return err
-	}
-
-	if changelog != nil && s.Changelog == "" {
-		s.Changelog, err = changelog.Changelog(output)
-		if err != nil {
-			return err
-		}
-	} else if changelog == nil && s.Changelog == "" {
-		s.Changelog = "We couldn't identify a way to automatically retrieve changelog information"
-	} else {
-		return fmt.Errorf("Something weird happened while setting changelog")
 	}
 
 	// Deprecated in favor of Transformers on 2021/01/3


### PR DESCRIPTION
In the default behavior, updatecli tries to guess changelog information using the value returned from a source. 
There is a bigger chance that this initial value can be used to retrieve changelog information than once it has been transformed for later stages.

Thanks, @dduportal  for identifying this issue

Btw I still have some plan to define a changelog configuration to customize the way we retrieve changelog information as described in this issue #159 

Signed-off-by: Olivier Vernin <olivier@vernin.me>