### PR TITLE
fix(file) add missing validation messages + improve test coverage 

### DIFF
--- a/examples/updateCli.generic/file.yaml
+++ b/examples/updateCli.generic/file.yaml
@@ -56,11 +56,10 @@ conditions:
       line: 3 # The line 3 of the file matches the source LineFromURL
   LocalFileHasLineMatchingSource:
     kind: file
-    disablesourceinput: true
-    sourceId: LineFromLocalFile
+    sourceID: LineFromLocalFile
     spec:
       file: LICENSE
-      line: 5 # The file './LICENSE' has a 5th line which is NOT empty and matches the source LineFromLocalFile
+      line: 3 # The file './LICENSE' has a 3rd line which is NOT empty and matches the source LineFromLocalFile
   LocalFileHasLineMatchingCustomContent:
     kind: file
     disablesourceinput: true

--- a/pkg/plugins/file/condition_test.go
+++ b/pkg/plugins/file/condition_test.go
@@ -225,6 +225,18 @@ func TestFile_ConditionFromSCM(t *testing.T) {
 				Location: "/tmp/foo.txt",
 			},
 		},
+		{
+			name: "Validation Failure with forcecreate specified",
+			spec: FileSpec{
+				File:        "foo.txt",
+				ForceCreate: true,
+			},
+			scm: &scm.MockScm{
+				WorkingDir: "/tmp",
+			},
+			inputSourceValue: "1.2.3",
+			wantErr:          true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/plugins/file/source.go
+++ b/pkg/plugins/file/source.go
@@ -10,10 +10,20 @@ import (
 
 // Source return a file content
 func (f *File) Source(workingDir string) (string, error) {
+	var validationErrors []string
+
 	if len(f.spec.ReplacePattern) > 0 {
-		validationError := fmt.Errorf("Validation error in source of type 'file': the attribute `spec.replacepattern` is only supported for targets.")
-		logrus.Errorf(validationError.Error())
-		return "", validationError
+		validationErrors = append(validationErrors, "Validation error in source of type 'file': the attribute `spec.replacepattern` is only supported for targets.")
+	}
+	if len(f.spec.Content) > 0 {
+		validationErrors = append(validationErrors, "Validation error in source of type 'file': the attribute `spec.content` is only supported for conditions and targets.")
+	}
+	if f.spec.ForceCreate {
+		validationErrors = append(validationErrors, "Validation error in source of type 'file': the attribute `spec.forcecreate` is only supported for targets.")
+	}
+	// Return all the validation errors if found any
+	if len(validationErrors) > 0 {
+		return "", fmt.Errorf("Validation error: the provided manifest configuration had the following validation errors:\n%s", strings.Join(validationErrors, "\n\n"))
 	}
 
 	if err := f.Read(); err != nil {

--- a/pkg/plugins/file/source_test.go
+++ b/pkg/plugins/file/source_test.go
@@ -95,6 +95,30 @@ d3cab7d777eec230b67eb9723f3b271cd43e29c688439e4c67e3398cdaf6406b  terraform_0.14
 			},
 			wantErr: true,
 		},
+		{
+			name: "Validation Failure with specified content",
+			spec: FileSpec{
+				Content: "Hello world",
+				File:    "/bar.txt",
+			},
+			wantErr: true,
+		},
+		{
+			name: "Validation Failure with specified forcecreate",
+			spec: FileSpec{
+				ForceCreate: true,
+				File:        "/bar.txt",
+			},
+			wantErr: true,
+		},
+		{
+			name: "Validation Failure with invalid regexp for MatchPattern",
+			spec: FileSpec{
+				MatchPattern: "(d+:1",
+				File:         "/bar.txt",
+			},
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/plugins/file/target.go
+++ b/pkg/plugins/file/target.go
@@ -41,6 +41,12 @@ func (f *File) writeTargetFile(source string, dryRun bool) (bool, []string, stri
 
 	// Case 1: The attribute 'spec.line' is specified, we only want to change a specific line of the target file
 	if f.spec.Line > 0 {
+		if f.spec.ForceCreate {
+			validationError := fmt.Errorf("Validation error in target of type 'file': 'spec.line' and 'spec.forcecreate' are mutually exclusive")
+			logrus.Errorf(validationError.Error())
+			return false, files, message, validationError
+		}
+
 		// Check that the specified exists or exit with error
 		if !f.contentRetriever.FileExists(f.spec.File) {
 			return false, files, message, os.ErrNotExist

--- a/pkg/plugins/file/target_test.go
+++ b/pkg/plugins/file/target_test.go
@@ -93,6 +93,27 @@ func TestFile_Target(t *testing.T) {
 			wantErr:    true,
 		},
 		{
+			name: "Validation failure with both line and forcecreate specified",
+			spec: FileSpec{
+				File:        "foo.txt",
+				ForceCreate: true,
+				Line:        2,
+			},
+			wantResult: false,
+			wantErr:    true,
+		},
+		{
+			name: "Validation Failure with invalid regexp for MatchPattern",
+			spec: FileSpec{
+				MatchPattern: "(d+:1",
+				File:         "/bar.txt",
+			},
+			mockReturnsFileExists: true,
+			mockReturnedContent:   `maven_version = "3.8.2"`,
+			wantResult:            false,
+			wantErr:               true,
+		},
+		{
 			name: "Error with file not existing (with line)",
 			spec: FileSpec{
 				File: "not_existing.txt",


### PR DESCRIPTION

While writing the documentation (https://github.com/updatecli/website/pull/161) for the new file features introduced in #313 , I caught missing error messages and an error in the "generic reference YAML example".

This PR aims to fix these.

## Test
To test this pull request, you can run the following commands:

```
  cp <to_package_directory>
  go test
```

## Additionnal Information

Please note that this PR should only result in a pacth version of `updatecli`/