### PR TITLE
fix(yaml) allow condition without a source input value 

### DIFF
--- a/examples/updateCli.generic/yaml.yaml
+++ b/examples/updateCli.generic/yaml.yaml
@@ -11,7 +11,6 @@ sources:
     spec:
       file: file://examples/values.yaml
       key: "github.user"
-  ## https://github.com/updatecli/updatecli/issues/357
   fromUrl:
     kind: yaml
     spec:
@@ -29,13 +28,12 @@ sources:
   #     file: examples/values.yaml
   #     key: "foo.bar"
 conditions:
-  ## https://github.com/updatecli/updatecli/issues/358
-  # checkGithubUsername:
-  #   kind: yaml
-  #   sourceID: default
-  #   spec:
-  #     file: examples/values.yaml
-  #     key: "github.user"
+  checkGithubUsername:
+    kind: yaml
+    sourceID: default
+    spec:
+      file: examples/values.yaml
+      key: "github.user"
   checkGithubRepository:
     kind: yaml
     disablesourceinput: true

--- a/pkg/plugins/yaml/condition.go
+++ b/pkg/plugins/yaml/condition.go
@@ -2,85 +2,73 @@ package yaml
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/sirupsen/logrus"
-
+	"github.com/updatecli/updatecli/pkg/core/result"
 	"github.com/updatecli/updatecli/pkg/core/scm"
 	"gopkg.in/yaml.v3"
 )
 
 // Condition checks if a key exists in a yaml file
 func (y *Yaml) Condition(source string) (bool, error) {
-	// Start by retrieving the specified file's content
-	if err := y.Read(); err != nil {
-		return false, err
-	}
-	data := y.CurrentContent
-
-	out := yaml.Node{}
-
-	err := yaml.Unmarshal([]byte(data), &out)
-
-	if err != nil {
-		return false, fmt.Errorf("cannot unmarshal data: %v", err)
-	}
-
-	valueFound, oldVersion, _ := replace(&out, strings.Split(y.Spec.Key, "."), y.Spec.Value, 1)
-
-	if valueFound && oldVersion == y.Spec.Value {
-		logrus.Infof("\u2714 Key '%s', from file '%v', is correctly set to %s'",
-			y.Spec.Key,
-			y.Spec.File,
-			y.Spec.Value)
-		return true, nil
-	} else if valueFound && oldVersion != y.Spec.Value {
-		logrus.Infof("\u2717 Key '%s', from file '%v', is incorrectly set to %s and should be %s'",
-			y.Spec.Key,
-			y.Spec.File,
-			oldVersion,
-			y.Spec.Value)
-	} else {
-		logrus.Infof("\u2717 cannot find key '%s' from file '%s'",
-			y.Spec.Key,
-			y.Spec.File)
-	}
-
-	return false, nil
+	return y.checkYamlCondition(source)
 }
 
 // ConditionFromSCM checks if a key exists in a yaml file
 func (y *Yaml) ConditionFromSCM(source string, scm scm.Scm) (bool, error) {
+	if !filepath.IsAbs(y.Spec.File) {
+		y.Spec.File = filepath.Join(scm.GetDirectory(), y.Spec.File)
+	}
+	return y.checkYamlCondition(source)
+}
+
+func (y *Yaml) checkYamlCondition(source string) (bool, error) {
 	// Start by retrieving the specified file's content
 	if err := y.Read(); err != nil {
 		return false, err
 	}
-	data := y.CurrentContent
-
 	out := yaml.Node{}
 
-	err := yaml.Unmarshal([]byte(data), &out)
+	err := yaml.Unmarshal([]byte(y.CurrentContent), &out)
 
 	if err != nil {
 		return false, fmt.Errorf("cannot unmarshal data: %v", err)
 	}
 
-	valueFound, oldVersion, _ := replace(&out, strings.Split(y.Spec.Key, "."), y.Spec.Value, 1)
+	// If a source is provided, then the key 'Value' cannot be specified
+	valueToCheck := y.Spec.Value
 
-	if valueFound && oldVersion == y.Spec.Value {
-		logrus.Infof("\u2714 Key '%s', from file '%v', is correctly set to %s'",
+	if len(source) > 0 {
+		if len(y.Spec.Value) > 0 {
+			validationError := fmt.Errorf("Validation error in condition of type 'yaml': the attributes `sourceID` and `spec.value` are mutually exclusive")
+			logrus.Errorf(validationError.Error())
+			return false, validationError
+		}
+
+		valueToCheck = source
+	}
+
+	valueFound, oldVersion, _ := replace(&out, strings.Split(y.Spec.Key, "."), valueToCheck, 1)
+
+	if valueFound && oldVersion == valueToCheck {
+		logrus.Infof("%s Key %q, in YAML file %q, is correctly set to %q",
+			result.SUCCESS,
 			y.Spec.Key,
 			y.Spec.File,
-			y.Spec.Value)
+			valueToCheck)
 		return true, nil
-	} else if valueFound && oldVersion != y.Spec.Value {
-		logrus.Infof("\u2717 Key '%s', from file '%v', is incorrectly set to %s and should be %s'",
+	} else if valueFound && oldVersion != valueToCheck {
+		logrus.Infof("%s Key %q, in YAML file %q, is incorrectly set to %s and should be %q",
+			result.FAILURE,
 			y.Spec.Key,
 			y.Spec.File,
 			oldVersion,
-			y.Spec.Value)
+			valueToCheck)
 	} else {
-		logrus.Infof("\u2717 cannot find key '%s' from file '%s'",
+		logrus.Infof("%s cannot find key %q in the YAML file %q",
+			result.FAILURE,
 			y.Spec.Key,
 			y.Spec.File)
 	}

--- a/pkg/plugins/yaml/condition_test.go
+++ b/pkg/plugins/yaml/condition_test.go
@@ -1,0 +1,205 @@
+package yaml
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/updatecli/updatecli/pkg/core/scm"
+	"github.com/updatecli/updatecli/pkg/core/text"
+)
+
+func Test_Condition(t *testing.T) {
+	tests := []struct {
+		name                string
+		spec                YamlSpec
+		inputSourceValue    string
+		wantResult          bool
+		wantErr             bool
+		wantMockState       text.MockTextRetriever
+		mockReturnedContent string
+		mockReturnedError   error
+	}{
+		{
+			name: "Passing Case",
+			spec: YamlSpec{
+				File: "test.yaml",
+				Key:  "github.owner",
+			},
+			inputSourceValue: "olblak",
+			mockReturnedContent: `---
+github:
+  owner: olblak
+  repository: charts
+`,
+			wantResult: true,
+			wantMockState: text.MockTextRetriever{
+				Location: "test.yaml",
+			},
+		},
+		{
+			name: "File does not exist",
+			spec: YamlSpec{
+				File: "not_existing.txt",
+			},
+			mockReturnedError: fmt.Errorf("no such file or directory"),
+			wantResult:        false,
+			wantErr:           true,
+		},
+		{
+			name: "Failing Case (key found but not the correct value)",
+			spec: YamlSpec{
+				File: "test.yaml",
+				Key:  "github.owner",
+			},
+			inputSourceValue: "asterix",
+			mockReturnedContent: `---
+github:
+  owner: olblak
+  repository: charts
+`,
+			wantResult: false,
+			wantMockState: text.MockTextRetriever{
+				Location: "test.yaml",
+			},
+		},
+		{
+			name: "Failing Case (key not found)",
+			spec: YamlSpec{
+				File: "test.yaml",
+				Key:  "github.admin",
+			},
+			inputSourceValue: "asterix",
+			mockReturnedContent: `---
+github:
+  owner: olblak
+  repository: charts
+`,
+			wantResult: false,
+			wantMockState: text.MockTextRetriever{
+				Location: "test.yaml",
+			},
+		},
+		{
+			name: "Validation Failure with both source and specified value",
+			spec: YamlSpec{
+				File:  "test.yaml",
+				Key:   "github.owner",
+				Value: "asterix",
+			},
+			inputSourceValue: "olblak",
+			wantErr:          true,
+		},
+		{
+			name: "Failure due to unvalid Yaml",
+			spec: YamlSpec{
+				File: "test.yaml",
+				Key:  "github.owner",
+			},
+			inputSourceValue: "olblak",
+			mockReturnedContent: `---
+github
+  owner: olblak
+  repository: charts
+`,
+			wantErr: true,
+		},
+		{
+			name: "Passing Case with no input source and only specified value",
+			spec: YamlSpec{
+				File:  "test.yaml",
+				Key:   "github.owner",
+				Value: "olblak",
+			},
+			mockReturnedContent: `---
+github:
+  owner: olblak
+  repository: charts
+`,
+			wantResult: true,
+			wantMockState: text.MockTextRetriever{
+				Location: "test.yaml",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockText := text.MockTextRetriever{
+				Content: tt.mockReturnedContent,
+				Err:     tt.mockReturnedError,
+			}
+			y := &Yaml{
+				Spec:             tt.spec,
+				contentRetriever: &mockText,
+			}
+			gotResult, gotErr := y.Condition(tt.inputSourceValue)
+			if tt.wantErr {
+				assert.Error(t, gotErr)
+				return
+			}
+
+			require.NoError(t, gotErr)
+			assert.Equal(t, tt.wantResult, gotResult)
+			assert.Equal(t, tt.wantMockState.Location, mockText.Location)
+			assert.Equal(t, tt.wantMockState.Line, mockText.Line)
+		})
+	}
+}
+
+func Test_ConditionFromSCM(t *testing.T) {
+	tests := []struct {
+		name                string
+		spec                YamlSpec
+		inputSourceValue    string
+		wantResult          bool
+		wantErr             bool
+		wantMockState       text.MockTextRetriever
+		mockReturnedContent string
+		mockReturnedError   error
+		scm                 scm.Scm
+	}{
+		{
+			name: "Passing Case with no input source and only specified value",
+			spec: YamlSpec{
+				File:  "test.yaml",
+				Key:   "github.owner",
+				Value: "olblak",
+			},
+			mockReturnedContent: `---
+github:
+  owner: olblak
+  repository: charts
+`,
+			scm: &scm.MockScm{
+				WorkingDir: "/tmp",
+			},
+			wantResult: true,
+			wantMockState: text.MockTextRetriever{
+				Location: "/tmp/test.yaml",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockText := text.MockTextRetriever{
+				Content: tt.mockReturnedContent,
+				Err:     tt.mockReturnedError,
+			}
+			y := &Yaml{
+				Spec:             tt.spec,
+				contentRetriever: &mockText,
+			}
+			gotResult, gotErr := y.ConditionFromSCM(tt.inputSourceValue, tt.scm)
+			if tt.wantErr {
+				assert.Error(t, gotErr)
+				return
+			}
+
+			require.NoError(t, gotErr)
+			assert.Equal(t, tt.wantResult, gotResult)
+			assert.Equal(t, tt.wantMockState.Location, mockText.Location)
+			assert.Equal(t, tt.wantMockState.Line, mockText.Line)
+		})
+	}
+}


### PR DESCRIPTION
Fix #358.

Depends on #360 

This PR ensures that a condition where the input source value is provided uses this value instead of failing.

## Test
To test this pull request, you can run the following commands:

```
go build -o ./dist/updatecli && ./dist/updatecli diff --config ./examples/updateCli.generic/yaml.yaml
```

## Additionnal Information

- Added unit tests for yaml condition (coverage of 100% for this source file)
- Factorized code in yaml condition to ensure the same behavior between SCM and non SCM
- Ensure that logging is reusing the constants for the unicode emojis