### PR TITLE
Update helm chart test

### DIFF
--- a/pkg/plugins/helm/chart/main_test.go
+++ b/pkg/plugins/helm/chart/main_test.go
@@ -55,10 +55,10 @@ func TestSource(t *testing.T) {
 	set := []dataSet{
 		{
 			chart: Chart{
-				URL:  "https://charts.jetstack.io",
-				Name: "tor-proxy",
+				URL:  "https://stenic.github.io/helm-charts",
+				Name: "proxy",
 			},
-			expected: "0.1.1",
+			expected: "1.0.3",
 		},
 		{
 			chart: Chart{


### PR DESCRIPTION
It appears that tor-proxy has been totally removed, I am just how long this new test will work
Signed-off-by: Olivier Vernin <olivier@vernin.me>