### PR TITLE
enh(file) improve Diff output when a file is changed

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -92,6 +92,7 @@ require (
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/hashicorp/vault/api v1.0.4 // indirect
 	github.com/hashicorp/vault/sdk v0.1.13 // indirect
+	github.com/hexops/gotextdiff v1.0.3 // indirect
 	github.com/howeyc/gopass v0.0.0-20170109162249-bf9dde6d0d2c // indirect
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -871,6 +871,8 @@ github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKe
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/heimdalr/dag v1.0.1 h1:iR2K3DSUFDYx0GeV7iXBnZkedWS1xePSGrylQ197uxg=
 github.com/heimdalr/dag v1.0.1/go.mod h1:t+ZkR+sjKL4xhlE1B9rwpvwfo+x+2R0363efS+Oghns=
+github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
+github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 github.com/howeyc/gopass v0.0.0-20170109162249-bf9dde6d0d2c h1:kQWxfPIHVLbgLzphqk3QUflDy9QdksZR4ygR807bpy0=
 github.com/howeyc/gopass v0.0.0-20170109162249-bf9dde6d0d2c/go.mod h1:lADxMC39cJJqL93Duh1xhAs4I2Zs8mKS89XWXFGp9cs=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=

--- a/pkg/core/text/main.go
+++ b/pkg/core/text/main.go
@@ -2,6 +2,7 @@ package text
 
 import (
 	"bufio"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net"
@@ -10,6 +11,10 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/hexops/gotextdiff"
+	"github.com/hexops/gotextdiff/myers"
+	"github.com/hexops/gotextdiff/span"
 )
 
 type TextRetriever interface {
@@ -140,19 +145,10 @@ func (t *Text) ReadLine(location string, line int) (string, error) {
 }
 
 // Diff return a diff like string, comparing string A and string B
-func Diff(a, b string) (result string) {
-
-	for _, line := range strings.Split(a, "\n") {
-		result = result + "< " + line + "\n"
-	}
-
-	result = result + "---\n"
-
-	for _, line := range strings.Split(b, "\n") {
-		result = result + "> " + line + "\n"
-	}
-	return result
-
+func Diff(filename, originalFileContent, newFileContent string) string {
+	edits := myers.ComputeEdits(span.URIFromPath(filename), originalFileContent, newFileContent)
+	diff := fmt.Sprint(gotextdiff.ToUnified(filename, filename, originalFileContent, edits))
+	return diff
 }
 
 // Show return a string where each line start with a tabulation

--- a/pkg/plugins/file/condition.go
+++ b/pkg/plugins/file/condition.go
@@ -84,7 +84,7 @@ func (f *File) condition(source string) (bool, error) {
 			logrus.Infof(
 				"\u2717 %s is different than the input source value:\n%s",
 				logMessage,
-				text.Diff(f.CurrentContent, source),
+				text.Diff(f.spec.File, f.CurrentContent, source),
 			)
 
 			return false, nil
@@ -110,7 +110,7 @@ func (f *File) condition(source string) (bool, error) {
 
 	if f.spec.Content != f.CurrentContent {
 		logrus.Infof("\u2717 %s is different than the specified content: \n%s",
-			logMessage, text.Diff(f.CurrentContent, f.spec.Content))
+			logMessage, text.Diff(f.spec.File, f.CurrentContent, f.spec.Content))
 
 		return false, nil
 	}

--- a/pkg/plugins/file/target.go
+++ b/pkg/plugins/file/target.go
@@ -79,7 +79,7 @@ func (f *File) target(source string, dryRun bool) (bool, []string, string, error
 		files = append(files, f.spec.File)
 		message = fmt.Sprintf("changed line %d of file %q", f.spec.Line, f.spec.File)
 
-		logrus.Infof("\u2714 The line %d of the file %q was updated: \n\n%s\n", f.spec.Line, f.spec.File, text.Diff(currentLine, newContent))
+		logrus.Infof("\u2714 The line %d of the file %q was updated: \n\n%s\n", f.spec.Line, f.spec.File, text.Diff(f.spec.File, currentLine, newContent))
 
 		return true, files, message, nil
 
@@ -143,7 +143,7 @@ func (f *File) target(source string, dryRun bool) (bool, []string, string, error
 	files = append(files, f.spec.File)
 	message = fmt.Sprintf("Updated the file %q\n", f.spec.File)
 
-	logrus.Infof("\u2714 File content for %q, updated. \n\n%s\n", f.spec.File, text.Diff(f.CurrentContent, newContent))
+	logrus.Infof("\u2714 File content for %q, updated. \n\n%s\n", f.spec.File, text.Diff(f.spec.File, f.CurrentContent, newContent))
 
 	return true, files, message, nil
 }


### PR DESCRIPTION


Fix #369 

Example of output:

```text
pdateGroovyCode
----------------

**Dry Run enabled**

✔ File content for "/var/folders/2s/09szbrgn22l2tcvxz1_k34g40000gn/T/updatecli/jenkins-infra/pipeline-library/vars/buildDockerAndPublishImage.groovy", updated. 

--- /var/folders/2s/09szbrgn22l2tcvxz1_k34g40000gn/T/updatecli/jenkins-infra/pipeline-library/vars/buildDockerAndPublishImage.groovy
+++ /var/folders/2s/09szbrgn22l2tcvxz1_k34g40000gn/T/updatecli/jenkins-infra/pipeline-library/vars/buildDockerAndPublishImage.groovy
@@ -33,7 +33,7 @@
       ),
       containerTemplate(
         name: 'next-version',
-        image: config.nextVersionImage ?: 'ghcr.io/jenkins-x/jx-release-version:2.4.13',
+        image: config.nextVersionImage ?: 'ghcr.io/jenkins-x/jx-release-version:2.5.1',
         command: 'cat',
         ttyEnabled: true,
         resourceRequestCpu: '200m',
         ```

## Test

To test this pull request, you can run the following commands:

```shell
cp <to_package_directory>
go test
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
