### PR TITLE
fix(pullrequests) Do not mention a pull request in dry run when there are no changes

### DIFF
--- a/pkg/core/pipeline/pullRequests.go
+++ b/pkg/core/pipeline/pullRequests.go
@@ -103,7 +103,15 @@ func (p *Pipeline) RunPullRequests() error {
 		pr.Changelog = changelog
 
 		if p.Options.Target.DryRun {
-			logrus.Infof("[Dry Run] A Pull Request is expected (with kind %q and title %q).", pr.Config.Kind, pr.Title)
+			if len(attentionTargetIDs) > 0 {
+				logrus.Infof("[Dry Run] A pull request with kind %q and title %q is expected.", pr.Config.Kind, pr.Title)
+
+				pullRequestDebugOutput := fmt.Sprintf("The expected pull request would have the following informations:\n\n##Title:\n%s\n\n##Changelog:\n\n%s\n\n##Report:\n\n%s\n\n=====\n",
+					pr.Title,
+					pr.Changelog,
+					pr.PipelineReport)
+				logrus.Debugf(strings.ReplaceAll(pullRequestDebugOutput, "\n", "\n\t|\t"))
+			}
 
 			pullRequestDebugOutput := fmt.Sprintf("The expected Pull Request would have the following informations:\n\n##Title:\n%s\n\n##Changelog:\n\n%s\n\n##Report:\n\n%s\n\n=====\n",
 				pr.Title,


### PR DESCRIPTION
# An expected pull request is mentioned in dry run logs even if there is no change
Fix #484 

In the current state, this PR fix two bugs which by the way could be split into two Pull requests :) 

1. In Dry mode, don't mention that a PR will be open if it's not the case (#484 )
2. Pull request object correctly using the updated configuration. This avoids open pull requests with a message containing templating instruction such as `Bump app to {{ source "source" }}`

## Test

To test this pull request, you can run the following commands:
1. Run updatecli in dry mode and debug enable, with a updatecli configuration that shouldn't open a pullrequest. We shouldn't have pull request message
2. Run updatecli in dry mode and debug enable, with a updatecli configuration that should open a pull request and where the title contains templating instruction. We should have pull request message with the correct title

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

While working on this PR, I realize that we have confusion about what a pull request title should be. The title should be configured in the spec level and not at the pull request level.

```
pullrequestID:
  kind: github
  title: my title
  spec:
     label: 
        - dependencies
```

or 


```
pullrequestID:
  kind: github
  spec:
    title: my title 
    label: 
        - dependencies
```
At the moment the latter example, is implement in the code in a way that it's totally useless. 
I also realize that the way to generate a pullrequest title is overly complicated and could drastically simplified by just having the two following cases
1 A title is specified in the spec, then we use that value
2. No title specified so we let GitHub should, which will be the first commit title