### PR TITLE
fix(pullrequest) show the correct report for the pull request section

### DIFF
--- a/pkg/core/pipeline/pullRequests.go
+++ b/pkg/core/pipeline/pullRequests.go
@@ -74,12 +74,6 @@ func (p *Pipeline) RunPullRequests() error {
 
 		failedTargetIDs, attentionTargetIDs, successTargetIDs, skippedTargetIDs := p.GetTargetsIDByResult(pr.Config.Targets)
 
-		// No target changed so nothing left to do
-		if len(attentionTargetIDs) == 0 {
-			logrus.Infof("Nothing left to do as no target related to pullrequest %q have changed", id)
-			return nil
-		}
-
 		// Ignoring failed targets
 		if len(failedTargetIDs) > 0 {
 			logrus.Errorf("%d target(s) (%s) failed for pullrequest %q", len(failedTargetIDs), strings.Join(failedTargetIDs, ","), id)
@@ -109,12 +103,13 @@ func (p *Pipeline) RunPullRequests() error {
 		pr.Changelog = changelog
 
 		if p.Options.Target.DryRun {
-			pullRequestOutput := fmt.Sprintf("A Pull request of kind %q, should be opened with the following information:\n\n##Title:\n%s\n\n##Changelog:\n\n%s\n\n##Report:\n\n%s\n\n=====\n",
-				pr.Config.Kind,
+			logrus.Infof("[Dry Run] A Pull Request is expected (with kind %q and title %q).", pr.Config.Kind, pr.Title)
+
+			pullRequestDebugOutput := fmt.Sprintf("The expected Pull Request would have the following informations:\n\n##Title:\n%s\n\n##Changelog:\n\n%s\n\n##Report:\n\n%s\n\n=====\n",
 				pr.Title,
 				pr.Changelog,
 				pr.PipelineReport)
-			logrus.Debugf(strings.ReplaceAll(pullRequestOutput, "\n", "\n\t|\t"))
+			logrus.Debugf(strings.ReplaceAll(pullRequestDebugOutput, "\n", "\n\t|\t"))
 
 			return nil
 		}

--- a/pkg/plugins/github/pullrequest.go
+++ b/pkg/plugins/github/pullrequest.go
@@ -225,7 +225,7 @@ func (p *PullRequest) updatePullRequest() error {
 		return err
 	}
 
-	logrus.Infof("\nPull Request available on:\n\n\t%s\n\n", mutation.UpdatePullRequest.PullRequest.Url)
+	logrus.Infof("\nPull Request available at:\n\n\t%s\n\n", mutation.UpdatePullRequest.PullRequest.Url)
 
 	return nil
 }


### PR DESCRIPTION
- Print a message by default when the dry run is used (and keep the debug detailed output)
- Do no print "Nothing left <...>" and proceed to opening/update Pull Requests when
  the targets reports "succeeded" (e.g. not changed). Closes #421
- Fix a typo on GitHub Pull Request log output

Signed-off-by: Damien Duportal <damien.duportal@gmail.com>
Co-authored-by: Olblak <me@olblak.com>

Fix #421 


With https://github.com/dduportal/docker-builder/blob/main/updatecli/updatecli.d/ghcli.yml

* Result in "diff" mode:

```
PULL REQUESTS
=============

[Dry Run] A Pull Request is expected (with kind "github" and title "[updatecli] Bump ghcli version").
```

* Result in "diff" mode with debug:

```
PULL REQUESTS
=============

[Dry Run] A Pull Request is expected (with kind "github" and title "[updatecli] Bump ghcli version").
DEBUG: The expected Pull Request would have the following informations:
        |
        |       ##Title:
        |       [updatecli] Bump ghcli version
        |
        |       ##Changelog:
        |
        |
        |       Release published on the 2021-12-02 18:04:53 +0000 UTC at the url https://github.com/cli/cli/releases/tag/v2.3.0
...
```