### PR TITLE
Feat/capture Adding a parameter for the transformer FindSubMatch

### DIFF
--- a/pkg/core/transformer/findSubMatch.go
+++ b/pkg/core/transformer/findSubMatch.go
@@ -1,0 +1,7 @@
+package transformer
+
+// FindSubMatch is struct used to feed regexp.findSubMatch
+type FindSubMatch struct {
+	Pattern      string `yaml:"pattern"`
+	CaptureIndex int    `yaml:"captureIndex"`
+}

--- a/pkg/core/transformer/findSubMatch.go
+++ b/pkg/core/transformer/findSubMatch.go
@@ -1,6 +1,6 @@
 package transformer
 
-// FindSubMatch is struct used to feed regexp.findSubMatch
+// FindSubMatch is a struct used to feed regexp.findSubMatch
 type FindSubMatch struct {
 	Pattern      string `yaml:"pattern"`
 	CaptureIndex int    `yaml:"captureIndex"`

--- a/pkg/core/transformer/main.go
+++ b/pkg/core/transformer/main.go
@@ -119,7 +119,7 @@ func (t *Transformer) Apply(input string) (output string, err error) {
 				return "", fmt.Errorf("no regex provided")
 			}
 
-			// Trying to compile the RegExp
+			// Check if the regular expression can be compiled
 			re, err := regexp.Compile(f.Pattern)
 			if err != nil {
 				return "", err

--- a/pkg/core/transformer/main.go
+++ b/pkg/core/transformer/main.go
@@ -110,7 +110,6 @@ func (t *Transformer) Apply(input string) (output string, err error) {
 			} else {
 				err := mapstructure.Decode(value, &f)
 				if err != nil {
-					fmt.Printf("Erreur de decodage %v\n", err)
 					return "", err
 				}
 			}
@@ -125,7 +124,6 @@ func (t *Transformer) Apply(input string) (output string, err error) {
 				return "", err
 			}
 
-			// Using the FindStringSubmatch function
 			found := re.FindStringSubmatch(output)
 
 			// Log if no match is found
@@ -134,7 +132,7 @@ func (t *Transformer) Apply(input string) (output string, err error) {
 				return "", nil
 			}
 
-			// I check if I got a capture with that index
+			// Log if there can't be a submatch corresponding to the captureIndex
 			if len(found) <= f.CaptureIndex {
 				logrus.Debugf("No capture found at position %v after applying regex %q to %q, full result with CaptureIndex 0 would be %v", f.CaptureIndex, f.Pattern, output, found)
 				return "", nil

--- a/pkg/core/transformer/main.go
+++ b/pkg/core/transformer/main.go
@@ -128,7 +128,7 @@ func (t *Transformer) Apply(input string) (output string, err error) {
 			// Using the FindStringSubmatch function
 			found := re.FindStringSubmatch(output)
 
-			// I check if nothing found
+			// Log if no match is found
 			if len(found) == 0 {
 				logrus.Debugf("No result found after applying regex %q to %q", f.Pattern, output)
 				return "", nil

--- a/pkg/core/transformer/main.go
+++ b/pkg/core/transformer/main.go
@@ -102,10 +102,8 @@ func (t *Transformer) Apply(input string) (output string, err error) {
 
 			f := FindSubMatch{}
 
-			// Here I deal with 2 ways of providing the data within the yaml
-			// only one parameter in string which is the pattern
-			// considering 0 as the CaptureIndex default
-			// or receiving both parameter as a map.
+			// If the manifest value is only a string (the pattern), then 0 is the implied captureIndex value
+			// Otherwise, both pattern and captureIndex are retrieved from the map value of the manifest
 			if _, ok := value.(string); ok {
 				f.Pattern = value.(string)
 				f.CaptureIndex = 0

--- a/pkg/core/transformer/main.go
+++ b/pkg/core/transformer/main.go
@@ -2,7 +2,6 @@ package transformer
 
 import (
 	"fmt"
-	"reflect"
 	"regexp"
 	"strings"
 
@@ -107,7 +106,7 @@ func (t *Transformer) Apply(input string) (output string, err error) {
 			// only one parameter in string which is the pattern
 			// considering 0 as the CaptureIndex default
 			// or receiving both parameter as a map.
-			if reflect.TypeOf(value).String() == "string" {
+			if _, ok := value.(string); ok {
 				f.Pattern = value.(string)
 				f.CaptureIndex = 0
 			} else {
@@ -118,7 +117,6 @@ func (t *Transformer) Apply(input string) (output string, err error) {
 				}
 			}
 
-			// Here I check if I got a non empty Pattern for the RegExp
 			if len(f.Pattern) == 0 {
 				return "", fmt.Errorf("no regex provided")
 			}

--- a/pkg/core/transformer/main.go
+++ b/pkg/core/transformer/main.go
@@ -138,7 +138,7 @@ func (t *Transformer) Apply(input string) (output string, err error) {
 				return "", nil
 			}
 
-			// here is the returned string
+			// Output the submatch corresponding to the captureIndex
 			output = found[f.CaptureIndex]
 
 		case "semverInc":

--- a/pkg/core/transformer/main_test.go
+++ b/pkg/core/transformer/main_test.go
@@ -187,6 +187,32 @@ var (
 			expectedErr:    nil,
 		},
 		Data{
+			input: "1.17.0",
+			rules: Transformers{
+				Transformer{
+					"findSubMatch": FindSubMatch{
+						Pattern:      `\d*.(\d*)`,
+						CaptureIndex: 1,
+					},
+				},
+			},
+			expectedOutput: "17",
+			expectedErr:    nil,
+		},
+		Data{
+			input: "1.17.0",
+			rules: Transformers{
+				Transformer{
+					"findSubMatch": FindSubMatch{
+						Pattern:      `\d*.\d*`,
+						CaptureIndex: 1,
+					},
+				},
+			},
+			expectedOutput: "",
+			expectedErr:    nil,
+		},
+		Data{
 			input: "", // explicit empty value
 			rules: Transformers{
 				Transformer{

--- a/pkg/core/transformer/main_test.go
+++ b/pkg/core/transformer/main_test.go
@@ -213,6 +213,32 @@ var (
 			expectedErr:    nil,
 		},
 		Data{
+			input: "1.17.0",
+			rules: Transformers{
+				Transformer{
+					"findSubMatch": FindSubMatch{
+						Pattern:      `\d*.(\d*).(\d*)`,
+						CaptureIndex: 2,
+					},
+				},
+			},
+			expectedOutput: "0",
+			expectedErr:    nil,
+		},
+		Data{
+			input: "1.17.0",
+			rules: Transformers{
+				Transformer{
+					"findSubMatch": FindSubMatch{
+						Pattern:      `\d*.(\d*).(\d*)`,
+						CaptureIndex: 3,
+					},
+				},
+			},
+			expectedOutput: "",
+			expectedErr:    nil,
+		},
+		Data{
 			input: "", // explicit empty value
 			rules: Transformers{
 				Transformer{


### PR DESCRIPTION
# Title

Fix [#517 ](https://github.com/updatecli/updatecli/issues/517)

<!-- Describe the changes introduced by this pull request -->

## Adding a parameter for the transformer FindSubMatch

To test this pull request, you can run the following commands:

```shell
cd pkg/core/transformer/
go test
```

## Additional Information

### Potential improvement

This pull request permit 2 ways of calling the FindSubMatch: 

New way : 

```
transformers:
  - findSubMatch: 
      # Note that it is indented, like the "replace"
      pattern: '"(.*?):(.*)'
      captureIndex: 1
```

or old way : 

```
transformers:
  - findSubMatch: '"(.*?):(.*)'
```

which is equivalent of : 

```
transformers:
  - findSubMatch: 
      pattern: '"(.*?):(.*)'
      captureIndex: 0
```

