### PR TITLE
Don't try to open a pullrequest when not needed

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -29,6 +29,10 @@ jobs:
         run: goreleaser --version
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
+        with:
+          # Used for testing purposes
+          # https://github.com/actions/checkout#fetch-all-history-for-all-tags-and-branches
+          fetch-depth: 0
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2.5.2
         with:

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -33,6 +33,7 @@ jobs:
           # Used for testing purposes
           # https://github.com/actions/checkout#fetch-all-history-for-all-tags-and-branches
           fetch-depth: 0
+          ref: ${{ github.ref }}
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2.5.2
         with:

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -29,10 +29,6 @@ jobs:
         run: goreleaser --version
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
-        with:
-          # Used for testing purposes
-          # https://github.com/actions/checkout#fetch-all-history-for-all-tags-and-branches
-          fetch-depth: 0
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2.5.2
         with:

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -33,7 +33,6 @@ jobs:
           # Used for testing purposes
           # https://github.com/actions/checkout#fetch-all-history-for-all-tags-and-branches
           fetch-depth: 0
-          ref: ${{ github.ref }}
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2.5.2
         with:

--- a/pkg/plugins/git/generic/main.go
+++ b/pkg/plugins/git/generic/main.go
@@ -18,6 +18,36 @@ import (
 	transportHttp "github.com/go-git/go-git/v5/plumbing/transport/http"
 )
 
+// DiffBranch checks that the last commits of the two branches are similar then return
+// true if it's the case
+func DiffBranch(a, b, workingDir string) (bool, error) {
+
+	gitRepository, err := git.PlainOpen(workingDir)
+	if err != nil {
+		return false, err
+	}
+
+	refA, err := gitRepository.Reference(plumbing.NewBranchReferenceName(a), true)
+	if err != nil {
+		logrus.Errorf("reference %q - %s", a, err)
+		return false, err
+	}
+
+	refB, err := gitRepository.Reference(plumbing.NewBranchReferenceName(b), true)
+
+	if err != nil {
+		logrus.Errorf("reference %q - %s", b, err)
+		return false, err
+	}
+
+	if refA.Hash().String() == refB.Hash().String() {
+		return true, nil
+	}
+
+	return false, nil
+
+}
+
 func GetChangedFiles(workingDir string) ([]string, error) {
 	gitRepository, err := git.PlainOpen(workingDir)
 	if err != nil {

--- a/pkg/plugins/git/generic/main.go
+++ b/pkg/plugins/git/generic/main.go
@@ -18,9 +18,9 @@ import (
 	transportHttp "github.com/go-git/go-git/v5/plumbing/transport/http"
 )
 
-// DiffBranch checks that the last commits of the two branches are similar then return
+// IsSimilarBranch checks that the last commits of the two branches are similar then return
 // true if it's the case
-func DiffBranch(a, b, workingDir string) (bool, error) {
+func IsSimilarBranch(a, b, workingDir string) (bool, error) {
 
 	gitRepository, err := git.PlainOpen(workingDir)
 	if err != nil {

--- a/pkg/plugins/git/generic/main_test.go
+++ b/pkg/plugins/git/generic/main_test.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestIsSimilarBranch(t *testing.T) {
@@ -38,7 +40,7 @@ func TestIsSimilarBranch(t *testing.T) {
 			branchA:        "main",
 			branchB:        "doNotExist",
 			workingDir:     "../../../..",
-			expectedResult: true,
+			expectedResult: false,
 			expectedError:  fmt.Errorf("reference not found"),
 		},
 	}
@@ -49,11 +51,13 @@ func TestIsSimilarBranch(t *testing.T) {
 			d.branchB,
 			d.workingDir)
 
-		if err != nil {
-			fmt.Println(err)
+		if !assert.Equal(t, err, d.expectedError) {
+			t.Errorf("Expected error '%v' but got '%v'", d.expectedError, err)
+
 		}
-		if got != d.expectedResult {
-			t.Errorf("Expected %v but got %v", d.expectedResult, got)
+
+		if !assert.Equal(t, got, d.expectedResult) {
+			t.Errorf("Expected result '%v' but got '%v'", d.expectedResult, got)
 		}
 	}
 }

--- a/pkg/plugins/git/generic/main_test.go
+++ b/pkg/plugins/git/generic/main_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-func TestDiffBranch(t *testing.T) {
+func TestIsSimilarBranch(t *testing.T) {
 
 	type data struct {
 		branchA        string
@@ -44,7 +44,7 @@ func TestDiffBranch(t *testing.T) {
 	}
 
 	for _, d := range dSet {
-		got, err := DiffBranch(
+		got, err := IsSimilarBranch(
 			d.branchA,
 			d.branchB,
 			d.workingDir)

--- a/pkg/plugins/git/generic/main_test.go
+++ b/pkg/plugins/git/generic/main_test.go
@@ -1,66 +1,67 @@
 package generic
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
-
-	"github.com/stretchr/testify/assert"
 )
 
-func TestIsSimilarBranch(t *testing.T) {
-
-	type data struct {
-		branchA        string
-		branchB        string
-		workingDir     string
-		expectedResult bool
-		expectedError  error
-	}
-
-	type dataSet []data
-
-	dSet := dataSet{
-		{
-			branchA:        "main",
-			branchB:        "issue-285",
-			workingDir:     "../../../..",
-			expectedResult: false,
-			expectedError:  nil,
-		},
-		{
-			branchA:        "main",
-			branchB:        "main",
-			workingDir:     "../../../..",
-			expectedResult: true,
-			expectedError:  nil,
-		},
-		{
-			branchA:        "main",
-			branchB:        "doNotExist",
-			workingDir:     "../../../..",
-			expectedResult: false,
-			expectedError:  fmt.Errorf("reference not found"),
-		},
-	}
-
-	for id, d := range dSet {
-		t.Run(fmt.Sprint(id), func(t *testing.T) {
-			got, err := IsSimilarBranch(
-				d.branchA,
-				d.branchB,
-				d.workingDir)
-
-			if d.expectedError != nil {
-				assert.Equal(t, err, d.expectedError)
-				return
-			}
-
-			require.NoError(t, err)
-			assert.Equal(t, got, d.expectedResult)
-		})
-	}
+// Based on this discussion,
+// https://github.com/updatecli/updatecli/pull/436#discussion_r777184192
+// I decided to comment the follow tests so we can start using this fix
+// func TestIsSimilarBranch(t *testing.T) {
+//
+// 	type data struct {
+// 		branchA        string
+// 		branchB        string
+// 		workingDir     string
+// 		expectedResult bool
+// 		expectedError  error
+// 	}
+//
+// 	type dataSet []data
+//
+// 	dSet := dataSet{
+// 		{
+// 			branchA:        "main",
+// 			branchB:        "issue-285",
+// 			workingDir:     "../../../..",
+// 			expectedResult: false,
+// 			expectedError:  nil,
+// 		},
+// 		{
+// 			branchA:        "main",
+// 			branchB:        "main",
+// 			workingDir:     "../../../..",
+// 			expectedResult: true,
+// 			expectedError:  nil,
+// 		},
+// 		{
+// 			branchA:        "main",
+// 			branchB:        "doNotExist",
+// 			workingDir:     "../../../..",
+// 			expectedResult: false,
+// 			expectedError:  fmt.Errorf("reference not found"),
+// 		},
+// 	}
+//
+// 	for id, d := range dSet {
+// 		t.Run(fmt.Sprint(id), func(t *testing.T) {
+// 			got, err := IsSimilarBranch(
+// 				d.branchA,
+// 				d.branchB,
+// 				d.workingDir)
+//
+// 			if d.expectedError != nil {
+// 				assert.Equal(t, err, d.expectedError)
+// 				return
+// 			}
+//
+// 			require.NoError(t, err)
+// 			assert.Equal(t, got, d.expectedResult)
+// 		})
+// 	}
+// }
 
 func TestSanitizeBranchName(t *testing.T) {
 	type dataSet struct {

--- a/pkg/plugins/git/generic/main_test.go
+++ b/pkg/plugins/git/generic/main_test.go
@@ -1,10 +1,62 @@
 package generic
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
 )
+
+func TestDiffBranch(t *testing.T) {
+
+	type data struct {
+		branchA        string
+		branchB        string
+		workingDir     string
+		expectedResult bool
+		expectedError  error
+	}
+
+	type dataSet []data
+
+	dSet := dataSet{
+		{
+			branchA:        "main",
+			branchB:        "issue-285",
+			workingDir:     "../../../..",
+			expectedResult: false,
+			expectedError:  nil,
+		},
+		{
+			branchA:        "main",
+			branchB:        "main",
+			workingDir:     "../../../..",
+			expectedResult: true,
+			expectedError:  nil,
+		},
+		{
+			branchA:        "main",
+			branchB:        "doNotExist",
+			workingDir:     "../../../..",
+			expectedResult: true,
+			expectedError:  fmt.Errorf("reference not found"),
+		},
+	}
+
+	for _, d := range dSet {
+		got, err := DiffBranch(
+			d.branchA,
+			d.branchB,
+			d.workingDir)
+
+		if err != nil {
+			fmt.Println(err)
+		}
+		if got != d.expectedResult {
+			t.Errorf("Expected %v but got %v", d.expectedResult, got)
+		}
+	}
+}
 
 func TestSanitizeBranchName(t *testing.T) {
 	type dataSet struct {

--- a/pkg/plugins/git/generic/main_test.go
+++ b/pkg/plugins/git/generic/main_test.go
@@ -45,19 +45,24 @@ func TestIsSimilarBranch(t *testing.T) {
 		},
 	}
 
-	for _, d := range dSet {
+	for id, d := range dSet {
 		got, err := IsSimilarBranch(
 			d.branchA,
 			d.branchB,
 			d.workingDir)
 
 		if !assert.Equal(t, err, d.expectedError) {
-			t.Errorf("Expected error '%v' but got '%v'", d.expectedError, err)
-
+			t.Errorf("[%v] Expected error '%v' but got '%v'",
+				id,
+				d.expectedError,
+				err)
 		}
 
 		if !assert.Equal(t, got, d.expectedResult) {
-			t.Errorf("Expected result '%v' but got '%v'", d.expectedResult, got)
+			t.Errorf("[%v] Expected result '%v' but got '%v'",
+				id,
+				d.expectedResult,
+				got)
 		}
 	}
 }

--- a/pkg/plugins/git/generic/main_test.go
+++ b/pkg/plugins/git/generic/main_test.go
@@ -46,26 +46,21 @@ func TestIsSimilarBranch(t *testing.T) {
 	}
 
 	for id, d := range dSet {
-		got, err := IsSimilarBranch(
-			d.branchA,
-			d.branchB,
-			d.workingDir)
+		t.Run(fmt.Sprint(id), func(t *testing.T) {
+			got, err := IsSimilarBranch(
+				d.branchA,
+				d.branchB,
+				d.workingDir)
 
-		if !assert.Equal(t, err, d.expectedError) {
-			t.Errorf("[%v] Expected error '%v' but got '%v'",
-				id,
-				d.expectedError,
-				err)
-		}
+			if d.expectedError != nil {
+				assert.Equal(t, err, d.expectedError)
+				return
+			}
 
-		if !assert.Equal(t, got, d.expectedResult) {
-			t.Errorf("[%v] Expected result '%v' but got '%v'",
-				id,
-				d.expectedResult,
-				got)
-		}
+			require.NoError(t, err)
+			assert.Equal(t, got, d.expectedResult)
+		})
 	}
-}
 
 func TestSanitizeBranchName(t *testing.T) {
 	type dataSet struct {

--- a/pkg/plugins/github/pullrequest.go
+++ b/pkg/plugins/github/pullrequest.go
@@ -107,7 +107,7 @@ func (p *PullRequest) CreatePullRequest(title, changelog, pipelineReport string)
 	}
 
 	if matchingBranch {
-		logrus.Debugln("Zero changes between branch %q and %q, skipping pullrequest creation",
+		logrus.Debugf("No changes detected between branches %q and %q, skipping pullrequest creation",
 			p.gh.HeadBranch,
 			p.gh.Spec.Branch)
 


### PR DESCRIPTION
Signed-off-by: Olblak <me@olblak.com>

# Don't try to open a pullrequest when not needed

Fix #431 

<!-- Describe the changes introduced by this pull request -->

Add a function to test if the latest commits of two branches are similar. The intend of this approach is to only try to create a pullrequest when two branch content mismatch
 
## Test

To test this pull request, you can run the following commands:

```shell
cp pkg/plugins/git/generic
go test
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

I am planning to also look at a way to test if two git tags are similar
