### PR TITLE
fix(conditions) prints validation error when found

### DIFF
--- a/pkg/core/engine/condition/main.go
+++ b/pkg/core/engine/condition/main.go
@@ -54,6 +54,7 @@ func (c *Condition) Run(source string) (err error) {
 	spec, err := Unmarshal(c)
 	if err != nil {
 		c.Result = result.FAILURE
+		logrus.Errorf("%s", err)
 		return err
 	}
 


### PR DESCRIPTION
This PR is a fix for a bug I found while working on #289 .

It ensures that the validation error messages are printed to the end user when a **condition** failed to be validated.

## Test

With a manifest having the following condition (missing `spec.file`)

```yaml
# ...
conditions:
  checkUsername:
    kind: yaml
    spec:
      key: github.username
```

With updatecli 0.16.0, you got:

```shell
# ...
CONDITIONS:
===========

checkUsername
-------------
✗ condition not met, skipping pipeline
```

=> result is expected but no message to help the end user.

With this PR, you got:
```shell
$ go build -o ./dist/updatecli && ./dist/updatecli diff
# ...
CONDITIONS:
===========

checkUsername
-------------
ERROR: Validation error: the provided manifest configuration had the following validation errors:
Invalid spec for yaml resource: 'file' is empty.

✗ condition not met, skipping pipeline
```

=> which is clearly an improvement

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
