### PR TITLE
Chore: bump golangcilint to 1.43 and apply updated code suggestions

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -33,16 +33,16 @@ linters-settings:
       - wrapperFunc
   gocyclo:
     min-complexity: 15
-  goimports:
   golint:
     min-confidence: 0
   gomnd:
     settings:
       mnd:
         # don't include the "operation" and "assign"
-        checks: argument,case,condition,return
+        checks: [argument,case,condition,return]
   govet:
     check-shadowing: true
+    fieldalignment:
     settings:
       printf:
         funcs:
@@ -56,6 +56,7 @@ linters-settings:
   maligned:
     suggest-new: true
   misspell:
+    locale: US
   nolintlint:
     allow-leading-space: true   # don't require machine-readable nolint directives (i.e. with no leading space)
     allow-unused: false         # report any unused nolint directives
@@ -83,9 +84,9 @@ linters:
     - gosec
     - gosimple
     - ineffassign
-    - interfacer
+    # - interfacer # deprecated since 1.38.0
     # - lll
-    - maligned
+    # - maligned  # deprecated since 1.38.0
     - misspell
     - nakedret
     - nolintlint
@@ -118,9 +119,3 @@ run:
     - internal/cache
     - internal/renameio
     - internal/robustio
-# golangci.com configuration
-# https://github.com/golangci/golangci/wiki/Configuration
-service:
-  golangci-lint-version: 1.27.x   # Use the fixed version to not introduce new linters unexpectedly
-  prepare:
-    - echo "here I can run custom commands, but no preparation needed for this repo"

--- a/pkg/plugins/file/main.go
+++ b/pkg/plugins/file/main.go
@@ -38,19 +38,9 @@ func New(spec FileSpec) (*File, error) {
 		return nil, err
 	}
 
-	err = newFileResource.Normalize()
-	if err != nil {
-		return nil, err
-	}
+	newFileResource.spec.File = strings.TrimPrefix(newFileResource.spec.File, "file://")
 
 	return newFileResource, nil
-}
-
-// Normalize ensures that the attributes of the object are following the expected conventions
-func (f *File) Normalize() error {
-	f.spec.File = strings.TrimPrefix(f.spec.File, "file://")
-
-	return nil
 }
 
 // Validate validates the object and returns an error (with all the failed validation messages) if it is not valid

--- a/pkg/plugins/file/main_test.go
+++ b/pkg/plugins/file/main_test.go
@@ -101,60 +101,6 @@ func Test_Validate(t *testing.T) {
 	}
 }
 
-func Test_Normalize(t *testing.T) {
-	tests := []struct {
-		name     string
-		spec     FileSpec
-		wantErr  bool
-		wantFile File
-	}{
-		{
-			name: "Normal case",
-			spec: FileSpec{
-				File: "/tmp/test.yaml",
-			},
-			wantErr: false,
-			wantFile: File{
-				contentRetriever: &text.Text{},
-				spec: FileSpec{
-					File: "/tmp/test.yaml",
-				},
-			},
-		},
-		{
-			name: "Normal case with a 'file://' prefix",
-			spec: FileSpec{
-				File: "file:///tmp/bar.yaml",
-			},
-			wantErr: false,
-			wantFile: File{
-				contentRetriever: &text.Text{},
-				spec: FileSpec{
-					File: "/tmp/bar.yaml",
-				},
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			file := File{
-				spec:             tt.spec,
-				contentRetriever: &text.Text{},
-			}
-
-			gotErr := file.Normalize()
-
-			if tt.wantErr {
-				require.Error(t, gotErr)
-				return
-			}
-			require.NoError(t, gotErr)
-
-			assert.Equal(t, tt.wantFile, file)
-		})
-	}
-}
-
 func TestFile_Read(t *testing.T) {
 	tests := []struct {
 		name                string

--- a/pkg/plugins/yaml/main.go
+++ b/pkg/plugins/yaml/main.go
@@ -46,20 +46,10 @@ func New(spec YamlSpec) (*Yaml, error) {
 		return nil, err
 	}
 
-	err = newYamlResource.Normalize()
-	if err != nil {
-		return nil, err
-	}
+	newYamlResource.Spec.File = strings.TrimPrefix(newYamlResource.Spec.File, "file://")
 
 	return newYamlResource, nil
 
-}
-
-// Normalize ensures that the attributes of the object are following the expected conventions
-func (y *Yaml) Normalize() error {
-	y.Spec.File = strings.TrimPrefix(y.Spec.File, "file://")
-
-	return nil
 }
 
 // Validate validates the object and returns an error (with all the failed validation messages) if it is not valid

--- a/pkg/plugins/yaml/main_test.go
+++ b/pkg/plugins/yaml/main_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/updatecli/updatecli/pkg/core/text"
 	"gopkg.in/yaml.v3"
@@ -451,64 +450,6 @@ func Test_Validate(t *testing.T) {
 				return
 			}
 			require.NoError(t, gotErr)
-		})
-	}
-}
-
-func Test_Normalize(t *testing.T) {
-	tests := []struct {
-		name     string
-		spec     YamlSpec
-		wantErr  bool
-		wantYaml Yaml
-	}{
-		{
-			name: "Normal case",
-			spec: YamlSpec{
-				File: "/tmp/test.yaml",
-				Key:  "foo.bar",
-			},
-			wantErr: false,
-			wantYaml: Yaml{
-				contentRetriever: &text.Text{},
-				Spec: YamlSpec{
-					File: "/tmp/test.yaml",
-					Key:  "foo.bar",
-				},
-			},
-		},
-		{
-			name: "Normal case with a 'file://' prefix",
-			spec: YamlSpec{
-				File: "file:///tmp/bar.yaml",
-				Key:  "foo.bar",
-			},
-			wantErr: false,
-			wantYaml: Yaml{
-				contentRetriever: &text.Text{},
-				Spec: YamlSpec{
-					File: "/tmp/bar.yaml",
-					Key:  "foo.bar",
-				},
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			yaml := Yaml{
-				Spec:             tt.spec,
-				contentRetriever: &text.Text{},
-			}
-
-			gotErr := yaml.Normalize()
-
-			if tt.wantErr {
-				require.Error(t, gotErr)
-				return
-			}
-			require.NoError(t, gotErr)
-
-			assert.Equal(t, tt.wantYaml, yaml)
 		})
 	}
 }


### PR DESCRIPTION
This PR comes from the work in #412 .

It updates the golantci-lint configuration file to support the latest 1.43.x line.

It also applies some of its suggestions.

## Test

To test this pull request, you can run the following commands:

```shell
go build -o dist/updatecli
./dist/updatecli diff --config ./examples/updatecli.generic/file.yaml
./dist/updatecli diff --config ./examples/updatecli.generic/yaml.yaml
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
