### PR TITLE
fix(yaml) do not crash when the specified YAML array index does not exist

### DIFF
--- a/pkg/plugins/yaml/main.go
+++ b/pkg/plugins/yaml/main.go
@@ -218,7 +218,7 @@ func replace(entry *yaml.Node, keys []string, version string, columnRef int) (fo
 
 					positionIndex := position
 
-					if positionIndex > len(entry.Content[index+1].Content) {
+					if positionIndex >= len(entry.Content[index+1].Content) {
 						return false, "", 0
 					}
 

--- a/pkg/plugins/yaml/main_test.go
+++ b/pkg/plugins/yaml/main_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/updatecli/updatecli/pkg/core/text"
 	"gopkg.in/yaml.v3"
@@ -211,7 +212,7 @@ func TestReplace(t *testing.T) {
 
 	//https://github.com/go-yaml/yaml/issues/599
 
-	dataset := []dataSet{
+	dataset1 := []dataSet{
 		{
 			key:                []string{"image", "tag"},
 			expectedOldVersion: "1.17",
@@ -246,6 +247,11 @@ func TestReplace(t *testing.T) {
 			key:                []string{"image3[3]", "version"},
 			expectedOldVersion: "5.5",
 			expectedValueFound: true,
+		},
+		{
+			key:                []string{"image3[4]", "version"},
+			expectedOldVersion: "",
+			expectedValueFound: false,
 		},
 		{
 			key:                []string{"image5::tag"},
@@ -310,38 +316,24 @@ func TestReplace(t *testing.T) {
 	out := yaml.Node{}
 
 	err := yaml.Unmarshal([]byte(data), &out)
-	if err != nil {
-		logrus.Errorf("err - %s", err)
-	}
+	require.NoError(t, err)
 
-	for _, d := range dataset {
+	for _, d := range dataset1 {
 		valueFound, oldVersion, _ := replace(&out, d.key, source, 1)
 
-		if valueFound != d.expectedValueFound {
-			t.Errorf("Value not found for key %v! expected %v, got %v", d.key, d.expectedValueFound, valueFound)
-		}
-
-		if oldVersion != d.expectedOldVersion {
-			t.Errorf("Old Version mismatch for key %v! expected %v, got %v", d.key, d.expectedOldVersion, oldVersion)
-		}
+		assert.Equal(t, d.expectedValueFound, valueFound)
+		assert.Equal(t, d.expectedOldVersion, oldVersion)
 	}
 
 	out2 := yaml.Node{}
 	err = yaml.Unmarshal([]byte(data2), &out2)
-	if err != nil {
-		logrus.Errorf("err - %s", err)
-	}
+	require.NoError(t, err)
 
 	for _, d := range dataset2 {
 		valueFound, oldVersion, _ := replace(&out2, d.key, source, 1)
 
-		if valueFound != d.expectedValueFound {
-			t.Errorf("Value not found for key %v! expected %v, got %v", d.key, d.expectedValueFound, valueFound)
-		}
-
-		if oldVersion != d.expectedOldVersion {
-			t.Errorf("Old Version mismatch for key %v! expected %v, got %v", d.key, d.expectedOldVersion, oldVersion)
-		}
+		assert.Equal(t, d.expectedValueFound, valueFound)
+		assert.Equal(t, d.expectedOldVersion, oldVersion)
 	}
 }
 

--- a/pkg/plugins/yaml/test.yaml
+++ b/pkg/plugins/yaml/test.yaml
@@ -1,3 +1,0 @@
-github:
-  owner: obiwankenobi
-  repository: charts


### PR DESCRIPTION
Fix #439

This was a quick one that fixes a real bug (a case on limit).

Thanks to the amount of unit tests that @olblak did on the homemade YAML parser, it was easy to add a failing case, and then fix it.

Now, the following error is thrown when an out of bounds index is specified for YAML arrays:

```
ERROR: ✗ cannot find key "spec.containers[1].name" in the YAML file ".tmp/PodTemplates.yaml"
```

## Test

To test this pull request, you can run the following commands:

```shell
$ make test-short # Fails without the fix on `pkg/plugins/yaml/main.go`
$ go build -o ./dist/updatecli && ./dist/updatecli diff --config ./.tmp/updatecli.yaml --values ~/workspace/jenkins-infra/kubernetes-management/updatecli/values.yaml
```

## Additional Information

- Also removed the "non cleaned" yaml file that was still commited (caught by @lemeurherve in his PR ❤️ ).
- Took the opportunity to switch the `Test_Replace()` to the `testify/assert` instructions 