### PR TITLE
Allow Release-drafter to ignore PullRequest

### DIFF
--- a/.github/release-drafter.yaml
+++ b/.github/release-drafter.yaml
@@ -45,3 +45,5 @@ version-resolver:
       - 'bug'
       - 'chore'
   default: patch
+exclude-labels:
+  - 'skip-changelog'


### PR DESCRIPTION
# Allow Release-drafter to ignore PullRequest

Not every pullrequest should be listed in updatecli release note.
Just following this [documentation](https://github.com/release-drafter/release-drafter#exclude-pull-requests)

