### PR TITLE
fix: correct regexp to retrieve last (non beta) go version

### DIFF
--- a/updatecli/scripts/updateGomodGoversion.sh
+++ b/updatecli/scripts/updateGomodGoversion.sh
@@ -13,24 +13,31 @@ go_version="${2}"
 new_version="$(echo "${go_version}" | cut -d. -f1,2)"
 tmp_dir="$(mktemp -d)"
 
-## Ensures that the correct golang version is used
+## Ensures that there is a golang version installed
 {
-  curl --silent --show-error --location --output "${tmp_dir}/go.tgz" \
-    "https://golang.org/dl/go${go_version}.linux-amd64.tar.gz"
-  mkdir -p "${tmp_dir}/.bin"
-  tar xzf "${tmp_dir}/go.tgz" -C "${tmp_dir}/.bin"
-  export PATH="${PATH}":"${tmp_dir}"/.bin/go/bin
+  if ! command -v go
+  then
+    curl --silent --show-error --location --output "${tmp_dir}/go.tgz" \
+      "https://golang.org/dl/go${go_version}.$(uname -s | tr '[:upper:]' '[:lower:]')-amd64.tar.gz"
+    mkdir -p "${tmp_dir}/.bin"
+    tar xzf "${tmp_dir}/go.tgz" -C "${tmp_dir}/.bin"
+    export PATH="${PATH}":"${tmp_dir}"/.bin/go/bin
+  fi
+
   command -v go
   go version
 } >&2
 
 ## Copy go mod's directory to a temp directory an start working from this temp. dir.
-cp -r "${go_mod_dir}" "${tmp_dir}" >&2
+cp -r "${go_mod_dir}"/* "${tmp_dir}" >&2
 cd "${tmp_dir}" >&2
+GOPATH="$(mktemp -d)"
+export GOPATH
 
 ## Update go mod properly
 go mod edit -go="${new_version}" >&2
 go mod tidy >&2
+echo "" >> go.mod ## Ad empty endline to be POSIX compliant
 
 ## Show new go mod
 cat go.mod

--- a/updatecli/updatecli.d/golang.yaml
+++ b/updatecli/updatecli.d/golang.yaml
@@ -1,4 +1,17 @@
 title: Bump Golang Version
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: updatecli
+      email: me@olblak.com
+      owner: updatecli
+      repository: updatecli
+      token: '{{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}'
+      username: '{{ requiredEnv "UPDATECLI_GITHUB_ACTOR" }}'
+      branch: main
+
 sources:
   latestGoVersion:
     name: Get Latest Go Release
@@ -20,11 +33,12 @@ sources:
       - latestGoVersion
     spec:
       command: ./updatecli/scripts/updateGomodGoversion.sh ./go.mod {{ source "latestGoVersion" }}
+
 conditions:
   workflowrelease-sandbox:
     name: Ensure GA step is defined in Github Action named release-sandbox
     kind: yaml
-    sourceID: latestGoVersion
+    disablesourceinput: true
     spec:
       file: .github/workflows/release-sandbox.yaml
       key: jobs.build.steps[3].id
@@ -32,7 +46,7 @@ conditions:
   workflowrelease:
     name: Ensure GA step is defined in Github Action named release
     kind: yaml
-    sourceID: latestGoVersion
+    disablesourceinput: true
     spec:
       file: .github/workflows/release.yaml
       key: jobs.build.steps[3].id
@@ -40,7 +54,7 @@ conditions:
   workflowgo:
     name: Ensure GA step is defined in Github Action named go
     kind: yaml
-    sourceID: latestGoVersion
+    disablesourceinput: true
     spec:
       file: .github/workflows/go.yaml
       key: jobs.build.steps[0].id
@@ -61,15 +75,7 @@ targets:
     spec:
       file: .github/workflows/release.yaml
       key: jobs.build.steps[3].with.go-version
-    scm:
-      github:
-        user: updatecli
-        email: me@olblak.com
-        owner: updatecli
-        repository: updatecli
-        token: '{{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}'
-        username: '{{ requiredEnv "UPDATECLI_GITHUB_ACTOR" }}'
-        branch: main
+    scmID: default
   release:
     name: '[release-sandbox.yaml] Update Golang version to {{ source "latestGoVersion" }}'
     sourceID: latestGoVersion
@@ -77,15 +83,7 @@ targets:
     spec:
       file: .github/workflows/release-sandbox.yaml
       key: jobs.build.steps[3].with.go-version
-    scm:
-      github:
-        user: updatecli
-        email: me@olblak.com
-        owner: updatecli
-        repository: updatecli
-        token: '{{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}'
-        username: '{{ requiredEnv "UPDATECLI_GITHUB_ACTOR" }}'
-        branch: main
+    scmID: default
   workflowgo:
     name: '[release.yaml] Update Golang version to {{ source "latestGoVersion" }}'
     kind: yaml
@@ -93,27 +91,25 @@ targets:
     spec:
       file: .github/workflows/go.yaml
       key: jobs.build.steps[0].with.go-version
-    scm:
-      github:
-        user: updatecli
-        email: me@olblak.com
-        owner: updatecli
-        repository: updatecli
-        token: '{{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}'
-        username: '{{ requiredEnv "UPDATECLI_GITHUB_ACTOR" }}'
-        branch: main
+    scmID: default
   go.mod:
     name: '[go.mod] Update Golang version to {{ source "latestGoVersion" }}'
     sourceID: gomod
     kind: file
     spec:
       file: go.mod
-    scm:
-      github:
-        user: updatecli
-        email: me@olblak.com
-        owner: updatecli
-        repository: updatecli
-        token: '{{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}'
-        username: '{{ requiredEnv "UPDATECLI_GITHUB_ACTOR" }}'
-        branch: main
+    scmID: default
+
+pullrequests:
+  default:
+    title: '[updatecli] Bump Golang version to {{ source "latestGoVersion" }}'
+    kind: github
+    scmID: default
+    targets:
+      - release-sandbox
+      - release
+      - workflowgo
+      - go.mod
+    spec:
+      labels:
+        - chore

--- a/updatecli/updatecli.d/golang.yaml
+++ b/updatecli/updatecli.d/golang.yaml
@@ -8,9 +8,9 @@ sources:
       repository: go
       token: '{{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}'
       username: '{{ requiredEnv "UPDATECLI_GITHUB_ACTOR" }}'
-    versionFilter:
-      kind: regex
-      pattern: 'go1\.(\d*)\.(\d*)$'
+      versionFilter:
+        kind: regex
+        pattern: 'go1\.(\d*)\.(\d*)$'
     transformers:
       - trimPrefix: go
   gomod:

--- a/updatecli/updatecli.d/golang.yaml
+++ b/updatecli/updatecli.d/golang.yaml
@@ -10,7 +10,7 @@ sources:
       username: '{{ requiredEnv "UPDATECLI_GITHUB_ACTOR" }}'
     versionFilter:
       kind: regex
-      pattern: 'go-1.(\d*).(\d*)$'
+      pattern: 'go1\.(\d*)\.(\d*)$'
     transformers:
       - trimPrefix: go
   gomod:


### PR DESCRIPTION
Related to #416 
