### PR TITLE
chore(yaml) improve condition validation error message to help end users

### DIFF
--- a/pkg/plugins/yaml/condition.go
+++ b/pkg/plugins/yaml/condition.go
@@ -42,7 +42,7 @@ func (y *Yaml) condition(source string) (bool, error) {
 
 	if len(source) > 0 {
 		if len(y.Spec.Value) > 0 {
-			validationError := fmt.Errorf("Validation error in condition of type 'yaml': the attributes `sourceID` and `spec.value` are mutually exclusive")
+			validationError := fmt.Errorf("Validation error in condition of type 'yaml': input source value detected, while `spec.value` specified. Add 'disablesourceinput: true' to your manifest to keep ``spec.value`.")
 			logrus.Errorf(validationError.Error())
 			return false, validationError
 		}


### PR DESCRIPTION
The previous validation error message was not clear when no `sourceID` attribute was specified but the default only source was implicitly used.

## Test

To test this pull request, you can run the following commands:

```shell
cp <to_package_directory>
go test
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
