### PR TITLE
fix(dockerfile) manage ENV legacy case without an equal sign

### DIFF
--- a/pkg/plugins/dockerfile/simpletextparser/keywords/env.go
+++ b/pkg/plugins/dockerfile/simpletextparser/keywords/env.go
@@ -1,6 +1,7 @@
 package keywords
 
 import (
+	"fmt"
 	"strings"
 )
 
@@ -14,6 +15,14 @@ func (a Env) ReplaceLine(source, originalLine, matcher string) string {
 
 	// With an ENV instruction, we only need to use the 2nd "word"
 	parsedLine := strings.Fields(originalLine)
+
+	// As per https://docs.docker.com/engine/reference/builder/#env
+	// syntax without an equal sign is still supported
+	// Let's check for presence of equal sign or not on the "parsed" key
+	if !strings.Contains(parsedLine[1], "=") {
+		// Legacy case: rewrite with new recommended syntax (by Docker)
+		return fmt.Sprintf("ENV %s=%s", parsedLine[1], source)
+	}
 
 	parsedLine[1] = matcher + "=" + source
 	return strings.Join(parsedLine, " ")

--- a/pkg/plugins/dockerfile/simpletextparser/keywords/env_test.go
+++ b/pkg/plugins/dockerfile/simpletextparser/keywords/env_test.go
@@ -15,9 +15,16 @@ func TestEnv_ReplaceLine(t *testing.T) {
 		want         string
 	}{
 		{
-			name:         "Match and change",
+			name:         "Match and change with equals sign",
 			source:       "{VERSION_TERRA}",
 			originalLine: "ENV TERRAFORM_VERSION={VERSIONTERRA}",
+			matcher:      "TERRAFORM_VERSION",
+			want:         "ENV TERRAFORM_VERSION={VERSION_TERRA}",
+		},
+		{
+			name:         "Match and change without equals sign",
+			source:       "{VERSION_TERRA}",
+			originalLine: "ENV TERRAFORM_VERSION {VERSIONTERRA}",
 			matcher:      "TERRAFORM_VERSION",
 			want:         "ENV TERRAFORM_VERSION={VERSION_TERRA}",
 		},


### PR DESCRIPTION
Fix #390

This PR add the support for `ENV` Dockerfile instruction without equal sign (which is considered "legacy" and not recommended by Docker as per https://docs.docker.com/engine/reference/builder/#env)

>  ⚠️ Alternative syntax
> The ENV instruction also allows an alternative syntax ENV <key> <value>, omitting the =. For example:
> ```Dockerfile
>    ENV MY_VAR my-value
> ```
> This syntax does not allow for multiple environment-variables to be set in a single ENV instruction, and can be confusing. For example, the following sets a single environment variable (ONE) with value "TWO= THREE=world":
> ```
>    ENV ONE TWO= THREE=world
> ```
> The alternative syntax is supported for backward compatibility, but discouraged for the reasons outlined above, and may be removed in a future release.


The behavior in these cases is to rewrite with the new "recommended" syntax which inserts an equal sign.

For instance in the reproduction case from #390:

```
updateReleaseInDockerfile
-------------------------
**Dry Run enabled**

🐋 On (Docker)file ".tmp/Dockerfile":

⚠ The line #3, matched by the keyword "ENV" and the matcher "WINDOWS_UPDATE_VERSION",
is changed from "ENV WINDOWS_UPDATE_VERSION 0.10.1" to "ENV WINDOWS_UPDATE_VERSION=v0.14.0".
```

## Test

To test this pull request, you can run the following commands:

```shell
make test-short
go build -o ./dist/updatecli && ./dist/updatecli diff --config examples/updatecli.generic/dockerfile/
make test-e2e
```

## Additional Information

