### PR TITLE
fix: log the config name at validation

### DIFF
--- a/pkg/core/config/main.go
+++ b/pkg/core/config/main.go
@@ -131,6 +131,8 @@ func (config *Config) Display() error {
 // Validate run various validation test on the configuration and update fields if necessary
 func (config *Config) Validate() error {
 
+	logrus.Infof("Validating %q", config.Name)
+
 	if config.Source.Kind != "" && (len(config.Sources) > 0) {
 		logrus.Errorf("Source and Sources can't be defined at the same time, please use the 'Sources' syntax")
 		return ErrBadConfig


### PR DESCRIPTION
Fixes #536

Log the config name (which default value is the manifest filename) so when updacli is running on a folder and there is an error it's easier to know which manifest has a problem.

## Test

To test this pull request, you can run the following commands:

```shell
cp <to_package_directory>
go test
```

## Additional Information

### Tradeoff

One additional line per manifest in the output

### Potential improvement (and fix of the tradeoff)

This log should even replace the one line 82: https://github.com/updatecli/updatecli/blob/01da81e6c25062cd9f902e173208b766fa4cbdee/pkg/core/config/main.go#L82

WDYT? In that case, this PR could be "fix: log the config name at validation instead of at loading"