### PR TITLE
fix [file,yaml] correct path resolution when using scm for file and yaml resources

### DIFF
--- a/pkg/plugins/file/condition.go
+++ b/pkg/plugins/file/condition.go
@@ -59,7 +59,7 @@ func (f *File) Condition(source string) (bool, error) {
 	}
 
 	if strings.Compare(f.Content, content) == 0 {
-		logrus.Infof("\u2714 Content from file '%v' is correct'", filepath.Join(f.File))
+		logrus.Infof("\u2714 Content from file '%v' is correct'", f.File)
 		return true, nil
 	}
 
@@ -79,7 +79,7 @@ func (f *File) ConditionFromSCM(source string, scm scm.Scm) (bool, error) {
 		f.Content = source
 	}
 
-	data, err := text.ReadAll(filepath.Join(f.File, scm.GetDirectory()))
+	data, err := text.ReadAll(filepath.Join(scm.GetDirectory(), f.File))
 	if err != nil {
 		return false, err
 	}

--- a/pkg/plugins/file/source.go
+++ b/pkg/plugins/file/source.go
@@ -11,7 +11,7 @@ import (
 // Source return a file content
 func (f *File) Source(workingDir string) (string, error) {
 
-	data, err := text.ReadAll(filepath.Join(f.File, workingDir))
+	data, err := text.ReadAll(filepath.Join(workingDir, f.File))
 	if err != nil {
 		return "", err
 	}

--- a/pkg/plugins/file/target.go
+++ b/pkg/plugins/file/target.go
@@ -101,7 +101,7 @@ func (f *File) TargetFromSCM(source string, scm scm.Scm, dryRun bool) (changed b
 
 	changed = false
 
-	data, err := text.ReadAll(filepath.Join(f.File, scm.GetDirectory()))
+	data, err := text.ReadAll(filepath.Join(scm.GetDirectory(), f.File))
 	if err != nil {
 		return changed, files, message, err
 	}

--- a/pkg/plugins/yaml/condition.go
+++ b/pkg/plugins/yaml/condition.go
@@ -61,7 +61,7 @@ func (y *Yaml) ConditionFromSCM(source string, scm scm.Scm) (bool, error) {
 		logrus.Warnf("Key 'Path' is obsolete and now directly defined from file")
 	}
 
-	data, err := text.ReadAll(filepath.Join(y.File, scm.GetDirectory()))
+	data, err := text.ReadAll(filepath.Join(scm.GetDirectory(), y.File))
 	if err != nil {
 		return false, err
 	}

--- a/pkg/plugins/yaml/source.go
+++ b/pkg/plugins/yaml/source.go
@@ -23,7 +23,7 @@ func (y *Yaml) Source(workingDir string) (string, error) {
 		logrus.Warnf("Key 'Path' is obsolete and now directly defined from file")
 	}
 
-	data, err := text.ReadAll(filepath.Join(y.File, workingDir))
+	data, err := text.ReadAll(filepath.Join(workingDir, y.File))
 	if err != nil {
 		return "", err
 	}

--- a/pkg/plugins/yaml/target.go
+++ b/pkg/plugins/yaml/target.go
@@ -117,7 +117,7 @@ func (y *Yaml) TargetFromSCM(source string, scm scm.Scm, dryRun bool) (changed b
 
 	changed = false
 
-	data, err := text.ReadAll(filepath.Join(y.File, scm.GetDirectory()))
+	data, err := text.ReadAll(filepath.Join(scm.GetDirectory(), y.File))
 	if err != nil {
 		return changed, files, message, err
 	}


### PR DESCRIPTION
This PR fixes a bug introduces in #318 which broke the `file` and `yaml` resources when used with an SCM.