### PR TITLE
Fix path when updating files from a git repository

### DIFF
--- a/pkg/plugins/file/target.go
+++ b/pkg/plugins/file/target.go
@@ -2,6 +2,7 @@ package file
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/sirupsen/logrus"
@@ -115,7 +116,7 @@ func (f *File) TargetFromSCM(source string, scm scm.Scm, dryRun bool) (changed b
 
 	if !dryRun {
 
-		err := WriteToFile(f.Content, f.File)
+		err := WriteToFile(f.Content, filepath.Join(scm.GetDirectory(), f.File))
 		if err != nil {
 			return false, files, message, err
 		}


### PR DESCRIPTION
Signed-off-by: Olivier Vernin <olivier@vernin.me>

# Fix path when committing file

When updating a file from a git repository, we were writing the new content to the wrong location 

## Test
To test this pull request, you can run the following commands:

```
  # Run from this directory 
  `go build -o bin/updatecli`
  # Using the updatecli configuration from [jenkins-infra/status](https://github.com/jenkins-infra/status)
  <from local updatecli>/bin/updatecli apply --config updatecli/updatecli.d --values updatecli/values.yaml  --push=false --debug --clean=false
   # Now double check the directory /tmp/updatecli/jenkins-infra/status/ contains the right commit  content
```

## Additionnal Information
### Tradeoff

/

### Potential improvement

/
