### PR TITLE
fix(shell) correct logging output

### DIFF
--- a/examples/updateCli.generic/shell/condition.sh
+++ b/examples/updateCli.generic/shell/condition.sh
@@ -4,3 +4,5 @@ set -eux -o pipefail
 
 # Test if the command grep is present
 command -v grep
+# Check file attributes of the grep binary
+ls -l "$(command -v grep)"

--- a/examples/updateCli.generic/shell/shell.yaml
+++ b/examples/updateCli.generic/shell/shell.yaml
@@ -1,13 +1,16 @@
 ---
+title: Generic Example for the shell resource
 sources:
   default:
     kind: shell
     spec:
       command: "./examples/updateCli.generic/shell/source.sh"
-  sayHello:
-    kind: shell
-    spec:
-      command: echo Hello
+  ## Uncomment to test a failing source
+  # noDirectoryTiTi:
+  #   kind: shell
+  #   spec:
+  #     command: ls /titi
+
 conditions:
   noSource:
     kind: shell
@@ -19,11 +22,27 @@ conditions:
     sourceID: default
     spec:
       command: echo
+  ## Uncomment to check a failing condition
+  # noDirectoryTiTi:
+  #   kind: shell
+  #   disablesourceinput: true
+  #   spec:
+  #     command: "ls /titi"
 
 targets:
-  default:
-    name: setGrepVersion
+  changeGrepVersion:
     sourceID: default
     kind: shell
     spec:
-      command: "./examples/updateCli.generic/shell/target.sh"
+      command: "./examples/updateCli.generic/shell/target.sh change"
+  doesNotChangeAnything:
+    sourceID: default
+    kind: shell
+    spec:
+      command: "./examples/updateCli.generic/shell/target.sh do-not-change"
+  ## Uncomment to test a failing source
+  # noDirectoryTiTi:
+  #   kind: shell
+  #   sourceID: default
+  #   spec:
+  #     command: ls /titi

--- a/examples/updateCli.generic/shell/target.sh
+++ b/examples/updateCli.generic/shell/target.sh
@@ -2,8 +2,37 @@
 
 set -eux -o pipefail
 
-## This script outputs the provided argument only if DRY_RUN is "true"
-if [[ "${DRY_RUN:-true}" == false ]]
+# log writes the provided string to stderr
+function log() {
+  >&2 echo "${1}"
+}
+
+test -n "${1}" || { log 'ERROR: Missing argument'; exit 1; }
+
+if [[ "${DRY_RUN}" == false ]]
 then
-  echo "$1"
+  # updatecli apply
+  if [[ "${1}" == 'change' ]]
+  then
+    log 'Change applied.'
+    # Prints to stdout to let updatecli knows that there was a change
+    command -v grep
+    ls -l "$(command -v grep)"
+  else
+    log 'No changes applied.'
+    exit 0
+  fi
+else
+  # updatecli diff
+  log 'Variable DRY_RUN is different than false'
+  if [[ "${1}" == 'change' ]]
+  then
+    log 'Change but in dry run'
+    # Prints to stdout to let updatecli knows what changed
+    command -v grep
+    ls -l "$(command -v grep)"
+  else
+    log "No changes applied in dry run"
+    exit 0
+  fi
 fi

--- a/pkg/plugins/shell/command.go
+++ b/pkg/plugins/shell/command.go
@@ -17,6 +17,7 @@ type commandResult struct {
 	ExitCode int
 	Stdout   string
 	Stderr   string
+	Cmd      string
 }
 
 type commandExecutor interface {
@@ -45,6 +46,7 @@ func (nce *nativeCommandExecutor) ExecuteCommand(inputCmd command) (commandResul
 			ExitCode: ee.ExitCode(),
 			Stdout:   out,
 			Stderr:   stderr.String(),
+			Cmd:      inputCmd.Cmd,
 		}, nil
 	}
 	if err != nil {
@@ -55,5 +57,6 @@ func (nce *nativeCommandExecutor) ExecuteCommand(inputCmd command) (commandResul
 		ExitCode: 0,
 		Stdout:   out,
 		Stderr:   stderr.String(),
+		Cmd:      inputCmd.Cmd,
 	}, nil
 }

--- a/pkg/plugins/shell/condition.go
+++ b/pkg/plugins/shell/condition.go
@@ -1,8 +1,6 @@
 package shell
 
 import (
-	"github.com/sirupsen/logrus"
-	"github.com/updatecli/updatecli/pkg/core/result"
 	"github.com/updatecli/updatecli/pkg/core/scm"
 )
 
@@ -17,21 +15,14 @@ func (s *Shell) ConditionFromSCM(source string, scm scm.Scm) (bool, error) {
 }
 
 func (s *Shell) condition(source, workingDir string) (bool, error) {
-	cmdResult, err := s.executor.ExecuteCommand(command{
+	s.executeCommand(command{
 		Cmd: s.appendSource(source),
 		Dir: workingDir,
 	})
 
-	if err != nil {
-		return false, err
-	}
-
-	if cmdResult.ExitCode != 0 {
-		logrus.Infof(errorMessage(cmdResult.ExitCode, s.appendSource(source), cmdResult.Stdout, cmdResult.Stderr))
+	if s.result.ExitCode != 0 {
 		return false, nil
 	}
-
-	logrus.Infof("%v The shell 🐚 command %q successfully validated the condition.", result.SUCCESS, s.appendSource(source))
 
 	return true, nil
 }

--- a/pkg/plugins/shell/condition_test.go
+++ b/pkg/plugins/shell/condition_test.go
@@ -10,13 +10,13 @@ import (
 
 func TestShell_Condition(t *testing.T) {
 	tests := []struct {
-		name          string
-		command       string
-		source        string
-		wantResult    bool
-		wantErr       bool
-		wantCommand   string
-		commandResult commandResult
+		name              string
+		command           string
+		source            string
+		wantResult        bool
+		wantErr           bool
+		wantCommand       string
+		mockCommandResult commandResult
 	}{
 		{
 			name:        "Successful Condition",
@@ -25,7 +25,7 @@ func TestShell_Condition(t *testing.T) {
 			wantResult:  true,
 			wantErr:     false,
 			wantCommand: "echo Hello 1.2.3",
-			commandResult: commandResult{
+			mockCommandResult: commandResult{
 				ExitCode: 0,
 				Stdout:   "Hello",
 			},
@@ -37,7 +37,7 @@ func TestShell_Condition(t *testing.T) {
 			wantResult:  false,
 			wantErr:     false,
 			wantCommand: "ls 1.2.3",
-			commandResult: commandResult{
+			mockCommandResult: commandResult{
 				ExitCode: 1,
 				Stderr:   "ls: 1.2.3: No such file or directory",
 			},
@@ -46,7 +46,7 @@ func TestShell_Condition(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mock := MockCommandExecutor{
-				Result: tt.commandResult,
+				Result: tt.mockCommandResult,
 			}
 			s := Shell{
 				executor: &mock,

--- a/pkg/plugins/shell/errors.go
+++ b/pkg/plugins/shell/errors.go
@@ -1,27 +1,13 @@
 package shell
 
-import (
-	"fmt"
-)
-
 type ErrEmptyCommand struct{}
 
 func (e *ErrEmptyCommand) Error() string {
 	return "Invalid spec for shell resource: command is empty."
 }
 
-// executionFailedError is used to help formatting errors reported to the user
-type executionFailedError struct {
-	ErrCode int
-	Stdout  string
-	Stderr  string
-	Command string
-}
+type ExecutionFailedError struct{}
 
-func (e *executionFailedError) Error() string {
-	return errorMessage(e.ErrCode, e.Command, e.Stdout, e.Stderr)
-}
-
-func errorMessage(exitCode int, command, stdout, stderr string) string {
-	return fmt.Sprintf("The shell 🐚 command %q failed with an exit code of %v and the following messages: \nstderr=\n%v\nstdout=\n%v\n", command, exitCode, stderr, stdout)
+func (e *ExecutionFailedError) Error() string {
+	return "Shell command exited on error."
 }

--- a/pkg/plugins/shell/main.go
+++ b/pkg/plugins/shell/main.go
@@ -1,5 +1,11 @@
 package shell
 
+import (
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+)
+
 // ShellSpec defines a specification for a "shell" resource
 // parsed from an updatecli manifest file
 type ShellSpec struct {
@@ -10,6 +16,7 @@ type ShellSpec struct {
 type Shell struct {
 	executor commandExecutor
 	spec     ShellSpec
+	result   commandResult
 }
 
 // New returns a reference to a newly initialized Shell object from a ShellSpec
@@ -32,4 +39,49 @@ func (s *Shell) appendSource(source string) string {
 	}
 
 	return s.spec.Command
+}
+
+// executeCommand call the shell command executor to execute its command
+// and sets the internal "result" to the command result
+func (s *Shell) executeCommand(inputCmd command) {
+	// No error catching: a non nil error means something went really wrong
+	// So the s.result is a nil value
+	s.result, _ = s.executor.ExecuteCommand(inputCmd)
+
+	// Logs the result
+	s.report()
+}
+
+// report logs the result of the shell command to the end user.
+func (s *Shell) report() {
+	message := fmt.Sprintf("The shell 🐚 command %q", s.result.Cmd)
+	stdoutMessage := fmt.Sprintf("with the following output:\n%s", formatShellBlock(s.result.Stdout))
+	stderrMessage := fmt.Sprintf("command stderr output was:\n%s", formatShellBlock(s.result.Stderr))
+
+	if s.result.ExitCode != 0 {
+		// Shell command exited with an error: log everything as info, including exit code and stderr
+		message += fmt.Sprintf(" exited on error (exit code %d) %s\n\n%s", s.result.ExitCode, stdoutMessage, stderrMessage)
+
+		logrus.Info(message)
+		return
+	}
+
+	// Shell command ran successfully: logs the command and its standard output as info, and stderr as debug
+	message += fmt.Sprintf(" ran successfully %s", stdoutMessage)
+
+	logrus.Info(message)
+	logrus.Debug(stderrMessage)
+}
+
+func formatShellBlock(content string) string {
+	const logShellBlockSeparator string = "----"
+	message := fmt.Sprintf("%s\n", logShellBlockSeparator)
+
+	if content != "" {
+		message += fmt.Sprintf("%s\n", content)
+	}
+
+	message += logShellBlockSeparator
+
+	return message
 }

--- a/pkg/plugins/shell/source.go
+++ b/pkg/plugins/shell/source.go
@@ -1,31 +1,16 @@
 package shell
 
-import (
-	"github.com/sirupsen/logrus"
-	"github.com/updatecli/updatecli/pkg/core/result"
-)
-
 // Source returns the stdout of the shell command if its exit code is 0
 // otherwise an error is returned with the content of stderr
 func (s *Shell) Source(workingDir string) (string, error) {
-	cmdResult, err := s.executor.ExecuteCommand(command{
+	s.executeCommand(command{
 		Cmd: s.spec.Command,
 		Dir: workingDir,
 	})
 
-	if err != nil {
-		return "", err
+	if s.result.ExitCode != 0 {
+		return "", &ExecutionFailedError{}
 	}
 
-	if cmdResult.ExitCode != 0 {
-		return "", &executionFailedError{
-			Command: s.spec.Command,
-			ErrCode: cmdResult.ExitCode,
-			Stdout:  cmdResult.Stdout,
-			Stderr:  cmdResult.Stderr}
-	}
-
-	logrus.Infof("%v The shell 🐚 command %q ran successfully and retrieved the following source value: %q", result.SUCCESS, s.spec.Command, cmdResult.Stdout)
-
-	return cmdResult.Stdout, nil
+	return s.result.Stdout, nil
 }

--- a/pkg/plugins/shell/target_test.go
+++ b/pkg/plugins/shell/target_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/updatecli/updatecli/pkg/core/result"
 	"github.com/updatecli/updatecli/pkg/core/scm"
 )
 
@@ -112,7 +111,7 @@ func TestShell_TargetFromSCM(t *testing.T) {
 			command:                  "change.sh",
 			source:                   "1.2.3",
 			mockReturnedChangedFiles: []string{"pom.xml"},
-			wantMessage:              result.ATTENTION + " The shell 🐚 command \"change.sh 1.2.3\" ran successfully and reported the following change: \"Changed value from 1.2.2 to 1.2.3.\".",
+			wantMessage:              `ran shell command "change.sh 1.2.3"`,
 			wantErr:                  false,
 			wantCommandInMock:        "change.sh 1.2.3",
 			commandResult: commandResult{


### PR DESCRIPTION
- Fixes #325 by printing newlines:

```
changeGrepVersion
-----------------

**Dry Run enabled**

The shell 🐚 command "./examples/updateCli.generic/shell/target.sh change GNU" ran successfully with the following output:
----
/usr/bin/grep
-rwxr-xr-x  1 root  wheel  173440 Oct 18 05:30 /usr/bin/grep
----
DEBUG: command stderr output was:
----
+ test -n change
+ [[ true == false ]]
+ log 'Variable DRY_RUN is different than false'
+ echo 'Variable DRY_RUN is different than false'
Variable DRY_RUN is different than false
+ [[ change == \c\h\a\n\g\e ]]
+ log 'Change but in dry run'
+ echo 'Change but in dry run'
Change but in dry run
+ command -v grep
++ command -v grep
+ ls -l /usr/bin/grep

----
```

- Centralized log method to avoid discrepancy between differents log output for shell

- Improves log for shell:
  - Stop using the characters `✔`, `⚠` and `✗` for the shell reporting (keeping their usage to the core that reports source/conditions/target)
  - Prints stderr only if the shell command fails (less verbose by default) unless the flag `--debug` is passed
  - Improved the messages

- Added a bunch of "generic examples" for shell to allow end to end testing

<details><summary>Click to view the new "normal" output with the generic shell example</summary>

```text


+++++++++++
+ PREPARE +
+++++++++++

Repository retrieved: 0


++++++++++++
+ PIPELINE +
++++++++++++



##########################################
# GENERIC EXAMPLE FOR THE SHELL RESOURCE #
##########################################


SOURCES
=======

noDirectoryTiTi
---------------
The shell 🐚 command "ls /titi" exited on error (exit code 1) with the following output:
----
----

command stderr output was:
----
ls: /titi: No such file or directory

----
ERROR: ✗ Shell command exited on error.

default
-------
The shell 🐚 command "./examples/updateCli.generic/shell/source.sh" ran successfully with the following output:
----
GNU
----


CONDITIONS:
===========

withSource
----------
The shell 🐚 command "echo GNU" ran successfully with the following output:
----
GNU
----

noSource
--------
The shell 🐚 command "./examples/updateCli.generic/shell/condition.sh" ran successfully with the following output:
----
/usr/bin/grep
-rwxr-xr-x  1 root  wheel  173440 Oct 18 05:30 /usr/bin/grep
----


TARGETS
========

doesNotChangeAnything
---------------------

**Dry Run enabled**

The shell 🐚 command "./examples/updateCli.generic/shell/target.sh do-not-change GNU" ran successfully with the following output:
----
----
No change detected

changeGrepVersion
-----------------

**Dry Run enabled**

The shell 🐚 command "./examples/updateCli.generic/shell/target.sh change GNU" ran successfully with the following output:
----
/usr/bin/grep
-rwxr-xr-x  1 root  wheel  173440 Oct 18 05:30 /usr/bin/grep
----

=============================

REPORTS:


✔ SHELL.YAML:
	Sources:
		✔ [default] (shell)
		✗ [noDirectoryTiTi] (shell)
	Condition:
		✔ [noSource] (shell)
		✔ [withSource] (shell)
	Target:
		⚠ [changeGrepVersion]  (shell)
		✔ [doesNotChangeAnything]  (shell)



Run Summary
===========
Pipeline(s) run:
  * Changed:	0
  * Failed:	0
  * Skipped:	0
  * Succeeded:	1
  * Total:	1
```

</details>

<details><summary>Click to view the new "debug" output with the generic shell example</summary>

```text


+++++++++++
+ PREPARE +
+++++++++++

Repository retrieved: 0


++++++++++++
+ PIPELINE +
++++++++++++



##########################################
# GENERIC EXAMPLE FOR THE SHELL RESOURCE #
##########################################


SOURCES
=======

noDirectoryTiTi
---------------
The shell 🐚 command "ls /titi" exited on error (exit code 1) with the following output:
----
----

command stderr output was:
----
ls: /titi: No such file or directory

----
ERROR: ✗ Shell command exited on error.

default
-------
The shell 🐚 command "./examples/updateCli.generic/shell/source.sh" ran successfully with the following output:
----
GNU
----
DEBUG: command stderr output was:
----
+ grep --version
+ head -n1
+ awk '{print $4}'

----


CONDITIONS:
===========

withSource
----------
The shell 🐚 command "echo GNU" ran successfully with the following output:
----
GNU
----
DEBUG: command stderr output was:
----
----

noSource
--------
The shell 🐚 command "./examples/updateCli.generic/shell/condition.sh" ran successfully with the following output:
----
/usr/bin/grep
-rwxr-xr-x  1 root  wheel  173440 Oct 18 05:30 /usr/bin/grep
----
DEBUG: command stderr output was:
----
+ command -v grep
++ command -v grep
+ ls -l /usr/bin/grep

----


TARGETS
========

doesNotChangeAnything
---------------------

**Dry Run enabled**

The shell 🐚 command "./examples/updateCli.generic/shell/target.sh do-not-change GNU" ran successfully with the following output:
----
----
DEBUG: command stderr output was:
----
+ test -n do-not-change
+ [[ true == false ]]
+ log 'Variable DRY_RUN is different than false'
+ echo 'Variable DRY_RUN is different than false'
Variable DRY_RUN is different than false
+ [[ do-not-change == \c\h\a\n\g\e ]]
+ log 'No changes applied in dry run'
+ echo 'No changes applied in dry run'
No changes applied in dry run
+ exit 0

----
No change detected

changeGrepVersion
-----------------

**Dry Run enabled**

The shell 🐚 command "./examples/updateCli.generic/shell/target.sh change GNU" ran successfully with the following output:
----
/usr/bin/grep
-rwxr-xr-x  1 root  wheel  173440 Oct 18 05:30 /usr/bin/grep
----
DEBUG: command stderr output was:
----
+ test -n change
+ [[ true == false ]]
+ log 'Variable DRY_RUN is different than false'
+ echo 'Variable DRY_RUN is different than false'
Variable DRY_RUN is different than false
+ [[ change == \c\h\a\n\g\e ]]
+ log 'Change but in dry run'
+ echo 'Change but in dry run'
Change but in dry run
+ command -v grep
++ command -v grep
+ ls -l /usr/bin/grep

----

=============================

REPORTS:


✔ SHELL.YAML:
	Sources:
		✔ [default] (shell)
		✗ [noDirectoryTiTi] (shell)
	Condition:
		✔ [noSource] (shell)
		✔ [withSource] (shell)
	Target:
		⚠ [changeGrepVersion]  (shell)
		✔ [doesNotChangeAnything]  (shell)



Run Summary
===========
Pipeline(s) run:
  * Changed:	0
  * Failed:	0
  * Skipped:	0
  * Succeeded:	1
  * Total:	1
```

</details>


Fix #325 

## Test
To test this pull request, you can run the following commands:

```
go build -o ./dist/updatecli && ./dist/updatecli --debug diff --config ./examples/updateCli.generic/shell/shell.yaml
```
