### PR TITLE
fix(dockerimage,transformers) improve validation failure cases

### DIFF
--- a/pkg/core/pipeline/target/main.go
+++ b/pkg/core/pipeline/target/main.go
@@ -163,7 +163,6 @@ func (t *Target) Run(source string, o *Options) (err error) {
 		source, err = t.Config.Transformers.Apply(source)
 		if err != nil {
 			t.Result = result.FAILURE
-			logrus.Error(err)
 			return err
 		}
 	}

--- a/pkg/core/transformer/main.go
+++ b/pkg/core/transformer/main.go
@@ -173,7 +173,6 @@ func (t *Transformers) Apply(input string) (output string, err error) {
 		output, err = transformer.Apply(output)
 
 		if err != nil {
-			logrus.Error(err)
 			return "", err
 		}
 	}

--- a/pkg/core/transformer/main.go
+++ b/pkg/core/transformer/main.go
@@ -19,6 +19,10 @@ type Transformers []Transformer
 // Apply applies a single transformation based on a key
 func (t *Transformer) Apply(input string) (output string, err error) {
 
+	if input == "" {
+		return "", fmt.Errorf("Validation error: input for transformer is empty.")
+	}
+
 	output = input
 
 	for key, value := range *t {

--- a/pkg/core/transformer/main_test.go
+++ b/pkg/core/transformer/main_test.go
@@ -186,6 +186,16 @@ var (
 			expectedOutput: "1.17",
 			expectedErr:    nil,
 		},
+		Data{
+			input: "", // explicit empty value
+			rules: Transformers{
+				Transformer{
+					"addPrefix": "alpha-",
+				},
+			},
+			expectedOutput: "",
+			expectedErr:    fmt.Errorf("Validation error: input for transformer is empty."),
+		},
 	}
 )
 

--- a/pkg/plugins/dockerimage/condition.go
+++ b/pkg/plugins/dockerimage/condition.go
@@ -1,6 +1,8 @@
 package dockerimage
 
 import (
+	"fmt"
+
 	"github.com/sirupsen/logrus"
 	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
 	"github.com/updatecli/updatecli/pkg/core/result"
@@ -16,6 +18,12 @@ func (di *DockerImage) ConditionFromSCM(source string, scm scm.ScmHandler) (bool
 // We assume that if we can't retrieve the docker image digest, then it means
 // it doesn't exist.
 func (di *DockerImage) Condition(source string) (bool, error) {
+
+	// Errors if both source input value and specified Tag are empty
+	if di.image.Tag == "" && source == "" {
+		return false, fmt.Errorf("Condition validation error for the image %q: source input is empty and no explicit tag is specified.", di.spec.Image)
+	}
+
 	// An empty input source value means that the attribute disablesourceinput is set to true
 	if source != "" {
 		di.image.Tag = source

--- a/pkg/plugins/dockerimage/condition_test.go
+++ b/pkg/plugins/dockerimage/condition_test.go
@@ -77,6 +77,19 @@ func TestDockerImage_Condition(t *testing.T) {
 			wantErr:                  true,
 			wantMockImageName:        "hub.docker.com/library/nginx:latest",
 		},
+		{
+			name:             "Error case with both source and tag empty",
+			inputSourceValue: "", // Default but in this case it's explicit
+			mockImg: dockerimage.Image{
+				Registry:     "hub.docker.com",
+				Namespace:    "library",
+				Repository:   "nginx",
+				Architecture: "amd64",
+				Tag:          "", // Default but in this case it's explicit
+			},
+			mockRegistryReturnDigest: "123456789",
+			wantErr:                  true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Fix #432

With updatecli 0.18.3 and 0.19.0, the dockerimage condition already fails thanks to #418 .
But this PR improves the user feedback when a dockerimage condition is provided with an empty tag.

It also fails transformers when they are applied with an empty input source (surprise bugfix!).

Finally, this PR ensure that a failing transformer does not duplicate the error message 3 times :)

## Test

To test this pull request, you can run the following commands:

```shell
make test
make test-short
make test-e2e
```

## Additional Information

- Result with the failing condition in #432 case:

```
CONDITIONS:
===========

checkDockerImage
----------------
ERROR: Condition validation error for the image "cytopia/yamllint": source input is empty and no explicit tag is specified.

✗ condition not met, skipping pipeline
```

- Result if the condition is removed (e.g. target's transformer failing due to empty input value):

```
⚠ empty source returned


TARGETS
========

show result
-----------
ERROR: Something went wrong in target "show result" :
ERROR: Validation error: input for transformer is empty.


=============================

REPORTS:


✗ UPDATECLI.YAML:
        Sources:
                ⚠ [lastRelease] Get latest yamllint version(githubRelease)
        Target:
                ✗ [show result]  Update yamllint version in PodTemplates.yaml(shell)

```