### PR TITLE
Init End To End test using venom

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -71,13 +71,8 @@ jobs:
         if: ${{ github.event_name == 'schedule' }}
 
       - name: Run End to End tests
+        run: make test-e2e
         env:
           IS_TTY: true # https://github.com/ovh/venom#use-venom-in-ci
           # Access only to ec2 AMI api in read-only
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
-        run: make test-e2e

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -21,10 +21,25 @@ jobs:
         with:
           go-version: 1.17.6
         id: go
+
+      # Manage and run your integration tests with efficiency
+      # https://github.com/ovh/venom
+      - name: Install Venom
+        run: |
+          curl -o /usr/local/bin/venom https://github.com/ovh/venom/releases/download/$VENOM_VERSION/venom.linux-amd64 -L
+          sudo chmod +x /usr/local/bin/venom
+          ls -lha /usr/local/bin/venom
+        env:
+          VENOM_VERSION: v1.0.1
+
+      - name: Show Venom version
+        run: venom version
+
       - name: Install GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:
           install-only: true
+
       - name: Show GoReleaser version
         run: goreleaser --version
       - name: Check out code into the Go module directory
@@ -57,6 +72,7 @@ jobs:
 
       - name: Run End to End tests
         env:
+          IS_TTY: true # https://github.com/ovh/venom#use-venom-in-ci
           # Access only to ec2 AMI api in read-only
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -54,3 +54,14 @@ jobs:
           DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
         run: make test
         if: ${{ github.event_name == 'schedule' }}
+
+      - name: Run End to End tests
+        env:
+          # Access only to ec2 AMI api in read-only
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
+        run: make test-e2e

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ dist/
 .vscode
 
 *.swp
+
+e2e/test_results.yaml

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,9 @@ DOCKER_TAG=$(shell git describe --tags)
 DOCKER_BUILDKIT=1
 export DOCKER_BUILDKIT
 
+VENOM_VAR_binpath=$(PWD)/dist/updatecli_linux_amd64
+export VENOM_VAR_binpath
+
 local_bin=./dist/updatecli_$(shell go env GOHOSTOS)_$(shell go env GOHOSTARCH)/updatecli
 
 clean: ## Clean go test cache
@@ -54,6 +57,10 @@ test: ## Execute the Golang's tests for updatecli
 
 test-short: ## Execute the Golang's tests for updatecli
 	go test ./... -short
+
+.PHONY: test-e2e
+test-e2e: ## Execute updatecli end to end tests
+	time venom run e2e/venom.d/* --output-dir ./e2e --format yaml
 
 .PHONY: lint
 lint: ## Execute the Golang's linters on updatecli's source code

--- a/e2e/updatecli.d/source/githubRelease.2.yaml
+++ b/e2e/updatecli.d/source/githubRelease.2.yaml
@@ -1,0 +1,14 @@
+---
+title: Test source githubRelease
+
+sources:
+  helm:
+    name: "Get Latest updatecli release version"
+    kind: "githubRelease"
+    spec:
+      owner: "updatecli"
+      repository: "updatecli"
+      token: '{{ requiredEnv .github.token }}'
+      username: '{{ requiredEnv .github.token }}'
+      versionFilter:
+        kind: "latest"

--- a/e2e/updatecli.d/source/githubRelease.2.yaml
+++ b/e2e/updatecli.d/source/githubRelease.2.yaml
@@ -9,6 +9,6 @@ sources:
       owner: "updatecli"
       repository: "updatecli"
       token: '{{ requiredEnv .github.token }}'
-      username: '{{ requiredEnv .github.token }}'
+      username: '{{ requiredEnv .github.username }}'
       versionFilter:
         kind: "latest"

--- a/e2e/updatecli.d/source/githubRelease.yaml
+++ b/e2e/updatecli.d/source/githubRelease.yaml
@@ -9,8 +9,8 @@ scms:
       email: "updatecli@olblak.com"
       owner: "updatecli"
       repository: "updatecli"
-      token: '{{ requiredEnv "GITHUB_TOKEN" }}'
-      username: '{{ requiredEnv "GITHUB_ACTOR" }}'
+      token: '{{ requiredEnv .github.token }}'
+      username: '{{ requiredEnv .github.username }}'
       branch: "main"
 
 sources:
@@ -20,7 +20,7 @@ sources:
     spec:
       owner: "updatecli"
       repository: "updatecli"
-      token: {{ requiredEnv .github.token }}
-      username: '{{ requiredEnv "GITHUB_ACTOR" }}'
+      token: '{{ requiredEnv .github.token }}'
+      username: '{{ requiredEnv .github.username }}'
       versionFilter:
         kind: latest

--- a/e2e/updatecli.d/source/githubRelease.yaml
+++ b/e2e/updatecli.d/source/githubRelease.yaml
@@ -1,0 +1,26 @@
+---
+title: Test source githubRelease
+
+scms:
+  updatecli:
+    kind: "github"
+    spec:
+      user: "updatecli"
+      email: "updatecli@olblak.com"
+      owner: "updatecli"
+      repository: "updatecli"
+      token: '{{ requiredEnv "GITHUB_TOKEN" }}'
+      username: '{{ requiredEnv "GITHUB_ACTOR" }}'
+      branch: "main"
+
+sources:
+  helm:
+    name: Get Latest helm release version
+    kind: githubRelease
+    spec:
+      owner: "updatecli"
+      repository: "updatecli"
+      token: {{ requiredEnv .github.token }}
+      username: '{{ requiredEnv "GITHUB_ACTOR" }}'
+      versionFilter:
+        kind: latest

--- a/e2e/values.yaml
+++ b/e2e/values.yaml
@@ -1,0 +1,4 @@
+github:
+  token: "GITHUB_TOKEN"
+  username: "GITHUB_ACTOR"
+  branch: main

--- a/e2e/venom.d/test_diff.yaml
+++ b/e2e/venom.d/test_diff.yaml
@@ -1,0 +1,15 @@
+---
+name: 'Updatecli Diff TestSuite'
+vars:
+  message:
+    warning: 'WARNING:'
+    error: 'ERROR:'
+testcases:
+  - name: "Test updatecli diff shouldn't fail"
+    steps:
+      - script: '{{ .binpath }}/updatecli diff --config  ../updatecli.d/ --values ../values.yaml'
+        type: 'exec'
+        assertions:
+          - 'result.code ShouldEqual 0'
+          - 'result.systemerr ShouldNotContainSubstring "{{ .message.warning }}"'
+          - 'result.systemerr ShouldNotContainSubstring "{{ .message.error }}"'

--- a/e2e/venom.d/test_version.yaml
+++ b/e2e/venom.d/test_version.yaml
@@ -1,0 +1,19 @@
+---
+name: 'Updatecli Version TestSuite'
+vars:
+  message:
+    warning: 'WARNING:'
+    error: 'ERROR:'
+testcases:
+  - name: 'Test updatecli version return code is 0'
+    steps:
+      - script: '{{ .binpath }}/updatecli version'
+        type: 'exec'
+        assertions:
+          - 'result.code ShouldEqual 0'
+          - 'result.systemerr ShouldNotContainSubstring "{{ .message.warning }}"'
+          - 'result.systemerr ShouldNotContainSubstring "{{ .message.error }}"'
+          - 'result.systemerr ShouldContainSubstring "VERSION"'
+          - 'result.systemerr ShouldContainSubstring "Application:"'
+          - 'result.systemerr ShouldContainSubstring "Golang     :"'
+          - 'result.systemerr ShouldContainSubstring "Build Time :"'

--- a/updatecli/updatecli.d/venom.yaml
+++ b/updatecli/updatecli.d/venom.yaml
@@ -1,0 +1,50 @@
+title: Bump venom version
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: updatecli
+      email: me@olblak.com
+      owner: updatecli
+      repository: updatecli
+      token: '{{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}'
+      username: '{{ requiredEnv "UPDATECLI_GITHUB_ACTOR" }}'
+      branch: main
+
+sources:
+  latestVersion:
+    name: Get latest Venom release
+    kind: githubRelease
+    spec:
+      owner: ovh
+      repository: venom
+      token: '{{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}'
+      username: '{{ requiredEnv "UPDATECLI_GITHUB_ACTOR" }}'
+      versioning:
+        kind: semver
+      transformers:
+        - addPrefix: "v"
+
+targets:
+  goWorkflow:
+    name: 'Bump Venom version to {{ source "latestVersion" }}'
+    kind: file
+    spec:
+      file: .github/workflows/go.yaml
+      matchPattern: 'VENOM_VERSION: .*'
+      content: 'VENOM_VERSION: {{ source `latestVersion` }}'
+    scmID: default
+
+pullrequests:
+  default:
+    title: '[updatecli] Bump Venom version to {{ source "latestVersion" }}'
+    kind: github
+    scmID: default
+    targets:
+      - goWorkflow
+    spec:
+      labels:
+        - chore
+        - skip-changelog
+


### PR DESCRIPTION
Signed-off-by: Olblak <me@olblak.com>

# Add End To End tests

<!-- Describe the changes introduced by this pull request -->

The goal of those tests is to better test different scenarios and to be sure that updatecli pipeline configurations is still working

## Test

To test this pull request, you can run the following commands from a Linux machine:

```shell
# export VENOM_VAR_binpath=<path to you updatecli binary directory>
make build
make test-e2e
```

## Additional Information

### Tradeoff

As a first iteration, I am testing that a pipeline configuration doesn't contain ERROR or WARNING.
Considering that I would like to land this pr as soon as possible so we can add more test cases later, I am not updating obsolete examples (yet).

### Potential improvement
Move obsolete examples in the e2e  directory
