### PR TITLE
bugfix: correct error report when using a shell resource (inverting stdout and stderr)

### DIFF
--- a/pkg/plugins/shell/errors.go
+++ b/pkg/plugins/shell/errors.go
@@ -19,7 +19,7 @@ type executionFailedError struct {
 }
 
 func (e *executionFailedError) Error() string {
-	return errorMessage(e.ErrCode, e.Command, e.Stderr, e.Stdout)
+	return errorMessage(e.ErrCode, e.Command, e.Stdout, e.Stderr)
 }
 
 func errorMessage(exitCode int, command, stdout, stderr string) string {


### PR DESCRIPTION
# bugfix: correct error report when using a shell resource (inverting stdout and stderr)

while writing the documentation for the new shell resource introduced in #264 in https://github.com/updatecli/website/pull/119, I caught this tiny bug (should only be a patch)

## Test
To test this pull request, you can run the following commands:

```
  cp <to_package_directory>
  go test
```

## Additionnal Information
### Tradeoff

<!-- Please describe the tradeoff that you found acceptable in this pr -->

### Potential improvement

<!-- Please describe potential improvement that you are envisioning -->
