### PR TITLE
fix(yaml,file) fail validation when the file does not exist

### DIFF
--- a/pkg/plugins/file/main.go
+++ b/pkg/plugins/file/main.go
@@ -28,42 +28,70 @@ type File struct {
 // New returns a reference to a newly initialized File object from a Filespec
 // or an error if the provided Filespec triggers a validation error.
 func New(spec FileSpec) (*File, error) {
+	newFileResource := &File{
+		spec:             spec,
+		contentRetriever: &text.Text{},
+	}
+	// TODO: generalize the Validate + Normalize as an interface to all resources
+	err := newFileResource.Validate()
+	if err != nil {
+		return nil, err
+	}
+
+	err = newFileResource.Normalize()
+	if err != nil {
+		return nil, err
+	}
+
+	return newFileResource, nil
+}
+
+// Normalize ensures that the attributes of the object are following the expected conventions
+func (f *File) Normalize() error {
+	if strings.HasPrefix(f.spec.File, "file://") {
+		f.spec.File = strings.TrimPrefix(f.spec.File, "file://")
+	}
+
+	return nil
+}
+
+// Validate validates the object and returns an error (with all the failed validation messages) if it is not valid
+func (f *File) Validate() error {
 	var validationErrors []string
 
 	// Check for all validation
-	if spec.File == "" {
+	if f.spec.File == "" {
 		validationErrors = append(validationErrors, "Invalid spec for file resource: 'file' is empty.")
+	} else {
+		if !f.contentRetriever.FileExists(f.spec.File) {
+			validationErrors = append(validationErrors, fmt.Sprintf("Invalid spec for yaml resource: the file %q does not exist.", f.spec.File))
+		}
 	}
-	if spec.Line < 0 {
+	if f.spec.Line < 0 {
 		validationErrors = append(validationErrors, "Line cannot be negative for a file resource.")
 	}
-	if spec.Line > 0 {
-		if spec.ForceCreate {
+	if f.spec.Line > 0 {
+		if f.spec.ForceCreate {
 			validationErrors = append(validationErrors, "Validation error in target of type 'file': the attributes `spec.forcecreate` and `spec.line` are mutually exclusive")
 		}
 
-		if len(spec.MatchPattern) > 0 {
+		if len(f.spec.MatchPattern) > 0 {
 			validationErrors = append(validationErrors, "Validation error in target of type 'file': the attributes `spec.matchpattern` and `spec.line` are mutually exclusive")
 		}
 
-		if len(spec.ReplacePattern) > 0 {
+		if len(f.spec.ReplacePattern) > 0 {
 			validationErrors = append(validationErrors, "Validation error in target of type 'file': the attributes `spec.replacepattern` and `spec.line` are mutually exclusive")
 		}
 	}
-	if len(spec.Content) > 0 && len(spec.ReplacePattern) > 0 {
+	if len(f.spec.Content) > 0 && len(f.spec.ReplacePattern) > 0 {
 		validationErrors = append(validationErrors, "Validation error in target of type 'file': the attributes `spec.replacepattern` and `spec.line` are mutually exclusive")
 	}
 	// Return all the validation errors if found any
 	if len(validationErrors) > 0 {
-		return nil, fmt.Errorf("Validation error: the provided manifest configuration had the following validation errors:\n%s", strings.Join(validationErrors, "\n\n"))
+		return fmt.Errorf("Validation error: the provided manifest configuration had the following validation errors:\n%s", strings.Join(validationErrors, "\n\n"))
 	}
-	if strings.HasPrefix(spec.File, "file://") {
-		spec.File = strings.TrimPrefix(spec.File, "file://")
-	}
-	return &File{
-		spec:             spec,
-		contentRetriever: &text.Text{},
-	}, nil
+
+	return nil
 }
 
 // Read defines CurrentContent to the content of the file which path is specified in spec.File

--- a/pkg/plugins/yaml/main.go
+++ b/pkg/plugins/yaml/main.go
@@ -36,29 +36,58 @@ type Yaml struct {
 // New returns a reference to a newly initialized Yaml object from a YamlSpec
 // or an error if the provided YamlSpec triggers a validation error.
 func New(spec YamlSpec) (*Yaml, error) {
+	newYamlResource := &Yaml{
+		Spec:             spec,
+		contentRetriever: &text.Text{},
+	}
+	// TODO: generalize the Validate + Normalize as an interface to all resources
+	err := newYamlResource.Validate()
+	if err != nil {
+		return nil, err
+	}
+
+	err = newYamlResource.Normalize()
+	if err != nil {
+		return nil, err
+	}
+
+	return newYamlResource, nil
+
+}
+
+// Normalize ensures that the attributes of the object are following the expected conventions
+func (y *Yaml) Normalize() error {
+	if strings.HasPrefix(y.Spec.File, "file://") {
+		y.Spec.File = strings.TrimPrefix(y.Spec.File, "file://")
+	}
+
+	return nil
+}
+
+// Validate validates the object and returns an error (with all the failed validation messages) if it is not valid
+func (y *Yaml) Validate() error {
 	var validationErrors []string
 
 	// Check for all validation
-	if len(spec.Path) > 0 {
+	if len(y.Spec.Path) > 0 {
 		validationErrors = append(validationErrors, "Invalid spec for yaml resource: Key 'path' is deprecated, use 'file' instead.")
 	}
-	if spec.File == "" {
+	if y.Spec.File == "" {
 		validationErrors = append(validationErrors, "Invalid spec for yaml resource: 'file' is empty.")
+	} else {
+		if !y.contentRetriever.FileExists(y.Spec.File) {
+			validationErrors = append(validationErrors, fmt.Sprintf("Invalid spec for yaml resource: the file %q does not exist.", y.Spec.File))
+		}
 	}
-	if spec.Key == "" {
+	if y.Spec.Key == "" {
 		validationErrors = append(validationErrors, "Invalid spec for yaml resource: 'key' is empty.")
 	}
 	// Return all the validation errors if found any
 	if len(validationErrors) > 0 {
-		return nil, fmt.Errorf("Validation error: the provided manifest configuration had the following validation errors:\n%s", strings.Join(validationErrors, "\n\n"))
+		return fmt.Errorf("Validation error: the provided manifest configuration had the following validation errors:\n%s", strings.Join(validationErrors, "\n\n"))
 	}
-	if strings.HasPrefix(spec.File, "file://") {
-		spec.File = strings.TrimPrefix(spec.File, "file://")
-	}
-	return &Yaml{
-		Spec:             spec,
-		contentRetriever: &text.Text{},
-	}, nil
+
+	return nil
 }
 
 // Read defines CurrentContent to the content of the file which path is specified in Spec.File


### PR DESCRIPTION
This PR follows up #398 and adds a validation for the resources yaml and file.

It fails the validation if the specified file does not exist: it helps end user when they have a typo...

Example of output:

```text
CONDITIONS:
===========

checkUsernameYaml
-----------------
ERROR: Validation error: the provided manifest configuration had the following validation errors:
Invalid spec for yaml resource: the file "toto;yaml" does not exist.

checkUsernameFile
-----------------
ERROR: Validation error: the provided manifest configuration had the following validation errors:
Invalid spec for yaml resource: the file "toto;yaml" does not exist.
```

## Test

To test this pull request, you can run the following commands:

- Nominal case (non regression):

```shell
go build -o dist/updatecli && ./dist/updatecli --config ./examples/updatecli.generic/yaml.yaml diff && ./dist/updatecli --config ./examples/updatecli.generic/file.yaml diff
```

- Check the new validation failure:

```yaml
# failing.yaml
sources:
  parentSource:
    kind: shell
    spec:
      command: echo olblak
conditions:
  checkUsernameFile:
    kind: file
    spec:
      file: toto;yaml
  checkUsernameFileEmpty:
    kind: file
    spec:
      file:
  checkUsernameYaml:
    kind: yaml
    spec:
      file: toto;yaml
      key: github.username
```

```shell
go build -o dist/updatecli && ./dist/updatecli --config ./failing.yaml
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
