### PR TITLE
fix(log messages) homogenize the emojis used for user output messages

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -38,7 +38,7 @@ func Execute() {
 	logrus.SetFormatter(log.NewTextFormat())
 
 	if err := rootCmd.Execute(); err != nil {
-		logrus.Errorf("\u26A0 %s", err)
+		logrus.Errorf("%s %s", result.FAILURE, err)
 		os.Exit(1)
 	}
 }

--- a/pkg/core/engine/main.go
+++ b/pkg/core/engine/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/updatecli/updatecli/pkg/core/config"
 	"github.com/updatecli/updatecli/pkg/core/pipeline"
 	"github.com/updatecli/updatecli/pkg/core/reports"
+	"github.com/updatecli/updatecli/pkg/core/result"
 	"github.com/updatecli/updatecli/pkg/core/scm"
 	"github.com/updatecli/updatecli/pkg/core/tmp"
 
@@ -36,7 +37,7 @@ func (e *Engine) Clean() (err error) {
 func GetFiles(root string) (files []string) {
 	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
-			logrus.Errorf("\n\u26A0 File %s: %s\n", path, err)
+			logrus.Errorf("\n%s File %s: %s\n", result.FAILURE, path, err)
 			os.Exit(1)
 		}
 		if info.Mode().IsRegular() {

--- a/pkg/core/engine/target/main.go
+++ b/pkg/core/engine/target/main.go
@@ -63,7 +63,7 @@ func (t *Target) Check() (bool, error) {
 	}
 
 	if len(required) > 0 {
-		err := fmt.Errorf("\u2717 Target parameter(s) required: [%v]", strings.Join(required, ","))
+		err := fmt.Errorf("%s Target parameter(s) required: [%v]", result.FAILURE, strings.Join(required, ","))
 		return false, err
 	}
 

--- a/pkg/plugins/aws/ami/condition.go
+++ b/pkg/plugins/aws/ami/condition.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/sirupsen/logrus"
+	"github.com/updatecli/updatecli/pkg/core/result"
 	"github.com/updatecli/updatecli/pkg/core/scm"
 )
 
@@ -47,18 +48,18 @@ func (a *AMI) Condition(source string) (bool, error) {
 		strings.TrimRight(
 			strings.ReplaceAll(a.Spec.String(), "\n", "\n  "), "\n  "))
 
-	result, err := a.getLatestAmiID(svc)
+	foundAMI, err := a.getLatestAmiID(svc)
 
 	if err != nil {
 		return false, err
 	}
 
-	if len(result) > 0 {
-		logrus.Infof("\u2714 AMI %q found\n", result)
+	if len(foundAMI) > 0 {
+		logrus.Infof("%s AMI %q found\n", result.SUCCESS, foundAMI)
 		return true, nil
 	}
 
-	fmt.Printf("\u2717 No AMI found matching criteria for region %s\n", a.Spec.Region)
+	fmt.Printf("%s No AMI found matching criteria for region %s\n", result.FAILURE, a.Spec.Region)
 
 	return false, nil
 }
@@ -66,7 +67,7 @@ func (a *AMI) Condition(source string) (bool, error) {
 // ConditionFromSCM is a placeholder to validate the condition interface
 func (a *AMI) ConditionFromSCM(source string, scm scm.Scm) (bool, error) {
 
-	fmt.Printf("\u2717 Condition with SCM is not supported, please remove the scm block \n")
+	fmt.Printf("%s Condition with SCM is not supported, please remove the scm block \n", result.FAILURE)
 
 	return false, errors.New("condition with SCM is not supported")
 }

--- a/pkg/plugins/aws/ami/source.go
+++ b/pkg/plugins/aws/ami/source.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/sirupsen/logrus"
+	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
 // Source returns the latest AMI matching filter(s)
@@ -23,18 +24,18 @@ func (a *AMI) Source(workingDir string) (string, error) {
 		strings.TrimRight(
 			strings.ReplaceAll(a.Spec.String(), "\n", "\n  "), "\n  "))
 
-	result, err := a.getLatestAmiID(svc)
+	foundAMI, err := a.getLatestAmiID(svc)
 
 	if err != nil {
 		return "", err
 	}
 
-	if len(result) > 0 {
-		logrus.Infof("\u2714 AMI %q found\n", result)
-		return result, nil
+	if len(foundAMI) > 0 {
+		logrus.Infof("%s AMI %q found\n", result.SUCCESS, foundAMI)
+		return foundAMI, nil
 	}
 
-	logrus.Infof("\u2717 No AMI found matching criteria in region %s\n", a.Spec.Region)
+	logrus.Infof("%s No AMI found matching criteria in region %s\n", result.FAILURE, a.Spec.Region)
 
 	return "", nil
 }

--- a/pkg/plugins/docker/condition.go
+++ b/pkg/plugins/docker/condition.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"github.com/updatecli/updatecli/pkg/core/result"
 	"github.com/updatecli/updatecli/pkg/core/scm"
 	"github.com/updatecli/updatecli/pkg/plugins/docker/registry/dockerhub"
 	"github.com/updatecli/updatecli/pkg/plugins/docker/registry/dockerregistry"
@@ -89,11 +90,11 @@ func (d *Docker) Condition(source string) (bool, error) {
 	}
 
 	if digest == "" {
-		logrus.Infof("\u2717 %s:%s doesn't exist on the Docker Registry", d.Image, d.Tag)
+		logrus.Infof("%s %s:%s doesn't exist on the Docker Registry", result.FAILURE, d.Image, d.Tag)
 		return false, nil
 	}
 
-	logrus.Infof("\u2714 %s:%s available on the Docker Registry", d.Image, d.Tag)
+	logrus.Infof("%s %s:%s available on the Docker Registry", result.SUCCESS, d.Image, d.Tag)
 
 	return true, nil
 

--- a/pkg/plugins/docker/dockerfile/mobyparser/main.go
+++ b/pkg/plugins/docker/dockerfile/mobyparser/main.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/moby/buildkit/frontend/dockerfile/parser"
 	"github.com/sirupsen/logrus"
+	"github.com/updatecli/updatecli/pkg/core/result"
 	"github.com/updatecli/updatecli/pkg/plugins/docker/dockerfile/types"
 )
 
@@ -39,18 +40,20 @@ func (m MobyParser) FindInstruction(dockerfileContent []byte) bool {
 	}
 
 	if !found {
-		logrus.Infof("\u2717 Instruction %q wasn't found", m.Instruction)
+		logrus.Infof("%s Instruction %q wasn't found", result.FAILURE, m.Instruction)
 		return false
 	}
 
 	if val == m.Value {
-		logrus.Infof("\u2714 Instruction %q is correctly set to %q",
+		logrus.Infof("%s Instruction %q is correctly set to %q",
+			result.SUCCESS,
 			m.Instruction,
 			m.Value)
 		return true
 	}
 
-	logrus.Infof("\u2717 Instruction %q found but incorrectly set to %q instead of %q",
+	logrus.Infof("%s Instruction %q found but incorrectly set to %q instead of %q",
+		result.FAILURE,
 		m.Instruction,
 		val,
 		m.Value)
@@ -74,17 +77,19 @@ func (m MobyParser) ReplaceInstructions(dockerfileContent []byte, sourceValue st
 	}
 
 	if !valueFound {
-		return dockerfileContent, changed, fmt.Errorf("\u2717 cannot find instruction %q", m.Instruction)
+		return dockerfileContent, changed, fmt.Errorf("%s cannot find instruction %q", result.FAILURE, m.Instruction)
 	}
 
 	if oldVersion == m.Value {
-		logrus.Infof("\u2714 Instruction %q already set to %q, nothing else need to be done",
+		logrus.Infof("%s Instruction %q already set to %q, nothing else need to be done",
+			result.SUCCESS,
 			m.Instruction,
 			m.Value)
 		return dockerfileContent, changed, nil
 	}
 
-	logrus.Infof("\u2714 Instruction %q, was updated from %q to %q",
+	logrus.Infof("%s Instruction %q, was updated from %q to %q",
+		result.ATTENTION,
 		m.Instruction,
 		oldVersion,
 		m.Value,

--- a/pkg/plugins/docker/dockerfile/simpletextparser/main.go
+++ b/pkg/plugins/docker/dockerfile/simpletextparser/main.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/sirupsen/logrus"
+	"github.com/updatecli/updatecli/pkg/core/result"
 	"github.com/updatecli/updatecli/pkg/plugins/docker/dockerfile/simpletextparser/keywords"
 	"github.com/updatecli/updatecli/pkg/plugins/docker/dockerfile/types"
 )
@@ -19,11 +20,11 @@ type SimpleTextDockerfileParser struct {
 
 func (s SimpleTextDockerfileParser) FindInstruction(dockerfileContent []byte) bool {
 	if found, originalLine := s.hasMatch(dockerfileContent); found {
-		logrus.Infof("\u2714 Line %q found, matching the keyword %q and the matcher %q.", originalLine, s.Keyword, s.Matcher)
+		logrus.Infof("%s Line %q found, matching the keyword %q and the matcher %q.", result.SUCCESS, originalLine, s.Keyword, s.Matcher)
 		return true
 	}
 
-	logrus.Infof("\u2717 No line found matching the keyword %q and the matcher %q.", s.Keyword, s.Matcher)
+	logrus.Infof("%s No line found matching the keyword %q and the matcher %q.", result.FAILURE, s.Keyword, s.Matcher)
 	return false
 }
 
@@ -48,7 +49,7 @@ func (s SimpleTextDockerfileParser) ReplaceInstructions(dockerfileContent []byte
 	changedLines := make(types.ChangedLines)
 
 	if found, _ := s.hasMatch(dockerfileContent); !found {
-		return dockerfileContent, changedLines, fmt.Errorf("\u2717 No line found matching the keyword %q and the matcher %q.", s.Keyword, s.Matcher)
+		return dockerfileContent, changedLines, fmt.Errorf("%s No line found matching the keyword %q and the matcher %q.", result.FAILURE, s.Keyword, s.Matcher)
 	}
 
 	var newDockerfile bytes.Buffer
@@ -66,7 +67,8 @@ func (s SimpleTextDockerfileParser) ReplaceInstructions(dockerfileContent []byte
 			newLine = s.KeywordLogic.ReplaceLine(sourceValue, originalLine, s.Matcher)
 
 			if newLine != originalLine {
-				logrus.Infof("\u2714 The line #%d, matched by the keyword %q and the matcher %q, is changed from %q to %q.",
+				logrus.Infof("%s The line #%d, matched by the keyword %q and the matcher %q, is changed from %q to %q.",
+					result.ATTENTION,
 					linePosition,
 					s.Keyword,
 					s.Matcher,
@@ -75,7 +77,8 @@ func (s SimpleTextDockerfileParser) ReplaceInstructions(dockerfileContent []byte
 				)
 				changedLines[linePosition] = types.LineDiff{Original: originalLine, New: newLine}
 			} else {
-				logrus.Infof("\u2714 The line #%d, matched by the keyword %q and the matcher %q, is correctly set to %q.",
+				logrus.Infof("%s The line #%d, matched by the keyword %q and the matcher %q, is correctly set to %q.",
+					result.SUCCESS,
 					linePosition,
 					s.Keyword,
 					s.Matcher,
@@ -144,11 +147,11 @@ var supportedKeywordsInitializers = map[string]keywords.Logic{
 func (s *SimpleTextDockerfileParser) setKeywordLogic() error {
 	keywordLogic, found := supportedKeywordsInitializers[strings.ToLower(s.Keyword)]
 	if !found {
-		return fmt.Errorf("\u2717 Unknown keyword %q provided for Dockerfile's instruction.", s.Keyword)
+		return fmt.Errorf("%s Unknown keyword %q provided for Dockerfile's instruction.", result.FAILURE, s.Keyword)
 	}
 
 	if keywordLogic == nil {
-		return fmt.Errorf("\u2717 Provided keyword %q not supported (yet). Feel free to open an issue explaining your use-case to help adding the implementation.", s.Keyword)
+		return fmt.Errorf("%s Provided keyword %q not supported (yet). Feel free to open an issue explaining your use-case to help adding the implementation.", result.FAILURE, s.Keyword)
 	}
 
 	s.KeywordLogic = keywordLogic

--- a/pkg/plugins/docker/dockerfile/simpletextparser/main_test.go
+++ b/pkg/plugins/docker/dockerfile/simpletextparser/main_test.go
@@ -1,11 +1,13 @@
 package simpletextparser
 
 import (
+	"fmt"
 	"io/ioutil"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/updatecli/updatecli/pkg/core/result"
 	"github.com/updatecli/updatecli/pkg/plugins/docker/dockerfile/simpletextparser/keywords"
 	"github.com/updatecli/updatecli/pkg/plugins/docker/dockerfile/types"
 )
@@ -65,7 +67,7 @@ func TestInstruction_setKeywordLogic(t *testing.T) {
 				Keyword: "ONBUILD",
 			},
 			wantLogic:        nil,
-			wantErrorMessage: "\u2717 Provided keyword \"ONBUILD\" not supported (yet). Feel free to open an issue explaining your use-case to help adding the implementation.",
+			wantErrorMessage: fmt.Sprintf("%s Provided keyword \"ONBUILD\" not supported (yet). Feel free to open an issue explaining your use-case to help adding the implementation.", result.FAILURE),
 		},
 		{
 			name: "Unknown instruction",
@@ -73,7 +75,7 @@ func TestInstruction_setKeywordLogic(t *testing.T) {
 				Keyword: "QUACK",
 			},
 			wantLogic:        nil,
-			wantErrorMessage: "\u2717 Unknown keyword \"QUACK\" provided for Dockerfile's instruction.",
+			wantErrorMessage: fmt.Sprintf("%s Unknown keyword \"QUACK\" provided for Dockerfile's instruction.", result.FAILURE),
 		},
 	}
 	for _, tt := range tests {
@@ -223,7 +225,7 @@ func TestSimpleTextDockerfileParser_ReplaceInstruction(t *testing.T) {
 				"matcher": "HELM_VERSION",
 			},
 			expectedChanges:      types.ChangedLines{},
-			expectedErrorMessage: "\u2717 No line found matching the keyword \"ARG\" and the matcher \"HELM_VERSION\".",
+			expectedErrorMessage: fmt.Sprintf("%s No line found matching the keyword \"ARG\" and the matcher \"HELM_VERSION\".", result.FAILURE),
 		},
 		{
 			name:              "Instruction kept the same",
@@ -333,7 +335,7 @@ func TestNewSimpleTextDockerfileParser(t *testing.T) {
 				"keyword": "QUIK",
 				"matcher": "JENKINS_VERSION",
 			},
-			wantErrorMessage: "\u2717 Unknown keyword \"QUIK\" provided for Dockerfile's instruction.",
+			wantErrorMessage: fmt.Sprintf("%s Unknown keyword \"QUIK\" provided for Dockerfile's instruction.", result.FAILURE),
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/plugins/docker/source.go
+++ b/pkg/plugins/docker/source.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"github.com/updatecli/updatecli/pkg/core/result"
 	"github.com/updatecli/updatecli/pkg/plugins/docker/registry/dockerhub"
 	"github.com/updatecli/updatecli/pkg/plugins/docker/registry/dockerregistry"
 	"github.com/updatecli/updatecli/pkg/plugins/docker/registry/quay"
@@ -74,9 +75,9 @@ func (d *Docker) Source(workingDir string) (string, error) {
 	}
 
 	if digest == "" {
-		logrus.Infof("\u2717 No Digest found for docker image %s:%s on the Docker Registry", d.Image, d.Tag)
+		logrus.Infof("%s No Digest found for docker image %s:%s on the Docker Registry", result.FAILURE, d.Image, d.Tag)
 	} else {
-		logrus.Infof("\u2714 Digest '%v' found for docker image %s:%s available from Docker Registry", digest, d.Image, d.Tag)
+		logrus.Infof("%s Digest '%v' found for docker image %s:%s available from Docker Registry", result.SUCCESS, digest, d.Image, d.Tag)
 		logrus.Infof("Remark: Do not forget to add @sha256 after your the docker image name")
 		logrus.Infof("Example: %v@sha256:%v", d.Image, digest)
 	}

--- a/pkg/plugins/file/condition.go
+++ b/pkg/plugins/file/condition.go
@@ -81,13 +81,14 @@ func (f *File) condition(source string) (bool, error) {
 
 		if !reg.MatchString(f.CurrentContent) {
 			logrus.Infof(
-				"\u2717 %s did not match the pattern %q",
+				"%s %s did not match the pattern %q",
+				result.FAILURE,
 				logMessage,
 				f.spec.MatchPattern,
 			)
 			return false, nil
 		}
-		logrus.Infof("\u2714 %s matched the pattern %q", logMessage, f.spec.MatchPattern)
+		logrus.Infof("%s %s matched the pattern %q", result.SUCCESS, logMessage, f.spec.MatchPattern)
 		return true, nil
 	}
 
@@ -103,7 +104,8 @@ func (f *File) condition(source string) (bool, error) {
 		// Compare the content of the file with the source's value
 		if f.CurrentContent != source {
 			logrus.Infof(
-				"\u2717 %s is different than the input source value:\n%s",
+				"%s %s is different than the input source value:\n%s",
+				result.FAILURE,
 				logMessage,
 				text.Diff(f.spec.File, f.CurrentContent, source),
 			)
@@ -111,7 +113,7 @@ func (f *File) condition(source string) (bool, error) {
 			return false, nil
 		}
 
-		logrus.Infof("\u2714 %s is the same as the input source value.", logMessage)
+		logrus.Infof("%s %s is the same as the input source value.", result.SUCCESS, logMessage)
 
 		return true, nil
 
@@ -124,11 +126,11 @@ func (f *File) condition(source string) (bool, error) {
 		// No content + no source input values means the user only want to check if the line "exists" (e.g. is not empty) and that's all
 		if f.spec.Line > 0 {
 			if f.CurrentContent == "" {
-				logrus.Infof("\u2717 %s is empty or the file does not exist.", logMessage)
+				logrus.Infof("%s %s is empty or the file does not exist.", result.FAILURE, logMessage)
 				return false, nil
 			}
 
-			logrus.Infof("\u2714 %s is not empty and the file exists.", logMessage)
+			logrus.Infof("%s %s is not empty and the file exists.", result.SUCCESS, logMessage)
 			return true, nil
 		}
 
@@ -139,12 +141,13 @@ func (f *File) condition(source string) (bool, error) {
 	logrus.Debug("Attribute `content` detected")
 
 	if f.spec.Content != f.CurrentContent {
-		logrus.Infof("\u2717 %s is different than the specified content: \n%s",
+		logrus.Infof("%s %s is different than the specified content: \n%s",
+			result.FAILURE,
 			logMessage, text.Diff(f.spec.File, f.CurrentContent, f.spec.Content))
 
 		return false, nil
 	}
 
-	logrus.Infof("\u2714 %s is the same as the specified content.", logMessage)
+	logrus.Infof("%s %s is the same as the specified content.", result.SUCCESS, logMessage)
 	return true, nil
 }

--- a/pkg/plugins/file/source.go
+++ b/pkg/plugins/file/source.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/sirupsen/logrus"
+	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
 // Source return a file content
@@ -30,7 +31,7 @@ func (f *File) Source(workingDir string) (string, error) {
 		return "", err
 	}
 
-	result := f.CurrentContent
+	foundContent := f.CurrentContent
 	// If a matchPattern is specified, then retrieve the string matched and returns the (eventually) multi-line string
 	if len(f.spec.MatchPattern) > 0 {
 		reg, err := regexp.Compile(f.spec.MatchPattern)
@@ -45,10 +46,10 @@ func (f *File) Source(workingDir string) (string, error) {
 		}
 		matchedStrings := reg.FindAllString(f.CurrentContent, -1)
 
-		result = strings.Join(matchedStrings, "\n")
+		foundContent = strings.Join(matchedStrings, "\n")
 	}
 
-	logrus.Infof("\u2714 Content: found from file %q:\n%v", f.spec.File, result)
+	logrus.Infof("%s Content: found from file %q:\n%v", result.SUCCESS, f.spec.File, foundContent)
 
-	return result, nil
+	return foundContent, nil
 }

--- a/pkg/plugins/file/target.go
+++ b/pkg/plugins/file/target.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"github.com/updatecli/updatecli/pkg/core/result"
 	"github.com/updatecli/updatecli/pkg/core/scm"
 	"github.com/updatecli/updatecli/pkg/core/text"
 )
@@ -80,7 +81,12 @@ func (f *File) target(source string, dryRun bool) (bool, []string, string, error
 		files = append(files, f.spec.File)
 		message = fmt.Sprintf("changed line %d of file %q", f.spec.Line, f.spec.File)
 
-		logrus.Infof("\u2714 The line %d of the file %q was updated: \n\n%s\n", f.spec.Line, f.spec.File, text.Diff(f.spec.File, currentLine, newContent))
+		logrus.Infof("%s The line %d of the file %q was updated: \n\n%s\n",
+			result.ATTENTION,
+			f.spec.Line,
+			f.spec.File,
+			text.Diff(f.spec.File, currentLine, newContent),
+		)
 
 		return true, files, message, nil
 
@@ -98,7 +104,8 @@ func (f *File) target(source string, dryRun bool) (bool, []string, string, error
 		}
 	} else {
 		if !f.spec.ForceCreate {
-			return false, files, message, fmt.Errorf("\u2717 The specified file %q does not exist. If you want to create it, you must set the attribute 'spec.forcecreate' to 'true'.\n", f.spec.File)
+			return false, files, message, fmt.Errorf("%s The specified file %q does not exist. If you want to create it, you must set the attribute 'spec.forcecreate' to 'true'.\n",
+				result.FAILURE, f.spec.File)
 		}
 		logrus.Infof("Creating a new file at %q", f.spec.File)
 	}
@@ -129,7 +136,7 @@ func (f *File) target(source string, dryRun bool) (bool, []string, string, error
 
 	// Nothing to do if the line is the same as the input source value
 	if newContent == f.CurrentContent {
-		logrus.Infof("\u2714 Content from file %q already up to date", f.spec.File)
+		logrus.Infof("%s Content from file %q already up to date", result.SUCCESS, f.spec.File)
 		return false, files, message, nil
 	}
 
@@ -144,7 +151,11 @@ func (f *File) target(source string, dryRun bool) (bool, []string, string, error
 	files = append(files, f.spec.File)
 	message = fmt.Sprintf("Updated the file %q\n", f.spec.File)
 
-	logrus.Infof("\u2714 File content for %q, updated. \n\n%s\n", f.spec.File, text.Diff(f.spec.File, f.CurrentContent, newContent))
+	logrus.Infof("%s File content for %q, updated. \n\n%s\n",
+		result.ATTENTION,
+		f.spec.File,
+		text.Diff(f.spec.File, f.CurrentContent, newContent),
+	)
 
 	return true, files, message, nil
 }

--- a/pkg/plugins/git/tag/condition.go
+++ b/pkg/plugins/git/tag/condition.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/sirupsen/logrus"
+	"github.com/updatecli/updatecli/pkg/core/result"
 	"github.com/updatecli/updatecli/pkg/core/scm"
 	"github.com/updatecli/updatecli/pkg/plugins/git/generic"
 )
@@ -40,11 +41,12 @@ func (t *Tag) Condition(source string) (bool, error) {
 	}
 
 	if strings.Compare(tag, t.VersionFilter.Pattern) == 0 {
-		logrus.Printf("\u2714 git tag %q matching\n", t.VersionFilter.Pattern)
+		logrus.Printf("%s git tag %q matching\n", result.SUCCESS, t.VersionFilter.Pattern)
 		return true, nil
 	}
 
-	logrus.Printf("\u2717 git tag %q not matching %q\n",
+	logrus.Printf("%s git tag %q not matching %q\n",
+		result.FAILURE,
 		t.VersionFilter.Pattern,
 		tag)
 
@@ -85,10 +87,11 @@ func (t *Tag) ConditionFromSCM(source string, scm scm.Scm) (bool, error) {
 	tag := t.foundVersion.ParsedVersion
 
 	if tag == t.VersionFilter.Pattern {
-		logrus.Printf("\u2714 Git Tag %q matching\n", t.VersionFilter.Pattern)
+		logrus.Printf("%s Git Tag %q matching\n", result.SUCCESS, t.VersionFilter.Pattern)
 		return true, nil
 	}
-	logrus.Printf("\u2717 Git Tag %q not matching %q\n",
+	logrus.Printf("%s Git Tag %q not matching %q\n",
+		result.FAILURE,
 		t.VersionFilter.Pattern,
 		tag)
 	return false, nil

--- a/pkg/plugins/git/tag/source.go
+++ b/pkg/plugins/git/tag/source.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/sirupsen/logrus"
+	"github.com/updatecli/updatecli/pkg/core/result"
 	"github.com/updatecli/updatecli/pkg/plugins/git/generic"
 )
 
@@ -34,10 +35,10 @@ func (t *Tag) Source(workingDir string) (string, error) {
 	value := t.foundVersion.ParsedVersion
 
 	if len(value) == 0 {
-		logrus.Infof("\u2717 No Git Tag found matching pattern %q", t.VersionFilter.Pattern)
+		logrus.Infof("%s No Git Tag found matching pattern %q", result.FAILURE, t.VersionFilter.Pattern)
 		return value, fmt.Errorf("no Git tag found matching pattern %q", t.VersionFilter.Pattern)
 	} else if len(value) > 0 {
-		logrus.Infof("\u2714 Git Tag %q found, matching pattern %q", value, t.VersionFilter.Pattern)
+		logrus.Infof("%s Git Tag %q found, matching pattern %q", result.SUCCESS, value, t.VersionFilter.Pattern)
 	} else {
 		logrus.Errorf("Something unexpected happened in gitTag source")
 	}

--- a/pkg/plugins/git/tag/target.go
+++ b/pkg/plugins/git/tag/target.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/sirupsen/logrus"
+	"github.com/updatecli/updatecli/pkg/core/result"
 	"github.com/updatecli/updatecli/pkg/core/scm"
 	"github.com/updatecli/updatecli/pkg/plugins/git"
 	"github.com/updatecli/updatecli/pkg/plugins/git/generic"
@@ -41,13 +42,13 @@ func (t *Tag) Target(source string, dryRun bool) (changed bool, err error) {
 
 	// A matching git tag has been found
 	if len(existingTag) != 0 {
-		logrus.Printf("\u2714 git tag %q already exist, nothing else todo", existingTag)
+		logrus.Printf("%s git tag %q already exist, nothing else todo", result.SUCCESS, existingTag)
 		return changed, nil
 	}
 
 	newTag := t.VersionFilter.Pattern
 
-	logrus.Printf("\u2714 git tag %q not found, will create it", newTag)
+	logrus.Printf("%s git tag %q not found, will create it", result.ATTENTION, newTag)
 
 	if dryRun {
 		return changed, err
@@ -58,7 +59,7 @@ func (t *Tag) Target(source string, dryRun bool) (changed bool, err error) {
 	if err != nil {
 		return changed, err
 	}
-	logrus.Printf("\u2714 git tag %q created", newTag)
+	logrus.Printf("%s git tag %q created", result.ATTENTION, newTag)
 
 	scm := git.Git{
 		Directory: t.Path,
@@ -71,7 +72,7 @@ func (t *Tag) Target(source string, dryRun bool) (changed bool, err error) {
 		return changed, err
 	}
 
-	logrus.Printf("\u2714 git tag %q pushed", newTag)
+	logrus.Printf("%s git tag %q pushed", result.ATTENTION, newTag)
 
 	return changed, err
 
@@ -113,14 +114,15 @@ func (t *Tag) TargetFromSCM(source string, scm scm.Scm, dryRun bool) (changed bo
 
 	// A matching git tag has been found
 	if len(existingTag) != 0 {
-		logrus.Printf("\u2714 git tag %q already exist, nothing else todo",
+		logrus.Printf("%s git tag %q already exist, nothing else todo",
+			result.SUCCESS,
 			existingTag)
 		return changed, files, message, err
 	}
 
 	newTag := t.VersionFilter.Pattern
 
-	logrus.Printf("\u2714 git tag %q not found, creating it", newTag)
+	logrus.Printf("%s git tag %q not found, creating it", result.ATTENTION, newTag)
 
 	if dryRun {
 		return changed, files, message, err
@@ -130,7 +132,7 @@ func (t *Tag) TargetFromSCM(source string, scm scm.Scm, dryRun bool) (changed bo
 	if err != nil {
 		return changed, files, message, err
 	}
-	logrus.Printf("\u2714 git tag %q created", newTag)
+	logrus.Printf("%s git tag %q created", result.ATTENTION, newTag)
 
 	err = scm.PushTag(newTag)
 
@@ -139,7 +141,7 @@ func (t *Tag) TargetFromSCM(source string, scm scm.Scm, dryRun bool) (changed bo
 		return changed, files, message, err
 	}
 
-	logrus.Printf("\u2714 git tag %q pushed", newTag)
+	logrus.Printf("%s git tag %q pushed", result.ATTENTION, newTag)
 
 	message = fmt.Sprintf("Git tag %q pushed", newTag)
 

--- a/pkg/plugins/github/source.go
+++ b/pkg/plugins/github/source.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/sirupsen/logrus"
+	"github.com/updatecli/updatecli/pkg/core/result"
 
 	"github.com/shurcooL/githubv4"
 )
@@ -20,7 +21,7 @@ func (g *Github) Source(workingDir string) (value string, err error) {
 	}
 
 	if len(versions) == 0 {
-		logrus.Infof("\u26A0 No GitHub Release found. As fallback Looking at published git tags")
+		logrus.Infof("%s No GitHub Release found. As fallback Looking at published git tags", result.ATTENTION)
 		versions, err = g.SearchTags()
 		if err != nil {
 			logrus.Errorf("%s", err)
@@ -40,10 +41,10 @@ func (g *Github) Source(workingDir string) (value string, err error) {
 	value = g.foundVersion.ParsedVersion
 
 	if len(value) == 0 {
-		logrus.Infof("\u2717 No Github Release version found matching pattern %q", g.spec.VersionFilter.Pattern)
+		logrus.Infof("%s No Github Release version found matching pattern %q", result.FAILURE, g.spec.VersionFilter.Pattern)
 		return value, fmt.Errorf("no Github Release version found matching pattern %q", g.spec.VersionFilter.Pattern)
 	} else if len(value) > 0 {
-		logrus.Infof("\u2714 Github Release version %q found matching pattern %q", value, g.spec.VersionFilter.Pattern)
+		logrus.Infof("%s Github Release version %q found matching pattern %q", result.SUCCESS, value, g.spec.VersionFilter.Pattern)
 	} else {
 		logrus.Errorf("Something unexpected happened in Github source")
 	}

--- a/pkg/plugins/helm/chart/condition.go
+++ b/pkg/plugins/helm/chart/condition.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"github.com/updatecli/updatecli/pkg/core/result"
 	"github.com/updatecli/updatecli/pkg/core/scm"
 )
 
@@ -47,11 +48,11 @@ func (c *Chart) Condition(source string) (bool, error) {
 	}
 
 	if index.Has(c.Name, c.Version) {
-		logrus.Infof("\u2714 Helm Chart '%s' is available on %s%s", c.Name, c.URL, message)
+		logrus.Infof("%s Helm Chart '%s' is available on %s%s", result.SUCCESS, c.Name, c.URL, message)
 		return true, nil
 	}
 
-	logrus.Infof("\u2717 Helm Chart '%s' isn't available on %s%s", c.Name, c.URL, message)
+	logrus.Infof("%s Helm Chart '%s' isn't available on %s%s", result.FAILURE, c.Name, c.URL, message)
 	return false, nil
 }
 

--- a/pkg/plugins/helm/chart/source.go
+++ b/pkg/plugins/helm/chart/source.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/sirupsen/logrus"
+	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
 // Source return the latest version
@@ -46,7 +47,8 @@ func (c *Chart) Source(workingDir string) (string, error) {
 	}
 
 	if e.Version != "" {
-		logrus.Infof("\u2714 Helm Chart '%s' version '%v' is found from repository %s",
+		logrus.Infof("%s Helm Chart '%s' version '%v' is found from repository %s",
+			result.SUCCESS,
 			c.Name,
 			e.Version,
 			c.URL)

--- a/pkg/plugins/jenkins/condition.go
+++ b/pkg/plugins/jenkins/condition.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/updatecli/updatecli/pkg/core/result"
 	"github.com/updatecli/updatecli/pkg/core/scm"
 )
 
@@ -52,15 +53,15 @@ func (j *Jenkins) Condition(source string) (bool, error) {
 		}
 	}
 	if !versionExist {
-		fmt.Printf("\u2717 Version '%v' doesn't exist\n", j.Version)
+		fmt.Printf("%s Version '%v' doesn't exist\n", result.FAILURE, j.Version)
 		return false, nil
 
 	} else if !validReleaseType {
-		fmt.Printf("\u2717 Wrong Release Type: %v for version %v\n", releaseType, j.Version)
+		fmt.Printf("%s Wrong Release Type: %v for version %v\n", result.FAILURE, releaseType, j.Version)
 		return false, nil
 	}
 
-	fmt.Printf("\u2714 %s release version '%s' available\n", releaseType, j.Version)
+	fmt.Printf("%s %s release version '%s' available\n", result.SUCCESS, releaseType, j.Version)
 
 	return true, nil
 }

--- a/pkg/plugins/jenkins/source.go
+++ b/pkg/plugins/jenkins/source.go
@@ -3,6 +3,8 @@ package jenkins
 import (
 	"fmt"
 	"strings"
+
+	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
 // Source return the latest Jenkins version based on release type
@@ -20,7 +22,7 @@ func (j *Jenkins) Source(workingDir string) (string, error) {
 	}
 
 	if strings.Compare(WEEKLY, j.Release) == 0 {
-		fmt.Printf("\u2714 Version %s found for the %s release", latest, WEEKLY)
+		fmt.Printf("%s Version %s found for the %s release", result.SUCCESS, latest, WEEKLY)
 		return latest, nil
 	}
 
@@ -29,12 +31,12 @@ func (j *Jenkins) Source(workingDir string) (string, error) {
 			v := NewVersion(s)
 			return v.Patch != ""
 		})
-		fmt.Printf("\u2714 Version %s found for the Jenkins %s release", found[len(found)-1], j.Release)
+		fmt.Printf("%s Version %s found for the Jenkins %s release", result.SUCCESS, found[len(found)-1], j.Release)
 		return found[len(found)-1], nil
 
 	}
 
-	fmt.Printf("\u2717 Unknown version %s found for the %s release", j.Version, j.Release)
+	fmt.Printf("%s Unknown version %s found for the %s release", result.FAILURE, j.Version, j.Release)
 
 	return "unknown", fmt.Errorf("Unknown Jenkins version found")
 }

--- a/pkg/plugins/maven/condition.go
+++ b/pkg/plugins/maven/condition.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"github.com/updatecli/updatecli/pkg/core/result"
 	"github.com/updatecli/updatecli/pkg/core/scm"
 )
 
@@ -51,13 +52,13 @@ func (m *Maven) Condition(source string) (bool, error) {
 
 	for _, version := range data.Versioning.Versions.Version {
 		if version == m.Version {
-			logrus.Infof("\u2713 Version %s is available on Maven Repository", m.Version)
+			logrus.Infof("%s Version %s is available on Maven Repository", result.SUCCESS, m.Version)
 			return true, nil
 		}
 
 	}
 
-	logrus.Infof("\u2716 Version %s is not available on Maven Repository", m.Version)
+	logrus.Infof("%s Version %s is not available on Maven Repository", result.FAILURE, m.Version)
 	return false, nil
 }
 

--- a/pkg/plugins/maven/source.go
+++ b/pkg/plugins/maven/source.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/sirupsen/logrus"
+	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
 // Source return the latest version
@@ -43,10 +44,10 @@ func (m *Maven) Source(workingDir string) (string, error) {
 	}
 
 	if data.Versioning.Latest != "" {
-		logrus.Infof("\u2714 Latest version is %s on Maven Repository", data.Versioning.Latest)
+		logrus.Infof("%s Latest version is %s on Maven Repository", result.SUCCESS, data.Versioning.Latest)
 		return data.Versioning.Latest, nil
 	}
 
-	logrus.Infof("\u2717 No latest version on Maven Repository")
+	logrus.Infof("%s No latest version on Maven Repository", result.FAILURE)
 	return "", nil
 }

--- a/pkg/plugins/yaml/source.go
+++ b/pkg/plugins/yaml/source.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/sirupsen/logrus"
+	"github.com/updatecli/updatecli/pkg/core/result"
 
 	"gopkg.in/yaml.v3"
 )
@@ -34,11 +35,12 @@ func (y *Yaml) Source(workingDir string) (string, error) {
 	valueFound, value, _ := replace(&out, strings.Split(y.Spec.Key, "."), y.Spec.Value, 1)
 
 	if valueFound {
-		logrus.Infof("\u2714 Value '%v' found for key %v in the yaml file %v", value, y.Spec.Key, y.Spec.File)
+		logrus.Infof("%s Value '%v' found for key %v in the yaml file %v", result.SUCCESS, value, y.Spec.Key, y.Spec.File)
 		return value, nil
 	}
 
-	logrus.Infof("\u2717 cannot find key '%s' from file '%s'",
+	logrus.Infof("%s cannot find key '%s' from file '%s'",
+		result.FAILURE,
 		y.Spec.Key,
 		y.Spec.File)
 	return "", nil


### PR DESCRIPTION
It's a "short term" fix to ensure that the log messages have the same behavior and all use the same emoji.
It also improve code readability as it's easier to understand the constant `result.ATTENTION` than `\u26A0`.

Please note the following changes:
- As we use the package name `result`, when a variable had a conflicting name then it had been changes (3 occurends, 2 are in the AMI package)
- There was slight differences of emojis (2416/2415 for instance) that have been simplified to all use the same from the `result` package
- Sources only have `FAILURE` or `SUCCESS` states
- Same for conditions: only `FAILURE` or `SUCCESS` states
- For targets, `FAILURE` indicates a real error, while `SUCCESS` is used when nothing had been changed, and `ATTENTION` when a change is expected (diff) or applied (apply).


Please note that a long term fix is to implement a custom `logger` package that would provide explicit method such as `ValidationErrorLog()`, `SuccessErrorLog()`, `ContentChangedLog()`, `FailureLog()` etc. to move the multiple usages of emojis to a central place, and get rid of the `result` package.