### PR TITLE
chore(yaml) cleanup file generated during test phase

### DIFF
--- a/pkg/plugins/yaml/target_test.go
+++ b/pkg/plugins/yaml/target_test.go
@@ -109,6 +109,7 @@ github-
 				contentRetriever: &mockText,
 			}
 			gotResult, gotErr := y.Target(tt.inputSourceValue, tt.dryRun)
+			defer os.Remove(y.spec.File)
 			if tt.wantErr {
 				assert.Error(t, gotErr)
 				return

--- a/pkg/plugins/yaml/target_test.go
+++ b/pkg/plugins/yaml/target_test.go
@@ -1,6 +1,7 @@
 package yaml
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"


### PR DESCRIPTION
This is a "quick" PR that cleans up the files generated fby thet target tests for YAML resource.

It was driving me (and @lemeurherve) crazy that running `go test ./... -short` was generating a file in the source code.

Since I haven't had time on the topic for unit tests with mock for YAML, let's do it that way.

Labelled as "skip-changelog" since it does not hold anything useful for end user

## Test

To test this pull request, you can run the following commands:

```shell
$ git status
# No git changes
$ go test ./... -short
# Should be success
$ git status
# No git changes
```

## Additional Information

### Tradeoff

- Could execute the tests in a temp directory

### Potential improvement

- Execute mocked tests without any interaction with the I/O file system (real unit tests)
