### PR TITLE
fix: correct updatecli golang manifest to update go.mod

### DIFF
--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -3,6 +3,8 @@ name: updatecli
 
 on:
   workflow_dispatch:
+  push:
+  pull_request:
   schedule:
     # * is a special character in YAML so you have to quote this string
     # Run every hour

--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -16,16 +16,17 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Diff
-        uses: updatecli/updatecli-action@v1.10.0
+        uses: updatecli/updatecli-action@v1.11.0
         with:
           command: diff
           flags: "--config ./updatecli/updatecli.d"
         env:
           UPDATECLI_GITHUB_ACTOR: ${{ github.actor }}
           UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          
+
       - name: Apply
-        uses: updatecli/updatecli-action@v1.10.0
+        uses: updatecli/updatecli-action@v1.11.0
+        if: github.ref == 'refs/heads/main'
         with:
           command: apply
           flags: "--config ./updatecli/updatecli.d"

--- a/updatecli/scripts/updateGomodGoversion.sh
+++ b/updatecli/scripts/updateGomodGoversion.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+## This script updates the go version of a go mod file and prints the resulting content in the stdout
+## Please note that it will NEVER change the go.mod file (works in a temp directory)
+##
+## Expected arguments:
+## - 1: the path to the go.mod file
+## - 2: the new golang version in semver format (major.minor.patch)
+
+set -eux
+
+go_mod_dir="$(dirname "${1}")"
+go_version="${2}"
+new_version="$(echo "${go_version}" | cut -d. -f1,2)"
+tmp_dir="$(mktemp -d)"
+
+## Ensures that the correct golang version is used
+{
+  curl --silent --show-error --location --output "${tmp_dir}/go.tgz" \
+    "https://golang.org/dl/go${go_version}.linux-amd64.tar.gz"
+  mkdir -p "${tmp_dir}/.bin"
+  tar xzf "${tmp_dir}/go.tgz" -C "${tmp_dir}/.bin"
+  export PATH="${PATH}":"${tmp_dir}"/.bin/go/bin
+  command -v go
+  go version
+} >&2
+
+## Copy go mod's directory to a temp directory an start working from this temp. dir.
+cp -r "${go_mod_dir}" "${tmp_dir}" >&2
+cd "${tmp_dir}" >&2
+
+## Update go mod properly
+go mod edit -go="${new_version}" >&2
+go mod tidy >&2
+
+## Show new go mod
+cat go.mod
+exit 0

--- a/updatecli/updatecli.d/golang.yaml
+++ b/updatecli/updatecli.d/golang.yaml
@@ -13,25 +13,13 @@ sources:
       pattern: 'go-1.(\d*).(\d*)$'
     transformers:
       - trimPrefix: go
-  currentGoVersion:
-    name: Upate go.mod
-    kind: file
-    spec:
-      file: go.mod
-    transformers:
-      - find: 'go (.*)'
   gomod:
-    name: Upate go.mod
-    kind: file
-    spec:
-      file: go.mod
+    name: Update go.mod
+    kind: shell
     depends_on:
-      - currentGoVersion
       - latestGoVersion
-    transformers:
-      - replacer: 
-          from: '{{ source "currentGoVersion" }}'
-          to: 'go {{ source "latestGoVersion" }}'
+    spec:
+      command: ./updatecli/scripts/updateGomodGoversion.sh ./go.mod {{ source "latestGoVersion" }}
 conditions:
   workflowrelease-sandbox:
     name: Ensure GA step is defined in Github Action named release-sandbox


### PR DESCRIPTION
This should lead to a successful update of #273 once merged.

As explained in https://github.com/updatecli/updatecli/pull/273#issuecomment-932687710, there is an issue with the current `go.mod` update process:

- The go.mod file expects a version without the patch (only major and minor) as per ref. https://golang.org/ref/mod#go-mod-file-go
- Ideally, changing the go version should be done with 2 go mod <..> commands:
  - go mod edit -go=<new version without patch>
  - When the go version is changed in the go.mod file, then the command go mod tidy is needed because the internal format can change between minor version (this is the case here with 1.16 to 1.17). It might also update the go.sum.

This PR uses a shell resource as a "source", to update the go version of the go mod in a temp dir, and prints the content of the tidied resuting go.mod file.

Please note that this PR also enables the `updatecli` workflow for all PR/branches:
- The `updatecli diff` command is always executed (to ensure that it's not broken when there are configuration changes)
- The `updatecli apply` command is only executed on the `main` branch of course
=> The goal is to validate that the new shell script resource works as expected (for instance that it successfully installs golang when runing withing its image)