### PR TITLE
fix [shell] correct error reporting when a condition execution fails

### DIFF
--- a/pkg/plugins/shell/condition.go
+++ b/pkg/plugins/shell/condition.go
@@ -27,7 +27,7 @@ func (s *Shell) condition(source, workingDir string) (bool, error) {
 	}
 
 	if cmdResult.ExitCode != 0 {
-		logrus.Infof(errorMessage(cmdResult.ExitCode, s.appendSource(source), cmdResult.Stderr, cmdResult.Stdout))
+		logrus.Infof(errorMessage(cmdResult.ExitCode, s.appendSource(source), cmdResult.Stdout, cmdResult.Stderr))
 		return false, nil
 	}
 


### PR DESCRIPTION
## Before the fix

stderr and stdout where inverted when using a shell condition that failed:

```text
CONDITIONS:
===========

The shell 🐚 command "./examples/updateCli.generic/shell/condition.sh 2.5.1-FreeBSD" failed with an exit code of 1 and the following messages: 
stderr=

stdout=
+ ls /titi
ls: /titi: No such file or directory


✗ condition not met, skipping pipeline

=============================
```

## After the fix

```text
CONDITIONS:
===========

The shell 🐚 command "./examples/updateCli.generic/shell/condition.sh 2.5.1-FreeBSD" failed with an exit code of 1 and the following messages: 
stderr=
+ ls /titi
ls: /titi: No such file or directory

stdout=


✗ condition not met, skipping pipeline

=============================
```