### PR TITLE
Allow to specify github pullrequest merge method

### DIFF
--- a/pkg/plugins/scms/github/main.go
+++ b/pkg/plugins/scms/github/main.go
@@ -84,6 +84,10 @@ func New(s Spec) (*Github, error) {
 func (s *Spec) Validate() (errs []error) {
 	required := []string{}
 
+	if err := s.PullRequest.Validate(); err != nil {
+		errs = append(errs, err)
+	}
+
 	if len(s.Token) == 0 {
 		required = append(required, "token")
 	}

--- a/pkg/plugins/scms/github/pullrequest.go
+++ b/pkg/plugins/scms/github/pullrequest.go
@@ -79,7 +79,7 @@ type PullRequestSpec struct {
 	Labels                 []string // Specify repository labels used for pull request. !! They must already exist
 	Draft                  bool     // Define if a pull request is set to draft, default false
 	MaintainerCannotModify bool     // Define if maintainer can modify pullRequest
-	MergeMethod            string   // MergeMethod defines which merge method is used to close pullRequest. Accept "merge", "sqash", "rebase", or ""
+	MergeMethod            string   // Define which merge method is used to incorporate the pull request. Accept "merge", "squash", "rebase", or ""
 }
 
 type PullRequest struct {

--- a/pkg/plugins/scms/github/pullrequest.go
+++ b/pkg/plugins/scms/github/pullrequest.go
@@ -384,7 +384,7 @@ func (p *PullRequest) OpenPullRequest() error {
 
 }
 
-// isAutoMergedEnabledOnRepository checks if a remote repository allow automerge pull request
+// isAutoMergedEnabledOnRepository checks if a remote repository allows automerging pull requests
 func (p *PullRequest) isAutoMergedEnabledOnRepository() (bool, error) {
 
 	var query struct {

--- a/pkg/plugins/scms/github/pullrequest.go
+++ b/pkg/plugins/scms/github/pullrequest.go
@@ -307,11 +307,15 @@ func (p *PullRequest) EnablePullRequestAutoMerge() error {
 	}
 
 	var mutation mutationEnablePullRequestAutoMerge
-	mergeMethod := githubv4.PullRequestMergeMethod(p.spec.MergeMethod)
 
 	input := githubv4.EnablePullRequestAutoMergeInput{
 		PullRequestID: githubv4.String(p.remotePullRequest.ID),
-		MergeMethod:   &mergeMethod,
+	}
+
+	// Github Api expect merge method to be capital letter
+	if len(p.spec.MergeMethod) > 0 {
+		mergeMethod := githubv4.PullRequestMergeMethod(strings.ToUpper(p.spec.MergeMethod))
+		input.MergeMethod = &mergeMethod
 	}
 
 	err = p.gh.client.Mutate(context.Background(), &mutation, input, nil)

--- a/pkg/plugins/scms/github/pullrequest.go
+++ b/pkg/plugins/scms/github/pullrequest.go
@@ -312,7 +312,8 @@ func (p *PullRequest) EnablePullRequestAutoMerge() error {
 		PullRequestID: githubv4.String(p.remotePullRequest.ID),
 	}
 
-	// Github Api expect merge method to be capital letter
+	// The Github Api expects the merge method to be capital letter and don't allows empty value
+	// hence the reason to set input.MergeMethod only if the value is not nil
 	if len(p.spec.MergeMethod) > 0 {
 		mergeMethod := githubv4.PullRequestMergeMethod(strings.ToUpper(p.spec.MergeMethod))
 		input.MergeMethod = &mergeMethod

--- a/pkg/plugins/scms/github/pullrequest.go
+++ b/pkg/plugins/scms/github/pullrequest.go
@@ -14,6 +14,8 @@ package github
 import (
 	"bytes"
 	"context"
+	"errors"
+	"strings"
 	"text/template"
 
 	"github.com/shurcooL/githubv4"
@@ -51,6 +53,11 @@ Please report any issues with this tool [here](https://github.com/updatecli/upda
 
 `
 
+var (
+	ErrAutomergeNotAllowOnRepository = errors.New("automerge is not allowed on repository")
+	ErrBadMergeMethod                = errors.New("wrong merge method defined, accepting one of 'squash', 'merge', 'rebase', or ''")
+)
+
 // PullRequest contains multiple fields mapped to Github V4 api
 type PullRequestApi struct {
 	BaseRefName string
@@ -72,6 +79,7 @@ type PullRequestSpec struct {
 	Labels                 []string // Specify repository labels used for pull request. !! They must already exist
 	Draft                  bool     // Define if a pull request is set to draft, default false
 	MaintainerCannotModify bool     // Define if maintainer can modify pullRequest
+	MergeMethod            string   // MergeMethod defines which merge method is used to close pullRequest. Accept "merge", "sqash", "rebase", or ""
 }
 
 type PullRequest struct {
@@ -83,6 +91,27 @@ type PullRequest struct {
 	remotePullRequest PullRequestApi
 }
 
+// isMergeMethodValid ensure that we specified a valid merge method.
+func isMergeMethodValid(method string) (bool, error) {
+	if len(method) == 0 ||
+		strings.ToUpper(method) == "SQUASH" ||
+		strings.ToUpper(method) == "MERGE" ||
+		strings.ToUpper(method) == "REBASE" {
+		return true, nil
+	}
+	logrus.Debugf("%s - %s", method, ErrBadMergeMethod)
+	return false, ErrBadMergeMethod
+}
+
+// Validate ensure that a pullrequest spec contains validate fields
+func (s *PullRequestSpec) Validate() error {
+
+	if _, err := isMergeMethodValid(s.MergeMethod); err != nil {
+		return err
+	}
+	return nil
+}
+
 // Graphql mutation used with GitHub api to enable automerge on a existing
 // pullrequest
 type mutationEnablePullRequestAutoMerge struct {
@@ -92,10 +121,12 @@ type mutationEnablePullRequestAutoMerge struct {
 }
 
 func NewPullRequest(spec PullRequestSpec, gh *Github) (PullRequest, error) {
+	err := spec.Validate()
+
 	return PullRequest{
 		gh:   gh,
 		spec: spec,
-	}, nil
+	}, err
 }
 
 func (p *PullRequest) CreatePullRequest(title, changelog, pipelineReport string) error {
@@ -265,13 +296,25 @@ func (p *PullRequest) updatePullRequest() error {
 // EnablePullRequestAutoMerge updates an existing pullrequest with the flag automerge
 func (p *PullRequest) EnablePullRequestAutoMerge() error {
 
+	// Test that automerge feature is enabled on repository but only if we plan to use it
+	autoMergeAllowed, err := p.isAutoMergedEnabledOnRepository()
+	if err != nil {
+		return err
+	}
+
+	if !autoMergeAllowed {
+		return ErrAutomergeNotAllowOnRepository
+	}
+
 	var mutation mutationEnablePullRequestAutoMerge
+	mergeMethod := githubv4.PullRequestMergeMethod(p.spec.MergeMethod)
 
 	input := githubv4.EnablePullRequestAutoMergeInput{
 		PullRequestID: githubv4.String(p.remotePullRequest.ID),
+		MergeMethod:   &mergeMethod,
 	}
 
-	err := p.gh.client.Mutate(context.Background(), &mutation, input, nil)
+	err = p.gh.client.Mutate(context.Background(), &mutation, input, nil)
 
 	if err != nil {
 		return err
@@ -338,6 +381,29 @@ func (p *PullRequest) OpenPullRequest() error {
 	p.remotePullRequest = mutation.CreatePullRequest.PullRequest
 
 	return nil
+
+}
+
+// isAutoMergedEnabledOnRepository checks if a remote repository allow automerge pull request
+func (p *PullRequest) isAutoMergedEnabledOnRepository() (bool, error) {
+
+	var query struct {
+		Repository struct {
+			AutoMergeAllowed bool
+		} `graphql:"repository(owner: $owner, name: $name)"`
+	}
+
+	variables := map[string]interface{}{
+		"owner": githubv4.String(p.gh.Spec.Owner),
+		"name":  githubv4.String(p.gh.Spec.Repository),
+	}
+
+	err := p.gh.client.Query(context.Background(), &query, variables)
+
+	if err != nil {
+		return false, err
+	}
+	return query.Repository.AutoMergeAllowed, nil
 
 }
 


### PR DESCRIPTION
Signed-off-by: Olblak <me@olblak.com>

# Allow to specify github pullrequest merge method

Fix #492 

Allow to specify a pullrequest merge method by using the key `mergemethod` set to ["","squash", "merge","rebase"]

## Test

To test this pull request, you can run the following commands:

```shell
go build -o bin/updatecli
# Then test using an updatecli manifest that tries to open a pullrequest 
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
