### PR TITLE
chore: fix homebrew publication

### DIFF
--- a/.github/workflows/release-sandbox.yaml
+++ b/.github/workflows/release-sandbox.yaml
@@ -37,5 +37,6 @@ jobs:
         if: success()
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
         run: |
           make release.snapshot

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,6 +43,7 @@ jobs:
         if: success()
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
         run: |
           make release
       - name: Clean up

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -123,6 +123,7 @@ brews:
     tap:
       owner: updatecli
       name: homebrew-updatecli
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
     commit_msg_template: "Brew formula update for {{ .ProjectName }} version {{ .Tag }}"
     homepage: "https://updatecli.io/"
     description: "Continuously update everything."


### PR DESCRIPTION
This PR aims at fixing the homebrew tap publication (ref. https://github.com/updatecli/updatecli/runs/3801471145?check_suite_focus=true#step:10:138) during its initial creation with the [v0.8.0 release](https://github.com/updatecli/updatecli/releases/tag/v0.8.0).

The failure was due to the token `GITHUB_TOKEN` provided to goreleaser by github actions. This token is able to publish release or packages to the repository `updatecli/updatecli`, but it does not have any authorization for the repository that should host the homebrew's tap (`updatecli/homebrew-updatecli`).

This PR defines a second token in goreleaser configuration, only for the homebrew publication.
I've created a PAT for this, and tested it for an initial "manual" release for v0.8.0 and it worked:

```
brew tap updatecli/updatecli
==> Tapping updatecli/updatecli
Cloning into '/usr/local/Homebrew/Library/Taps/updatecli/homebrew-updatecli'...
remote: Enumerating objects: 4, done.
remote: Counting objects: 100% (4/4), done.
remote: Compressing objects: 100% (2/2), done.
remote: Total 4 (delta 0), reused 0 (delta 0), pack-reused 0
Receiving objects: 100% (4/4), done.
Tapped 1 formula (12 files, 6.7KB).
admin@MacBook-Pro-16-de-Dadou ~ % brew install updatecli      
==> Downloading https://github.com/dduportal/updatecli/releases/download/v0.8.0/updatecli_Darwin_x86_64.tar.gz
==> Downloading from https://github-releases.githubusercontent.com/333694256/eff55370-a4ae-41f1-973b-71fedd2d0334?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20211005%2Fus-east-1%2F
######################################################################## 100.0%
==> Installing updatecli from updatecli/updatecli
🍺  /usr/local/Cellar/updatecli/0.8.0: 5 files, 53.7MB, built in 6 seconds
admin@MacBook-Pro-16-de-Dadou ~ % updatecli version

VERSION

Application:	0.8.0
Golang     :	1.17.1 darwin/amd64
Build Time :	2021-10-05T10:29:07Z

admin@MacBook-Pro-16-de-Dadou ~ % which updatecli
```

But it uses the binaries published on my own fork of updatecli: a new release `v0.8.1` is required after this PR (i'm taking care of it)