### PR TITLE
Fix golang version automated update

### DIFF
--- a/updatecli/updatecli.d/golang.yaml
+++ b/updatecli/updatecli.d/golang.yaml
@@ -134,8 +134,10 @@ targets:
     sourceID: latestGoVersion
     kind: dockerfile
     spec:
-      keyword: "ARG"
-      matcher: "GOLANG_VERSION"
+      file: Dockerfile
+      instruction:
+        keyword: "ARG"
+        matcher: "GOLANG_VERSION"
     scm:
       github:
         user: updatecli

--- a/updatecli/updatecli.d/gorelease.yaml
+++ b/updatecli/updatecli.d/gorelease.yaml
@@ -24,7 +24,7 @@ targets:
   dockerfile:
     name: Update Goreleaser version
     kind: dockerfile
-    spec: 
+    spec:
       file: Dockerfile
       instruction:
         keyword: "ARG"


### PR DESCRIPTION
# Fix golang version automated update

Fix wrong updatecli configuration introduced by https://github.com/updatecli/updatecli/pull/270
