### PR TITLE
fix: fail validation when SourceID is missing on conditions and targets

### DIFF
--- a/pkg/core/config/main.go
+++ b/pkg/core/config/main.go
@@ -144,7 +144,12 @@ func (config *Config) Validate() error {
 	}
 
 	for id, c := range config.Conditions {
-
+		if len(c.SourceID) > 0 {
+			if _, ok := config.Sources[c.SourceID]; !ok {
+				logrus.Errorf("the specified SourceID %q for condition[id] does not exist", c.SourceID)
+				return ErrBadConfig
+			}
+		}
 		// Only check/guess the sourceID if the user did not disable it (default is enabled)
 		if !c.DisableSourceInput {
 			// Try to guess SourceID

--- a/pkg/core/config/main.go
+++ b/pkg/core/config/main.go
@@ -174,6 +174,12 @@ func (config *Config) Validate() error {
 		if len(t.PipelineID) == 0 {
 			t.PipelineID = config.PipelineID
 		}
+		if len(t.SourceID) > 0 {
+			if _, ok := config.Sources[t.SourceID]; !ok {
+				logrus.Errorf("the specified SourceID %q for condition[id] does not exist", t.SourceID)
+				return ErrBadConfig
+			}
+		}
 		// Try to guess SourceID
 		if len(t.SourceID) == 0 && len(config.Sources) > 1 {
 

--- a/pkg/core/config/main_test.go
+++ b/pkg/core/config/main_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/updatecli/updatecli/pkg/core/engine/condition"
 	"github.com/updatecli/updatecli/pkg/core/engine/source"
 )
 
@@ -283,6 +284,34 @@ var (
 			},
 			ExpectedUpdateErr:   ErrNotAllowedTemplatedKey,
 			ExpectedValidateErr: ErrNotAllowedTemplatedKey,
+		},
+		{
+			ID: "8",
+			Config: Config{
+				Name: "jenkins - {{ source \"default\" }}",
+				Sources: map[string]source.Config{
+					"default": {
+						Name: "Get Version",
+						Kind: "jenkins",
+					},
+				},
+				Conditions: map[string]condition.Config{
+					"default": {
+						Name:     "Test SourceID",
+						Kind:     "shell",
+						SourceID: "ShouldNotExist",
+					},
+				},
+			},
+			Context: context{
+				Sources: map[string]mockSourceContext{
+					"default": {
+						Output: "2.289.2",
+					},
+				},
+			},
+			ExpectedUpdateErr:   ErrBadConfig,
+			ExpectedValidateErr: ErrBadConfig,
 		},
 	}
 )

--- a/pkg/core/config/main_test.go
+++ b/pkg/core/config/main_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/updatecli/updatecli/pkg/core/engine/condition"
 	"github.com/updatecli/updatecli/pkg/core/engine/source"
+	"github.com/updatecli/updatecli/pkg/core/engine/target"
 )
 
 // Mocking the context package
@@ -296,6 +297,34 @@ var (
 					},
 				},
 				Conditions: map[string]condition.Config{
+					"default": {
+						Name:     "Test SourceID",
+						Kind:     "shell",
+						SourceID: "ShouldNotExist",
+					},
+				},
+			},
+			Context: context{
+				Sources: map[string]mockSourceContext{
+					"default": {
+						Output: "2.289.2",
+					},
+				},
+			},
+			ExpectedUpdateErr:   ErrBadConfig,
+			ExpectedValidateErr: ErrBadConfig,
+		},
+		{
+			ID: "9",
+			Config: Config{
+				Name: "jenkins - {{ source \"default\" }}",
+				Sources: map[string]source.Config{
+					"default": {
+						Name: "Get Version",
+						Kind: "jenkins",
+					},
+				},
+				Targets: map[string]target.Config{
 					"default": {
 						Name:     "Test SourceID",
 						Kind:     "shell",


### PR DESCRIPTION
# fix: fail validation when SourceID is missing on conditions and targets

Fix #281

fix(condition) fail validation when SourceID is missing
fix(target) fail validation when SourceID is missing

## Test

To test this pull request, you can run the following commands:

test.yaml
```
sources:
  getLatestVersion:
    kind: shell
    spec:
      command: echo ami-XXXXX
conditions:
  checkIfAmiExist:
    name: Test if ami1 exist
    sourceID: doNotExist
    kind: shell
    spec:
      command: echo OK
targets:
  updateAmiValue:
    name: update the AMI value
    sourceID: doNotExist
    kind: shell
    spec:
      command: echo OK
```

```shell
go build -o ./dist/updatecli
./dist/updatecli diff --config test.yaml
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
