### PR TITLE
fix(target) do not open a PR when a target does not change a file

### DIFF
--- a/pkg/core/engine/target/main.go
+++ b/pkg/core/engine/target/main.go
@@ -240,14 +240,13 @@ func (t *Target) Run(source string, o *Options) (err error) {
 		return err
 	}
 
-	if changed {
-		t.Result = result.ATTENTION
-	} else {
+	if !changed {
 		t.Result = result.SUCCESS
+		return nil
 	}
 
-	if changed && !o.DryRun {
-
+	t.Result = result.ATTENTION
+	if !o.DryRun {
 		if message == "" {
 			t.Result = result.FAILURE
 			return fmt.Errorf("target has no change message")
@@ -277,20 +276,19 @@ func (t *Target) Run(source string, o *Options) (err error) {
 					t.Result = result.FAILURE
 					return err
 				}
+				if pr != nil {
+					err = pr.CreatePullRequest(
+						t.ReportTitle,
+						t.Changelog,
+						t.ReportBody,
+					)
+					if err != nil {
+						t.Result = result.FAILURE
+						return err
+					}
+				}
 			}
 		}
-	}
-	if pr != nil && !o.DryRun && o.Push {
-		err = pr.CreatePullRequest(
-			t.ReportTitle,
-			t.Changelog,
-			t.ReportBody,
-		)
-		if err != nil {
-			t.Result = result.FAILURE
-			return err
-		}
-
 	}
 
 	return nil


### PR DESCRIPTION
Fix #375 

The problem was caused because the "if block"  responsible to open the pull request was not position in the correct location.

To fix this issue, we are returning early when a target does not change anything: it removes 1 layer of "if/else" and it ensures that the "if" block responsible for PR creation is NEVER called when there isn"t any change.
Also, the "if block" had been put in the most specific if branch to avoid repeated conditions (!dry run and o.push).

=> IF it causes logic trouble in the cinematic for opening PR, then it means that addition refactoring will be required to ensure that the concept of "happy path" + "early return" are met. Unit tests would greatly help in this case.

Verified against https://github.com/dduportal/charts:

```shell
$ updatecli --debug apply --values ./updatecli/values.yaml --config ./updatecli/updatecli.d/charts/acme.yaml
# ...
TARGETS
========

updateChartVersion
------------------
DEBUG: stage: git-checkout

DEBUG: checkout branch "updatecli_08bce438947f81e32d2fcf5d995be35020abe6ae73a1d04bad797f3489031748", based on "main" to directory "/var/folders/2s/09szbrgn22l2tcvxz1_k34g40000gn/T/updatecli/dduportal/charts"
DEBUG: branch 'updatecli_08bce438947f81e32d2fcf5d995be35020abe6ae73a1d04bad797f3489031748' doesn't exist, creating it from branch 'main'
DEBUG: branch "updatecli_08bce438947f81e32d2fcf5d995be35020abe6ae73a1d04bad797f3489031748" successfully created
✔ Content from file "/var/folders/2s/09szbrgn22l2tcvxz1_k34g40000gn/T/updatecli/dduportal/charts/clusters/publick8s.yaml" already up to date

=============================

REPORTS:


✔ ACME.YAML:
        Sources:
                ✔ [lastChartVersion] (helmChart)
        Target:
                ✔ [updateChartVersion]  Update the chart version for acme(file)
```
