### PR TITLE
fix(yaml) specifying a value takes precedence over the source input

### DIFF
--- a/examples/updateCli.generic/yaml.yaml
+++ b/examples/updateCli.generic/yaml.yaml
@@ -62,11 +62,10 @@ targets:
     spec:
       file: examples/values.yaml
       key: "github.owner"
-  ## https://github.com/updatecli/updatecli/issues/359
-  # setGitHubRepository:
-  #   kind: yaml
-  #   sourceID: default
-  #   spec:
-  #     file: examples/values.yaml
-  #     key: "github.repository"
-  #     value: "charts"
+  setGitHubRepository:
+    kind: yaml
+    sourceID: default
+    spec:
+      file: examples/values.yaml
+      key: "github.repository"
+      value: "charts"

--- a/pkg/plugins/file/condition.go
+++ b/pkg/plugins/file/condition.go
@@ -15,7 +15,7 @@ import (
 // Condition test if a file content match the content provided via configuration.
 // If the configuration doesn't specify a value then it fall back to the source output
 func (f *File) Condition(source string) (bool, error) {
-	return f.checkFileCondition(source)
+	return f.condition(source)
 }
 
 // ConditionFromSCM test if a file content from SCM match the content provided via configuration.
@@ -24,10 +24,10 @@ func (f *File) ConditionFromSCM(source string, scm scm.Scm) (bool, error) {
 	if !filepath.IsAbs(f.spec.File) {
 		f.spec.File = filepath.Join(scm.GetDirectory(), f.spec.File)
 	}
-	return f.checkFileCondition(source)
+	return f.condition(source)
 }
 
-func (f *File) checkFileCondition(source string) (bool, error) {
+func (f *File) condition(source string) (bool, error) {
 	var validationErrors []string
 
 	if len(f.spec.ReplacePattern) > 0 {

--- a/pkg/plugins/file/target.go
+++ b/pkg/plugins/file/target.go
@@ -15,7 +15,7 @@ import (
 // Target creates or updates a file located locally.
 // The default content is the value retrieved from source
 func (f *File) Target(source string, dryRun bool) (bool, error) {
-	changed, _, _, err := f.writeTargetFile(source, dryRun)
+	changed, _, _, err := f.target(source, dryRun)
 	return changed, err
 }
 
@@ -25,10 +25,10 @@ func (f *File) TargetFromSCM(source string, scm scm.Scm, dryRun bool) (bool, []s
 	if !filepath.IsAbs(f.spec.File) {
 		f.spec.File = filepath.Join(scm.GetDirectory(), f.spec.File)
 	}
-	return f.writeTargetFile(source, dryRun)
+	return f.target(source, dryRun)
 }
 
-func (f *File) writeTargetFile(source string, dryRun bool) (bool, []string, string, error) {
+func (f *File) target(source string, dryRun bool) (bool, []string, string, error) {
 	var files []string
 	var message string
 

--- a/pkg/plugins/yaml/condition.go
+++ b/pkg/plugins/yaml/condition.go
@@ -13,7 +13,7 @@ import (
 
 // Condition checks if a key exists in a yaml file
 func (y *Yaml) Condition(source string) (bool, error) {
-	return y.checkYamlCondition(source)
+	return y.condition(source)
 }
 
 // ConditionFromSCM checks if a key exists in a yaml file
@@ -21,10 +21,10 @@ func (y *Yaml) ConditionFromSCM(source string, scm scm.Scm) (bool, error) {
 	if !filepath.IsAbs(y.Spec.File) {
 		y.Spec.File = filepath.Join(scm.GetDirectory(), y.Spec.File)
 	}
-	return y.checkYamlCondition(source)
+	return y.condition(source)
 }
 
-func (y *Yaml) checkYamlCondition(source string) (bool, error) {
+func (y *Yaml) condition(source string) (bool, error) {
 	// Start by retrieving the specified file's content
 	if err := y.Read(); err != nil {
 		return false, err

--- a/pkg/plugins/yaml/target.go
+++ b/pkg/plugins/yaml/target.go
@@ -3,107 +3,38 @@ package yaml
 import (
 	"fmt"
 	"os"
-	"os/user"
 	"path/filepath"
 	"strings"
 
 	"github.com/sirupsen/logrus"
 
+	"github.com/updatecli/updatecli/pkg/core/result"
 	"github.com/updatecli/updatecli/pkg/core/scm"
 	"github.com/updatecli/updatecli/pkg/core/text"
 	"gopkg.in/yaml.v3"
 )
 
 // Target updates a scm repository based on the modified yaml file.
-func (y *Yaml) Target(source string, dryRun bool) (changed bool, err error) {
-	y.Spec.Value = source
-
-	// Test if target reference is an URL. In that case we don't know how to update.
-	if text.IsURL(y.Spec.File) {
-		return false, fmt.Errorf("unsupported filename prefix")
-	}
-
-	changed = false
-
-	if err := y.Read(); err != nil {
-		return false, err
-	}
-	data := y.CurrentContent
-
-	out := yaml.Node{}
-
-	err = yaml.Unmarshal([]byte(data), &out)
-
-	if err != nil {
-		return changed, fmt.Errorf("cannot unmarshal data: %v", err)
-	}
-
-	valueFound, oldVersion, _ := replace(&out, strings.Split(y.Spec.Key, "."), y.Spec.Value, 1)
-
-	if valueFound {
-		if oldVersion == y.Spec.Value {
-			logrus.Infof("\u2714 Key '%s', from file '%v', already set to %s, nothing else need to be done",
-				y.Spec.Key,
-				y.Spec.File,
-				y.Spec.Value)
-			return changed, nil
-		}
-
-		changed = true
-		logrus.Infof("\u2714 Key '%s', from file '%v', was updated from '%s' to '%s'",
-			y.Spec.Key,
-			y.Spec.File,
-			oldVersion,
-			y.Spec.Value)
-	} else {
-		logrus.Infof("\u2717 cannot find key '%s' from file '%s'", y.Spec.Key, y.Spec.File)
-		return changed, nil
-	}
-
-	if !dryRun {
-		fileInfo, err := os.Stat(y.Spec.File)
-		if err != nil {
-			logrus.Errorf("unable to get file info: %s", err)
-		}
-
-		logrus.Debugf("fileInfo for %s mode=%s", y.Spec.File, fileInfo.Mode().String())
-
-		user, err := user.Current()
-		if err != nil {
-			logrus.Errorf("unable to get user info: %s", err)
-		}
-
-		logrus.Debugf("user: username=%s, uid=%s, gid=%s", user.Username, user.Uid, user.Gid)
-
-		newFile, err := os.Create(y.Spec.File)
-		if err != nil {
-			return changed, fmt.Errorf("unable to write to file %s: %v", y.Spec.File, err)
-		}
-
-		defer newFile.Close()
-
-		encoder := yaml.NewEncoder(newFile)
-		defer encoder.Close()
-		encoder.SetIndent(yamlIdent)
-		err = encoder.Encode(&out)
-
-		if err != nil {
-			return changed, fmt.Errorf("something went wrong while encoding %v", err)
-		}
-	}
-
-	return changed, nil
+func (y *Yaml) Target(source string, dryRun bool) (bool, error) {
+	changed, _, _, err := y.target(source, dryRun)
+	return changed, err
 }
 
 // TargetFromSCM updates a scm repository based on the modified yaml file.
-func (y *Yaml) TargetFromSCM(source string, scm scm.Scm, dryRun bool) (changed bool, files []string, message string, err error) {
+func (y *Yaml) TargetFromSCM(source string, scm scm.Scm, dryRun bool) (bool, []string, string, error) {
+	if !filepath.IsAbs(y.Spec.File) {
+		y.Spec.File = filepath.Join(scm.GetDirectory(), y.Spec.File)
+	}
+	return y.target(source, dryRun)
+}
+
+func (y *Yaml) target(source string, dryRun bool) (bool, []string, string, error) {
+	var files []string
+	var message string
+
 	if text.IsURL(y.Spec.File) {
 		return false, files, message, fmt.Errorf("unsupported filename prefix")
 	}
-
-	y.Spec.Value = source
-
-	changed = false
 
 	if err := y.Read(); err != nil {
 		return false, files, message, err
@@ -112,41 +43,51 @@ func (y *Yaml) TargetFromSCM(source string, scm scm.Scm, dryRun bool) (changed b
 
 	out := yaml.Node{}
 
-	err = yaml.Unmarshal([]byte(data), &out)
+	err := yaml.Unmarshal([]byte(data), &out)
 
 	if err != nil {
-		return changed, files, message, fmt.Errorf("cannot unmarshal data: %v", err)
+		return false, files, message, fmt.Errorf("cannot unmarshal data: %v", err)
 	}
 
-	valueFound, oldVersion, _ := replace(&out, strings.Split(y.Spec.Key, "."), y.Spec.Value, 1)
+	valueToWrite := source
+	if y.Spec.Value != "" {
+		valueToWrite = y.Spec.Value
+		logrus.Info("INFO: Using spec.Value instead of source input value.")
+	}
+
+	valueFound, oldVersion, _ := replace(&out, strings.Split(y.Spec.Key, "."), valueToWrite, 1)
 
 	if valueFound {
-		if oldVersion == y.Spec.Value {
-			logrus.Infof("\u2714 Key '%s', from file '%v', already set to %s, nothing else need to be done",
+		if oldVersion == valueToWrite {
+			logrus.Infof("%s Key '%s', from file '%v', already set to %s, nothing else need to be done",
+				result.SUCCESS,
 				y.Spec.Key,
 				y.Spec.File,
-				y.Spec.Value)
-			return changed, files, message, nil
+				valueToWrite)
+			return false, files, message, nil
 		}
-		changed = true
-		logrus.Infof("\u2714 Key '%s', from file '%v', was updated from '%s' to '%s'",
+		logrus.Infof("%s Key '%s', from file '%v', was updated from '%s' to '%s'",
+			result.ATTENTION,
 			y.Spec.Key,
 			y.Spec.File,
 			oldVersion,
-			y.Spec.Value)
+			valueToWrite)
 
 	} else {
-		logrus.Infof("\u2717 cannot find key '%s' from file '%s'", y.Spec.Key, y.Spec.File)
-		return changed, files, message, nil
+		logrus.Infof("%s cannot find key '%s' from file '%s'",
+			result.FAILURE,
+			y.Spec.Key,
+			y.Spec.File)
+		return false, files, message, nil
 	}
 
 	if !dryRun {
 
-		newFile, err := os.Create(filepath.Join(scm.GetDirectory(), y.Spec.File))
+		newFile, err := os.Create(y.Spec.File)
 		defer newFile.Close()
 
 		if err != nil {
-			return changed, files, message, nil
+			return false, files, message, nil
 		}
 
 		encoder := yaml.NewEncoder(newFile)
@@ -155,7 +96,7 @@ func (y *Yaml) TargetFromSCM(source string, scm scm.Scm, dryRun bool) (changed b
 		err = encoder.Encode(&out)
 
 		if err != nil {
-			return changed, files, message, err
+			return false, files, message, err
 		}
 	}
 
@@ -163,5 +104,5 @@ func (y *Yaml) TargetFromSCM(source string, scm scm.Scm, dryRun bool) (changed b
 
 	message = fmt.Sprintf("Update key %q from file %q", y.Spec.Key, y.Spec.File)
 
-	return changed, files, message, nil
+	return true, files, message, nil
 }

--- a/pkg/plugins/yaml/target_test.go
+++ b/pkg/plugins/yaml/target_test.go
@@ -1,0 +1,103 @@
+package yaml
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/updatecli/updatecli/pkg/core/text"
+)
+
+func Test_Target(t *testing.T) {
+	tests := []struct {
+		spec                  YamlSpec
+		wantMockState         text.MockTextRetriever
+		name                  string
+		inputSourceValue      string
+		mockReturnedContent   string
+		mockReturnedError     error
+		mockReturnsFileExists bool
+		wantResult            bool
+		wantErr               bool
+		dryRun                bool
+	}{
+		{
+			name: "Passing Case with both input source and specified value (specified value should be used)",
+			spec: YamlSpec{
+				File:  "test.yaml",
+				Key:   "github.owner",
+				Value: "obiwankenobi",
+			},
+			mockReturnsFileExists: true,
+			inputSourceValue:      "olblak",
+			mockReturnedContent: `---
+github:
+  owner: olblak
+  repository: charts
+`,
+			wantResult: true,
+		},
+		{
+			name: "Validation failure with an https:// URL instead of a file",
+			spec: YamlSpec{
+				File:  "https://github.com/foo.yaml",
+				Key:   "github.owner",
+				Value: "obiwankenobi",
+			},
+			wantResult: false,
+			wantErr:    true,
+		},
+		{
+			name: "Not passing: file already up to date",
+			spec: YamlSpec{
+				File: "test.yaml",
+				Key:  "github.owner",
+			},
+			mockReturnsFileExists: true,
+			inputSourceValue:      "olblak",
+			mockReturnedContent: `---
+github:
+  owner: olblak
+  repository: charts
+`,
+			wantResult: false,
+		},
+		{
+			name: "Not passing: key does ot exist",
+			spec: YamlSpec{
+				File:  "test.yaml",
+				Key:   "github.ship",
+				Value: "obiwankenobi",
+			},
+			mockReturnsFileExists: true,
+			inputSourceValue:      "olblak",
+			mockReturnedContent: `---
+github:
+  owner: olblak
+  repository: charts
+`,
+			wantResult: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockText := text.MockTextRetriever{
+				Content: tt.mockReturnedContent,
+				Err:     tt.mockReturnedError,
+				Exists:  tt.mockReturnsFileExists,
+			}
+			y := &Yaml{
+				Spec:             tt.spec,
+				contentRetriever: &mockText,
+			}
+			gotResult, gotErr := y.Target(tt.inputSourceValue, tt.dryRun)
+			if tt.wantErr {
+				assert.Error(t, gotErr)
+				return
+			}
+
+			require.NoError(t, gotErr)
+			assert.Equal(t, tt.wantResult, gotResult)
+		})
+	}
+}


### PR DESCRIPTION
Fix #359 .

Depends on #360 and #362 

## Test
To test this pull request, you can run the following commands:

```
go build -o ./dist/updatecli && ./dist/updatecli diff --config ./examples/updateCli.generic/yaml.yaml
```

## Additionnal Information

- Added unit tests for yaml target (not complete coverage: Yaml encoder mocking ain't easy)
- Factorized code in yaml target to ensure the same behavior between SCM and non SCM
- Ensure that logging is reusing the constants for the unicode emojis