### PR TITLE
fix(condition) do not execute target if a condition fails

### DIFF
--- a/e2e/skipped.targets.d/multiple-conditions.yaml
+++ b/e2e/skipped.targets.d/multiple-conditions.yaml
@@ -1,0 +1,36 @@
+title: Skip targets with only one (failing) condition
+
+sources:
+  default:
+    name: Default Source (dummy)
+    kind: shell
+    spec:
+      command: echo DUMMY
+
+conditions:
+  condition1:
+    name: This conditions always succeed
+    sourceID: default
+    kind: shell
+    spec:
+      command: "true"
+  condition2:
+    name: This conditions always fail
+    sourceID: default
+    kind: shell
+    spec:
+      command: "false"
+  condition3:
+    name: This conditions always succeed
+    sourceID: default
+    kind: shell
+    spec:
+      command: "true"
+
+targets:
+  shouldNeverRun:
+    name: This target should never run
+    sourceID: default
+    kind: shell
+    spec:
+      command: echo SHOULD NOT RUN

--- a/e2e/skipped.targets.d/one-condition.yaml
+++ b/e2e/skipped.targets.d/one-condition.yaml
@@ -1,0 +1,24 @@
+title: Skip targets with only one (failing) condition
+
+sources:
+  default:
+    name: Default Source (dummy)
+    kind: shell
+    spec:
+      command: echo DUMMY
+
+conditions:
+  failingCondition:
+    name: This conditions always fail
+    sourceID: default
+    kind: shell
+    spec:
+      command: "false"
+
+targets:
+  shouldNeverRun:
+    name: This target should never run
+    sourceID: default
+    kind: shell
+    spec:
+      command: echo SHOULD NOT RUN

--- a/e2e/venom.d/test_skipped_targets.yaml
+++ b/e2e/venom.d/test_skipped_targets.yaml
@@ -1,0 +1,23 @@
+---
+name: 'Updatecli Skipped Targets TestSuite'
+vars:
+  message:
+    warning: 'WARNING:'
+    error: 'ERROR:'
+testcases:
+  - name: "Test that all the manifests in skipped.targets.d have at least a target named shouldNeverRun"
+    steps:
+      - script: 'find ../skipped.targets.d -type f -name "*yaml" -exec cat {} \;'
+        type: 'exec'
+        assertions:
+          - 'result.code ShouldEqual 0'
+          - 'result.systemout ShouldContainSubstring "shouldNeverRun:"'
+  - name: "Test that no target is ever run in this set of updatecli manifests"
+    steps:
+      - script: '{{ .binpath }}/updatecli diff --config  ../skipped.targets.d/ --values ../values.yaml'
+        type: 'exec'
+        assertions:
+          - 'result.code ShouldEqual 0'
+          - 'result.systemerr ShouldNotContainSubstring "{{ .message.warning }}"'
+          - 'result.systemerr ShouldNotContainSubstring "{{ .message.error }}"'
+          - 'result.systemerr ShouldContainSubstring "- [shouldNeverRun]"'

--- a/pkg/core/pipeline/conditions.go
+++ b/pkg/core/pipeline/conditions.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/sirupsen/logrus"
+	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
 // RunConditions run every conditions for a given configuration config.
@@ -42,21 +43,18 @@ func (p *Pipeline) RunConditions() (globalResult bool, err error) {
 			p.Sources[condition.Config.SourceID].Config.Prefix +
 				p.Sources[condition.Config.SourceID].Output +
 				p.Sources[condition.Config.SourceID].Config.Postfix)
-
 		if err != nil {
-			// Show error to end user if any
+			// Show error to end user if any but continue the flow execution
 			logrus.Error(err)
-			// Fail globally (even though other conditions will be executed)
-			globalResult = false
-		} else {
-			// Update pipeline's configuration after each condition run
-			err = p.Config.Update(p)
-			if err != nil {
-				globalResult = false
-				return globalResult, err
-			}
 		}
+
+		// Reports the result of the execution of this condition
 		rpt.Result = condition.Result
+
+		// If there was an error OR if the condition is not successful then defines the global result as false
+		if err != nil || condition.Result != result.SUCCESS {
+			globalResult = false
+		}
 
 		p.Conditions[id] = condition
 		p.Report.Conditions[id] = rpt


### PR DESCRIPTION
Fix #526 

This PR revamps what I broke in #470:

- No more updating the pipeline configuration (as it's only required after source execution: there is no point in rendering the template after each condition as for today)
- Keep showing the error (if any) of a condition execution (that was the value of #470)
- Fix the "flow" that was broken by #470 by setting the global result to "false" if there is an error OR if the conditions failed (e.g. did not error but returned with "false").

## Test

Please note that a new e2e test suite had been added to catch this case (non regression in the future), as the "flow" tests are hard to test today (pkg/core/pipeline is not unit-tested a lot).

To test this pull request, you can run the following commands:

```shell
make test
make test-short
make test-e2e
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
