### PR TITLE
fix(helm) correct error `unsupported protocol scheme ""`

### DIFF
--- a/pkg/core/pipeline/condition/main.go
+++ b/pkg/core/pipeline/condition/main.go
@@ -208,14 +208,16 @@ func Unmarshal(condition *Condition) (conditioner Conditioner, err error) {
 		conditioner = &g
 
 	case "helmChart":
-		ch := helm.Chart{}
+		var conditionSpec helm.Spec
 
-		err := mapstructure.Decode(condition.Config.Spec, &ch)
-		if err != nil {
+		if err := mapstructure.Decode(condition.Config.Spec, &conditionSpec); err != nil {
 			return nil, err
 		}
 
-		conditioner = &ch
+		conditioner, err = helm.New(conditionSpec)
+		if err != nil {
+			return nil, err
+		}
 
 	case "yaml":
 		var conditionSpec yaml.Spec

--- a/pkg/core/pipeline/source/main.go
+++ b/pkg/core/pipeline/source/main.go
@@ -209,15 +209,18 @@ func (s *Source) Unmarshal() (sourcer Sourcer, changelog Changelog, err error) {
 		}
 
 	case "helmChart":
-		c := helm.Chart{}
-		err := mapstructure.Decode(s.Config.Spec, &c)
+		var sourceSpec helm.Spec
 
-		if err != nil {
+		if err := mapstructure.Decode(s.Config.Spec, &sourceSpec); err != nil {
 			return nil, nil, err
 		}
 
-		sourcer = &c
-		changelog = &c
+		helmChartResource, err := helm.New(sourceSpec)
+		if err != nil {
+			return nil, nil, err
+		}
+		sourcer = helmChartResource
+		changelog = helmChartResource
 
 	case "jenkins":
 		j := jenkins.Jenkins{}

--- a/pkg/core/pipeline/target/main.go
+++ b/pkg/core/pipeline/target/main.go
@@ -73,16 +73,17 @@ func (t *Target) Check() (bool, error) {
 func Unmarshal(target *Target) (targeter Targeter, err error) {
 	switch target.Config.Kind {
 	case "helmChart":
-		ch := helm.Chart{}
+		targetSpec := helm.Spec{}
 
-		err := mapstructure.Decode(target.Config.Spec, &ch)
-
+		err := mapstructure.Decode(target.Config.Spec, &targetSpec)
 		if err != nil {
-			logrus.Errorf("err - %s", err)
 			return nil, err
 		}
 
-		targeter = &ch
+		targeter, err = helm.New(targetSpec)
+		if err != nil {
+			return nil, err
+		}
 
 	case "dockerfile":
 		targetSpec := dockerfile.Spec{}

--- a/pkg/plugins/file/main.go
+++ b/pkg/plugins/file/main.go
@@ -25,7 +25,7 @@ type File struct {
 	CurrentContent   string
 }
 
-// New returns a reference to a newly initialized File object from a Filespec
+// New returns a reference to a newly initialized File object from a Spec
 // or an error if the provided Filespec triggers a validation error.
 func New(spec Spec) (*File, error) {
 	newResource := &File{

--- a/pkg/plugins/helm/main.go
+++ b/pkg/plugins/helm/main.go
@@ -50,9 +50,21 @@ type Spec struct {
 	AppVersion       bool   // [target] Boolean that define we must update the App Version
 }
 
-// Chart describe helm repository metadata
+// Chart defines a resource of kind "helmchart"
 type Chart struct {
 	spec Spec
+}
+
+// New returns a reference to a newly initialized Chart object from a Spec
+// or an error if the provided YamlSpec triggers a validation error.
+func New(newSpec Spec) (*Chart, error) {
+
+	newResource := &Chart{
+		spec: newSpec,
+	}
+
+	return newResource, nil
+
 }
 
 // loadIndex loads an index file and does minimal validity checking.

--- a/pkg/plugins/yaml/main.go
+++ b/pkg/plugins/yaml/main.go
@@ -34,7 +34,7 @@ type Yaml struct {
 	currentContent   string
 }
 
-// New returns a reference to a newly initialized Yaml object from a YamlSpec
+// New returns a reference to a newly initialized Yaml object from a Spec
 // or an error if the provided YamlSpec triggers a validation error.
 func New(newSpec Spec) (*Yaml, error) {
 


### PR DESCRIPTION
Fix #458

Sounds like I messed up the helm chart plugin in https://github.com/updatecli/updatecli/pull/437.

This PR fixes it by adding the necessary New() constructor method (otherwise it was not initialized).

Tested on https://github.com/jenkins-infra/kubernetes-management/tree/main/updatecli/updatecli.d/charts manifests with success.

## Test

To test this pull request, you can run the following commands:

```shell
go build -o ./dist/updatecli && ./dist/updatecli --debug diff --config examples/updatecli.generic/helmChart
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
