### PR TITLE
Various Git cleanup

### DIFF
--- a/pkg/plugins/git/main_test.go
+++ b/pkg/plugins/git/main_test.go
@@ -1,0 +1,66 @@
+package git
+
+import (
+	"strings"
+	"testing"
+)
+
+type DataSet []Data
+
+type Data struct {
+	g                     Git
+	expectedDirectoryName string
+}
+
+var (
+	Dataset DataSet = DataSet{
+		{
+			g: Git{
+				URL:      "https://github.com/updatecli/updatecli.git",
+				Username: "git",
+				Password: "password",
+			}, expectedDirectoryName: "github_com_updatecli_updatecli_git",
+		},
+		{
+			g: Git{
+				URL:      "https://github.com/updatecli/updatecli.git",
+				Username: "git",
+				Password: "password",
+			}, expectedDirectoryName: "github_com_updatecli_updatecli_git",
+		},
+		{
+			g: Git{
+				URL:      "https://github.com/updatecli/updatecli.git",
+				Password: "password",
+			}, expectedDirectoryName: "github_com_updatecli_updatecli_git",
+		},
+		{
+			g: Git{
+				URL:      "https://github.com/updatecli/updatecli.git",
+				Username: "git",
+			}, expectedDirectoryName: "github_com_updatecli_updatecli_git",
+		},
+		{
+			g: Git{
+				URL:      "https://@github.com/updatecli/updatecli.git",
+				Username: "git",
+			}, expectedDirectoryName: "github_com_updatecli_updatecli_git",
+		},
+		{
+			g: Git{
+				URL:      "ssh://server:project.git",
+				Username: "bob",
+			}, expectedDirectoryName: "server_project_git",
+		},
+	}
+)
+
+func TestSanitizeDirectoryName(t *testing.T) {
+	for _, data := range Dataset {
+		got := sanitizeDirectoryName(data.g.URL)
+
+		if strings.Compare(got, data.expectedDirectoryName) != 0 {
+			t.Errorf("got sanitize directory name %q, expected %q", got, data.expectedDirectoryName)
+		}
+	}
+}

--- a/pkg/plugins/git/scm.go
+++ b/pkg/plugins/git/scm.go
@@ -43,9 +43,14 @@ func (g *Git) Clean() error {
 // Clone run `git clone`.
 func (g *Git) Clone() (string, error) {
 
-	g.setDirectory()
+	err := g.Init("", "")
 
-	err := git.Clone(
+	if err != nil {
+		logrus.Errorf("err - %s", err)
+		return "", err
+	}
+
+	err = git.Clone(
 		g.Username,
 		g.Password,
 		g.URL,
@@ -82,10 +87,24 @@ func (g *Git) Commit(message string) error {
 }
 
 // Init set Git parameters if needed.
-func (g *Git) Init(source string, pipelineID string) error {
-	g.Version = source
-	g.setDirectory()
+func (g *Git) Init(source string, pipelineID string) (err error) {
+	if len(g.Version) == 0 && len(source) > 0 {
+		g.Version = source
+	}
+
+	if len(g.Directory) == 0 {
+		g.Directory, err = newDirectory(g.URL)
+		if err != nil {
+			return err
+		}
+	}
+
 	g.remoteBranch = git.SanitizeBranchName(g.Branch)
+
+	if len(g.Branch) == 0 {
+		g.Branch = "main"
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
- Fix git directory setting, even if we specified the value via the updatecli configuration it was always overridden by the default 
- Default git branch set to main
- Sanitize git directory name to remove cumbersome characters