### PR TITLE
Test at runtime if a yaml file exists

### DIFF
--- a/pkg/plugins/resources/yaml/condition.go
+++ b/pkg/plugins/resources/yaml/condition.go
@@ -25,6 +25,12 @@ func (y *Yaml) ConditionFromSCM(source string, scm scm.ScmHandler) (bool, error)
 }
 
 func (y *Yaml) condition(source string) (bool, error) {
+
+	// Test at runtime if a file exist
+	if !y.contentRetriever.FileExists(y.spec.File) {
+		return false, fmt.Errorf("the yaml file %q does not exist", y.spec.File)
+	}
+
 	// Start by retrieving the specified file's content
 	if err := y.Read(); err != nil {
 		return false, err

--- a/pkg/plugins/resources/yaml/condition_test.go
+++ b/pkg/plugins/resources/yaml/condition_test.go
@@ -185,6 +185,7 @@ github:
 			mockText := text.MockTextRetriever{
 				Content: tt.mockReturnedContent,
 				Err:     tt.mockReturnedError,
+				Exists:  true,
 			}
 			y := &Yaml{
 				spec:             tt.spec,
@@ -242,6 +243,7 @@ github:
 			mockText := text.MockTextRetriever{
 				Content: tt.mockReturnedContent,
 				Err:     tt.mockReturnedError,
+				Exists:  true,
 			}
 			y := &Yaml{
 				spec:             tt.spec,

--- a/pkg/plugins/resources/yaml/main.go
+++ b/pkg/plugins/resources/yaml/main.go
@@ -71,17 +71,21 @@ func (y *Yaml) Validate() error {
 	}
 	if y.spec.File == "" {
 		validationErrors = append(validationErrors, "Invalid spec for yaml resource: 'file' is empty.")
-	} else {
-		if !y.contentRetriever.FileExists(y.spec.File) {
-			validationErrors = append(validationErrors, fmt.Sprintf("Invalid spec for yaml resource: the file %q does not exist.", y.spec.File))
-		}
+		// As explained on https://github.com/updatecli/updatecli/issues/410 , we can't always test if a file exists.
+		// There are situation where a first step is required such as cloning a git repository before validating that a file exists.
+		// Hence why I am commenting the following the code until https://github.com/updatecli/updatecli/issues/410 is fixed.
+		// And I am testing at runtime in source/condition/target that the file exist.
+		//	} else {
+		//		if !y.contentRetriever.FileExists(y.spec.File) {
+		//			validationErrors = append(validationErrors, fmt.Sprintf("Invalid spec for yaml resource: the file %q does not exist.", y.spec.File))
+		//		}
 	}
 	if y.spec.Key == "" {
 		validationErrors = append(validationErrors, "Invalid spec for yaml resource: 'key' is empty.")
 	}
 	// Return all the validation errors if found any
 	if len(validationErrors) > 0 {
-		return fmt.Errorf("Validation error: the provided manifest configuration had the following validation errors:\n%s", strings.Join(validationErrors, "\n\n"))
+		return fmt.Errorf("validation error: the provided manifest configuration had the following validation errors:\n%s", strings.Join(validationErrors, "\n\n"))
 	}
 
 	return nil

--- a/pkg/plugins/resources/yaml/main.go
+++ b/pkg/plugins/resources/yaml/main.go
@@ -71,14 +71,6 @@ func (y *Yaml) Validate() error {
 	}
 	if y.spec.File == "" {
 		validationErrors = append(validationErrors, "Invalid spec for yaml resource: 'file' is empty.")
-		// As explained on https://github.com/updatecli/updatecli/issues/410 , we can't always test if a file exists.
-		// There are situation where a first step is required such as cloning a git repository before validating that a file exists.
-		// Hence why I am commenting the following the code until https://github.com/updatecli/updatecli/issues/410 is fixed.
-		// And I am testing at runtime in source/condition/target that the file exist.
-		//	} else {
-		//		if !y.contentRetriever.FileExists(y.spec.File) {
-		//			validationErrors = append(validationErrors, fmt.Sprintf("Invalid spec for yaml resource: the file %q does not exist.", y.spec.File))
-		//		}
 	}
 	if y.spec.Key == "" {
 		validationErrors = append(validationErrors, "Invalid spec for yaml resource: 'key' is empty.")

--- a/pkg/plugins/resources/yaml/main_test.go
+++ b/pkg/plugins/resources/yaml/main_test.go
@@ -418,15 +418,6 @@ func Test_Validate(t *testing.T) {
 			mockFileExist: true,
 			wantErr:       true,
 		},
-		{
-			name: "raises an error when 'File' does not exist",
-			spec: Spec{
-				File: "/tmp/toto.yaml",
-				Key:  "foo.bar",
-			},
-			mockFileExist: false,
-			wantErr:       true,
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/plugins/resources/yaml/source.go
+++ b/pkg/plugins/resources/yaml/source.go
@@ -14,6 +14,11 @@ import (
 func (y *Yaml) Source(workingDir string) (string, error) {
 	// By default workingDir is set to local directory
 
+	// Test at runtime if a file exist
+	if !y.contentRetriever.FileExists(y.spec.File) {
+		return "", fmt.Errorf("the yaml file %q does not exist", y.spec.File)
+	}
+
 	if y.spec.Value != "" {
 		logrus.Warnf("Key 'Value' is not used by source YAML")
 	}

--- a/pkg/plugins/resources/yaml/target.go
+++ b/pkg/plugins/resources/yaml/target.go
@@ -32,6 +32,11 @@ func (y *Yaml) target(source string, dryRun bool) (bool, []string, string, error
 	var files []string
 	var message string
 
+	// Test at runtime if a file exist
+	if !y.contentRetriever.FileExists(y.spec.File) {
+		return false, files, message, fmt.Errorf("the yaml file %q does not exist", y.spec.File)
+	}
+
 	if text.IsURL(y.spec.File) {
 		return false, files, message, fmt.Errorf("unsupported filename prefix")
 	}
@@ -82,11 +87,12 @@ func (y *Yaml) target(source string, dryRun bool) (bool, []string, string, error
 	if !dryRun {
 
 		newFile, err := os.Create(y.spec.File)
-		defer newFile.Close()
 
 		if err != nil {
 			return false, files, message, nil
 		}
+
+		defer newFile.Close()
 
 		encoder := yaml.NewEncoder(newFile)
 		defer encoder.Close()

--- a/pkg/plugins/resources/yaml/target.go
+++ b/pkg/plugins/resources/yaml/target.go
@@ -88,11 +88,13 @@ func (y *Yaml) target(source string, dryRun bool) (bool, []string, string, error
 
 		newFile, err := os.Create(y.spec.File)
 
+		// https://staticcheck.io/docs/checks/#SA5001
+		//lint:ignore SA5001 We want to defer the file closing before exiting the function
+		defer newFile.Close()
+
 		if err != nil {
 			return false, files, message, nil
 		}
-
-		defer newFile.Close()
 
 		encoder := yaml.NewEncoder(newFile)
 		defer encoder.Close()


### PR DESCRIPTION
Signed-off-by: Olblak <me@olblak.com>

# Test at runtime if a YAML file exists

There are situations where a first step is required such as cloning a git repository before validating that a file exists.
So instead I prefer to test that a file exists at runtime for the source/condition/target.

## Test

To test this pull request, we can run updatecli command with whatever updatecli manifest as long as we don't execute updatecli from the root of the git directory containing the updatecli manifest. 

## Additional Information

### Tradeoff

This pull request doesn't fix https://github.com/updatecli/updatecli/issues/410 but instead, it moves the `fileexist` to a function executed at runtime. 

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
