### PR TITLE
feat(file) allow condition to only check for file existence

### DIFF
--- a/examples/updatecli.generic/file.yaml
+++ b/examples/updatecli.generic/file.yaml
@@ -35,6 +35,16 @@ conditions:
     sourceID: ContentFromLocalFile
     spec:
       file: LICENSE
+  LocalFileExists:
+    kind: file
+    disablesourceinput: true
+    spec:
+      file: LICENSE
+  RemoteFileExists:
+    kind: file
+    disablesourceinput: true
+    spec:
+      file: https://get.helm.sh/helm-v3.5.0-darwin-amd64.tar.gz.sha256sum
   URLFileMatchesSpecifiedContent:
     kind: file
     disablesourceinput: true

--- a/pkg/core/text/main.go
+++ b/pkg/core/text/main.go
@@ -37,7 +37,7 @@ func readFromURL(url string, line int) (string, error) {
 	}
 	logrus.Debugf("HTTP GET to %q got a response with code %d", url, resp.StatusCode)
 	if resp.StatusCode > 399 {
-		logrus.Debugf("Status code for URL %q is not in the 1XX, 2XX or 3XX ranges: %d", url, resp.StatusCode)
+		logrus.Debugf("HTTP return code %q for URL %q", resp.StatusCode, url)
 		return "", fmt.Errorf("URL %q not found or in error", url)
 	}
 

--- a/pkg/core/text/main.go
+++ b/pkg/core/text/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hexops/gotextdiff"
 	"github.com/hexops/gotextdiff/myers"
 	"github.com/hexops/gotextdiff/span"
+	"github.com/sirupsen/logrus"
 )
 
 type TextRetriever interface {
@@ -34,14 +35,22 @@ func readFromURL(url string, line int) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	logrus.Debugf("HTTP GET to %q got a response with code %d", url, resp.StatusCode)
+	if resp.StatusCode > 399 {
+		logrus.Debugf("Status code for URL %q is not in the 1XX, 2XX or 3XX ranges: %d", url, resp.StatusCode)
+		return "", fmt.Errorf("URL %q not found or in error", url)
+	}
+
 	defer resp.Body.Close()
 
 	// Only retrieve the specified line in memory if specified
 	if line > 0 {
+		logrus.Debugf("Reading line %d of the content returned from url %q", line, url)
 		return getLine(bufio.NewReader(resp.Body), line), nil
 	}
 
 	// Otherwise retrieve the whole file content. Can be heavy.
+	logrus.Debugf("Reading content returned from the url %q", url)
 	bodyContent, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
@@ -95,6 +104,7 @@ func getLine(reader io.Reader, line int) string {
 // "https://", or file url "file://" or filepath (default)
 func (t *Text) ReadAll(location string) (string, error) {
 	if IsURL(location) {
+		logrus.Debugf("URL detected for location %q", location)
 		content, err := readFromURL(location, 0)
 		if err != nil {
 			return "", err
@@ -171,7 +181,7 @@ func Show(content string) (result string) {
 func IsURL(location string) bool {
 	_, err := os.Stat(location)
 	if err == nil {
-		// If "location" exists is not an exitring file, then let's try an URL
+		// If "location" is not an existing file, then let's try an URL
 		// Note that we do not check error type: URL parsing will cover edge cases
 		return false
 	}
@@ -256,7 +266,16 @@ func (t *Text) WriteLineToFile(lineContent, location string, lineNumber int) (er
 }
 
 func (t *Text) FileExists(location string) bool {
-	// Check that the specified exists or exit with error
+	if IsURL(location) {
+		logrus.Debugf("URL detected for file %q", location)
+		// Try to only get the first line of the remote URL
+		_, err := readFromURL(location, 1)
+
+		// No error means that the remote URL exists (1XX, 2XX or 3XX)
+		return err == nil
+	}
+
+	// Not an URL: check that the specified exists or exit with error
 	if _, err := os.Stat(location); err != nil {
 		return false
 	}

--- a/pkg/plugins/file/condition.go
+++ b/pkg/plugins/file/condition.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"github.com/updatecli/updatecli/pkg/core/result"
 	"github.com/updatecli/updatecli/pkg/core/scm"
 	"github.com/updatecli/updatecli/pkg/core/text"
 )
@@ -15,7 +16,7 @@ import (
 // Condition test if a file content match the content provided via configuration.
 // If the configuration doesn't specify a value then it fall back to the source output
 func (f *File) Condition(source string) (bool, error) {
-	return f.condition(source)
+	return f.checkCondition(source)
 }
 
 // ConditionFromSCM test if a file content from SCM match the content provided via configuration.
@@ -23,8 +24,24 @@ func (f *File) Condition(source string) (bool, error) {
 func (f *File) ConditionFromSCM(source string, scm scm.Scm) (bool, error) {
 	if !filepath.IsAbs(f.spec.File) {
 		f.spec.File = filepath.Join(scm.GetDirectory(), f.spec.File)
+		logrus.Debugf("Relative path detected: changing to absolute path from SCM: %q", f.spec.File)
 	}
-	return f.condition(source)
+	return f.checkCondition(source)
+}
+
+func (f *File) checkCondition(source string) (bool, error) {
+	passing, err := f.condition(source)
+	if err != nil {
+		logrus.Infof("%s Condition on file %q errored", result.FAILURE, f.spec.File)
+	} else {
+		if passing {
+			logrus.Infof("%s Condition on file %q passed", result.SUCCESS, f.spec.File)
+		} else {
+			logrus.Infof("%s Condition on file %q did not pass", result.FAILURE, f.spec.File)
+		}
+	}
+
+	return passing, err
 }
 
 func (f *File) condition(source string) (bool, error) {
@@ -42,7 +59,9 @@ func (f *File) condition(source string) (bool, error) {
 	}
 
 	// Start by retrieving the specified file's content
+	logrus.Debugf("Reading file %q", f.spec.File)
 	if err := f.Read(); err != nil {
+		logrus.Debugf("Error while reading file: %q", err.Error())
 		return false, err
 	}
 
@@ -53,6 +72,7 @@ func (f *File) condition(source string) (bool, error) {
 
 	// If a matchPattern is specified, then return its result
 	if len(f.spec.MatchPattern) > 0 {
+		logrus.Debugf("Attribute 'matchpattern' found: %s", f.spec.MatchPattern)
 		reg, err := regexp.Compile(f.spec.MatchPattern)
 		if err != nil {
 			logrus.Errorf("Validation error in condition of type 'file': Unable to parse the regexp specified at f.spec.MatchPattern (%q)", f.spec.MatchPattern)
@@ -73,6 +93,7 @@ func (f *File) condition(source string) (bool, error) {
 
 	// When a source is provided, try to compare the file content with the source
 	if len(source) > 0 {
+		logrus.Debugf("Using source input value: %q", source)
 		if len(f.spec.Content) > 0 {
 			validationError := fmt.Errorf("Validation error in condition of type 'file': the attributes `sourceID` and `spec.content` are mutually exclusive")
 			logrus.Errorf(validationError.Error())
@@ -97,16 +118,25 @@ func (f *File) condition(source string) (bool, error) {
 	}
 
 	// No sourceID provided: the specified attribute must be used to determine which content to compare the file with
-	if len(f.spec.Content) == 0 && f.spec.Line > 0 {
+	logrus.Debug("No source input value (disabled or empty)")
+	if len(f.spec.Content) == 0 {
+		logrus.Debug("No attribute 'content' provided")
 		// No content + no source input values means the user only want to check if the line "exists" (e.g. is not empty) and that's all
-		if f.CurrentContent == "" {
-			logrus.Infof("\u2717 %s is empty or the file does not exist.", logMessage)
-			return false, nil
+		if f.spec.Line > 0 {
+			if f.CurrentContent == "" {
+				logrus.Infof("\u2717 %s is empty or the file does not exist.", logMessage)
+				return false, nil
+			}
+
+			logrus.Infof("\u2714 %s is not empty and the file exists.", logMessage)
+			return true, nil
 		}
 
-		logrus.Infof("\u2714 %s is not empty and the file exists.", logMessage)
-		return true, nil
+		// No source, no content, no line: Only check for existence of the file
+		return f.contentRetriever.FileExists(f.spec.File), nil
 	}
+
+	logrus.Debug("Attribute `content` detected")
 
 	if f.spec.Content != f.CurrentContent {
 		logrus.Infof("\u2717 %s is different than the specified content: \n%s",

--- a/pkg/plugins/file/target.go
+++ b/pkg/plugins/file/target.go
@@ -24,6 +24,7 @@ func (f *File) Target(source string, dryRun bool) (bool, error) {
 func (f *File) TargetFromSCM(source string, scm scm.Scm, dryRun bool) (bool, []string, string, error) {
 	if !filepath.IsAbs(f.spec.File) {
 		f.spec.File = filepath.Join(scm.GetDirectory(), f.spec.File)
+		logrus.Debugf("Relative path detected: changing to absolute path from SCM: %q", f.spec.File)
 	}
 	return f.target(source, dryRun)
 }


### PR DESCRIPTION
Fix #290 

No need for a specific atttribute: only have to disable the source input in condition.
2 examples added in the PR to show how to use it + test units to cover additional cases.

It also add improved output for end user:

- info message for each condition to report if it passed, did not pass, or errored (easier to read when multiple conditions)
- more debug messages on the text package and file condition

## Test

To test this pull request, you can run the following commands:

```shell
go build -o ./dist/updatecli
./dist/updatecli diff --config ./examples/updateCli.generic/file.yaml
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
