### PR TITLE
fix: correctly escape changelog

### DIFF
--- a/pkg/plugins/github/pullrequest.go
+++ b/pkg/plugins/github/pullrequest.go
@@ -38,7 +38,7 @@ const PULLREQUESTBODY = `
 
 <details><summary>Click to expand</summary>
 
-` + "```\n{{ .Description }}\n```" + `
+` + "````\n{{ .Description }}\n````" + `
 
 </details>
 


### PR DESCRIPTION
To avoid putting the changelog as unescaped/preformated text like in this PR: https://github.com/jenkins-infra/docker-builder/pull/26

Fixes https://github.com/jenkins-infra/docker-builder/issues/27

