### PR TITLE
fix(pullrequests,reports) renders templated values in title and descriptions

### DIFF
--- a/pkg/core/engine/main.go
+++ b/pkg/core/engine/main.go
@@ -169,7 +169,7 @@ func (e *Engine) LoadConfigurations() error {
 
 }
 
-// Run run the full process one yaml file.
+// Run runs the full process for one yaml file.
 func (e *Engine) Run() (err error) {
 	logrus.Infof("\n\n%s\n", strings.Repeat("+", len("Pipeline")+4))
 	logrus.Infof("+ %s +\n", strings.ToTitle("Pipeline"))

--- a/pkg/core/pipeline/conditions.go
+++ b/pkg/core/pipeline/conditions.go
@@ -32,6 +32,8 @@ func (p *Pipeline) RunConditions() (globalResult bool, err error) {
 		condition.Config = p.Config.Conditions[id]
 
 		rpt := p.Report.Conditions[id]
+		// Update report's name as the condition configuration might have been updated (templated values)
+		rpt.Name = condition.Config.Name
 
 		logrus.Infof("\n%s\n", id)
 		logrus.Infof("%s\n", strings.Repeat("-", len(id)))

--- a/pkg/core/pipeline/conditions.go
+++ b/pkg/core/pipeline/conditions.go
@@ -32,7 +32,7 @@ func (p *Pipeline) RunConditions() (globalResult bool, err error) {
 		condition.Config = p.Config.Conditions[id]
 
 		rpt := p.Report.Conditions[id]
-		// Update report's name as the condition configuration might have been updated (templated values)
+		// Update report name as the condition configuration might has been updated (templated values)
 		rpt.Name = condition.Config.Name
 
 		logrus.Infof("\n%s\n", id)

--- a/pkg/core/pipeline/pullRequests.go
+++ b/pkg/core/pipeline/pullRequests.go
@@ -22,6 +22,9 @@ func (p *Pipeline) RunPullRequests() error {
 		inheritedSCM := p.SCMs[pr.Config.ScmID]
 		pr.Scm = &inheritedSCM
 
+		pr = p.PullRequests[id]
+		pr.Config = p.Config.PullRequests[id]
+
 		err := pr.Update()
 		if err != nil {
 			return err

--- a/pkg/core/pipeline/pullrequest/main.go
+++ b/pkg/core/pipeline/pullrequest/main.go
@@ -35,7 +35,7 @@ type PullRequest struct {
 	Title          string
 	Changelog      string
 	PipelineReport string
-	Config         *Config
+	Config         Config
 	Scm            *scm.Scm
 	Handler        PullRequestHandler
 }
@@ -70,7 +70,7 @@ func New(config *Config, sourceControlManager *scm.Scm) (PullRequest, error) {
 
 	p := PullRequest{
 		Title:  config.Title,
-		Config: config,
+		Config: *config,
 		Scm:    sourceControlManager,
 	}
 

--- a/pkg/core/pipeline/sources.go
+++ b/pkg/core/pipeline/sources.go
@@ -29,6 +29,8 @@ func (p *Pipeline) RunSources() error {
 		source.Config = p.Config.Sources[id]
 
 		rpt := p.Report.Sources[id]
+		// Update report's name as the source configuration might have been updated (templated values)
+		rpt.Name = source.Config.Name
 
 		logrus.Infof("\n%s\n", id)
 		logrus.Infof("%s\n", strings.Repeat("-", len(id)))

--- a/pkg/core/pipeline/sources.go
+++ b/pkg/core/pipeline/sources.go
@@ -29,7 +29,7 @@ func (p *Pipeline) RunSources() error {
 		source.Config = p.Config.Sources[id]
 
 		rpt := p.Report.Sources[id]
-		// Update report's name as the source configuration might have been updated (templated values)
+		// Update report name as the source configuration might has been updated (templated values)
 		rpt.Name = source.Config.Name
 
 		logrus.Infof("\n%s\n", id)

--- a/pkg/core/pipeline/targets.go
+++ b/pkg/core/pipeline/targets.go
@@ -39,6 +39,8 @@ func (p *Pipeline) RunTargets() error {
 		target.Config = p.Config.Targets[id]
 
 		rpt := p.Report.Targets[id]
+		// Update report's name as the target configuration might have been updated (templated values)
+		rpt.Name = target.Config.Name
 
 		if target.Config.Prefix == "" && p.Sources[target.Config.SourceID].Config.Prefix != "" {
 			target.Config.Prefix = p.Sources[target.Config.SourceID].Config.Prefix

--- a/pkg/core/pipeline/targets.go
+++ b/pkg/core/pipeline/targets.go
@@ -39,7 +39,7 @@ func (p *Pipeline) RunTargets() error {
 		target.Config = p.Config.Targets[id]
 
 		rpt := p.Report.Targets[id]
-		// Update report's name as the target configuration might have been updated (templated values)
+		// Update report name as the target configuration might has been updated (templated values)
 		rpt.Name = target.Config.Name
 
 		if target.Config.Prefix == "" && p.Sources[target.Config.SourceID].Config.Prefix != "" {

--- a/pkg/core/reports/main.go
+++ b/pkg/core/reports/main.go
@@ -15,26 +15,26 @@ const reportsTpl string = `
 REPORTS:
 
 {{ range . }}
-{{ if  .Err }}
+{{ if .Err }}
 {{- .Result }} {{ .Name -}}:{{"\n"}}
 {{ "\t"}}Error: {{ .Err}}
 {{ else }}
 {{- .Result }} {{ .Name -}}:{{"\n"}}
 {{- "\t"}}Sources:
 {{ range $ID,$source := .Sources }}
-{{- "\t" }}{{"\t"}}{{- $source.Result }} [{{ $ID }}] {{ $source.Name -}}({{- $source.Kind -}}){{"\n"}}
+{{- "\t" }}{{"\t"}}{{- $source.Result }} [{{ $ID }}] {{ $source.Name }} (kind: {{ $source.Kind -}}){{"\n"}}
 {{- end }}
 
 {{- if .Conditions -}}
 {{- "\t" }}Condition:
 {{ range $ID, $condition := .Conditions }}
-{{- "\t" }}{{"\t"}}{{- $condition.Result }} [{{ $ID }}] {{ $condition.Name -}}({{- $condition.Kind -}}){{"\n"}}
+{{- "\t" }}{{"\t"}}{{- $condition.Result }} [{{ $ID }}] {{ $condition.Name }} (kind: {{ $condition.Kind -}}){{"\n"}}
 {{- end -}}
 {{- end -}}
 
 {{- "\t" -}}Target:
 {{ range $ID, $target := .Targets }}
-{{- "\t" }}{{"\t"}}{{- $target.Result }} [{{ $ID }}]  {{ $target.Name -}}({{- $target.Kind -}}){{"\n"}}
+{{- "\t" }}{{"\t"}}{{- $target.Result }} [{{ $ID }}] {{ $target.Name }} (kind: {{ $target.Kind -}}){{"\n"}}
 {{- end }}
 {{ end }}
 {{ end }}

--- a/pkg/core/reports/report.go
+++ b/pkg/core/reports/report.go
@@ -21,14 +21,14 @@ const (
 	TARGETREPORTTEMPLATE string = `
 {{- "\t" -}}Target:
 {{ range $ID, $target := .Targets }}
-{{- "\t" }}{{"\t"}}{{- $target.Result }} [{{ $ID }}]  {{ $target.Name -}}({{- $target.Kind -}}){{"\n"}}
+{{- "\t" }}{{"\t"}}{{- $target.Result }} [{{ $ID }}] {{ $target.Name -}}({{- $target.Kind -}}){{"\n"}}
 {{- end }}
 `
 	// SOURCEREPORTTEMPLATE ...
 	SOURCEREPORTTEMPLATE string = `
 {{- "\t"}}Source:
 {{ range $ID,$source := .Sources }}
-{{- "\t" }}{{"\t"}}{{- $source.Result }} [{{ $ID }}]  {{ $source.Name -}}({{- $source.Kind -}}){{"\n"}}
+{{- "\t" }}{{"\t"}}{{- $source.Result }} [{{ $ID }}] {{ $source.Name -}}({{- $source.Kind -}}){{"\n"}}
 {{- end }}
 `
 
@@ -38,26 +38,26 @@ const (
 
 REPORTS:
 
-{{ if  .Err }}
+{{ if .Err }}
 {{- .Result }} {{ .Name -}}{{"\n"}}
 {{ "\t"}}Error: {{ .Err}}
 {{ else }}
 {{- .Result }} {{ .Name -}}{{"\n"}}
 {{- "\t"}}Source:
 {{ range $ID, $source := .Sources }}
-{{- "\t" }}{{"\t"}}{{- $source.Result }} [{{ $ID }}] {{ $source.Name -}}({{- $source.Kind -}}){{"\n"}}
+{{- "\t" }}{{"\t"}}{{- $source.Result }} [{{ $ID }}] {{ $source.Name }} (kind: {{ $source.Kind -}}){{"\n"}}
 {{- end }}
 
 {{- if .Conditions -}}
 {{- "\t" }}Condition:
-{{ range  $ID, $condition := .Conditions }}
-{{- "\t" }}{{"\t"}}{{- $condition.Result }} [{{ $ID }}] {{ $condition.Name -}}({{- $condition.Kind -}}){{"\n"}}
+{{ range $ID, $condition := .Conditions }}
+{{- "\t" }}{{"\t"}}{{- $condition.Result }} [{{ $ID }}] {{ $condition.Name }} (kind: {{ $condition.Kind -}}){{"\n"}}
 {{- end -}}
 {{- end -}}
 
 {{- "\t" -}}Target:
 {{ range $ID,$target := .Targets }}
-{{- "\t" }}{{"\t"}}{{- $target.Result }} [{{ $ID}}] {{ $target.Name -}}({{- $target.Kind -}}){{"\n"}}
+{{- "\t" }}{{"\t"}}{{- $target.Result }} [{{ $ID}}] {{ $target.Name -}} (kind: {{ $target.Kind -}}){{"\n"}}
 {{- end }}
 {{ end }}
 `
@@ -73,7 +73,7 @@ type Report struct {
 	Targets    map[string]Stage
 }
 
-// Init init a new report for a specific configuration
+// Init initializes a new report for a specific configuration
 //func (config *Config) InitReport() (report *Report) {
 func (r *Report) Init(name string, sourceNbr, conditionNbr, targetNbr int) {
 
@@ -85,7 +85,7 @@ func (r *Report) Init(name string, sourceNbr, conditionNbr, targetNbr int) {
 	r.Targets = make(map[string]Stage, targetNbr)
 }
 
-// String return a report as a string
+// String returns a report as a string
 func (r *Report) String(mode string) (report string, err error) {
 	t := &template.Template{}
 

--- a/pkg/core/reports/stage.go
+++ b/pkg/core/reports/stage.go
@@ -6,9 +6,3 @@ type Stage struct {
 	Kind   string
 	Result string
 }
-
-// New init a new state object
-func (s *Stage) New(kind, result string) {
-	s.Kind = kind
-	s.Result = result
-}


### PR DESCRIPTION
Fix #440 

This PR ensures that the GitHub pull requests (title + description) and command line output are correctly rendered when there is a templated value.

There are 3 commits:

- The 1st commit is cherry-picked from @olblak 's work in #496 that had been modified to have 1 PR == 1 fix + adapted (comments). It applies the same update + rendering of internal configuration behavior when processing pullrequests as when processing sources,conditions and targets.
- The 2nd commit ensures that reports are updated (e.g. rendering templates) as well as the internal configuration when processing sources, but also conditions and targets.
- The 3rd commit is a minor improvement for the reports (deleting unused code + cleaning up/adding spaces)

Example of result: https://github.com/dduportal/updatecli/pull/15

## Test

To test this pull request, you can run the following commands:

```shell
make test-short
make test
make test-e2e
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
