### PR TITLE
Update oldest tag in gitgeneric test

### DIFF
--- a/pkg/plugins/utils/gitgeneric/main_test.go
+++ b/pkg/plugins/utils/gitgeneric/main_test.go
@@ -128,7 +128,7 @@ func TestTagsIntegration(t *testing.T) {
 		t.Errorf("Don't expect error: %q", err)
 	}
 
-	expectedTag := "untagged-902d9ce264ba6334c5d0"
+	expectedTag := "v0.0.1"
 	found := false
 
 	// Test that the first tag from array is also the oldest one


### PR DESCRIPTION
Signed-off-by: Olivier Vernin <olivier@vernin.me>

# Update oldest tag in gitgeneric test

Fix test for all open pullrequest
The two oldest tag are `v0.0.1` and `untagged-902d9ce264ba6334c5d`
The gitgeneric test check the oldest tag. For some reason it now detects `v0.0.1` instead of `untagged-902d9ce264ba6334c5d`
I would propose to just delete the tag `untagged-902d9ce264ba6334c5d` as I don't see its valuue.

## Test

To test this pull request, you can run the following commands:

```shell
make test-short
```

## Additional Information

### Tradeoff

🤷🏿 

### Potential improvement

/
