### PR TITLE
fix(git-generic) Ensure that git add works with absolute file paths

### DIFF
--- a/pkg/plugins/git/generic/main.go
+++ b/pkg/plugins/git/generic/main.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -50,7 +51,17 @@ func Add(files []string, workingDir string) error {
 	logrus.Debugf("stage: git-add\n\n")
 
 	for _, file := range files {
-		logrus.Debugf("adding file: %s\n", file)
+		logrus.Debugf("adding file: %q\n", file)
+
+		// Strip working directory from file path if it's provided as an absolute path
+		if filepath.IsAbs(file) {
+			relativeFilePath, err := filepath.Rel(workingDir, file)
+			if err != nil {
+				return err
+			}
+			logrus.Debugf("absolute file path detected: %q converted to relative path %q\n", file, relativeFilePath)
+			file = relativeFilePath
+		}
 
 		r, err := git.PlainOpen(workingDir)
 		if err != nil {


### PR DESCRIPTION
Fix #366 

The PRs #313 and #363 reworked the resources `file` and `yaml` with the side effect of switching the list of file path returned by their `TargetFromScm()` function to absolute paths, leading to error `entry not found` when git-adding the files in a target with scm case.

This PR fixes this behavior by treating the file path directly into the git generic plugin: if the file path that should be git added are absolute, then updatecli tries to convert these paths as relative to the scm's working directory (or raise an error otherwise).

## Test

To test this pull request, you can run the following commands:

```shell
git checkout https://github.com/jenkins-infra/pipeline-library -b c5c4b22
cd pipeline-library
updatecli-next --debug apply --values ./updatecli/values.yaml --config ./updatecli/updatecli.d/docker-builder.yml
```

=> Tested successfully on my fork: https://github.com/dduportal/pipeline-library/pull/10

## Additional Information

### Tradeoff

The resources `file` or `yaml` could have been updated to fix the file path, but fixing it on the "central" git seemed safer: it removes a constraint on the plugins code for any contributor. WDYT @olblak ?

### Potential improvement

The resources `file` or `yaml` could be updated to use relative path in complement of the fix.
