### PR TITLE
fix(shell) Fix target with an SCM to correctly add the changed files by the shell command

### DIFF
--- a/pkg/core/scm/main.go
+++ b/pkg/core/scm/main.go
@@ -19,6 +19,7 @@ type Scm interface {
 	Commit(message string) error
 	Clean() error
 	PushTag(tag string) error
+	GetChangedFiles(workingDir string) ([]string, error)
 }
 
 // Unmarshal parses a scm struct like git or github and returns a scm interface

--- a/pkg/plugins/git/generic/main.go
+++ b/pkg/plugins/git/generic/main.go
@@ -17,6 +17,33 @@ import (
 	transportHttp "github.com/go-git/go-git/v5/plumbing/transport/http"
 )
 
+func GetChangedFiles(workingDir string) ([]string, error) {
+	gitRepository, err := git.PlainOpen(workingDir)
+	if err != nil {
+		return []string{}, err
+	}
+
+	gitWorktree, err := gitRepository.Worktree()
+	if err != nil {
+		return []string{}, err
+	}
+
+	gitStatus, err := gitWorktree.Status()
+	if err != nil {
+		return []string{}, err
+	}
+
+	// gitStatus is a list of changed (as per git definition) files in the provided workingDir
+	// We only retrieve the list of changed files without checking the file status (https://pkg.go.dev/github.com/go-git/go-git/v5@v5.4.2?utm_source=gopls#StatusCode)
+	// as we assume all changes have been done by the target and shall be added, even if already added
+	filesChanged := []string{}
+	for changedFile := range gitStatus {
+		filesChanged = append(filesChanged, changedFile)
+	}
+
+	return filesChanged, nil
+}
+
 // Add run `git add`.
 func Add(files []string, workingDir string) error {
 

--- a/pkg/plugins/git/scm.go
+++ b/pkg/plugins/git/scm.go
@@ -141,3 +141,7 @@ func (g *Git) PushTag(tag string) error {
 
 	return nil
 }
+
+func (g *Git) GetChangedFiles(workingDir string) ([]string, error) {
+	return git.GetChangedFiles(workingDir)
+}

--- a/pkg/plugins/github/scm.go
+++ b/pkg/plugins/github/scm.go
@@ -112,3 +112,7 @@ func (g *Github) PushTag(tag string) error {
 
 	return nil
 }
+
+func (g *Github) GetChangedFiles(workingDir string) ([]string, error) {
+	return git.GetChangedFiles(workingDir)
+}

--- a/pkg/plugins/shell/main_test.go
+++ b/pkg/plugins/shell/main_test.go
@@ -26,11 +26,18 @@ func (mce *mockCommandExecutor) ExecuteCommand(cmd command) (commandResult, erro
 type mockScm struct {
 	scm.Scm
 
-	workingDir string
+	workingDir   string
+	changedFiles []string
+	err          error
 }
 
 func (m *mockScm) GetDirectory() (directory string) {
 	return m.workingDir
+}
+
+func (m *mockScm) GetChangedFiles(workingDir string) ([]string, error) {
+	m.workingDir = workingDir
+	return m.changedFiles, m.err
 }
 
 func TestShell_New(t *testing.T) {

--- a/pkg/plugins/shell/target.go
+++ b/pkg/plugins/shell/target.go
@@ -9,12 +9,22 @@ import (
 )
 
 func (s *Shell) Target(source string, dryRun bool) (bool, error) {
-	changed, _, _, err := s.target(source, "", dryRun)
+	changed, _, err := s.target(source, "", dryRun)
 	return changed, err
 }
 
-func (s *Shell) TargetFromSCM(source string, scm scm.Scm, dryRun bool) (changed bool, commands []string, message string, err error) {
-	return s.target(source, scm.GetDirectory(), dryRun)
+func (s *Shell) TargetFromSCM(source string, scm scm.Scm, dryRun bool) (bool, []string, string, error) {
+	changed, message, err := s.target(source, scm.GetDirectory(), dryRun)
+	if err != nil {
+		return false, []string{}, "", err
+	}
+
+	// Once the changes have been applied inside the scm's temp directory, then we have to get the list of these changes
+	files, err := scm.GetChangedFiles(scm.GetDirectory())
+	if err != nil {
+		return false, []string{}, "", err
+	}
+	return changed, files, message, err
 }
 
 // Target executes the provided command (concatenated with the source) to apply the change.
@@ -23,19 +33,18 @@ func (s *Shell) TargetFromSCM(source string, scm scm.Scm, dryRun bool) (changed 
 //	- An exit code of 0 and something on the stdout means: "successful command with a changed value"
 //	- Any other exit code means "failed command with no change"
 // The environment variable 'DRY_RUN' is set to true or false based on the input parameter (e.g. 'updatecli diff' or 'apply'?)
-func (s *Shell) target(source, workingDir string, dryRun bool) (changed bool, commands []string, message string, err error) {
+func (s *Shell) target(source, workingDir string, dryRun bool) (bool, string, error) {
 	cmdResult, err := s.executor.ExecuteCommand(command{
 		Cmd: s.appendSource(source),
 		Dir: workingDir,
 		Env: []string{fmt.Sprintf("DRY_RUN=%v", dryRun)},
 	})
-
 	if err != nil {
-		return false, commands, message, err
+		return false, "", err
 	}
 
 	if cmdResult.ExitCode != 0 {
-		return false, commands, message, &executionFailedError{
+		return false, "", &executionFailedError{
 			Command: s.appendSource(source),
 			ErrCode: cmdResult.ExitCode,
 			Stdout:  cmdResult.Stdout,
@@ -43,15 +52,13 @@ func (s *Shell) target(source, workingDir string, dryRun bool) (changed bool, co
 		}
 	}
 
-	commands = append(commands, s.appendSource(source))
-
 	if cmdResult.Stdout == "" {
 		logrus.Infof("%v The shell 🐚 command %q ran successfully with no change.", result.SUCCESS, s.appendSource(source))
-		return false, commands, message, nil
+		return false, "", nil
 	}
 
-	message = fmt.Sprintf("%v The shell 🐚 command %q ran successfully and reported the following change: %q.", result.ATTENTION, s.appendSource(source), cmdResult.Stdout)
+	message := fmt.Sprintf("%v The shell 🐚 command %q ran successfully and reported the following change: %q.", result.ATTENTION, s.appendSource(source), cmdResult.Stdout)
 	logrus.Infof(message)
 
-	return true, commands, message, nil
+	return true, message, nil
 }

--- a/pkg/plugins/shell/target_test.go
+++ b/pkg/plugins/shell/target_test.go
@@ -93,33 +93,33 @@ func TestShell_Target(t *testing.T) {
 
 func TestShell_TargetFromSCM(t *testing.T) {
 	tests := []struct {
-		commandResult     commandResult
-		wantCommands      []string
-		commandEnv        []string
-		name              string
-		command           string
-		source            string
-		scmDir            string
-		wantMessage       string
-		wantCommandInMock string
-		dryrun            bool
-		wantChanged       bool
-		wantErr           bool
+		commandResult            commandResult
+		wantFilesChanged         []string
+		commandEnv               []string
+		name                     string
+		command                  string
+		source                   string
+		scmDir                   string
+		mockReturnedChangedFiles []string
+		wantMessage              string
+		wantCommandInMock        string
+		wantErr                  bool
+		dryrun                   bool
 	}{
 		{
-			name:              "runs a target that changes a value and no dryrun",
-			command:           "change.sh",
-			source:            "1.2.3",
-			wantChanged:       true,
-			wantCommands:      []string{"change.sh 1.2.3"},
-			wantMessage:       result.ATTENTION + " The shell 🐚 command \"change.sh 1.2.3\" ran successfully and reported the following change: \"Changed value from 1.2.2 to 1.2.3.\".",
-			wantErr:           false,
-			wantCommandInMock: "change.sh 1.2.3",
+			name:                     "runs a target that changes a value and no dryrun",
+			command:                  "change.sh",
+			source:                   "1.2.3",
+			mockReturnedChangedFiles: []string{"pom.xml"},
+			wantMessage:              result.ATTENTION + " The shell 🐚 command \"change.sh 1.2.3\" ran successfully and reported the following change: \"Changed value from 1.2.2 to 1.2.3.\".",
+			wantErr:                  false,
+			wantCommandInMock:        "change.sh 1.2.3",
 			commandResult: commandResult{
 				ExitCode: 0,
 				Stdout:   "Changed value from 1.2.2 to 1.2.3.",
 			},
-			commandEnv: []string{"DRY_RUN=false"},
+			wantFilesChanged: []string{"pom.xml"},
+			commandEnv:       []string{"DRY_RUN=false"},
 		},
 	}
 	for _, tt := range tests {
@@ -128,7 +128,8 @@ func TestShell_TargetFromSCM(t *testing.T) {
 				result: tt.commandResult,
 			}
 			ms := mockScm{
-				workingDir: tt.scmDir,
+				workingDir:   tt.scmDir,
+				changedFiles: tt.mockReturnedChangedFiles,
 			}
 			s := Shell{
 				executor: &mock,
@@ -137,7 +138,7 @@ func TestShell_TargetFromSCM(t *testing.T) {
 				},
 			}
 
-			gotChanged, gotCommands, gotMessage, err := s.TargetFromSCM(tt.source, &ms, tt.dryrun)
+			gotChanged, gotFilesChanged, gotMessage, err := s.TargetFromSCM(tt.source, &ms, tt.dryrun)
 
 			if tt.wantErr {
 				assert.Error(t, err)
@@ -147,8 +148,8 @@ func TestShell_TargetFromSCM(t *testing.T) {
 
 			require.NoError(t, err)
 
-			assert.Equal(t, tt.wantChanged, gotChanged)
-			assert.Equal(t, tt.wantCommands, gotCommands)
+			assert.Equal(t, len(tt.wantFilesChanged) > 0, gotChanged)
+			assert.Equal(t, tt.wantFilesChanged, gotFilesChanged)
 			assert.Equal(t, tt.wantMessage, gotMessage)
 
 			assert.Equal(t, tt.wantCommandInMock, mock.gotCommand.Cmd)


### PR DESCRIPTION
Fix #342 

This PR will unblocks https://github.com/jenkinsci/bom/pull/698.

A manual test had been run , resulting in https://github.com/dduportal/bom/pull/2.

Please note that this PR should only result on a patch update (no breaking change, no new feature: only a bugfix)

## Test
To test this pull request, you can run the following commands:

```
# Unit Tests
  cp pkg/plugins/shell
  go test

# End to End
go build -o dist/updatecli
updatecli diff (...) # in your failing context
```

## Additional Information

- This solution was found with a common brainstomring with @timja and @olblak : thanks folks!
- Please note that it changes the interface of the `scm.Scm` type: it is required to allow mock injection during the unit tests (otherwise we could have only used the `git/generic` method)