### PR TITLE
Allow '-' in git branch name

### DIFF
--- a/pkg/plugins/git/generic/main.go
+++ b/pkg/plugins/git/generic/main.go
@@ -382,7 +382,7 @@ func Push(username string, password string, workingDir string, force bool) error
 func SanitizeBranchName(branch string) string {
 
 	removedCharacter := []string{
-		":", "=", "+", "-", "$", "&", "#", "!", "@", "*", " ",
+		":", "=", "+", "$", "&", "#", "!", "@", "*", " ",
 	}
 
 	replacedByUnderscore := []string{


### PR DESCRIPTION
Allow '-' in git branch name as it's a valid branch name character
Signed-off-by: Olivier Vernin <olivier@vernin.me>