### PR TITLE
fix: skip sources when their parent source failed

### DIFF
--- a/pkg/core/config/main_test.go
+++ b/pkg/core/config/main_test.go
@@ -8,11 +8,13 @@ import (
 	"github.com/updatecli/updatecli/pkg/core/engine/condition"
 	"github.com/updatecli/updatecli/pkg/core/engine/source"
 	"github.com/updatecli/updatecli/pkg/core/engine/target"
+	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
 // Mocking the context package
 type mockSourceContext struct {
 	Output string
+	Result string
 }
 
 // Mocking the context package
@@ -78,6 +80,7 @@ var (
 				Sources: map[string]mockSourceContext{
 					"default": {
 						Output: "2.289.2",
+						Result: result.SUCCESS,
 					},
 				},
 			},
@@ -91,6 +94,28 @@ var (
 				},
 			},
 			ExpectedUpdateErr:   nil,
+			ExpectedValidateErr: nil,
+		},
+		// Test a failed source
+		{
+			ID: "1.2",
+			Config: Config{
+				Name: "jenkins - {{ source \"default\" }}",
+				Sources: map[string]source.Config{
+					"default": {
+						Name: "Get Version",
+						Kind: "jenkins",
+					},
+				},
+			},
+			Context: context{
+				Sources: map[string]mockSourceContext{
+					"default": {
+						Result: result.FAILURE,
+					},
+				},
+			},
+			ExpectedUpdateErr:   fmt.Errorf("template: cfg:1:19: executing \"cfg\" at <source \"default\">: error calling source: Parent source \"default\" failed"),
 			ExpectedValidateErr: nil,
 		},
 		// Testing key case sensitive
@@ -139,6 +164,7 @@ var (
 				Sources: map[string]mockSourceContext{
 					"default": {
 						Output: "2.289.2",
+						Result: result.SUCCESS,
 					},
 				},
 			},
@@ -255,6 +281,7 @@ var (
 				Sources: map[string]mockSourceContext{
 					"default": {
 						Output: "2.289.2",
+						Result: result.SUCCESS,
 					},
 				},
 			},
@@ -356,6 +383,7 @@ func TestUpdate(t *testing.T) {
 					err.Error())
 				continue
 			}
+
 		} else if err != nil && data.ExpectedUpdateErr == nil {
 			t.Errorf("Wrong error expected for dataset ID %q:\n\tExpected:\t\t%q\n\tGot\t\t%q\n",
 				data.ID,

--- a/pkg/core/pipeline/sources.go
+++ b/pkg/core/pipeline/sources.go
@@ -33,7 +33,16 @@ func (p *Pipeline) RunSources() error {
 		logrus.Infof("\n%s\n", id)
 		logrus.Infof("%s\n", strings.Repeat("-", len(id)))
 
-		err = source.Run()
+		shouldRunSource := true
+		for _, parentSource := range source.Config.DependsOn {
+			if p.Sources[parentSource].Result != result.SUCCESS {
+				logrus.Warningf("Parent source[%q] did not succeed. Skipping execution of the source[%q]", parentSource, id)
+				shouldRunSource = false
+			}
+		}
+		if shouldRunSource {
+			err = source.Run()
+		}
 		rpt.Result = source.Result
 
 		if len(source.Changelog) > 0 {


### PR DESCRIPTION
Fix #285

When a source, referenced through a template function ``{{ source `<source id>` }}`` on another source, is failing,
then the "children" sources are now skipped with an error message.

No worry for conditions: if any source fail, then the condition are never run.

## Test

To test this pull request, you can run the following commands:

```shell
$ cat .tmp/updatecli.yaml
sources:
  parentSource:
    kind: shell
    spec:
      command: ls /titi
  childSource:
    kind: shell
    depends_on:
      - parentSource
    spec:
      command: echo CHILD-{{ source "parentSource" }}
target:
  printResult:
    kind: shell
    sourceID: childSource
    spec:
      command: echo

$ go build -o ./dist/updatecli && ./dist/updatecli --debug diff -c .tmp/updatecli.yaml
```

example of output:

```
SOURCES
=======

parentSource
------------
The shell 🐚 command "ls /titi" exited on error (exit code 1) with the following output:
----
----

command stderr output was:
----
ls: /titi: No such file or directory

----
ERROR: ✗ Shell command exited on error.
Pipeline "UPDATECLI.YAML" failed
Skipping due to:
        "sources stage:\t\"template: cfg:25:35: executing \\\"cfg\\\" at <source \\\"parentSource\\\">: error calling source: Parent source \\\"parentSource\\\" failed\"\n"
sources stage:  "template: cfg:25:35: executing \"cfg\" at <source \"parentSource\">: error calling source: Parent source \"parentSource\" failed"

=============================

REPORTS:


✗ UPDATECLI.YAML:
        Sources:
                - [childSource] (shell)
                ✗ [parentSource] (shell)
        Target:
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
