### PR TITLE
fix(github) open a new pullrequest if the previous were closed 

### DIFF
--- a/pkg/plugins/github/pullrequest.go
+++ b/pkg/plugins/github/pullrequest.go
@@ -328,7 +328,7 @@ func (p *PullRequest) getRemotePullRequest() error {
 		Repository struct {
 			PullRequests struct {
 				Nodes []PullRequestApi
-			} `graphql:"pullRequests(baseRefName: $baseRefName, headRefName: $headRefName, last: 1, states: [OPEN,CLOSED])"`
+			} `graphql:"pullRequests(baseRefName: $baseRefName, headRefName: $headRefName, last: 1, states: [OPEN])"`
 		} `graphql:"repository(owner: $owner, name: $name)"`
 	}
 


### PR DESCRIPTION
(e.g. do not query GitHub API for closed PRs)

Co-authored with @olblak to fix #424.

## Test

Tested on https://github.com/dduportal/docker-builder/pulls?q=is%3Apr

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
