### PR TITLE
Feat(condition) allow to not specify a sourceID for conditions (resulting in no source used by the condition)

### DIFF
--- a/examples/updateCli.generic/shell/shell.yaml
+++ b/examples/updateCli.generic/shell/shell.yaml
@@ -4,11 +4,22 @@ sources:
     kind: shell
     spec:
       command: "./examples/updateCli.generic/shell/source.sh"
-conditions:
-  default:
+  sayHello:
     kind: shell
     spec:
+      command: echo Hello
+conditions:
+  noSource:
+    kind: shell
+    disableSourceInput: true
+    spec:
       command: "./examples/updateCli.generic/shell/condition.sh"
+  withSource:
+    kind: shell
+    sourceID: default
+    spec:
+      command: echo
+
 targets:
   default:
     name: setGrepVersion

--- a/pkg/core/config/main.go
+++ b/pkg/core/config/main.go
@@ -144,13 +144,17 @@ func (config *Config) Validate() error {
 	}
 
 	for id, c := range config.Conditions {
-		// Try to guess SourceID
-		if len(c.SourceID) == 0 && len(config.Sources) > 1 {
-			logrus.Errorf("{empty 'sourceID' for condition '%s'", id)
-			return ErrBadConfig
-		} else if len(c.SourceID) == 0 && len(config.Sources) == 1 {
-			for id := range config.Sources {
-				c.SourceID = id
+
+		// Only check/guess the sourceID if the user did not disable it (default is enabled)
+		if !c.DisableSourceInput {
+			// Try to guess SourceID
+			if len(c.SourceID) == 0 && len(config.Sources) > 1 {
+				logrus.Errorf("The condition %q has an empty 'sourceID' attribute.", id)
+				return ErrBadConfig
+			} else if len(c.SourceID) == 0 && len(config.Sources) == 1 {
+				for id := range config.Sources {
+					c.SourceID = id
+				}
 			}
 		}
 

--- a/pkg/core/engine/condition/main.go
+++ b/pkg/core/engine/condition/main.go
@@ -29,15 +29,16 @@ type Condition struct {
 
 // Config defines conditions input parameters
 type Config struct {
-	DependsOn    []string `yaml:"depends_on"`
-	Name         string
-	Kind         string
-	Prefix       string // Deprecated in favor of Transformers on 2021/01/3
-	Postfix      string // Deprecated in favor of Transformers on 2021/01/3
-	Transformers transformer.Transformers
-	Spec         interface{}
-	Scm          map[string]interface{}
-	SourceID     string `yaml:"sourceID"`
+	DependsOn          []string `yaml:"depends_on"`
+	Name               string
+	Kind               string
+	Prefix             string // Deprecated in favor of Transformers on 2021/01/3
+	Postfix            string // Deprecated in favor of Transformers on 2021/01/3
+	Transformers       transformer.Transformers
+	Spec               interface{}
+	Scm                map[string]interface{}
+	SourceID           string `yaml:"sourceID"`
+	DisableSourceInput bool   `yaml:"disableSourceInput"`
 }
 
 // Conditioner is an interface that test if condition is met

--- a/pkg/plugins/shell/main.go
+++ b/pkg/plugins/shell/main.go
@@ -1,8 +1,7 @@
 package shell
 
 type ShellSpec struct {
-	Command        string
-	SuppressSource bool
+	Command string
 }
 
 type Shell struct {
@@ -25,7 +24,7 @@ func New(spec ShellSpec) (*Shell, error) {
 // appendSource appends the source as last argument if not empty.
 func (s *Shell) appendSource(source string) string {
 	// Append the source as last argument if not empty
-	if source != "" && !s.spec.SuppressSource {
+	if source != "" {
 		return s.spec.Command + " " + source
 	}
 


### PR DESCRIPTION
Fix #305

This PR introduces a new attribute `disableSourceInput` for conditions. It allows to disable the source's value input, letting condition to be "standalone".

The behavior depends on each resource: for instance in the case of a "shell", it won't append the value at the end of the command.

Todo:

- [x] Test that no plugins are broken: checked with jenkins-infra/charts with success
- [x] Opening a PR to the website to update documentation - https://github.com/updatecli/website/pull/154

