### PR TITLE
Refactor plugin "AWS AMI"

### DIFF
--- a/examples/updatecli.generic/aws_ami.yaml
+++ b/examples/updatecli.generic/aws_ami.yaml
@@ -32,7 +32,8 @@ conditions:
 targets:
   file:
     name: Update fictive file
-    sourceID: ami1
+    sourceID: opensuse202006
     kind: file
     spec:
       file: /tmp/updatecli_ci_test
+      forcecreate: true

--- a/pkg/core/pipeline/condition/main.go
+++ b/pkg/core/pipeline/condition/main.go
@@ -8,7 +8,7 @@ import (
 	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
 	"github.com/updatecli/updatecli/pkg/core/result"
 	"github.com/updatecli/updatecli/pkg/core/transformer"
-	"github.com/updatecli/updatecli/pkg/plugins/aws/ami"
+	"github.com/updatecli/updatecli/pkg/plugins/awsami"
 	"github.com/updatecli/updatecli/pkg/plugins/docker"
 	"github.com/updatecli/updatecli/pkg/plugins/docker/dockerfile"
 	"github.com/updatecli/updatecli/pkg/plugins/file"
@@ -130,7 +130,7 @@ func Unmarshal(condition *Condition) (conditioner Conditioner, err error) {
 	switch condition.Config.Kind {
 
 	case "aws/ami":
-		a := ami.AMI{}
+		a := awsami.AMI{}
 
 		err := mapstructure.Decode(condition.Config.Spec, &a.Spec)
 

--- a/pkg/core/pipeline/condition/main.go
+++ b/pkg/core/pipeline/condition/main.go
@@ -130,15 +130,16 @@ func Unmarshal(condition *Condition) (conditioner Conditioner, err error) {
 	switch condition.Config.Kind {
 
 	case "aws/ami":
-		a := awsami.AMI{}
+		var conditionSpec awsami.Spec
 
-		err := mapstructure.Decode(condition.Config.Spec, &a.Spec)
-
-		if err != nil {
+		if err := mapstructure.Decode(condition.Config.Spec, &conditionSpec); err != nil {
 			return nil, err
 		}
 
-		conditioner = &a
+		conditioner, err = awsami.New(conditionSpec)
+		if err != nil {
+			return nil, err
+		}
 
 	case "dockerImage":
 		d := docker.Docker{}

--- a/pkg/core/pipeline/source/main.go
+++ b/pkg/core/pipeline/source/main.go
@@ -11,7 +11,7 @@ import (
 	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
 	"github.com/updatecli/updatecli/pkg/core/result"
 	"github.com/updatecli/updatecli/pkg/core/transformer"
-	"github.com/updatecli/updatecli/pkg/plugins/aws/ami"
+	"github.com/updatecli/updatecli/pkg/plugins/awsami"
 	"github.com/updatecli/updatecli/pkg/plugins/docker"
 	"github.com/updatecli/updatecli/pkg/plugins/file"
 	gitTag "github.com/updatecli/updatecli/pkg/plugins/git/tag"
@@ -155,7 +155,7 @@ func (s *Source) Run() (err error) {
 func (s *Source) Unmarshal() (sourcer Sourcer, changelog Changelog, err error) {
 	switch s.Config.Kind {
 	case "aws/ami":
-		a := ami.AMI{}
+		a := awsami.AMI{}
 
 		err := mapstructure.Decode(s.Config.Spec, &a.Spec)
 

--- a/pkg/core/pipeline/source/main.go
+++ b/pkg/core/pipeline/source/main.go
@@ -155,15 +155,16 @@ func (s *Source) Run() (err error) {
 func (s *Source) Unmarshal() (sourcer Sourcer, changelog Changelog, err error) {
 	switch s.Config.Kind {
 	case "aws/ami":
-		a := awsami.AMI{}
+		var sourceSpec awsami.Spec
 
-		err := mapstructure.Decode(s.Config.Spec, &a.Spec)
-
-		if err != nil {
+		if err := mapstructure.Decode(s.Config.Spec, &sourceSpec); err != nil {
 			return nil, nil, err
 		}
 
-		sourcer = &a
+		sourcer, err = awsami.New(sourceSpec)
+		if err != nil {
+			return nil, nil, err
+		}
 
 	case "githubRelease":
 		githubSpec := github.Spec{}

--- a/pkg/plugins/awsami/condition.go
+++ b/pkg/plugins/awsami/condition.go
@@ -1,4 +1,4 @@
-package ami
+package awsami
 
 import (
 	"errors"

--- a/pkg/plugins/awsami/condition.go
+++ b/pkg/plugins/awsami/condition.go
@@ -38,17 +38,11 @@ func (a *AMI) Condition(source string) (bool, error) {
 		})
 	}
 
-	svc, err := a.Init()
-
-	if err != nil {
-		return false, err
-	}
-
 	logrus.Debugf("Looking for latest AMI ID matching:\n  ---\n  %s\n  ---\n\n",
 		strings.TrimRight(
 			strings.ReplaceAll(a.Spec.String(), "\n", "\n  "), "\n  "))
 
-	foundAMI, err := a.getLatestAmiID(svc)
+	foundAMI, err := a.getLatestAmiID()
 
 	if err != nil {
 		return false, err

--- a/pkg/plugins/awsami/condition_test.go
+++ b/pkg/plugins/awsami/condition_test.go
@@ -1,4 +1,4 @@
-package ami
+package awsami
 
 import (
 	"errors"

--- a/pkg/plugins/awsami/condition_test.go
+++ b/pkg/plugins/awsami/condition_test.go
@@ -3,6 +3,9 @@ package awsami
 import (
 	"errors"
 	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
 )
 
 func TestCondition(t *testing.T) {
@@ -12,6 +15,9 @@ func TestCondition(t *testing.T) {
 	}
 
 	for id, d := range dataset {
+		d.ami.apiClient = mockDescribeImagesOutput{
+			Resp: d.mockedResponse,
+		}
 		got, err := d.ami.Condition("")
 
 		if !errors.Is(err, d.expectedError) {
@@ -28,13 +34,27 @@ func TestCondition(t *testing.T) {
 	}
 
 	// Test inject image-id
+	imageID := "ami-0a9972d9b4dbdabc7"
+
 	ami := AMI{
 		Spec: Spec{
 			Region:  "eu-west-1",
 			Filters: Filters{},
 		},
+		apiClient: mockDescribeImagesOutput{
+			Resp: ec2.DescribeImagesOutput{
+				Images: []*ec2.Image{
+					{
+						Name:         aws.String("openSUSE-Tumbleweed-v20200626-HVM-x86_64-48127030-1a96-4fef-b318-56ab8588c3c2-ami-0fe97336dfbbcbb07.4"),
+						CreationDate: aws.String("2020-06-26"),
+						ImageId:      aws.String(imageID),
+						Description:  aws.String("openSUSE Tumbleweed (HVM, 64-bit) cabelo@opensuse.org"),
+					},
+				},
+			},
+		},
 	}
-	imageID := "ami-0a9972d9b4dbdabc7"
+
 	exist, err := ami.Condition(imageID)
 	if err != nil {
 		t.Errorf("Unexpected error: %q",

--- a/pkg/plugins/awsami/data_test.go
+++ b/pkg/plugins/awsami/data_test.go
@@ -1,4 +1,4 @@
-package ami
+package awsami
 
 import (
 	"github.com/aws/aws-sdk-go/aws"

--- a/pkg/plugins/awsami/filter.go
+++ b/pkg/plugins/awsami/filter.go
@@ -1,4 +1,4 @@
-package ami
+package awsami
 
 import "fmt"
 

--- a/pkg/plugins/awsami/helpers.go
+++ b/pkg/plugins/awsami/helpers.go
@@ -7,18 +7,17 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 	"github.com/sirupsen/logrus"
 )
 
 // getLatestAmiID query the AWS API to return the newest AMI image id
-func (a *AMI) getLatestAmiID(svc ec2iface.EC2API) (string, error) {
+func (a *AMI) getLatestAmiID() (string, error) {
 	input := ec2.DescribeImagesInput{
 		DryRun:  &a.Spec.DryRun,
 		Filters: a.ec2Filters,
 	}
 
-	result, err := svc.DescribeImages(&input)
+	result, err := a.apiClient.DescribeImages(&input)
 
 	if err != nil {
 		if aerr, ok := err.(awserr.Error); ok {

--- a/pkg/plugins/awsami/helpers.go
+++ b/pkg/plugins/awsami/helpers.go
@@ -1,4 +1,4 @@
-package ami
+package awsami
 
 import (
 	"fmt"

--- a/pkg/plugins/awsami/helpers_test.go
+++ b/pkg/plugins/awsami/helpers_test.go
@@ -1,4 +1,4 @@
-package ami
+package awsami
 
 import (
 	"strings"

--- a/pkg/plugins/awsami/helpers_test.go
+++ b/pkg/plugins/awsami/helpers_test.go
@@ -8,9 +8,10 @@ import (
 func TestGetLatestAmiID(t *testing.T) {
 
 	for id, d := range dataset {
-		got, err := d.ami.getLatestAmiID(
-			mockDescribeImagesOutput{
-				Resp: d.mockedResponse})
+		d.ami.apiClient = mockDescribeImagesOutput{
+			Resp: d.mockedResponse,
+		}
+		got, err := d.ami.getLatestAmiID()
 		if err != nil {
 			t.Errorf("Unexpected error: %q",
 				err)

--- a/pkg/plugins/awsami/main.go
+++ b/pkg/plugins/awsami/main.go
@@ -1,4 +1,4 @@
-package ami
+package awsami
 
 import (
 	"errors"

--- a/pkg/plugins/awsami/main.go
+++ b/pkg/plugins/awsami/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 	"github.com/sirupsen/logrus"
 )
 
@@ -26,13 +27,13 @@ var (
 type AMI struct {
 	Spec       Spec
 	ec2Filters []*ec2.Filter
+	apiClient  ec2iface.EC2API
 }
 
-// Init run basic parameter initiation
-func (a *AMI) Init() (svc *ec2.EC2, err error) {
-
-	errs := a.Spec.Validate()
-
+// New returns a reference to a newly initialized AMI object from an AMISpec
+// or an error if the provided AMISpec triggers a validation error.
+func New(spec Spec) (*AMI, error) {
+	errs := spec.Validate()
 	if len(errs) > 0 {
 		logrus.Errorln("failed to validate aws/ami configuration")
 		for _, err := range errs {
@@ -41,29 +42,29 @@ func (a *AMI) Init() (svc *ec2.EC2, err error) {
 		return nil, ErrSpecNotValid
 	}
 
-	// Init ec2Filters
-	for i := 0; i < len(a.Spec.Filters); i++ {
+	var newFilters []*ec2.Filter
+	for i := 0; i < len(spec.Filters); i++ {
 		filter := ec2.Filter{
-			Name:   aws.String(a.Spec.Filters[i].Name),
-			Values: aws.StringSlice(strings.Split(a.Spec.Filters[i].Values, ","))}
+			Name:   aws.String(spec.Filters[i].Name),
+			Values: aws.StringSlice(strings.Split(spec.Filters[i].Values, ","))}
 
-		a.ec2Filters = append(a.ec2Filters, &filter)
+		newFilters = append(newFilters, &filter)
 	}
 
-	svc = ec2.New(session.New(), &aws.Config{
+	newClient := ec2.New(session.New(), &aws.Config{
 		CredentialsChainVerboseErrors: func(verbose bool) *bool {
 			return &verbose
 		}(true),
-		Region:   aws.String(a.Spec.Region),
-		Endpoint: aws.String(a.Spec.Endpoint),
+		Region:   aws.String(spec.Region),
+		Endpoint: aws.String(spec.Endpoint),
 		Credentials: credentials.NewChainCredentials(
 			[]credentials.Provider{
 				&credentials.EnvProvider{},
 				&credentials.SharedCredentialsProvider{},
 				&credentials.StaticProvider{
 					Value: credentials.Value{
-						AccessKeyID:     a.Spec.AccessKey,
-						SecretAccessKey: a.Spec.SecretKey,
+						AccessKeyID:     spec.AccessKey,
+						SecretAccessKey: spec.SecretKey,
 					},
 				},
 			}),
@@ -71,5 +72,13 @@ func (a *AMI) Init() (svc *ec2.EC2, err error) {
 		MaxRetries: func(val int) *int { return &val }(3),
 	})
 
-	return svc, err
+	if newClient == nil {
+		return nil, ErrWrongServiceConnection
+	}
+
+	return &AMI{
+		Spec:       spec,
+		ec2Filters: newFilters,
+		apiClient:  newClient,
+	}, nil
 }

--- a/pkg/plugins/awsami/sort.go
+++ b/pkg/plugins/awsami/sort.go
@@ -1,4 +1,4 @@
-package ami
+package awsami
 
 import (
 	"time"

--- a/pkg/plugins/awsami/source.go
+++ b/pkg/plugins/awsami/source.go
@@ -1,4 +1,4 @@
-package ami
+package awsami
 
 import (
 	"strings"

--- a/pkg/plugins/awsami/source.go
+++ b/pkg/plugins/awsami/source.go
@@ -9,6 +9,10 @@ import (
 
 // Source returns the latest AMI matching filter(s)
 func (a *AMI) Source(workingDir string) (string, error) {
+	if len(a.ec2Filters) == 0 {
+		return "", ErrNoFilter
+	}
+
 	logrus.Debugf("Looking for latest AMI ID matching:\n  ---\n  %s\n  ---\n\n",
 		strings.TrimRight(
 			strings.ReplaceAll(a.Spec.String(), "\n", "\n  "), "\n  "))

--- a/pkg/plugins/awsami/source.go
+++ b/pkg/plugins/awsami/source.go
@@ -9,22 +9,11 @@ import (
 
 // Source returns the latest AMI matching filter(s)
 func (a *AMI) Source(workingDir string) (string, error) {
-
-	svc, err := a.Init()
-
-	if err != nil {
-		return "", err
-	}
-
-	if svc == nil {
-		return "", ErrWrongServiceConnection
-	}
-
 	logrus.Debugf("Looking for latest AMI ID matching:\n  ---\n  %s\n  ---\n\n",
 		strings.TrimRight(
 			strings.ReplaceAll(a.Spec.String(), "\n", "\n  "), "\n  "))
 
-	foundAMI, err := a.getLatestAmiID(svc)
+	foundAMI, err := a.getLatestAmiID()
 
 	if err != nil {
 		return "", err

--- a/pkg/plugins/awsami/source_test.go
+++ b/pkg/plugins/awsami/source_test.go
@@ -1,4 +1,4 @@
-package ami
+package awsami
 
 import (
 	"errors"

--- a/pkg/plugins/awsami/source_test.go
+++ b/pkg/plugins/awsami/source_test.go
@@ -14,6 +14,15 @@ func TestSource(t *testing.T) {
 	}
 
 	for id, d := range dataset {
+		// Do not run test for source if the spec is not valid
+		if d.expectedError == ErrSpecNotValid {
+			return
+		}
+
+		d.ami.apiClient = mockDescribeImagesOutput{
+			Resp: d.mockedResponse,
+		}
+
 		got, err := d.ami.Source("")
 
 		if !errors.Is(err, d.expectedError) {

--- a/pkg/plugins/awsami/spec.go
+++ b/pkg/plugins/awsami/spec.go
@@ -1,4 +1,4 @@
-package ami
+package awsami
 
 import (
 	"errors"

--- a/pkg/plugins/awsami/spec.go
+++ b/pkg/plugins/awsami/spec.go
@@ -50,10 +50,6 @@ func (s *Spec) Validate() (errs []error) {
 		s.Endpoint = fmt.Sprintf("https://ec2.%s.amazonaws.com", s.Region)
 	}
 
-	if len(s.Filters) == 0 {
-		errs = append(errs, ErrNoFilter)
-	}
-
 	if len(s.SortBy) > 0 {
 		found := false
 		for _, acceptedValue := range getSortByAcceptedValues() {


### PR DESCRIPTION
This PR comes from the work in #412 .

It refactor the plugin "AWS AMI" to:

- Rename it to follow convention (no direct subdirectories)
- Introduce a method `New(Spec)` to allow initializing an object with a state
- Move the "svc" logic as part of the object state, into an "apiClient" attribute to allow mocking and avoid initializing too late

## Test

To test this pull request, you can run the following commands:

```shell
go build -o dist/updatecli
./dist/updatecli diff --config ./examples/updatecli.generic/aws_ami.yaml

```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
