### PR TITLE
chore(release-drafter) use an automatic determined version with current labels

### DIFF
--- a/.github/release-drafter.yaml
+++ b/.github/release-drafter.yaml
@@ -1,6 +1,6 @@
 ---
-name-template: 'v$NEXT_MINOR_VERSION 🌈'
-tag-template: 'v$NEXT_MINOR_VERSION'
+name-template: 'v$RESOLVED_VERSION 🌈'
+tag-template: 'v$RESOLVED_VERSION'
 categories:
   - title: '🚀 Features'
     labels:
@@ -12,7 +12,7 @@ categories:
       - 'bugfix'
       - 'bug'
   - title: '🧰 Maintenance'
-    labels: 
+    labels:
       - 'chore'
       - 'dependencies'
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
@@ -25,3 +25,23 @@ template: |
   ## Contributors
 
   $CONTRIBUTORS
+
+version-resolver:
+  major:
+    labels:
+      - 'major'
+      - 'breaking'
+  minor:
+    labels:
+      - 'minor'
+      - 'feature'
+      - 'enhancement'
+      - 'dependencies'
+  patch:
+    labels:
+      - 'patch'
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+      - 'chore'
+  default: patch


### PR DESCRIPTION
This PR ensures that release drafter determines the next upcoming version correctly, based on current labels.

Once merged, it should change to a patch version (`0.16.1` instead of `0.17.0` when writing these lines)