### PR TITLE
Add transformer semverInc

### DIFF
--- a/pkg/core/transformer/main.go
+++ b/pkg/core/transformer/main.go
@@ -101,6 +101,10 @@ func (t *Transformer) Apply(input string) (output string, err error) {
 				return "", fmt.Errorf("unknown value for find: %v", val)
 			}
 
+			if len(val) == 0 {
+				return "", fmt.Errorf("no incremental semantic versioning rule, accept comma separated list of major,minor,patch")
+			}
+
 			v, err := semver.NewVersion(input)
 			if err != nil {
 				return "", fmt.Errorf("wrong semantic version input: %q", val)

--- a/pkg/core/transformer/main.go
+++ b/pkg/core/transformer/main.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/mitchellh/mapstructure"
 	"github.com/sirupsen/logrus"
 )
@@ -92,6 +93,33 @@ func (t *Transformer) Apply(input string) (output string, err error) {
 			found := re.FindString(output)
 
 			output = found
+
+		case "semverInc":
+			val, ok := value.(string)
+
+			if !ok {
+				return "", fmt.Errorf("unknown value for find: %v", val)
+			}
+
+			v, err := semver.NewVersion(input)
+			if err != nil {
+				return "", fmt.Errorf("wrong semantic version input: %q", val)
+			}
+
+			rules := strings.Split(val, ",")
+			for _, rule := range rules {
+				switch rule {
+				case "major":
+					*v = v.IncMajor()
+				case "minor":
+					*v = v.IncMinor()
+				case "patch":
+					*v = v.IncPatch()
+				default:
+					return "", fmt.Errorf("unsupported incremental semantic versioning rule %q, only accept a comma separated list between major, minor, patch", val)
+				}
+			}
+			output = v.String()
 
 		default:
 			return "", fmt.Errorf("key '%v' not supported", key)

--- a/pkg/core/transformer/main_test.go
+++ b/pkg/core/transformer/main_test.go
@@ -1,6 +1,8 @@
 package transformer
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 )
 
@@ -23,6 +25,45 @@ var (
 				},
 			},
 			expectedOutput: "alpha-2.263",
+		},
+		Data{
+			input: "2.263",
+			rules: Transformers{
+				Transformer{
+					"wrong": "xxx",
+				},
+			},
+			expectedOutput: "",
+			expectedErr:    fmt.Errorf("key 'wrong' not supported"),
+		},
+		Data{
+			input: "1.0.0",
+			rules: Transformers{
+				Transformer{
+					"semverInc": "wrong",
+				},
+			},
+			expectedOutput: "",
+			expectedErr:    fmt.Errorf("unsupported incremental semantic versioning rule \"wrong\", only accept a comma separated list between major, minor, patch"),
+		},
+		Data{
+			input: "1.x.y",
+			rules: Transformers{
+				Transformer{
+					"semverInc": "major",
+				},
+			},
+			expectedOutput: "",
+			expectedErr:    fmt.Errorf("wrong semantic version input: \"major\""),
+		},
+		Data{
+			input: "1.0.0",
+			rules: Transformers{
+				Transformer{
+					"semverInc": "major,minor,patch",
+				},
+			},
+			expectedOutput: "2.1.1",
 		},
 		Data{
 			input: "2.263",
@@ -131,8 +172,13 @@ var (
 func TestApply(t *testing.T) {
 	for _, d := range dataSet {
 		got, err := d.rules.Apply(d.input)
-		if err != nil {
-			t.Errorf("%v\n", err)
+		if err != nil &&
+			strings.Compare(
+				d.expectedErr.Error(),
+				err.Error()) != 0 {
+			t.Errorf("Error:\n\tExpected:\t%q\n\tGot:\t\t%q\n",
+				d.expectedErr,
+				err)
 		}
 
 		if got != d.expectedOutput {

--- a/pkg/core/transformer/main_test.go
+++ b/pkg/core/transformer/main_test.go
@@ -37,6 +37,16 @@ var (
 			expectedErr:    fmt.Errorf("key 'wrong' not supported"),
 		},
 		Data{
+			input: "2.263",
+			rules: Transformers{
+				Transformer{
+					"semverInc": "",
+				},
+			},
+			expectedOutput: "",
+			expectedErr:    fmt.Errorf("no incremental semantic versioning rule, accept comma separated list of major,minor,patch"),
+		},
+		Data{
 			input: "1.0.0",
 			rules: Transformers{
 				Transformer{


### PR DESCRIPTION
Signed-off-by: Olivier Vernin <olivier@vernin.me>

`semverImc` is a new transformer that increment following semantic versioning rules. 
It accepts comma separated list of ["major","minor","patch"]

```
transformers:
  - semverInc: "major"
  - semverImc: "major,minor,patch"
```