### PR TITLE
Feat: enable distribution with homebrew

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -45,7 +45,7 @@ dockers:
       - 'updatecli/updatecli:{{ .Tag }}-amd64'
       - 'ghcr.io/updatecli/updatecli:{{ .Tag }}-amd64'
     dockerfile: Dockerfile.release
-    use_buildx: true
+    use: buildx
     build_flag_templates:
       - "--pull"
       - "--no-cache"
@@ -63,7 +63,7 @@ dockers:
       - 'updatecli/updatecli:{{ .Tag }}-arm64'
       - 'ghcr.io/updatecli/updatecli:{{ .Tag }}-arm64'
     dockerfile: Dockerfile.release
-    use_buildx: true
+    use: buildx
     build_flag_templates:
       - "--pull"
       - "--no-cache"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -116,3 +116,16 @@ nfpms:
 
 snapshot:
   name_template: "{{ .Tag }}-next"
+
+brews:
+  - name: updatecli
+    folder: Formula
+    tap:
+      owner: updatecli
+      name: homebrew-updatecli
+    commit_msg_template: "Brew formula update for {{ .ProjectName }} version {{ .Tag }}"
+    homepage: "https://updatecli.io/"
+    description: "Continuously update everything."
+    license: "MIT"
+    test: |
+      system "#{bin}/updatecli version"


### PR DESCRIPTION
Fix #154 (this PR is the last mile)

This PR enables distribution of updatecli through an [homebrew tam](https://docs.brew.sh/Taps).

It follows the [goreleaser's homebrew documentation](https://goreleaser.com/customization/homebrew/) and the official [homebrew tap maintainer documentation](https://docs.brew.sh/How-to-Create-and-Maintain-a-Tap).

The repository updatecli/hombrew-updatecli had been created (empty) to hosts the formula with the homebrew default convention naming.

## Test
We have to perform a release to end-2-end validate.

Once a release will be performed after merging this PR, then a macOS user will be able to install updatecli with:

```
brew install updatecli/updatecli
```

## Additionnal Information
### Tradeoff

<!-- Please describe the tradeoff that you found acceptable in this pr -->

### Potential improvement

<!-- Please describe potential improvement that you are envisioning -->
