### PR TITLE
chore(release-drafter) PR about dependencies should only bump patch

### DIFF
--- a/.github/release-drafter.yaml
+++ b/.github/release-drafter.yaml
@@ -36,7 +36,6 @@ version-resolver:
       - 'minor'
       - 'feature'
       - 'enhancement'
-      - 'dependencies'
   patch:
     labels:
       - 'patch'
@@ -44,6 +43,7 @@ version-resolver:
       - 'bugfix'
       - 'bug'
       - 'chore'
+      - 'dependencies'
   default: patch
 exclude-labels:
   - 'skip-changelog'


### PR DESCRIPTION
Unless the tag "minor" is added to the PR for "big" dependency updates
