### PR TITLE
hotfix(conditions) show error message when a condition errors

### DIFF
--- a/pkg/core/pipeline/conditions.go
+++ b/pkg/core/pipeline/conditions.go
@@ -4,7 +4,6 @@ import (
 	"strings"
 
 	"github.com/sirupsen/logrus"
-	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
 // RunConditions run every conditions for a given configuration config.
@@ -43,22 +42,19 @@ func (p *Pipeline) RunConditions() (globalResult bool, err error) {
 				p.Sources[condition.Config.SourceID].Config.Postfix)
 
 		if err != nil {
-			// Show error to end user
+			// Show error to end user if any
 			logrus.Error(err)
-			if condition.Result != result.SUCCESS {
-				globalResult = false
-			}
-		}
-		rpt.Result = condition.Result
-
-		// Update pipeline after each condition run
-		if err == nil {
+			// Fail globally (even though other conditions will be executed)
+			globalResult = false
+		} else {
+			// Update pipeline's configuration after each condition run
 			err = p.Config.Update(p)
 			if err != nil {
 				globalResult = false
 				return globalResult, err
 			}
 		}
+		rpt.Result = condition.Result
 
 		p.Conditions[id] = condition
 		p.Report.Conditions[id] = rpt

--- a/pkg/core/pipeline/conditions.go
+++ b/pkg/core/pipeline/conditions.go
@@ -42,20 +42,22 @@ func (p *Pipeline) RunConditions() (globalResult bool, err error) {
 				p.Sources[condition.Config.SourceID].Output +
 				p.Sources[condition.Config.SourceID].Config.Postfix)
 
+		if err != nil {
+			// Show error to end user
+			logrus.Error(err)
+			if condition.Result != result.SUCCESS {
+				globalResult = false
+			}
+		}
 		rpt.Result = condition.Result
 
+		// Update pipeline after each condition run
 		if err == nil {
-
-			// Update pipeline after each condition run
 			err = p.Config.Update(p)
 			if err != nil {
 				globalResult = false
 				return globalResult, err
 			}
-		}
-
-		if err != nil || strings.Compare(condition.Result, result.SUCCESS) != 0 {
-			globalResult = false
 		}
 
 		p.Conditions[id] = condition


### PR DESCRIPTION
Not usre when this "misbehavior" was introduced but currently, conditions that fails because of an error does not show the error message.

It's not really convenient, particularly when it is a validation error 😅 

This PR fixes the print of error message (minor cleanups around happy path / string comparisons)

## Test

To test this pull request, you can run the following commands:

```shell
make build
make test
make test-e2e
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
