### PR TITLE
Add git conventional commit

### DIFF
--- a/pkg/core/engine/target/main.go
+++ b/pkg/core/engine/target/main.go
@@ -220,7 +220,7 @@ func (t *Target) Run(source string, o *Options) (changed bool, err error) {
 				}
 			}
 		}
-		if pr != nil && !o.DryRun {
+		if pr != nil && !o.DryRun && o.Push {
 			ID, err := pr.IsPullRequest()
 
 			logrus.Debugf("Pull Request ID: %v", ID)

--- a/pkg/plugins/docker/dockerfile/target.go
+++ b/pkg/plugins/docker/dockerfile/target.go
@@ -66,7 +66,7 @@ func (d *Dockerfile) TargetFromSCM(source string, scm scm.Scm, dryRun bool) (cha
 		// Generate a multiline string with one message per line (each message maps to a line changed by the parser)
 		messageList := strings.Join(d.messages, "\n")
 		// Generate a nice commit message with a first line title, and append the previous message list
-		message = fmt.Sprintf("[updatecli] Instructions changed from Dockerfile %q:\n"+messageList, d.File)
+		message = fmt.Sprintf("Update Dockerfile instruction for %q\n%s\n", d.File, messageList)
 	}
 
 	return changed, files, message, err

--- a/pkg/plugins/file/target.go
+++ b/pkg/plugins/file/target.go
@@ -122,7 +122,7 @@ func (f *File) TargetFromSCM(source string, scm scm.Scm, dryRun bool) (changed b
 	}
 
 	files = append(files, f.File)
-	message = fmt.Sprintf("[updatecli] Content for file '%v' updated\n", f.File)
+	message = fmt.Sprintf("Update %q content\n", f.File)
 
 	return changed, files, message, nil
 }

--- a/pkg/plugins/git/commit/main.go
+++ b/pkg/plugins/git/commit/main.go
@@ -12,7 +12,7 @@ import (
 const (
 	commitTpl string = "{{ .Type}}{{if .Scope}}({{.Scope}}){{ end }}: {{ .Title }}" +
 		"{{ if .Body }}\n\n{{ .Body }}{{ end }}" +
-		"{{ if not .HideCredits }}\nMade with ❤️️  by updatecli{{end}}" +
+		"{{ if not .HideCredits }}\n\nMade with ❤️️  by updatecli{{end}}" +
 		"{{ if .Footers }}\n\n{{ .Footers }}{{ end }}"
 )
 

--- a/pkg/plugins/git/commit/main.go
+++ b/pkg/plugins/git/commit/main.go
@@ -25,7 +25,6 @@ var (
 // More information on what is conventional commits
 // -> https://www.conventionalcommits.org/en/v1.0.0/#summary
 type Commit struct {
-	Version     string // Define conventionalCommit version
 	Type        string // Define commit type, like chore, fix, etc
 	Scope       string // Define commit type scope
 	Footers     string // Define commit footer
@@ -46,19 +45,11 @@ func (c *Commit) Generate(raw string) (string, error) {
 
 	t := template.Must(template.New("commit").Parse(commitTpl))
 
-	title, body, err := ParseMessage(raw)
+	err = c.ParseMessage(raw)
 
 	if err != nil {
 		logrus.Errorf(err.Error())
 		return "", err
-	}
-
-	if len(c.Title) == 0 {
-		c.Title = title
-	}
-
-	if len(c.Body) == 0 {
-		c.Body = body
 	}
 
 	buffer := new(bytes.Buffer)
@@ -76,18 +67,22 @@ func (c *Commit) Generate(raw string) (string, error) {
 
 // ParseMessage parses a message then return the commit message title and its body.
 // The message title can't be longer than 72 characters
-func ParseMessage(message string) (title, body string, err error) {
+func (c *Commit) ParseMessage(message string) (err error) {
 	if len(message) == 0 {
-		return "", "", ErrEmptyCommitMessage
+		return ErrEmptyCommitMessage
 	}
 	lines := strings.Split(message, "\n")
 
+	maxMessageCharacter := 72 - (len(c.Type) + len(c.Scope))
+	title := ""
+	body := ""
+
 	// If Title based on first line message is too long
 	// then split the message title into the body
-	if len(lines[0]) > 72 {
+	if len(lines[0]) > maxMessageCharacter {
 		line := lines[0]
-		title = line[0:69] + "..."
-		body = body + "... " + line[69:] + "\n"
+		title = line[0:(maxMessageCharacter-3)] + "..."
+		body = body + "... " + line[(maxMessageCharacter-3):] + "\n"
 
 	} else {
 		title = lines[0]
@@ -100,7 +95,18 @@ func ParseMessage(message string) (title, body string, err error) {
 	// Remove trailing \b so we can handle it from the go template
 	body = strings.TrimRight(body, "\n")
 
-	return title, body, nil
+	// Only set title if not already defined
+	// so we can specify its value from the updatecli configuration
+	if len(c.Title) == 0 {
+		c.Title = title
+	}
+	// Only set body if not already defined
+	// so we can specify its value from the updatecli configuration
+	if len(c.Body) == 0 {
+		c.Body = body
+	}
+
+	return nil
 }
 
 // Validate validates "conventional commit" default parameters.

--- a/pkg/plugins/git/commit/main.go
+++ b/pkg/plugins/git/commit/main.go
@@ -12,7 +12,7 @@ import (
 const (
 	commitTpl string = "{{ .Type}}{{if .Scope}}({{.Scope}}){{ end }}: {{ .Title }}" +
 		"{{ if .Body }}\n\n{{ .Body }}{{ end }}" +
-		"{{ if not .HideCredits }}\nMade with ❤️️ by updatecli{{end}}" +
+		"{{ if not .HideCredits }}\nMade with ❤️️  by updatecli{{end}}" +
 		"{{ if .Footers }}\n\n{{ .Footers }}{{ end }}"
 )
 

--- a/pkg/plugins/git/commit/main.go
+++ b/pkg/plugins/git/commit/main.go
@@ -12,7 +12,7 @@ import (
 const (
 	commitTpl string = "{{ .Type}}{{if .Scope}}({{.Scope}}){{ end }}: {{ .Title }}" +
 		"{{ if .Body }}\n\n{{ .Body }}{{ end }}" +
-		"{{ if not .HideCredits }}\n\nMade with ❤️️  by updatecli{{end}}" +
+		"{{ if not .HideCredit }}\n\nMade with ❤️️  by updatecli{{end}}" +
 		"{{ if .Footers }}\n\n{{ .Footers }}{{ end }}"
 )
 
@@ -25,12 +25,12 @@ var (
 // More information on what is conventional commits
 // -> https://www.conventionalcommits.org/en/v1.0.0/#summary
 type Commit struct {
-	Type        string // Define commit type, like chore, fix, etc
-	Scope       string // Define commit type scope
-	Footers     string // Define commit footer
-	Title       string // Define commit title
-	Body        string // Define commit body
-	HideCredits bool   // Display updatecli credits inside commit message body
+	Type       string // Define commit type, like chore, fix, etc
+	Scope      string // Define commit type scope
+	Footers    string // Define commit footer
+	Title      string // Define commit title
+	Body       string // Define commit body
+	HideCredit bool   // Display updatecli credits inside commit message body
 }
 
 // Generate generates the conventional commit

--- a/pkg/plugins/git/commit/main.go
+++ b/pkg/plugins/git/commit/main.go
@@ -1,0 +1,110 @@
+package commit
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"text/template"
+
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	commitTpl string = "{{ .Type}}{{if .Scope}}({{.Scope}}){{ end }}: {{ .Title }}" +
+		"{{ if .Body }}\n{{ .Body }}{{ end }}" +
+		"{{ if .Footers }}\n{{ .Footers }}\n{{ end }}"
+)
+
+var (
+	// ErrEmptyCommitMessage is returned when the commit message is empty
+	ErrEmptyCommitMessage error = errors.New("error: empty commmit messager")
+)
+
+// Commit contains conventionnal commit information
+// More information on what is conventionnal commits
+// -> https://www.conventionalcommits.org/en/v1.0.0/#summary
+type Commit struct {
+	Version string // Define conventionnalCommit version
+	Type    string // Define commit type, like chore, fix, etc
+	Scope   string // Define commit type scope
+	Footers string // Define commit footer
+	Title   string // Define commit title
+	Body    string // Define commit body
+}
+
+// Generate generates the conventionnal commit
+func (c Commit) Generate(raw string) (string, error) {
+
+	err := c.Validate()
+
+	if err != nil {
+		logrus.Errorf(err.Error())
+		return "", err
+	}
+
+	t := template.Must(template.New("commit").Parse(commitTpl))
+
+	title, body, err := ParseMessage(raw)
+
+	if err != nil {
+		logrus.Errorf(err.Error())
+		return "", err
+	}
+
+	if len(c.Title) == 0 {
+		c.Title = title
+	}
+
+	if len(c.Body) == 0 {
+		c.Body = body
+	}
+
+	buffer := new(bytes.Buffer)
+
+	err = t.Execute(buffer, c)
+
+	commitMessage := buffer.String()
+
+	if err != nil {
+		return "", err
+	}
+
+	return commitMessage, nil
+}
+
+// ParseMessage parses a message then return the commit message title and its body.
+// The message title can't be longer than 72 characters
+func ParseMessage(message string) (title, body string, err error) {
+	if len(message) == 0 {
+		return "", "", ErrEmptyCommitMessage
+	}
+	lines := strings.Split(message, "\n")
+
+	// If Title based on first line message is too long
+	// then split the message title into the body
+	if len(lines[0]) > 72 {
+		line := lines[0]
+		title = line[0:69] + "..."
+		body = body + "... " + line[69:] + "\n"
+
+	} else {
+		title = lines[0]
+	}
+
+	if len(lines) > 1 {
+		body = body + strings.Join(lines[1:], "\n")
+	}
+
+	return title, body, nil
+}
+
+// Validate validates "conventionnal commit" default parameters.
+func (c Commit) Validate() error {
+	if len(c.Type) == 0 {
+		c.Type = "chore"
+	}
+	if len(c.Scope) == 0 {
+		c.Scope = "deps"
+	}
+	return nil
+}

--- a/pkg/plugins/git/commit/main.go
+++ b/pkg/plugins/git/commit/main.go
@@ -12,6 +12,7 @@ import (
 const (
 	commitTpl string = "{{ .Type}}{{if .Scope}}({{.Scope}}){{ end }}: {{ .Title }}" +
 		"{{ if .Body }}\n\n{{ .Body }}{{ end }}" +
+		"{{ if not .HideCredits }}\nMade with ❤️️ by updatecli{{end}}" +
 		"{{ if .Footers }}\n\n{{ .Footers }}{{ end }}"
 )
 
@@ -24,12 +25,13 @@ var (
 // More information on what is conventional commits
 // -> https://www.conventionalcommits.org/en/v1.0.0/#summary
 type Commit struct {
-	Version string // Define conventionalCommit version
-	Type    string // Define commit type, like chore, fix, etc
-	Scope   string // Define commit type scope
-	Footers string // Define commit footer
-	Title   string // Define commit title
-	Body    string // Define commit body
+	Version     string // Define conventionalCommit version
+	Type        string // Define commit type, like chore, fix, etc
+	Scope       string // Define commit type scope
+	Footers     string // Define commit footer
+	Title       string // Define commit title
+	Body        string // Define commit body
+	HideCredits bool   // Display updatecli credits inside commit message body
 }
 
 // Generate generates the conventional commit

--- a/pkg/plugins/git/commit/main.go
+++ b/pkg/plugins/git/commit/main.go
@@ -11,8 +11,8 @@ import (
 
 const (
 	commitTpl string = "{{ .Type}}{{if .Scope}}({{.Scope}}){{ end }}: {{ .Title }}" +
-		"{{ if .Body }}\n{{ .Body }}{{ end }}" +
-		"{{ if .Footers }}\n{{ .Footers }}\n{{ end }}"
+		"{{ if .Body }}\n\n{{ .Body }}{{ end }}" +
+		"{{ if .Footers }}\n\n{{ .Footers }}{{ end }}"
 )
 
 var (
@@ -94,6 +94,9 @@ func ParseMessage(message string) (title, body string, err error) {
 	if len(lines) > 1 {
 		body = body + strings.Join(lines[1:], "\n")
 	}
+
+	// Remove trailing \b so we can handle it from the go template
+	body = strings.TrimRight(body, "\n")
 
 	return title, body, nil
 }

--- a/pkg/plugins/git/commit/main.go
+++ b/pkg/plugins/git/commit/main.go
@@ -20,11 +20,11 @@ var (
 	ErrEmptyCommitMessage error = errors.New("error: empty commmit messager")
 )
 
-// Commit contains conventionnal commit information
-// More information on what is conventionnal commits
+// Commit contains conventional commit information
+// More information on what is conventional commits
 // -> https://www.conventionalcommits.org/en/v1.0.0/#summary
 type Commit struct {
-	Version string // Define conventionnalCommit version
+	Version string // Define conventionalCommit version
 	Type    string // Define commit type, like chore, fix, etc
 	Scope   string // Define commit type scope
 	Footers string // Define commit footer
@@ -32,7 +32,7 @@ type Commit struct {
 	Body    string // Define commit body
 }
 
-// Generate generates the conventionnal commit
+// Generate generates the conventional commit
 func (c Commit) Generate(raw string) (string, error) {
 
 	err := c.Validate()
@@ -98,7 +98,7 @@ func ParseMessage(message string) (title, body string, err error) {
 	return title, body, nil
 }
 
-// Validate validates "conventionnal commit" default parameters.
+// Validate validates "conventional commit" default parameters.
 func (c Commit) Validate() error {
 	if len(c.Type) == 0 {
 		c.Type = "chore"

--- a/pkg/plugins/git/commit/main.go
+++ b/pkg/plugins/git/commit/main.go
@@ -33,7 +33,7 @@ type Commit struct {
 }
 
 // Generate generates the conventional commit
-func (c Commit) Generate(raw string) (string, error) {
+func (c *Commit) Generate(raw string) (string, error) {
 
 	err := c.Validate()
 
@@ -99,12 +99,10 @@ func ParseMessage(message string) (title, body string, err error) {
 }
 
 // Validate validates "conventional commit" default parameters.
-func (c Commit) Validate() error {
+func (c *Commit) Validate() error {
 	if len(c.Type) == 0 {
 		c.Type = "chore"
 	}
-	if len(c.Scope) == 0 {
-		c.Scope = "deps"
-	}
+
 	return nil
 }

--- a/pkg/plugins/git/commit/main_test.go
+++ b/pkg/plugins/git/commit/main_test.go
@@ -25,14 +25,14 @@ var (
 			ExpectedBody:   "",
 			ExpectedTitle:  "Bump updatecli version",
 			Commit: Commit{
-				Type:        "chore",
-				Scope:       "deps",
-				HideCredits: true,
+				Type:       "chore",
+				Scope:      "deps",
+				HideCredit: true,
 			},
 		},
 		{
 			Message:        "Bump updatecli version",
-			ExpectedOutput: "chore: Bump updatecli version\nMade with ❤️️ by updatecli",
+			ExpectedOutput: "chore: Bump updatecli version\n\nMade with ❤️️  by updatecli",
 			ExpectedError:  nil,
 			ExpectedBody:   "",
 			ExpectedTitle:  "Bump updatecli version",
@@ -45,8 +45,8 @@ var (
 			ExpectedBody:   "",
 			ExpectedTitle:  "Bump updatecli version",
 			Commit: Commit{
-				Type:        "chore",
-				HideCredits: true,
+				Type:       "chore",
+				HideCredit: true,
 			},
 		},
 		{
@@ -56,9 +56,9 @@ var (
 			ExpectedBody:   "",
 			ExpectedTitle:  "Bump updatecli version",
 			Commit: Commit{
-				Type:        "chore",
-				Footers:     "BREAKING CHANGE",
-				HideCredits: true,
+				Type:       "chore",
+				Footers:    "BREAKING CHANGE",
+				HideCredit: true,
 			},
 		},
 		{
@@ -68,9 +68,9 @@ var (
 			ExpectedBody:   "... aaaaaaaaaaa",
 			ExpectedTitle:  "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa...",
 			Commit: Commit{
-				Type:        "chore",
-				Footers:     "BREAKING CHANGE",
-				HideCredits: true,
+				Type:       "chore",
+				Footers:    "BREAKING CHANGE",
+				HideCredit: true,
 			},
 		},
 		{
@@ -80,8 +80,8 @@ var (
 			ExpectedBody:   "... aaaaaaaaaaa",
 			ExpectedTitle:  "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa...",
 			Commit: Commit{
-				Type:        "chore",
-				HideCredits: true,
+				Type:       "chore",
+				HideCredit: true,
 			},
 		},
 		{
@@ -91,8 +91,8 @@ var (
 			ExpectedBody:   "",
 			ExpectedTitle:  "",
 			Commit: Commit{
-				Type:        "chore",
-				HideCredits: true,
+				Type:       "chore",
+				HideCredit: true,
 			},
 		},
 	}

--- a/pkg/plugins/git/commit/main_test.go
+++ b/pkg/plugins/git/commit/main_test.go
@@ -29,13 +29,14 @@ var (
 			ExpectedOutput: "chore(deps): Bump updatecli version",
 			ExpectedError:  nil,
 			Commit: Commit{
-				Type:  "chore",
-				Scope: "deps",
+				Type:        "chore",
+				Scope:       "deps",
+				HideCredits: true,
 			},
 		},
 		{
 			Message:        "Bump updatecli version",
-			ExpectedOutput: "chore: Bump updatecli version",
+			ExpectedOutput: "chore: Bump updatecli version\nMade with ❤️️ by updatecli",
 			ExpectedError:  nil,
 			Commit:         Commit{},
 		},
@@ -44,7 +45,8 @@ var (
 			ExpectedOutput: "chore: Bump updatecli version",
 			ExpectedError:  nil,
 			Commit: Commit{
-				Type: "chore",
+				Type:        "chore",
+				HideCredits: true,
 			},
 		},
 		{
@@ -52,8 +54,9 @@ var (
 			ExpectedOutput: "chore: Bump updatecli version\n\nBREAKING CHANGE",
 			ExpectedError:  nil,
 			Commit: Commit{
-				Type:    "chore",
-				Footers: "BREAKING CHANGE",
+				Type:        "chore",
+				Footers:     "BREAKING CHANGE",
+				HideCredits: true,
 			},
 		},
 		{
@@ -61,8 +64,9 @@ var (
 			ExpectedOutput: "chore: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa...\n\n... aaaaaa\n\nBREAKING CHANGE",
 			ExpectedError:  nil,
 			Commit: Commit{
-				Type:    "chore",
-				Footers: "BREAKING CHANGE",
+				Type:        "chore",
+				Footers:     "BREAKING CHANGE",
+				HideCredits: true,
 			},
 		},
 		{
@@ -70,7 +74,8 @@ var (
 			ExpectedOutput: "chore: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa...\n\n... aaaaaa",
 			ExpectedError:  nil,
 			Commit: Commit{
-				Type: "chore",
+				Type:        "chore",
+				HideCredits: true,
 			},
 		},
 		{
@@ -78,7 +83,8 @@ var (
 			ExpectedOutput: "",
 			ExpectedError:  ErrEmptyCommitMessage,
 			Commit: Commit{
-				Type: "chore",
+				Type:        "chore",
+				HideCredits: true,
 			},
 		},
 	}

--- a/pkg/plugins/git/commit/main_test.go
+++ b/pkg/plugins/git/commit/main_test.go
@@ -6,20 +6,14 @@ import (
 )
 
 type DataSet []Data
-type MessageDataSet []MessageData
 
 type Data struct {
 	Message        string
 	ExpectedOutput string
 	ExpectedError  error
+	ExpectedTitle  string
+	ExpectedBody   string
 	Commit         Commit
-}
-
-type MessageData struct {
-	Message       string
-	ExpectedTitle string
-	ExpectedBody  string
-	ExpectedError error
 }
 
 var (
@@ -28,6 +22,8 @@ var (
 			Message:        "Bump updatecli version",
 			ExpectedOutput: "chore(deps): Bump updatecli version",
 			ExpectedError:  nil,
+			ExpectedBody:   "",
+			ExpectedTitle:  "Bump updatecli version",
 			Commit: Commit{
 				Type:        "chore",
 				Scope:       "deps",
@@ -38,12 +34,16 @@ var (
 			Message:        "Bump updatecli version",
 			ExpectedOutput: "chore: Bump updatecli version\nMade with ❤️️ by updatecli",
 			ExpectedError:  nil,
+			ExpectedBody:   "",
+			ExpectedTitle:  "Bump updatecli version",
 			Commit:         Commit{},
 		},
 		{
 			Message:        "Bump updatecli version",
 			ExpectedOutput: "chore: Bump updatecli version",
 			ExpectedError:  nil,
+			ExpectedBody:   "",
+			ExpectedTitle:  "Bump updatecli version",
 			Commit: Commit{
 				Type:        "chore",
 				HideCredits: true,
@@ -53,6 +53,8 @@ var (
 			Message:        "Bump updatecli version",
 			ExpectedOutput: "chore: Bump updatecli version\n\nBREAKING CHANGE",
 			ExpectedError:  nil,
+			ExpectedBody:   "",
+			ExpectedTitle:  "Bump updatecli version",
 			Commit: Commit{
 				Type:        "chore",
 				Footers:     "BREAKING CHANGE",
@@ -61,8 +63,10 @@ var (
 		},
 		{
 			Message:        strings.Repeat("a", 75),
-			ExpectedOutput: "chore: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa...\n\n... aaaaaa\n\nBREAKING CHANGE",
+			ExpectedOutput: "chore: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa...\n\n... aaaaaaaaaaa\n\nBREAKING CHANGE",
 			ExpectedError:  nil,
+			ExpectedBody:   "... aaaaaaaaaaa",
+			ExpectedTitle:  "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa...",
 			Commit: Commit{
 				Type:        "chore",
 				Footers:     "BREAKING CHANGE",
@@ -71,8 +75,10 @@ var (
 		},
 		{
 			Message:        strings.Repeat("a", 75),
-			ExpectedOutput: "chore: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa...\n\n... aaaaaa",
+			ExpectedOutput: "chore: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa...\n\n... aaaaaaaaaaa",
 			ExpectedError:  nil,
+			ExpectedBody:   "... aaaaaaaaaaa",
+			ExpectedTitle:  "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa...",
 			Commit: Commit{
 				Type:        "chore",
 				HideCredits: true,
@@ -82,42 +88,12 @@ var (
 			Message:        "",
 			ExpectedOutput: "",
 			ExpectedError:  ErrEmptyCommitMessage,
+			ExpectedBody:   "",
+			ExpectedTitle:  "",
 			Commit: Commit{
 				Type:        "chore",
 				HideCredits: true,
 			},
-		},
-	}
-	messagedataset = MessageDataSet{
-		{
-			Message:       "Bump updatecli version",
-			ExpectedTitle: "Bump updatecli version",
-			ExpectedBody:  "",
-			ExpectedError: nil,
-		},
-		{
-			Message:       strings.Repeat("a", 72),
-			ExpectedTitle: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-			ExpectedBody:  "",
-			ExpectedError: nil,
-		},
-		{
-			Message:       strings.Repeat("a", 75),
-			ExpectedTitle: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa...",
-			ExpectedBody:  "... aaaaaa",
-			ExpectedError: nil,
-		},
-		{
-			Message:       "Title\nBody",
-			ExpectedTitle: "Title",
-			ExpectedBody:  "Body",
-			ExpectedError: nil,
-		},
-		{
-			Message:       "",
-			ExpectedTitle: "",
-			ExpectedBody:  "",
-			ExpectedError: ErrEmptyCommitMessage,
 		},
 	}
 )
@@ -144,8 +120,8 @@ func TestCommit(t *testing.T) {
 
 func TestParseMessage(t *testing.T) {
 
-	for id, data := range messagedataset {
-		gotTitle, gotBody, err := ParseMessage(data.Message)
+	for id, data := range dataset {
+		err := data.Commit.ParseMessage(data.Message)
 
 		if err != nil && data.ExpectedError != nil {
 			if strings.Compare(err.Error(), data.ExpectedError.Error()) != 0 {
@@ -155,16 +131,16 @@ func TestParseMessage(t *testing.T) {
 			t.Errorf("Unexpected error %q for commit #%d", err, id)
 		}
 
-		if strings.Compare(data.ExpectedTitle, gotTitle) != 0 {
+		if strings.Compare(data.ExpectedTitle, data.Commit.Title) != 0 {
 			t.Errorf("Wrong Commit Title %d:\n\tGot:\t\t%q\n\tExpected:\t%q",
 				id,
-				gotTitle,
+				data.Commit.Title,
 				data.ExpectedTitle)
 		}
-		if strings.Compare(data.ExpectedBody, gotBody) != 0 {
+		if strings.Compare(data.ExpectedBody, data.Commit.Body) != 0 {
 			t.Errorf("Wrong Commit Body %d:\n\tGot:\t\t%q\n\tExpected:\t%q",
 				id,
-				gotBody,
+				data.Commit.Body,
 				data.ExpectedBody)
 		}
 	}

--- a/pkg/plugins/git/commit/main_test.go
+++ b/pkg/plugins/git/commit/main_test.go
@@ -37,6 +37,12 @@ var (
 			Message:        "Bump updatecli version",
 			ExpectedOutput: "chore: Bump updatecli version",
 			ExpectedError:  nil,
+			Commit:         Commit{},
+		},
+		{
+			Message:        "Bump updatecli version",
+			ExpectedOutput: "chore: Bump updatecli version",
+			ExpectedError:  nil,
 			Commit: Commit{
 				Type: "chore",
 			},

--- a/pkg/plugins/git/commit/main_test.go
+++ b/pkg/plugins/git/commit/main_test.go
@@ -49,7 +49,7 @@ var (
 		},
 		{
 			Message:        "Bump updatecli version",
-			ExpectedOutput: "chore: Bump updatecli version\nBREAKING CHANGE\n",
+			ExpectedOutput: "chore: Bump updatecli version\n\nBREAKING CHANGE",
 			ExpectedError:  nil,
 			Commit: Commit{
 				Type:    "chore",
@@ -58,7 +58,7 @@ var (
 		},
 		{
 			Message:        strings.Repeat("a", 75),
-			ExpectedOutput: "chore: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa...\n... aaaaaa\n\nBREAKING CHANGE\n",
+			ExpectedOutput: "chore: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa...\n\n... aaaaaa\n\nBREAKING CHANGE",
 			ExpectedError:  nil,
 			Commit: Commit{
 				Type:    "chore",
@@ -67,7 +67,7 @@ var (
 		},
 		{
 			Message:        strings.Repeat("a", 75),
-			ExpectedOutput: "chore: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa...\n... aaaaaa\n",
+			ExpectedOutput: "chore: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa...\n\n... aaaaaa",
 			ExpectedError:  nil,
 			Commit: Commit{
 				Type: "chore",
@@ -98,7 +98,7 @@ var (
 		{
 			Message:       strings.Repeat("a", 75),
 			ExpectedTitle: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa...",
-			ExpectedBody:  "... aaaaaa\n",
+			ExpectedBody:  "... aaaaaa",
 			ExpectedError: nil,
 		},
 		{

--- a/pkg/plugins/git/commit/main_test.go
+++ b/pkg/plugins/git/commit/main_test.go
@@ -1,0 +1,159 @@
+package commit
+
+import (
+	"strings"
+	"testing"
+)
+
+type DataSet []Data
+type MessageDataSet []MessageData
+
+type Data struct {
+	Message        string
+	ExpectedOutput string
+	ExpectedError  error
+	Commit         Commit
+}
+
+type MessageData struct {
+	Message       string
+	ExpectedTitle string
+	ExpectedBody  string
+	ExpectedError error
+}
+
+var (
+	dataset = DataSet{
+		{
+			Message:        "Bump updatecli version",
+			ExpectedOutput: "chore(deps): Bump updatecli version",
+			ExpectedError:  nil,
+			Commit: Commit{
+				Type:  "chore",
+				Scope: "deps",
+			},
+		},
+		{
+			Message:        "Bump updatecli version",
+			ExpectedOutput: "chore: Bump updatecli version",
+			ExpectedError:  nil,
+			Commit: Commit{
+				Type: "chore",
+			},
+		},
+		{
+			Message:        "Bump updatecli version",
+			ExpectedOutput: "chore: Bump updatecli version\nBREAKING CHANGE\n",
+			ExpectedError:  nil,
+			Commit: Commit{
+				Type:    "chore",
+				Footers: "BREAKING CHANGE",
+			},
+		},
+		{
+			Message:        strings.Repeat("a", 75),
+			ExpectedOutput: "chore: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa...\n... aaaaaa\n\nBREAKING CHANGE\n",
+			ExpectedError:  nil,
+			Commit: Commit{
+				Type:    "chore",
+				Footers: "BREAKING CHANGE",
+			},
+		},
+		{
+			Message:        strings.Repeat("a", 75),
+			ExpectedOutput: "chore: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa...\n... aaaaaa\n",
+			ExpectedError:  nil,
+			Commit: Commit{
+				Type: "chore",
+			},
+		},
+		{
+			Message:        "",
+			ExpectedOutput: "",
+			ExpectedError:  ErrEmptyCommitMessage,
+			Commit: Commit{
+				Type: "chore",
+			},
+		},
+	}
+	messagedataset = MessageDataSet{
+		{
+			Message:       "Bump updatecli version",
+			ExpectedTitle: "Bump updatecli version",
+			ExpectedBody:  "",
+			ExpectedError: nil,
+		},
+		{
+			Message:       strings.Repeat("a", 72),
+			ExpectedTitle: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			ExpectedBody:  "",
+			ExpectedError: nil,
+		},
+		{
+			Message:       strings.Repeat("a", 75),
+			ExpectedTitle: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa...",
+			ExpectedBody:  "... aaaaaa\n",
+			ExpectedError: nil,
+		},
+		{
+			Message:       "Title\nBody",
+			ExpectedTitle: "Title",
+			ExpectedBody:  "Body",
+			ExpectedError: nil,
+		},
+		{
+			Message:       "",
+			ExpectedTitle: "",
+			ExpectedBody:  "",
+			ExpectedError: ErrEmptyCommitMessage,
+		},
+	}
+)
+
+func TestCommit(t *testing.T) {
+
+	for id, data := range dataset {
+		got, err := data.Commit.Generate(data.Message)
+		if err != nil && data.ExpectedError != nil {
+			if strings.Compare(err.Error(), data.ExpectedError.Error()) != 0 {
+				t.Errorf("Wrong commit %d err:\n\tExpected:\t\t%v\n\tGot:\t\t%v\n", id, data.ExpectedError, err)
+			}
+		} else if err != nil {
+			t.Errorf("Unexpected error %q for commit #%d", err, id)
+		}
+		if strings.Compare(data.ExpectedOutput, got) != 0 {
+			t.Errorf("Wrong Commit Message %d:\n\tGot:\t\t%q\n\tExpected:\t%q",
+				id,
+				got,
+				data.ExpectedOutput)
+		}
+	}
+}
+
+func TestParseMessage(t *testing.T) {
+
+	for id, data := range messagedataset {
+		gotTitle, gotBody, err := ParseMessage(data.Message)
+
+		if err != nil && data.ExpectedError != nil {
+			if strings.Compare(err.Error(), data.ExpectedError.Error()) != 0 {
+				t.Errorf("Wrong commit %d err:\n\tExpected:\t\t%v\n\tGot:\t\t%v\n", id, data.ExpectedError, err)
+			}
+		} else if err != nil {
+			t.Errorf("Unexpected error %q for commit #%d", err, id)
+		}
+
+		if strings.Compare(data.ExpectedTitle, gotTitle) != 0 {
+			t.Errorf("Wrong Commit Title %d:\n\tGot:\t\t%q\n\tExpected:\t%q",
+				id,
+				gotTitle,
+				data.ExpectedTitle)
+		}
+		if strings.Compare(data.ExpectedBody, gotBody) != 0 {
+			t.Errorf("Wrong Commit Body %d:\n\tGot:\t\t%q\n\tExpected:\t%q",
+				id,
+				gotBody,
+				data.ExpectedBody)
+		}
+	}
+}

--- a/pkg/plugins/git/main.go
+++ b/pkg/plugins/git/main.go
@@ -22,8 +22,8 @@ type Git struct {
 	Email         string
 	Directory     string
 	Version       string
-	Force         bool // Force is used during the git push phase to run `git push --force`.
-	CommitMessage commit.Commit // CommitMessage contains conventionnal commit metadata as type or scope, used to generate the final commit message.
+	Force         bool          // Force is used during the git push phase to run `git push --force`.
+	CommitMessage commit.Commit // CommitMessage contains conventional commit metadata as type or scope, used to generate the final commit message.
 }
 
 func newDirectory(URL string) (string, error) {

--- a/pkg/plugins/git/main.go
+++ b/pkg/plugins/git/main.go
@@ -8,20 +8,22 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/olblak/updateCli/pkg/core/tmp"
+	"github.com/olblak/updateCli/pkg/plugins/git/commit"
 )
 
 // Git contains settings to manipulate a git repository.
 type Git struct {
-	URL          string
-	Username     string
-	Password     string
-	Branch       string
-	remoteBranch string
-	User         string
-	Email        string
-	Directory    string
-	Version      string
-	Force        bool // Force is used during the git push phase to run `git push --force`.
+	URL           string
+	Username      string
+	Password      string
+	Branch        string
+	remoteBranch  string
+	User          string
+	Email         string
+	Directory     string
+	Version       string
+	Force         bool // Force is used during the git push phase to run `git push --force`.
+	CommitMessage commit.Commit // CommitMessage contains conventionnal commit metadata as type or scope, used to generate the final commit message.
 }
 
 func newDirectory(URL string) (string, error) {

--- a/pkg/plugins/git/scm.go
+++ b/pkg/plugins/git/scm.go
@@ -75,7 +75,7 @@ func (g *Git) Clone() (string, error) {
 // Commit run `git commit`.
 func (g *Git) Commit(message string) error {
 
-	// Generate the conventionnal commit message
+	// Generate the conventional commit message
 	commitMessage, err := g.CommitMessage.Generate(message)
 	if err != nil {
 		return err

--- a/pkg/plugins/git/scm.go
+++ b/pkg/plugins/git/scm.go
@@ -74,10 +74,17 @@ func (g *Git) Clone() (string, error) {
 
 // Commit run `git commit`.
 func (g *Git) Commit(message string) error {
-	err := git.Commit(
+
+	// Generate the conventionnal commit message
+	commitMessage, err := g.CommitMessage.Generate(message)
+	if err != nil {
+		return err
+	}
+
+	err = git.Commit(
 		g.User,
 		g.Email,
-		message,
+		commitMessage,
 		g.GetDirectory())
 
 	if err != nil {

--- a/pkg/plugins/github/main.go
+++ b/pkg/plugins/github/main.go
@@ -32,8 +32,8 @@ type Github struct {
 	remoteBranch           string
 	User                   string
 	Email                  string
-    Force                  bool // Force is used during the git push phase to run `git push --force`.
-	CommitMessage          commit.Commit // CommitMessage represents conventionnal commit metadata as type or scope, used to generate the final commit message.
+	Force                  bool          // Force is used during the git push phase to run `git push --force`.
+	CommitMessage          commit.Commit // CommitMessage represents conventional commit metadata as type or scope, used to generate the final commit message.
 }
 
 // Check verifies if mandatory Github parameters are provided and return false if not.

--- a/pkg/plugins/github/main.go
+++ b/pkg/plugins/github/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/olblak/updateCli/pkg/core/tmp"
+	"github.com/olblak/updateCli/pkg/plugins/git/commit"
 	"github.com/olblak/updateCli/pkg/plugins/version"
 	"github.com/shurcooL/githubv4"
 	"golang.org/x/oauth2"
@@ -31,7 +32,8 @@ type Github struct {
 	remoteBranch           string
 	User                   string
 	Email                  string
-	Force                  bool // Force is used during the git push phase to run `git push --force`.
+    Force                  bool // Force is used during the git push phase to run `git push --force`.
+	CommitMessage          commit.Commit // CommitMessage represents conventionnal commit metadata as type or scope, used to generate the final commit message.
 }
 
 // Check verifies if mandatory Github parameters are provided and return false if not.

--- a/pkg/plugins/github/scm.go
+++ b/pkg/plugins/github/scm.go
@@ -66,7 +66,14 @@ func (g *Github) Clone() (string, error) {
 
 // Commit run `git commit`.
 func (g *Github) Commit(message string) error {
-	err := git.Commit(g.User, g.Email, message, g.GetDirectory())
+
+	// Generate the conventionnal commit message
+	commitMessage, err := g.CommitMessage.Generate(message)
+	if err != nil {
+		return err
+	}
+
+	err = git.Commit(g.User, g.Email, commitMessage, g.GetDirectory())
 	if err != nil {
 		return err
 	}

--- a/pkg/plugins/github/scm.go
+++ b/pkg/plugins/github/scm.go
@@ -67,7 +67,7 @@ func (g *Github) Clone() (string, error) {
 // Commit run `git commit`.
 func (g *Github) Commit(message string) error {
 
-	// Generate the conventionnal commit message
+	// Generate the conventional commit message
 	commitMessage, err := g.CommitMessage.Generate(message)
 	if err != nil {
 		return err

--- a/pkg/plugins/helm/chart/main_test.go
+++ b/pkg/plugins/helm/chart/main_test.go
@@ -55,10 +55,10 @@ func TestSource(t *testing.T) {
 	set := []dataSet{
 		{
 			chart: Chart{
-				URL:  "https://charts.jetstack.io",
-				Name: "tor-proxy",
+				URL:  "https://stenic.github.io/helm-charts",
+				Name: "proxy",
 			},
-			expected: "0.1.1",
+			expected: "1.0.3",
 		},
 		{
 			chart: Chart{

--- a/pkg/plugins/yaml/target.go
+++ b/pkg/plugins/yaml/target.go
@@ -172,11 +172,8 @@ func (y *Yaml) TargetFromSCM(source string, scm scm.Scm, dryRun bool) (changed b
 	}
 
 	files = append(files, y.File)
-	message = fmt.Sprintf("[updatecli] Key '%s', from file '%v', was updated from %s to '%s'",
-		y.Key,
-		y.File,
-		oldVersion,
-		y.Value)
+
+	message = fmt.Sprintf("Update key %q from file %q", y.Key, y.File)
 
 	return changed, files, message, nil
 }


### PR DESCRIPTION
Add Git conventional commit support to updatecli. 
It can now be used from the scm configuration within target definition as defined in the following example.

- [x] Documentation pull request

```
targets:
  imageTag:
    name: "jenkins/jenkins docker tag"
    kind: yaml
    spec:
      file: "charts/jenkins/values.yaml"
      key: "jenkins.controller.imageTag"
    scm:
      git:
        url: "git@github.com:olblak/charts.git"
        branch: master
        user: olblak
        email: me@olblak.com
        directory: "/home/olblak/Project/Jenkins-infra/charts"
        commitMessage:
          type: fix
          scope: deps
```

```
commitMessage:
  type:       // Specify commit type, default set to chore
  scope:    // Specify commit scope,  *Optional
  footer:     // Specify commit footer message *Optional
  title:        // Override default body message
  hideCredit: // Remove "Made with ❤️️  by updatecli" from commit message
  body:      // Override default body message
```

If no "commitMessage" is defined then the default behavior displays a commit message like 
```
Author: olblak <updatecli@updatecli.io>
Date:   Tue May 4 15:41:44 2021 +0200

    chore: Update key "dependencies[0].version" from file "charts/jenkins/r...
    
    ... equirements.yaml"
    
    Made with ❤️️  by updatecli
```
Signed-off-by: Olivier Vernin <olivier@vernin.me>