### PR TITLE
Fix for Authentication Bug with Private Git Repos

### DIFF
--- a/pkg/plugins/scms/git/scm.go
+++ b/pkg/plugins/scms/git/scm.go
@@ -19,7 +19,7 @@ func (g *Git) Add(files []string) error {
 
 // Checkout create and then uses a temporary git branch.
 func (g *Git) Checkout() error {
-	err := git.Checkout(g.Branch, g.remoteBranch, g.GetDirectory())
+	err := git.Checkout(g.Username, g.Password, g.Branch, g.remoteBranch, g.GetDirectory())
 	if err != nil {
 		return err
 	}

--- a/pkg/plugins/scms/github/scm.go
+++ b/pkg/plugins/scms/github/scm.go
@@ -46,7 +46,7 @@ func (g *Github) Clone() (string, error) {
 	}
 
 	if len(g.HeadBranch) > 0 && len(g.GetDirectory()) > 0 {
-		err = git.Checkout(g.Spec.Branch, g.HeadBranch, g.GetDirectory())
+		err = git.Checkout(g.Spec.Username, g.Spec.Token, g.Spec.Branch, g.HeadBranch, g.GetDirectory())
 	}
 
 	if err != nil {
@@ -74,7 +74,7 @@ func (g *Github) Commit(message string) error {
 
 // Checkout create and then uses a temporary git branch.
 func (g *Github) Checkout() error {
-	err := git.Checkout(g.Spec.Branch, g.HeadBranch, g.Spec.Directory)
+	err := git.Checkout(g.Spec.Username, g.Spec.Token, g.Spec.Branch, g.HeadBranch, g.Spec.Directory)
 	if err != nil {
 		return err
 	}

--- a/pkg/plugins/utils/gitgeneric/main.go
+++ b/pkg/plugins/utils/gitgeneric/main.go
@@ -113,7 +113,7 @@ func Add(files []string, workingDir string) error {
 }
 
 // Checkout create and then uses a temporary git branch.
-func Checkout(branch, remoteBranch, workingDir string) error {
+func Checkout(username, password, branch, remoteBranch, workingDir string) error {
 
 	logrus.Debugf("stage: git-checkout\n\n")
 
@@ -135,7 +135,13 @@ func Checkout(branch, remoteBranch, workingDir string) error {
 
 	b := bytes.Buffer{}
 
+	auth := transportHttp.BasicAuth{
+		Username: username, // anything except an empty string
+		Password: password,
+	}
+
 	err = w.Pull(&git.PullOptions{
+		Auth:     &auth,
 		Force:    true,
 		Progress: &b,
 	})
@@ -200,7 +206,7 @@ func Checkout(branch, remoteBranch, workingDir string) error {
 		if err != nil {
 			return err
 		}
-		refs, err := remote.List(&git.ListOptions{})
+		refs, err := remote.List(&git.ListOptions{Auth: &auth})
 
 		if err != nil {
 			return err


### PR DESCRIPTION
# Fix for Authentication Bug with Private Git Repos

As it is right now, authentication with Private Git Repo is not working properly. It can be replicated by trying to make a `pullrequest` to a private repository.

The following PR adds `Auth` property to all the methods supporting `AuthOptions` in `Checkout` method.

## Test

```shell
plugins/utils/gitgeneric on  feature/auth-checkout via 🐹 v1.17.5 on ☁️  (us-west-2)
❯ go test

PASS
ok  	github.com/updatecli/updatecli/pkg/plugins/utils/gitgeneric	4.447s
```

## Additional Information

### Tradeoff

n/a
