### PR TITLE
fix(pullrequests) retrieve changelog from both 'successful' and 'attention' targets

### DIFF
--- a/pkg/core/pipeline/pullRequests.go
+++ b/pkg/core/pipeline/pullRequests.go
@@ -90,8 +90,9 @@ func (p *Pipeline) RunPullRequests() error {
 			return fmt.Errorf("%d target(s) (%s) skipped for pullrequest %q", len(skippedTargetIDs), strings.Join(skippedTargetIDs, ","), id)
 		}
 
-		// Ensure we don't add changelog from the same sourceID twice.
-		for _, targetID := range successTargetIDs {
+		// Ensure we don't add changelog from the same sourceID twice
+		// Please note that the targets with both results (success and attention) need to be checked for changelog
+		for _, targetID := range append(successTargetIDs, attentionTargetIDs...) {
 			sourceID := p.Targets[targetID].Config.SourceID
 
 			found := false


### PR DESCRIPTION
Fix #423 

## Test

Tested on my fork, it opened the following PR: https://github.com/dduportal/docker-builder/pull/3
which has the changelog content in the expandable block 

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

In the future, wemight consider to separate the "execution" result of a target (failed, changed, not changed) from its status (run, skipped)
