### PR TITLE
Add a new resource of type "shell"

### DIFF
--- a/examples/updateCli.generic/shell/condition.sh
+++ b/examples/updateCli.generic/shell/condition.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -eux -o pipefail
+
+# Test if the command grep is present
+command -v grep

--- a/examples/updateCli.generic/shell/shell.yaml
+++ b/examples/updateCli.generic/shell/shell.yaml
@@ -3,16 +3,16 @@ sources:
   default:
     kind: shell
     spec:
-      command: "bash -x ./examples/updateCli.generic/shell/source.sh"
+      command: "./examples/updateCli.generic/shell/source.sh"
 conditions:
   default:
     kind: shell
     spec:
-      command: "bash -x ./examples/updateCli.generic/shell/condition.sh"
+      command: "./examples/updateCli.generic/shell/condition.sh"
 targets:
   default:
     name: setGrepVersion
     sourceID: default
     kind: shell
     spec:
-      command: "bash -x ./examples/updateCli.generic/shell/target.sh"
+      command: "./examples/updateCli.generic/shell/target.sh"

--- a/examples/updateCli.generic/shell/shell.yaml
+++ b/examples/updateCli.generic/shell/shell.yaml
@@ -1,0 +1,18 @@
+---
+sources:
+  default:
+    kind: shell
+    spec:
+      command: "bash -x ./examples/updateCli.generic/shell/source.sh"
+conditions:
+  default:
+    kind: shell
+    spec:
+      command: "bash -x ./examples/updateCli.generic/shell/condition.sh"
+targets:
+  default:
+    name: setGrepVersion
+    sourceID: default
+    kind: shell
+    spec:
+      command: "bash -x ./examples/updateCli.generic/shell/target.sh"

--- a/examples/updateCli.generic/shell/source.sh
+++ b/examples/updateCli.generic/shell/source.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -eux -o pipefail
+
+## Prints the version of grep
+# Can be '2.5.1-FreeBSD' (macOS) or '3.4' (Ubuntu 20.04) for instance
+grep --version 2>&1 | head -n1 | awk '{print $4}'

--- a/examples/updateCli.generic/shell/target.sh
+++ b/examples/updateCli.generic/shell/target.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -eux -o pipefail
+
+## This script outputs the provided argument only if DRY_RUN is "true"
+if [[ "${DRY_RUN:-true}" == false ]]
+then
+  echo "$1"
+fi

--- a/pkg/core/engine/condition/main.go
+++ b/pkg/core/engine/condition/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/updatecli/updatecli/pkg/plugins/helm/chart"
 	"github.com/updatecli/updatecli/pkg/plugins/jenkins"
 	"github.com/updatecli/updatecli/pkg/plugins/maven"
+	"github.com/updatecli/updatecli/pkg/plugins/shell"
 	"github.com/updatecli/updatecli/pkg/plugins/yaml"
 )
 
@@ -182,6 +183,16 @@ func Unmarshal(condition *Condition) (spec Spec, err error) {
 		}
 
 		spec = &y
+
+	case "shell":
+		shellResourceSpec := shell.ShellSpec{}
+
+		err := mapstructure.Decode(condition.Spec, &shellResourceSpec)
+		if err != nil {
+			return nil, err
+		}
+
+		spec = shell.New(shellResourceSpec)
 
 	default:
 		return nil, fmt.Errorf("Don't support condition: %v", condition.Kind)

--- a/pkg/core/engine/condition/main.go
+++ b/pkg/core/engine/condition/main.go
@@ -187,8 +187,7 @@ func Unmarshal(condition *Condition) (spec Spec, err error) {
 	case "shell":
 		shellResourceSpec := shell.ShellSpec{}
 
-		err := mapstructure.Decode(condition.Spec, &shellResourceSpec)
-		if err != nil {
+		if err := mapstructure.Decode(condition.Spec, &shellResourceSpec); err != nil {
 			return nil, err
 		}
 

--- a/pkg/core/engine/condition/main.go
+++ b/pkg/core/engine/condition/main.go
@@ -185,7 +185,7 @@ func Unmarshal(condition *Condition) (spec Spec, err error) {
 		spec = &y
 
 	case "shell":
-		shellResourceSpec := shell.ShellSpec{}
+		var shellResourceSpec shell.ShellSpec
 
 		if err := mapstructure.Decode(condition.Spec, &shellResourceSpec); err != nil {
 			return nil, err

--- a/pkg/core/engine/condition/main.go
+++ b/pkg/core/engine/condition/main.go
@@ -191,7 +191,10 @@ func Unmarshal(condition *Condition) (spec Spec, err error) {
 			return nil, err
 		}
 
-		spec = shell.New(shellResourceSpec)
+		spec, err = shell.New(shellResourceSpec)
+		if err != nil {
+			return nil, err
+		}
 
 	default:
 		return nil, fmt.Errorf("Don't support condition: %v", condition.Kind)

--- a/pkg/core/engine/source/main.go
+++ b/pkg/core/engine/source/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/updatecli/updatecli/pkg/plugins/helm/chart"
 	"github.com/updatecli/updatecli/pkg/plugins/jenkins"
 	"github.com/updatecli/updatecli/pkg/plugins/maven"
+	"github.com/updatecli/updatecli/pkg/plugins/shell"
 	"github.com/updatecli/updatecli/pkg/plugins/yaml"
 )
 
@@ -232,6 +233,16 @@ func (s *Source) Unmarshal() (spec Spec, changelog Changelog, err error) {
 		}
 
 		spec = &y
+
+	case "shell":
+		shellResourceSpec := shell.ShellSpec{}
+
+		err := mapstructure.Decode(s.Spec, &shellResourceSpec)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		spec = shell.New(shellResourceSpec)
 
 	default:
 		return nil, nil, fmt.Errorf("⚠ Don't support source kind: %v", s.Kind)

--- a/pkg/core/engine/source/main.go
+++ b/pkg/core/engine/source/main.go
@@ -242,7 +242,10 @@ func (s *Source) Unmarshal() (spec Spec, changelog Changelog, err error) {
 			return nil, nil, err
 		}
 
-		spec = shell.New(shellResourceSpec)
+		spec, err = shell.New(shellResourceSpec)
+		if err != nil {
+			return nil, nil, err
+		}
 
 	default:
 		return nil, nil, fmt.Errorf("⚠ Don't support source kind: %v", s.Kind)

--- a/pkg/core/engine/target/main.go
+++ b/pkg/core/engine/target/main.go
@@ -124,7 +124,10 @@ func Unmarshal(target *Target) (spec Spec, err error) {
 			return nil, err
 		}
 
-		spec = shell.New(shellResourceSpec)
+		spec, err = shell.New(shellResourceSpec)
+		if err != nil {
+			return nil, err
+		}
 
 	default:
 		return nil, fmt.Errorf("⚠ Don't support target kind: %v", target.Kind)

--- a/pkg/core/engine/target/main.go
+++ b/pkg/core/engine/target/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/updatecli/updatecli/pkg/plugins/file"
 	"github.com/updatecli/updatecli/pkg/plugins/git/tag"
 	"github.com/updatecli/updatecli/pkg/plugins/helm/chart"
+	"github.com/updatecli/updatecli/pkg/plugins/shell"
 	"github.com/updatecli/updatecli/pkg/plugins/yaml"
 )
 
@@ -114,6 +115,16 @@ func Unmarshal(target *Target) (spec Spec, err error) {
 		}
 
 		spec = &f
+
+	case "shell":
+		shellResourceSpec := shell.ShellSpec{}
+
+		err := mapstructure.Decode(target.Spec, &shellResourceSpec)
+		if err != nil {
+			return nil, err
+		}
+
+		spec = shell.New(shellResourceSpec)
 
 	default:
 		return nil, fmt.Errorf("⚠ Don't support target kind: %v", target.Kind)

--- a/pkg/plugins/shell/command.go
+++ b/pkg/plugins/shell/command.go
@@ -27,7 +27,7 @@ type commandExecutor interface {
 type nativeCommandExecutor struct {}
 
 func (nce *nativeCommandExecutor) ExecuteCommand(inputCmd command) (commandResult, error) {
-	if inputCmd.Cmd == "" {
+	if strings.TrimSpace(inputCmd.Cmd) == "" {
 		return commandResult{}, fmt.Errorf(ErrEmptyCommand)
 	}
 

--- a/pkg/plugins/shell/command.go
+++ b/pkg/plugins/shell/command.go
@@ -3,7 +3,6 @@ package shell
 import (
 	"bytes"
 	"errors"
-	"fmt"
 	"os/exec"
 	"strings"
 )
@@ -24,13 +23,9 @@ type commandExecutor interface {
 	ExecuteCommand(cmd command) (commandResult, error)
 }
 
-type nativeCommandExecutor struct {}
+type nativeCommandExecutor struct{}
 
 func (nce *nativeCommandExecutor) ExecuteCommand(inputCmd command) (commandResult, error) {
-	if strings.TrimSpace(inputCmd.Cmd) == "" {
-		return commandResult{}, fmt.Errorf(ErrEmptyCommand)
-	}
-
 	var stdout, stderr bytes.Buffer
 	cmdFields := strings.Fields(inputCmd.Cmd)
 	command := exec.Command(cmdFields[0], cmdFields[1:]...) //nolint: gosec

--- a/pkg/plugins/shell/command.go
+++ b/pkg/plugins/shell/command.go
@@ -34,9 +34,7 @@ func (nce *nativeCommandExecutor) ExecuteCommand(inputCmd command) (commandResul
 	var stdout, stderr bytes.Buffer
 	cmdFields := strings.Fields(inputCmd.Cmd)
 	command := exec.Command(cmdFields[0], cmdFields[1:]...) //nolint: gosec
-	if inputCmd.Dir != "" {
-		command.Dir = inputCmd.Dir
-	}
+	command.Dir = inputCmd.Dir
 	command.Stdout = &stdout
 	command.Stderr = &stderr
 	// Pass current environment to process and append the customized environment variables used internally by updatecli (such as DRY_RUN)
@@ -63,5 +61,4 @@ func (nce *nativeCommandExecutor) ExecuteCommand(inputCmd command) (commandResul
 		Stdout:   out,
 		Stderr:   stderr.String(),
 	}, nil
-
 }

--- a/pkg/plugins/shell/command.go
+++ b/pkg/plugins/shell/command.go
@@ -1,0 +1,68 @@
+package shell
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+type command struct {
+	Cmd string
+	Dir string
+	Env []string
+}
+
+type commandResult struct {
+	ExitCode int
+	Stdout   string
+	Stderr   string
+}
+
+type commandExecutor interface {
+	ExecuteCommand(cmd command) (commandResult, error)
+}
+
+type nativeCommandExecutor struct {
+}
+
+func (nce *nativeCommandExecutor) ExecuteCommand(inputCmd command) (commandResult, error) {
+	if inputCmd.Cmd == "" {
+		return commandResult{}, fmt.Errorf(ErrEmptyCommand)
+	}
+
+	var stdout, stderr bytes.Buffer
+	cmdFields := strings.Fields(inputCmd.Cmd)
+	command := exec.Command(cmdFields[0], cmdFields[1:]...) //nolint: gosec
+	if inputCmd.Dir != "" {
+		command.Dir = inputCmd.Dir
+	}
+	command.Stdout = &stdout
+	command.Stderr = &stderr
+	// Pass current environment to process and append the customized environment variables used internally by updatecli (such as DRY_RUN)
+	command.Env = append(command.Env, inputCmd.Env...)
+	err := command.Run()
+
+	// Remove line returns from stdout
+	out := strings.TrimSuffix(stdout.String(), "\n")
+
+	var ee *exec.ExitError
+	if errors.As(err, &ee) {
+		return commandResult{
+			ExitCode: ee.ExitCode(),
+			Stdout:   out,
+			Stderr:   stderr.String(),
+		}, nil
+	}
+	if err != nil {
+		return commandResult{}, err
+	}
+
+	return commandResult{
+		ExitCode: 0,
+		Stdout:   out,
+		Stderr:   stderr.String(),
+	}, nil
+
+}

--- a/pkg/plugins/shell/command.go
+++ b/pkg/plugins/shell/command.go
@@ -24,8 +24,7 @@ type commandExecutor interface {
 	ExecuteCommand(cmd command) (commandResult, error)
 }
 
-type nativeCommandExecutor struct {
-}
+type nativeCommandExecutor struct {}
 
 func (nce *nativeCommandExecutor) ExecuteCommand(inputCmd command) (commandResult, error) {
 	if inputCmd.Cmd == "" {

--- a/pkg/plugins/shell/command_test.go
+++ b/pkg/plugins/shell/command_test.go
@@ -69,9 +69,7 @@ func TestNativeCommandExecutor_ExecuteCommand(t *testing.T) {
 			require.NoError(t, err)
 
 			assert.Equal(t, tt.wantExitCode, got.ExitCode)
-
 			assert.Equal(t, tt.wantStdout, got.Stdout)
-
 			assert.Equal(t, tt.wandStderr, got.Stderr)
 		})
 	}

--- a/pkg/plugins/shell/command_test.go
+++ b/pkg/plugins/shell/command_test.go
@@ -1,0 +1,78 @@
+package shell
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNativeCommandExecutor_ExecuteCommand(t *testing.T) {
+	var sut nativeCommandExecutor
+	tests := []struct {
+		name         string
+		cmd          command
+		wantExitCode int
+		wantStdout   string
+		wandStderr   string
+		wantErr      bool
+	}{
+		{
+			name: "Runs command with exit code 0",
+			cmd: command{
+				Cmd: "echo Hello",
+			},
+			wantExitCode: 0,
+			wantStdout:   "Hello",
+		},
+		{
+			name: "Runs command with exit code 1",
+			cmd: command{
+				Cmd: "false",
+			},
+			wantExitCode: 1,
+		},
+		{
+			name: "Runs command with exit code 0 in a custom directory",
+			cmd: command{
+				Cmd: "pwd",
+				// This directory should exist as we do not mock here. Avoid /tmp as it can be a link to another location
+				Dir: "/",
+			},
+			wantExitCode: 0,
+			wantStdout:   "/",
+		},
+		{
+			name: "Runs command with exit code 0 in a non existing directory",
+			cmd: command{
+				Cmd: "pwd",
+				Dir: "/toto",
+			},
+			wantErr: true,
+		},
+		{
+			name: "Runs empty command",
+			cmd: command{
+				Cmd: "",
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := sut.ExecuteCommand(tt.cmd)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.wantExitCode, got.ExitCode)
+
+			assert.Equal(t, tt.wantStdout, got.Stdout)
+
+			assert.Equal(t, tt.wandStderr, got.Stderr)
+		})
+	}
+}

--- a/pkg/plugins/shell/command_test.go
+++ b/pkg/plugins/shell/command_test.go
@@ -50,13 +50,6 @@ func TestNativeCommandExecutor_ExecuteCommand(t *testing.T) {
 			},
 			wantErr: true,
 		},
-		{
-			name: "Runs empty command",
-			cmd: command{
-				Cmd: "",
-			},
-			wantErr: true,
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/plugins/shell/condition.go
+++ b/pkg/plugins/shell/condition.go
@@ -17,10 +17,8 @@ func (s *Shell) ConditionFromSCM(source string, scm scm.Scm) (bool, error) {
 }
 
 func (s *Shell) condition(source, workingDir string) (bool, error) {
-	customCommand := s.customCommand(source)
-
 	cmdResult, err := s.executor.ExecuteCommand(command{
-		Cmd: s.customCommand(source),
+		Cmd: s.appendSource(source),
 		Dir: workingDir,
 	})
 
@@ -29,11 +27,11 @@ func (s *Shell) condition(source, workingDir string) (bool, error) {
 	}
 
 	if cmdResult.ExitCode != 0 {
-		logrus.Infof(errorMessage(cmdResult.ExitCode, customCommand, cmdResult.Stderr, cmdResult.Stdout))
+		logrus.Infof(errorMessage(cmdResult.ExitCode, s.appendSource(source), cmdResult.Stderr, cmdResult.Stdout))
 		return false, nil
 	}
 
-	logrus.Infof("%v The shell 🐚 command %q successfully validated the condition.", result.SUCCESS, customCommand)
+	logrus.Infof("%v The shell 🐚 command %q successfully validated the condition.", result.SUCCESS, s.appendSource(source))
 
 	return true, nil
 }

--- a/pkg/plugins/shell/condition.go
+++ b/pkg/plugins/shell/condition.go
@@ -20,7 +20,7 @@ func (s *Shell) condition(source, workingDir string) (bool, error) {
 	customCommand := s.customCommand(source)
 
 	cmdResult, err := s.executor.ExecuteCommand(command{
-		Cmd: customCommand,
+		Cmd: s.customCommand(source),
 		Dir: workingDir,
 	})
 

--- a/pkg/plugins/shell/condition.go
+++ b/pkg/plugins/shell/condition.go
@@ -1,8 +1,6 @@
 package shell
 
 import (
-	"fmt"
-
 	"github.com/sirupsen/logrus"
 	"github.com/updatecli/updatecli/pkg/core/result"
 	"github.com/updatecli/updatecli/pkg/core/scm"
@@ -20,9 +18,8 @@ func (s *Shell) ConditionFromSCM(source string, scm scm.Scm) (bool, error) {
 
 func (s *Shell) condition(source, workingDir string) (bool, error) {
 	customCommand := s.spec.Command
-	if customCommand == "" {
-		return false, fmt.Errorf(ErrEmptyCommand)
-	}
+
+	// Append the source as last argument if not empty
 	if source != "" {
 		customCommand += " " + source
 	}

--- a/pkg/plugins/shell/condition.go
+++ b/pkg/plugins/shell/condition.go
@@ -17,12 +17,8 @@ func (s *Shell) ConditionFromSCM(source string, scm scm.Scm) (bool, error) {
 }
 
 func (s *Shell) condition(source, workingDir string) (bool, error) {
-	customCommand := s.spec.Command
+	customCommand := s.customCommand(source)
 
-	// Append the source as last argument if not empty
-	if source != "" {
-		customCommand += " " + source
-	}
 	cmdResult, err := s.executor.ExecuteCommand(command{
 		Cmd: customCommand,
 		Dir: workingDir,

--- a/pkg/plugins/shell/condition.go
+++ b/pkg/plugins/shell/condition.go
@@ -36,7 +36,7 @@ func (s *Shell) condition(source, workingDir string) (bool, error) {
 	}
 
 	if cmdResult.ExitCode != 0 {
-		logrus.Infof("%v The shell 🐚 command %q failed to validate the condition:\nexit code was %q\nstderr=\n%v\nstdout=\n%v\n.", result.FAILURE, customCommand, cmdResult.ExitCode, cmdResult.Stderr, cmdResult.Stdout)
+		logrus.Infof(errorMessage(cmdResult.ExitCode, customCommand, cmdResult.Stderr, cmdResult.Stdout))
 		return false, nil
 	}
 

--- a/pkg/plugins/shell/condition_test.go
+++ b/pkg/plugins/shell/condition_test.go
@@ -41,20 +41,6 @@ func TestShell_Condition(t *testing.T) {
 				Stderr:   "ls: 1.2.3: No such file or directory",
 			},
 		},
-		{
-			name:       "Empty command with empty source",
-			command:    "",
-			source:     "",
-			wantResult: false,
-			wantErr:    true,
-		},
-		{
-			name:       "Empty command with non empty source",
-			command:    "",
-			source:     "1.2.3",
-			wantResult: false,
-			wantErr:    true,
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -107,14 +93,6 @@ func TestShell_ConditionFromSCM(t *testing.T) {
 				ExitCode: 0,
 				Stdout:   "Hello",
 			},
-		},
-		{
-			name:       "Empty command with non empty source in existing SCM",
-			command:    "",
-			source:     "1.2.3",
-			scmDir:     "/dummy/dir",
-			wantResult: false,
-			wantErr:    true,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/plugins/shell/condition_test.go
+++ b/pkg/plugins/shell/condition_test.go
@@ -1,0 +1,163 @@
+package shell
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestShell_Condition(t *testing.T) {
+	tests := []struct {
+		name          string
+		command       string
+		source        string
+		wantResult    bool
+		wantErr       bool
+		wantCommand   string
+		commandResult commandResult
+	}{
+		{
+			name:        "Successful Condition",
+			command:     "echo Hello",
+			source:      "1.2.3",
+			wantResult:  true,
+			wantErr:     false,
+			wantCommand: "echo Hello 1.2.3",
+			commandResult: commandResult{
+				ExitCode: 0,
+				Stdout:   "Hello",
+			},
+		},
+		{
+			name:        "Failed Condition",
+			command:     "ls",
+			source:      "1.2.3",
+			wantResult:  false,
+			wantErr:     false,
+			wantCommand: "ls 1.2.3",
+			commandResult: commandResult{
+				ExitCode: 1,
+				Stderr:   "ls: 1.2.3: No such file or directory",
+			},
+		},
+		{
+			name:       "Empty command with empty source",
+			command:    "",
+			source:     "",
+			wantResult: false,
+			wantErr:    true,
+		},
+		{
+			name:       "Empty command with non empty source",
+			command:    "",
+			source:     "1.2.3",
+			wantResult: false,
+			wantErr:    true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := mockCommandExecutor{
+				result: tt.commandResult,
+			}
+			s := Shell{
+				executor: &mock,
+				spec: ShellSpec{
+					Command: tt.command,
+				},
+			}
+
+			gotResult, err := s.Condition(tt.source)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.False(t, gotResult)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantResult, gotResult)
+
+			assert.Equal(t, tt.wantCommand, mock.gotCommand.Cmd)
+		})
+	}
+}
+
+func TestShell_ConditionFromSCM(t *testing.T) {
+	tests := []struct {
+		name          string
+		command       string
+		source        string
+		scmDir        string
+		wantResult    bool
+		wantErr       bool
+		wantCommand   string
+		commandResult commandResult
+	}{
+		{
+			name:        "Successful Condition in existing SCM",
+			command:     "echo Hello",
+			source:      "1.2.3",
+			scmDir:      "/dummy/dir",
+			wantResult:  true,
+			wantErr:     false,
+			wantCommand: "echo Hello 1.2.3",
+			commandResult: commandResult{
+				ExitCode: 0,
+				Stdout:   "Hello",
+			},
+		},
+		{
+			name:        "Failed Condition in existing SCM",
+			command:     "ls",
+			source:      "1.2.3",
+			scmDir:      "/dummy/dir",
+			wantResult:  false,
+			wantErr:     false,
+			wantCommand: "ls 1.2.3",
+			commandResult: commandResult{
+				ExitCode: 1,
+				Stderr:   "ls: 1.2.3: No such file or directory",
+			},
+		},
+		{
+			name:       "Empty command with non empty source in existing SCM",
+			command:    "",
+			source:     "1.2.3",
+			scmDir:     "/dummy/dir",
+			wantResult: false,
+			wantErr:    true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mce := mockCommandExecutor{
+				result: tt.commandResult,
+			}
+			ms := mockScm{
+				workingDir: tt.scmDir,
+			}
+			s := Shell{
+				executor: &mce,
+				spec: ShellSpec{
+					Command: tt.command,
+				},
+			}
+
+			gotResult, err := s.ConditionFromSCM(tt.source, &ms)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.False(t, gotResult)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantResult, gotResult)
+
+			assert.Equal(t, tt.wantCommand, mce.gotCommand.Cmd)
+			assert.Equal(t, tt.scmDir, mce.gotCommand.Dir)
+		})
+	}
+}

--- a/pkg/plugins/shell/condition_test.go
+++ b/pkg/plugins/shell/condition_test.go
@@ -109,19 +109,6 @@ func TestShell_ConditionFromSCM(t *testing.T) {
 			},
 		},
 		{
-			name:        "Failed Condition in existing SCM",
-			command:     "ls",
-			source:      "1.2.3",
-			scmDir:      "/dummy/dir",
-			wantResult:  false,
-			wantErr:     false,
-			wantCommand: "ls 1.2.3",
-			commandResult: commandResult{
-				ExitCode: 1,
-				Stderr:   "ls: 1.2.3: No such file or directory",
-			},
-		},
-		{
 			name:       "Empty command with non empty source in existing SCM",
 			command:    "",
 			source:     "1.2.3",

--- a/pkg/plugins/shell/errors.go
+++ b/pkg/plugins/shell/errors.go
@@ -1,6 +1,26 @@
 package shell
 
+import (
+	"fmt"
+)
+
 const (
 	//ErrEmptyCommand is the error message when the provided command is empty
 	ErrEmptyCommand string = "command is empty"
 )
+
+// executionFailedError is used to help formatting errors reported to the user
+type executionFailedError struct {
+	ErrCode int
+	Stdout  string
+	Stderr  string
+	Command string
+}
+
+func (e *executionFailedError) Error() string {
+	return errorMessage(e.ErrCode, e.Command, e.Stderr, e.Stdout)
+}
+
+func errorMessage(exitCode int, command, stdout, stderr string) string {
+	return fmt.Sprintf("The shell 🐚 command %q failed with an exit code of %v and the following messages: \nstderr=\n%v\nstdout=\n%v\n", command, exitCode, stderr, stdout)
+}

--- a/pkg/plugins/shell/errors.go
+++ b/pkg/plugins/shell/errors.go
@@ -7,7 +7,7 @@ import (
 type ErrEmptyCommand struct{}
 
 func (e *ErrEmptyCommand) Error() string {
-	return fmt.Sprintf("Invalid spec for shell resource: command is empty.")
+	return "Invalid spec for shell resource: command is empty."
 }
 
 // executionFailedError is used to help formatting errors reported to the user

--- a/pkg/plugins/shell/errors.go
+++ b/pkg/plugins/shell/errors.go
@@ -1,0 +1,6 @@
+package shell
+
+const (
+	//ErrEmptyCommand is the error message when the provided command is empty
+	ErrEmptyCommand string = "command is empty"
+)

--- a/pkg/plugins/shell/errors.go
+++ b/pkg/plugins/shell/errors.go
@@ -4,10 +4,11 @@ import (
 	"fmt"
 )
 
-const (
-	//ErrEmptyCommand is the error message when the provided command is empty
-	ErrEmptyCommand string = "command is empty"
-)
+type ErrEmptyCommand struct{}
+
+func (e *ErrEmptyCommand) Error() string {
+	return fmt.Sprintf("Invalid spec for shell resource: command is empty.")
+}
 
 // executionFailedError is used to help formatting errors reported to the user
 type executionFailedError struct {

--- a/pkg/plugins/shell/main.go
+++ b/pkg/plugins/shell/main.go
@@ -9,6 +9,8 @@ type Shell struct {
 	spec     ShellSpec
 }
 
+// New returns a reference to a newly initialized Shell object from a shellspec
+// or an error if the provided shellspec triggers a validation error.
 func New(spec ShellSpec) (*Shell, error) {
 	if spec.Command == "" {
 		return nil, &ErrEmptyCommand{}
@@ -19,7 +21,7 @@ func New(spec ShellSpec) (*Shell, error) {
 	}, nil
 }
 
-// Append the source as last argument if not empty. 
+// appendSource appends the source as last argument if not empty.
 func (s *Shell) appendSource(source string) string {
 	// Append the source as last argument if not empty
 	if source != "" {

--- a/pkg/plugins/shell/main.go
+++ b/pkg/plugins/shell/main.go
@@ -19,7 +19,8 @@ func New(spec ShellSpec) (*Shell, error) {
 	}, nil
 }
 
-func (s *Shell) customCommand(source string) string {
+// Append the source as last argument if not empty. 
+func (s *Shell) appendSource(source string) string {
 	// Append the source as last argument if not empty
 	if source != "" {
 		return s.spec.Command + " " + source

--- a/pkg/plugins/shell/main.go
+++ b/pkg/plugins/shell/main.go
@@ -1,0 +1,17 @@
+package shell
+
+type ShellSpec struct {
+	Command string
+}
+
+type Shell struct {
+	executor commandExecutor
+	spec     ShellSpec
+}
+
+func New(spec ShellSpec) *Shell {
+	return &Shell{
+		executor: &nativeCommandExecutor{},
+		spec:     spec,
+	}
+}

--- a/pkg/plugins/shell/main.go
+++ b/pkg/plugins/shell/main.go
@@ -9,9 +9,12 @@ type Shell struct {
 	spec     ShellSpec
 }
 
-func New(spec ShellSpec) *Shell {
+func New(spec ShellSpec) (*Shell, error) {
+	if spec.Command == "" {
+		return nil, &ErrEmptyCommand{}
+	}
 	return &Shell{
 		executor: &nativeCommandExecutor{},
 		spec:     spec,
-	}
+	}, nil
 }

--- a/pkg/plugins/shell/main.go
+++ b/pkg/plugins/shell/main.go
@@ -18,3 +18,12 @@ func New(spec ShellSpec) (*Shell, error) {
 		spec:     spec,
 	}, nil
 }
+
+func (s *Shell) customCommand(source string) string {
+	// Append the source as last argument if not empty
+	if source != "" {
+		return s.spec.Command + " " + source
+	}
+
+	return s.spec.Command
+}

--- a/pkg/plugins/shell/main_test.go
+++ b/pkg/plugins/shell/main_test.go
@@ -75,3 +75,35 @@ func TestShell_New(t *testing.T) {
 		})
 	}
 }
+
+func TestShell_customCommand(t *testing.T) {
+	tests := []struct {
+		name    string
+		source  string
+		want    string
+		command string
+	}{
+		{
+			name:    "case with empty source",
+			source:  "",
+			command: "Hello There",
+			want:    "Hello There",
+		},
+		{
+			name:    "case with source",
+			command: "Hello There",
+			source:  "General Kenobi",
+			want:    "Hello There General Kenobi",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sut := &Shell{
+				spec: ShellSpec{
+					Command: tt.command,
+				},
+			}
+			assert.Equal(t, sut.customCommand(tt.source), tt.want)
+		})
+	}
+}

--- a/pkg/plugins/shell/main_test.go
+++ b/pkg/plugins/shell/main_test.go
@@ -1,6 +1,10 @@
 package shell
 
 import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/updatecli/updatecli/pkg/core/scm"
 )
 
@@ -27,4 +31,47 @@ type mockScm struct {
 
 func (m *mockScm) GetDirectory() (directory string) {
 	return m.workingDir
+}
+
+func TestShell_New(t *testing.T) {
+	tests := []struct {
+		name      string
+		spec      ShellSpec
+		wantErr   bool
+		wantShell *Shell
+	}{
+		{
+			name: "Normal case",
+			spec: ShellSpec{
+				Command: "echo Hello",
+			},
+			wantErr: false,
+			wantShell: &Shell{
+				executor: &nativeCommandExecutor{},
+				spec: ShellSpec{
+					Command: "echo Hello",
+				},
+			},
+		},
+		{
+			name: "raises an error when command is empty",
+			spec: ShellSpec{
+				Command: "",
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotShell, gotErr := New(tt.spec)
+
+			if tt.wantErr {
+				require.Error(t, gotErr)
+				return
+			}
+			require.NoError(t, gotErr)
+
+			assert.Equal(t, tt.wantShell, gotShell)
+		})
+	}
 }

--- a/pkg/plugins/shell/main_test.go
+++ b/pkg/plugins/shell/main_test.go
@@ -1,0 +1,53 @@
+package shell
+
+import "fmt"
+
+////////////// Test Utilities method aimed at mocking calls to other objects
+
+// mocking commandExecutor.ExecuteCommand
+type mockCommandExecutor struct {
+	gotCommand command
+	result     commandResult
+	err        error
+}
+
+func (mce *mockCommandExecutor) ExecuteCommand(cmd command) (commandResult, error) {
+	mce.gotCommand = cmd
+	if mce.gotCommand.Cmd == "" {
+		return commandResult{}, fmt.Errorf(ErrEmptyCommand)
+	}
+	return mce.result, mce.err
+}
+
+// mocking SCM object (no introspection: only get values)
+type mockScm struct {
+	workingDir string
+}
+
+func (m *mockScm) Add(files []string) error {
+	return nil
+}
+func (m *mockScm) Clone() (string, error) {
+	return "", nil
+}
+func (m *mockScm) Checkout() error {
+	return nil
+}
+func (m *mockScm) GetDirectory() (directory string) {
+	return m.workingDir
+}
+func (m *mockScm) Init(source string, pipelineID string) error {
+	return nil
+}
+func (m *mockScm) Push() error {
+	return nil
+}
+func (m *mockScm) Commit(message string) error {
+	return nil
+}
+func (m *mockScm) Clean() error {
+	return nil
+}
+func (m *mockScm) PushTag(tag string) error {
+	return nil
+}

--- a/pkg/plugins/shell/main_test.go
+++ b/pkg/plugins/shell/main_test.go
@@ -75,35 +75,3 @@ func TestShell_New(t *testing.T) {
 		})
 	}
 }
-
-func TestShell_customCommand(t *testing.T) {
-	tests := []struct {
-		name    string
-		source  string
-		want    string
-		command string
-	}{
-		{
-			name:    "case with empty source",
-			source:  "",
-			command: "Hello There",
-			want:    "Hello There",
-		},
-		{
-			name:    "case with source",
-			command: "Hello There",
-			source:  "General Kenobi",
-			want:    "Hello There General Kenobi",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			sut := &Shell{
-				spec: ShellSpec{
-					Command: tt.command,
-				},
-			}
-			assert.Equal(t, sut.customCommand(tt.source), tt.want)
-		})
-	}
-}

--- a/pkg/plugins/shell/main_test.go
+++ b/pkg/plugins/shell/main_test.go
@@ -1,10 +1,12 @@
 package shell
 
-import "fmt"
+import (
+	"github.com/updatecli/updatecli/pkg/core/scm"
+)
 
-////////////// Test Utilities method aimed at mocking calls to other objects
-
-// mockCommandExecutor is a stub implementation of the `commandExecutor` interface to be used in our test suite. It stores the received `command` and returns the preconfigured `result` and `err`.
+// mockCommandExecutor is a stub implementation of the `commandExecutor` interface
+// to be used in our test suite.
+// It stores the received `command` and returns the preconfigured `result` and `err`.
 type mockCommandExecutor struct {
 	gotCommand command
 	result     commandResult
@@ -13,9 +15,6 @@ type mockCommandExecutor struct {
 
 func (mce *mockCommandExecutor) ExecuteCommand(cmd command) (commandResult, error) {
 	mce.gotCommand = cmd
-	if mce.gotCommand.Cmd == "" {
-		return commandResult{}, fmt.Errorf(ErrEmptyCommand)
-	}
 	return mce.result, mce.err
 }
 

--- a/pkg/plugins/shell/main_test.go
+++ b/pkg/plugins/shell/main_test.go
@@ -4,7 +4,7 @@ import "fmt"
 
 ////////////// Test Utilities method aimed at mocking calls to other objects
 
-// mocking commandExecutor.ExecuteCommand
+// mockCommandExecutor is a stub implementation of the `commandExecutor` interface to be used in our test suite. It stores the received `command` and returns the preconfigured `result` and `err`.
 type mockCommandExecutor struct {
 	gotCommand command
 	result     commandResult
@@ -21,33 +21,11 @@ func (mce *mockCommandExecutor) ExecuteCommand(cmd command) (commandResult, erro
 
 // mocking SCM object (no introspection: only get values)
 type mockScm struct {
+	scm.Scm
+
 	workingDir string
 }
 
-func (m *mockScm) Add(files []string) error {
-	return nil
-}
-func (m *mockScm) Clone() (string, error) {
-	return "", nil
-}
-func (m *mockScm) Checkout() error {
-	return nil
-}
 func (m *mockScm) GetDirectory() (directory string) {
 	return m.workingDir
-}
-func (m *mockScm) Init(source string, pipelineID string) error {
-	return nil
-}
-func (m *mockScm) Push() error {
-	return nil
-}
-func (m *mockScm) Commit(message string) error {
-	return nil
-}
-func (m *mockScm) Clean() error {
-	return nil
-}
-func (m *mockScm) PushTag(tag string) error {
-	return nil
 }

--- a/pkg/plugins/shell/source.go
+++ b/pkg/plugins/shell/source.go
@@ -20,7 +20,7 @@ func (s *Shell) Source(workingDir string) (string, error) {
 	}
 
 	if cmdResult.ExitCode != 0 {
-		return "", fmt.Errorf("%v The shell 🐚 command %q failed with the following message: \nstderr=\n%v\nstdout=\n%v\n", result.FAILURE, s.spec.Command, cmdResult.Stderr, cmdResult.Stdout)
+		return "",  &ExecutionFailedError{Code: code, Stdout: stdout, Stderr: stderr}
 	}
 
 	logrus.Infof("%v The shell 🐚 command %q ran successfully and retrieved the following source value: %q", result.SUCCESS, s.spec.Command, cmdResult.Stdout)

--- a/pkg/plugins/shell/source.go
+++ b/pkg/plugins/shell/source.go
@@ -1,0 +1,29 @@
+package shell
+
+import (
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+	"github.com/updatecli/updatecli/pkg/core/result"
+)
+
+// Source returns the stdout of the shell command if its exit code is 0
+// otherwise an error is returned with the content of stderr
+func (s *Shell) Source(workingDir string) (string, error) {
+	cmdResult, err := s.executor.ExecuteCommand(command{
+		Cmd: s.spec.Command,
+		Dir: workingDir,
+	})
+
+	if err != nil {
+		return "", err
+	}
+
+	if cmdResult.ExitCode != 0 {
+		return "", fmt.Errorf("%v The shell 🐚 command %q failed with the following message: \nstderr=\n%v\nstdout=\n%v\n", result.FAILURE, s.spec.Command, cmdResult.Stderr, cmdResult.Stdout)
+	}
+
+	logrus.Infof("%v The shell 🐚 command %q ran successfully and retrieved the following source value: %q", result.SUCCESS, s.spec.Command, cmdResult.Stdout)
+
+	return cmdResult.Stdout, nil
+}

--- a/pkg/plugins/shell/source.go
+++ b/pkg/plugins/shell/source.go
@@ -1,8 +1,6 @@
 package shell
 
 import (
-	"fmt"
-
 	"github.com/sirupsen/logrus"
 	"github.com/updatecli/updatecli/pkg/core/result"
 )
@@ -20,7 +18,11 @@ func (s *Shell) Source(workingDir string) (string, error) {
 	}
 
 	if cmdResult.ExitCode != 0 {
-		return "",  &ExecutionFailedError{Code: code, Stdout: stdout, Stderr: stderr}
+		return "", &executionFailedError{
+			Command: s.spec.Command,
+			ErrCode: cmdResult.ExitCode,
+			Stdout:  cmdResult.Stdout,
+			Stderr:  cmdResult.Stderr}
 	}
 
 	logrus.Infof("%v The shell 🐚 command %q ran successfully and retrieved the following source value: %q", result.SUCCESS, s.spec.Command, cmdResult.Stdout)

--- a/pkg/plugins/shell/source_test.go
+++ b/pkg/plugins/shell/source_test.go
@@ -1,0 +1,79 @@
+package shell
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestShell_Source(t *testing.T) {
+	tests := []struct {
+		name          string
+		command       string
+		workingDir    string
+		wantSource    string
+		wantCommand   string
+		wantErr       bool
+		commandResult commandResult
+	}{
+		{
+			name:        "Get a source from a successful command in working directory",
+			command:     "echo Hello",
+			workingDir:  "/home/ucli",
+			wantSource:  "Hello",
+			wantCommand: "echo Hello",
+			wantErr:     false,
+			commandResult: commandResult{
+				ExitCode: 0,
+				Stdout:   "Hello",
+			},
+		},
+		{
+			name:       "Raise an error with a failing command in working directory",
+			command:    "false",
+			workingDir: "/home/ucli",
+			wantSource: "",
+			wantErr:    true,
+			commandResult: commandResult{
+				ExitCode: 1,
+			},
+		},
+		{
+			name:       "Raise an error with an empty command in working directory",
+			command:    "",
+			workingDir: "/home/ucli",
+			wantSource: "",
+			wantErr:    true,
+			commandResult: commandResult{
+				ExitCode: 1,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := mockCommandExecutor{
+				result: tt.commandResult,
+			}
+			s := Shell{
+				executor: &mock,
+				spec: ShellSpec{
+					Command: tt.command,
+				},
+			}
+
+			source, err := s.Source(tt.workingDir)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Equal(t, tt.wantSource, source)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantSource, source)
+
+			assert.Equal(t, tt.wantCommand, mock.gotCommand.Cmd)
+		})
+	}
+}

--- a/pkg/plugins/shell/target.go
+++ b/pkg/plugins/shell/target.go
@@ -42,7 +42,12 @@ func (s *Shell) target(source, workingDir string, dryRun bool) (changed bool, co
 	}
 
 	if cmdResult.ExitCode != 0 {
-		return false, commands, message, fmt.Errorf("The command %q failed with the following message: \nstderr=\n%v\nstdout=\n%v\n", s.spec.Command, cmdResult.Stderr, cmdResult.Stdout)
+		return false, commands, message, &executionFailedError{
+			Command: customCommand,
+			ErrCode: cmdResult.ExitCode,
+			Stdout:  cmdResult.Stdout,
+			Stderr:  cmdResult.Stderr,
+		}
 	}
 
 	commands = append(commands, customCommand)

--- a/pkg/plugins/shell/target.go
+++ b/pkg/plugins/shell/target.go
@@ -25,9 +25,8 @@ func (s *Shell) TargetFromSCM(source string, scm scm.Scm, dryRun bool) (changed 
 // The environment variable 'DRY_RUN' is set to true or false based on the input parameter (e.g. 'updatecli diff' or 'apply'?)
 func (s *Shell) target(source, workingDir string, dryRun bool) (changed bool, commands []string, message string, err error) {
 	customCommand := s.spec.Command
-	if customCommand == "" {
-		return false, commands, message, fmt.Errorf(ErrEmptyCommand)
-	}
+
+	// Append the source as last argument if not empty
 	if source != "" {
 		customCommand += " " + source
 	}

--- a/pkg/plugins/shell/target.go
+++ b/pkg/plugins/shell/target.go
@@ -24,12 +24,8 @@ func (s *Shell) TargetFromSCM(source string, scm scm.Scm, dryRun bool) (changed 
 //	- Any other exit code means "failed command with no change"
 // The environment variable 'DRY_RUN' is set to true or false based on the input parameter (e.g. 'updatecli diff' or 'apply'?)
 func (s *Shell) target(source, workingDir string, dryRun bool) (changed bool, commands []string, message string, err error) {
-	customCommand := s.spec.Command
+	customCommand := s.customCommand(source)
 
-	// Append the source as last argument if not empty
-	if source != "" {
-		customCommand += " " + source
-	}
 	cmdResult, err := s.executor.ExecuteCommand(command{
 		Cmd: customCommand,
 		Dir: workingDir,

--- a/pkg/plugins/shell/target.go
+++ b/pkg/plugins/shell/target.go
@@ -1,0 +1,59 @@
+package shell
+
+import (
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+	"github.com/updatecli/updatecli/pkg/core/result"
+	"github.com/updatecli/updatecli/pkg/core/scm"
+)
+
+func (s *Shell) Target(source string, dryRun bool) (bool, error) {
+	changed, _, _, err := s.target(source, "", dryRun)
+	return changed, err
+}
+
+func (s *Shell) TargetFromSCM(source string, scm scm.Scm, dryRun bool) (changed bool, commands []string, message string, err error) {
+	return s.target(source, scm.GetDirectory(), dryRun)
+}
+
+// Target executes the provided command (concatenated with the source) to apply the change.
+//	The command is expected, if it changes something, to print the new value to the stdout
+//	- An exit code of 0 and an empty stdout means: "successful command and no change"
+//	- An exit code of 0 and something on the stdout means: "successful command with a changed value"
+//	- Any other exit code means "failed command with no change"
+// The environment variable 'DRY_RUN' is set to true or false based on the input parameter (e.g. 'updatecli diff' or 'apply'?)
+func (s *Shell) target(source, workingDir string, dryRun bool) (changed bool, commands []string, message string, err error) {
+	customCommand := s.spec.Command
+	if customCommand == "" {
+		return false, commands, message, fmt.Errorf(ErrEmptyCommand)
+	}
+	if source != "" {
+		customCommand += " " + source
+	}
+	cmdResult, err := s.executor.ExecuteCommand(command{
+		Cmd: customCommand,
+		Dir: workingDir,
+		Env: []string{fmt.Sprintf("DRY_RUN=%v", dryRun)},
+	})
+
+	if err != nil {
+		return false, commands, message, err
+	}
+
+	if cmdResult.ExitCode != 0 {
+		return false, commands, message, fmt.Errorf("The command %q failed with the following message: \nstderr=\n%v\nstdout=\n%v\n", s.spec.Command, cmdResult.Stderr, cmdResult.Stdout)
+	}
+
+	commands = append(commands, customCommand)
+
+	if cmdResult.Stdout == "" {
+		logrus.Infof("%v The shell 🐚 command %q ran successfully with no change.", result.SUCCESS, customCommand)
+		return false, commands, message, nil
+	}
+
+	message = fmt.Sprintf("%v The shell 🐚 command %q ran successfully and reported the following change: %q.", result.CHANGED, customCommand, cmdResult.Stdout)
+	logrus.Infof(message)
+
+	return true, commands, message, nil
+}

--- a/pkg/plugins/shell/target_test.go
+++ b/pkg/plugins/shell/target_test.go
@@ -1,0 +1,167 @@
+package shell
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/updatecli/updatecli/pkg/core/result"
+)
+
+func TestShell_Target(t *testing.T) {
+	tests := []struct {
+		name              string
+		command           string
+		source            string
+		dryrun            bool
+		wantChanged       bool
+		wantErr           bool
+		wantCommandInMock string
+		commandResult     commandResult
+		commandEnv        []string
+	}{
+		{
+			name:              "runs a target that does not change anything and no dryrun",
+			command:           "do_not_change.sh",
+			source:            "1.2.3",
+			wantChanged:       false,
+			wantErr:           false,
+			wantCommandInMock: "do_not_change.sh 1.2.3",
+			commandResult: commandResult{
+				ExitCode: 0,
+				Stdout:   "",
+			},
+			commandEnv: []string{"DRY_RUN=false"},
+		},
+		{
+			name:              "runs a target that changes a value and no dryrun",
+			command:           "change.sh",
+			source:            "1.2.3",
+			wantChanged:       true,
+			wantErr:           false,
+			wantCommandInMock: "change.sh 1.2.3",
+			commandResult: commandResult{
+				ExitCode: 0,
+				Stdout:   "1.2.3",
+			},
+			commandEnv: []string{"DRY_RUN=false"},
+		},
+		{
+			name:              "runs a target with exit code 2 and no dryrun",
+			command:           "change.sh",
+			source:            "1.2.3",
+			wantChanged:       false,
+			wantErr:           true,
+			wantCommandInMock: "change.sh 1.2.3",
+			commandResult: commandResult{
+				ExitCode: 2,
+				Stderr:   "Error: unable to change value to 1.2.3.",
+			},
+			commandEnv: []string{"DRY_RUN=false"},
+		},
+		{
+			name:        "raises an error with an empty command and non empty source",
+			command:     "",
+			source:      "1.2.3",
+			wantChanged: false,
+			wantErr:     true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := mockCommandExecutor{
+				result: tt.commandResult,
+			}
+			s := Shell{
+				executor: &mock,
+				spec: ShellSpec{
+					Command: tt.command,
+				},
+			}
+
+			gotChanged, err := s.Target(tt.source, tt.dryrun)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.False(t, gotChanged)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantChanged, gotChanged)
+
+			assert.Equal(t, tt.wantCommandInMock, mock.gotCommand.Cmd)
+			for _, wantEnv := range tt.commandEnv {
+				assert.Contains(t, mock.gotCommand.Env, wantEnv)
+			}
+		})
+	}
+}
+
+func TestShell_TargetFromSCM(t *testing.T) {
+	tests := []struct {
+		commandResult     commandResult
+		wantCommands      []string
+		commandEnv        []string
+		name              string
+		command           string
+		source            string
+		scmDir            string
+		wantMessage       string
+		wantCommandInMock string
+		dryrun            bool
+		wantChanged       bool
+		wantErr           bool
+	}{
+		{
+			name:              "runs a target that changes a value and no dryrun",
+			command:           "change.sh",
+			source:            "1.2.3",
+			wantChanged:       true,
+			wantCommands:      []string{"change.sh 1.2.3"},
+			wantMessage:       result.CHANGED + " The shell 🐚 command \"change.sh 1.2.3\" ran successfully and reported the following change: \"Changed value from 1.2.2 to 1.2.3.\".",
+			wantErr:           false,
+			wantCommandInMock: "change.sh 1.2.3",
+			commandResult: commandResult{
+				ExitCode: 0,
+				Stdout:   "Changed value from 1.2.2 to 1.2.3.",
+			},
+			commandEnv: []string{"DRY_RUN=false"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := mockCommandExecutor{
+				result: tt.commandResult,
+			}
+			ms := mockScm{
+				workingDir: tt.scmDir,
+			}
+			s := Shell{
+				executor: &mock,
+				spec: ShellSpec{
+					Command: tt.command,
+				},
+			}
+
+			gotChanged, gotCommands, gotMessage, err := s.TargetFromSCM(tt.source, &ms, tt.dryrun)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.False(t, gotChanged)
+				return
+			}
+
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.wantChanged, gotChanged)
+			assert.Equal(t, tt.wantCommands, gotCommands)
+			assert.Equal(t, tt.wantMessage, gotMessage)
+
+			assert.Equal(t, tt.wantCommandInMock, mock.gotCommand.Cmd)
+			for _, wantEnv := range tt.commandEnv {
+				assert.Contains(t, mock.gotCommand.Env, wantEnv)
+			}
+		})
+	}
+}

--- a/pkg/plugins/shell/target_test.go
+++ b/pkg/plugins/shell/target_test.go
@@ -59,13 +59,6 @@ func TestShell_Target(t *testing.T) {
 			},
 			commandEnv: []string{"DRY_RUN=false"},
 		},
-		{
-			name:        "raises an error with an empty command and non empty source",
-			command:     "",
-			source:      "1.2.3",
-			wantChanged: false,
-			wantErr:     true,
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
# Add a new resource of type "shell"

Closes #263 

## What this PR does?

It introduces a new resource of type `shell` to allow executing a custom command.

* For sources, this resource uses the stdout of the command to report the value to updatecli, if and only if the exit code is 0, otherwise it fails, and the stderr of the command is reported by updatecli to the end user.

* For conditions, this resource executes a command with the associated source appended as last argument. If the exit code is 0 then the condition succeed, otherwise it fails.

* For targets, this resource executes a command with the associated source appended as last argument. Then:
  * If the exit code is zero AND the stdout reports a non empty string, then updatecli reports that there was a change, and the stdout reports what has changed.
  * If the exit code is zero and stdout is empty, then updatecli report that there was no change (but still success)
  * Another exit code means that the target failed.
  * The environment variable `DRY_RUN` is set either to `false` or `true` in the target's command environment

There is an generic example in `examples/updateCli.generic/shell/shell.yaml` (along with shell scripts).

## What this PR does not?

## Test

To test this pull request, you can run the following commands:

```
go test ./pkg/plugins/shell -v
```

~95% of the package `shell` is covered

## Additional Information

* Not tested on Windows, but as it relies on `os/exec` Golang package AND each command is a single strings, it should work as expected

### Potential improvement

* If someone raises the issue, the `command` specification could be improved to support "array mode" ala Dockerfile (for entrypoints/CMD in `Dockerfiles`)