### PR TITLE
Add Signing To Commit Function

### DIFF
--- a/pkg/plugins/scms/git/main.go
+++ b/pkg/plugins/scms/git/main.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/updatecli/updatecli/pkg/core/tmp"
 	"github.com/updatecli/updatecli/pkg/plugins/scms/git/commit"
+	"github.com/updatecli/updatecli/pkg/plugins/scms/git/sign"
 )
 
 // Git contains settings to manipulate a git repository.
@@ -24,6 +25,7 @@ type Git struct {
 	Version       string
 	Force         bool          // Force is used during the git push phase to run `git push --force`.
 	CommitMessage commit.Commit // CommitMessage contains conventional commit metadata as type or scope, used to generate the final commit message.
+	GPG           sign.GPGSpec  // GPG key and passphrased used for commit signing
 }
 
 func newDirectory(URL string) (string, error) {

--- a/pkg/plugins/scms/git/scm.go
+++ b/pkg/plugins/scms/git/scm.go
@@ -83,9 +83,6 @@ func (g *Git) Commit(message string) error {
 
 	gpgSigningKey := g.GPG.SigningKey
 	gpgPassphrase := g.GPG.Passphrase
-	if !g.GPG.Enabled {
-		gpgSigningKey = ""
-	}
 
 	err = git.Commit(
 		g.User,

--- a/pkg/plugins/scms/git/scm.go
+++ b/pkg/plugins/scms/git/scm.go
@@ -81,16 +81,13 @@ func (g *Git) Commit(message string) error {
 		return err
 	}
 
-	gpgSigningKey := g.GPG.SigningKey
-	gpgPassphrase := g.GPG.Passphrase
-
 	err = git.Commit(
 		g.User,
 		g.Email,
 		commitMessage,
 		g.GetDirectory(),
-		gpgSigningKey,
-		gpgPassphrase)
+		g.GPG.SigningKey,
+		g.GPG.Passphrase)
 
 	if err != nil {
 		return err

--- a/pkg/plugins/scms/git/scm.go
+++ b/pkg/plugins/scms/git/scm.go
@@ -81,11 +81,19 @@ func (g *Git) Commit(message string) error {
 		return err
 	}
 
+	gpgSigningKey := g.GPG.SigningKey
+	gpgPassphrase := g.GPG.Passphrase
+	if !g.GPG.Enabled {
+		gpgSigningKey = ""
+	}
+
 	err = git.Commit(
 		g.User,
 		g.Email,
 		commitMessage,
-		g.GetDirectory())
+		g.GetDirectory(),
+		gpgSigningKey,
+		gpgPassphrase)
 
 	if err != nil {
 		return err

--- a/pkg/plugins/scms/git/sign/main.go
+++ b/pkg/plugins/scms/git/sign/main.go
@@ -9,7 +9,6 @@ import (
 type GPGSpec struct {
 	SigningKey string
 	Passphrase string
-	Enabled    bool
 }
 
 func GetCommitSignKey(armoredKeyRing string, keyPassphrase string) (*openpgp.Entity, error) {

--- a/pkg/plugins/scms/git/sign/main.go
+++ b/pkg/plugins/scms/git/sign/main.go
@@ -1,0 +1,31 @@
+package sign
+
+import (
+	"strings"
+
+	"github.com/ProtonMail/go-crypto/openpgp"
+)
+
+type GPGSpec struct {
+	SigningKey string
+	Passphrase string
+	Enabled    bool
+}
+
+func GetCommitSignKey(armoredKeyRing string, keyPassphrase string) (*openpgp.Entity, error) {
+	s := strings.NewReader(armoredKeyRing)
+	es, err := openpgp.ReadArmoredKeyRing(s)
+
+	if err != nil {
+		return nil, err
+	}
+
+	key := es[0]
+	err = key.PrivateKey.Decrypt([]byte(keyPassphrase))
+
+	if err != nil {
+		return nil, err
+	}
+
+	return key, nil
+}

--- a/pkg/plugins/scms/git/sign/main_test.go
+++ b/pkg/plugins/scms/git/sign/main_test.go
@@ -12,7 +12,6 @@ type DataSet []Data
 type Data struct {
 	SigningKey    string
 	Passphrase    string
-	Enabled       bool
 	ExpectedError error
 }
 

--- a/pkg/plugins/scms/git/sign/main_test.go
+++ b/pkg/plugins/scms/git/sign/main_test.go
@@ -105,7 +105,7 @@ woa!
 func TestParseMessage(t *testing.T) {
 
 	for id, data := range dataset {
-		gpg := GPGSpec{SigningKey: data.SigningKey, Passphrase: data.Passphrase, Enabled: true}
+		gpg := GPGSpec{SigningKey: data.SigningKey, Passphrase: data.Passphrase}
 
 		_, err := GetCommitSignKey(gpg.SigningKey, gpg.Passphrase)
 

--- a/pkg/plugins/scms/git/sign/main_test.go
+++ b/pkg/plugins/scms/git/sign/main_test.go
@@ -1,0 +1,120 @@
+package sign
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ProtonMail/go-crypto/openpgp/errors"
+)
+
+type DataSet []Data
+
+type Data struct {
+	SigningKey    string
+	Passphrase    string
+	Enabled       bool
+	ExpectedError error
+}
+
+var (
+	dataset = DataSet{
+		{
+			SigningKey: `
+-----BEGIN PGP PRIVATE KEY BLOCK-----
+
+lQOsBGIqZEEBCACOnlRGd40w2SvqxFe0FRtBhruQIHLWpWAkYxz6otNRuCAkK7w1
+GwPvFlxpYuR1Yb2X4Ex1skXGbCnb7yTwgJIKXV6btagA8MDYnonzGudnNQE8vKr3
+IKRp5fDHYjIrml4jmyLiDiGvGhjQLwlB6Xc+qLZZVGiHy0YKJNWZiCF5HfJhszB5
+cWeUgXwXfqLXYbhfn4qSRUKN0jcpnUfI+UWCAaH3vuodo7q/8rm4ESh6ioiCDe3M
+a0+jMPa+EaLUv6Rlye+UBzj5xLWXEMgJwJVFJKXtH1mjGCM6H7herVEyChZmjXo9
+RFnTz6s4Ohh9YuCbiRDQlueghp58oVJeo42fABEBAAH/AwMCFmrvPQSYi65g9w4O
+cPSntz8UAm5sVksLxP7ScjEAw1KVel+bEcj+TOfY/Io+H05+X080PBdffbmsFRIK
+BRoXb0BfCgpY7cDHgPuYKXcxfzJfom3MxmjFulrXI0Ia3ALWbSarwSAWFDqyoSE2
+0i8ZTin/RNAuFEAwJ+9jrj/IjY8R2aIe4i4TZ8llmAKBQdTITkZQ1c1pZbZNYiWG
+LVMAiM4RmYg21DVwoAcRFWOnjYgsYULyIz9GW9KsQMSZ/9oU2axT6BBQ0EcMIda3
+fCoWg17EGC/g55rz36MXANIeaLf5DB1GEi+HMy6geq81fFChQt/DwopIWUImUZBL
+6JYLqkTknbu1ZByYaZeHq+sWpa1dlCa38ToFjgYonI9X8QS5rG/c6nrplCC+9gWB
+0HTlHSFK72unFhuyrBMg0eoKJa1btd5lvUdulM51+MfAvk3KcIn7iFIdxsZC/jW4
+4GLdjihwzqKVH9DVRGdip1iNEjdDzpZ5O+2I+QuHGMRLnPN2dqTOW+dxtSfOBScf
+vyozYlQBjT/sVQM5k6tWbiAagNwQLPSZbzSwNTrf0k4yakU051hf80TS3qTdmkCF
+MDWxMlebESwcDoQOVyq7pLNyYN3Y5WwiBlaZZLAD71uztfAPMJQ+DWLq/nhLuE5v
+xMTeTBtlN5qy2/LPjrqMW5JoMWzOJO3IZdP8Vo5d4LvC29Cy7UOgEwYsBJ0KDo/Z
+Uz8uWucsPevJ5fEmpa6EkWlSm7adky2pMCPdxfdMT+RjYBKShr8NSsXe4ukbXakt
+mHYJcqCbKlUy3J1/U1g07JUtv6jKEjUPUdKPqy0iXTglmdeOs5OWfffX9TITNxdQ
+31RZjCVwIGiuszfdQ572qGPZw49SitoTMxJshMJEY7QLZm9vQGJhci5jb22JARwE
+EAECAAYFAmIqZEEACgkQXAIYP4CH4zaoNQf/cSsNjUq84Frd1l96o3stxw/k7DGa
+x1SvQ6T4zTlTndWZirnPv3OncrtzjpXjCFbymxBKhFKgrTA5hgT/Gm0z/BQWEGqf
+GtiIcTnoPIJfrxGXYqqaMVMzFUIha3vfqf4DqmOcZIebUmOp926uWKnp7AMFt2Qs
+1uhGIq5gxf44zKp3dKfLTU0GaqsGx8F0Hfc8uguXhKB8OdkhmwEwZMdFvTg4y8px
+akA1wLgb4M2/j876jL16SacsmrOfD/f9OygPCUJWOPf83frmcJHrJJGeJ2G+V4Nv
+yxxawXzHgc4q6+YvBjgCn3LWojXqh/07nRLiRNfFNX5DKKSa7AUE4ET4Mg==
+=YcmB
+-----END PGP PRIVATE KEY BLOCK-----
+`,
+			Passphrase:    "abcd123",
+			ExpectedError: nil,
+		},
+		{
+			SigningKey: `
+-----BEGIN PGP PRIVATE KEY BLOCK-----
+
+lQOsBGIqZEEBCACOnlRGd40w2SvqxFe0FRtBhruQIHLWpWAkYxz6otNRuCAkK7w1
+GwPvFlxpYuR1Yb2X4Ex1skXGbCnb7yTwgJIKXV6btagA8MDYnonzGudnNQE8vKr3
+IKRp5fDHYjIrml4jmyLiDiGvGhjQLwlB6Xc+qLZZVGiHy0YKJNWZiCF5HfJhszB5
+cWeUgXwXfqLXYbhfn4qSRUKN0jcpnUfI+UWCAaH3vuodo7q/8rm4ESh6ioiCDe3M
+a0+jMPa+EaLUv6Rlye+UBzj5xLWXEMgJwJVFJKXtH1mjGCM6H7herVEyChZmjXo9
+RFnTz6s4Ohh9YuCbiRDQlueghp58oVJeo42fABEBAAH/AwMCFmrvPQSYi65g9w4O
+cPSntz8UAm5sVksLxP7ScjEAw1KVel+bEcj+TOfY/Io+H05+X080PBdffbmsFRIK
+BRoXb0BfCgpY7cDHgPuYKXcxfzJfom3MxmjFulrXI0Ia3ALWbSarwSAWFDqyoSE2
+0i8ZTin/RNAuFEAwJ+9jrj/IjY8R2aIe4i4TZ8llmAKBQdTITkZQ1c1pZbZNYiWG
+LVMAiM4RmYg21DVwoAcRFWOnjYgsYULyIz9GW9KsQMSZ/9oU2axT6BBQ0EcMIda3
+fCoWg17EGC/g55rz36MXANIeaLf5DB1GEi+HMy6geq81fFChQt/DwopIWUImUZBL
+6JYLqkTknbu1ZByYaZeHq+sWpa1dlCa38ToFjgYonI9X8QS5rG/c6nrplCC+9gWB
+0HTlHSFK72unFhuyrBMg0eoKJa1btd5lvUdulM51+MfAvk3KcIn7iFIdxsZC/jW4
+4GLdjihwzqKVH9DVRGdip1iNEjdDzpZ5O+2I+QuHGMRLnPN2dqTOW+dxtSfOBScf
+vyozYlQBjT/sVQM5k6tWbiAagNwQLPSZbzSwNTrf0k4yakU051hf80TS3qTdmkCF
+MDWxMlebESwcDoQOVyq7pLNyYN3Y5WwiBlaZZLAD71uztfAPMJQ+DWLq/nhLuE5v
+xMTeTBtlN5qy2/LPjrqMW5JoMWzOJO3IZdP8Vo5d4LvC29Cy7UOgEwYsBJ0KDo/Z
+Uz8uWucsPevJ5fEmpa6EkWlSm7adky2pMCPdxfdMT+RjYBKShr8NSsXe4ukbXakt
+mHYJcqCbKlUy3J1/U1g07JUtv6jKEjUPUdKPqy0iXTglmdeOs5OWfffX9TITNxdQ
+31RZjCVwIGiuszfdQ572qGPZw49SitoTMxJshMJEY7QLZm9vQGJhci5jb22JARwE
+EAECAAYFAmIqZEEACgkQXAIYP4CH4zaoNQf/cSsNjUq84Frd1l96o3stxw/k7DGa
+x1SvQ6T4zTlTndWZirnPv3OncrtzjpXjCFbymxBKhFKgrTA5hgT/Gm0z/BQWEGqf
+GtiIcTnoPIJfrxGXYqqaMVMzFUIha3vfqf4DqmOcZIebUmOp926uWKnp7AMFt2Qs
+1uhGIq5gxf44zKp3dKfLTU0GaqsGx8F0Hfc8uguXhKB8OdkhmwEwZMdFvTg4y8px
+akA1wLgb4M2/j876jL16SacsmrOfD/f9OygPCUJWOPf83frmcJHrJJGeJ2G+V4Nv
+yxxawXzHgc4q6+YvBjgCn3LWojXqh/07nRLiRNfFNX5DKKSa7AUE4ET4Mg==
+=YcmB
+-----END PGP PRIVATE KEY BLOCK-----
+`,
+			Passphrase:    "not-real-passphrase",
+			ExpectedError: errors.StructuralError("private key checksum failure"),
+		},
+		{
+			SigningKey: `
+-----BEGIN PGP PRIVATE KEY BLOCK-----
+woa!
+-----END PGP PRIVATE KEY BLOCK-----
+`,
+			Passphrase:    "abcd123",
+			ExpectedError: errors.InvalidArgumentError("no armored data found"),
+		},
+	}
+)
+
+func TestParseMessage(t *testing.T) {
+
+	for id, data := range dataset {
+		gpg := GPGSpec{SigningKey: data.SigningKey, Passphrase: data.Passphrase, Enabled: true}
+
+		_, err := GetCommitSignKey(gpg.SigningKey, gpg.Passphrase)
+
+		if err != nil {
+			if strings.Compare(err.Error(), data.ExpectedError.Error()) != 0 {
+				t.Errorf("Wrong sign %d err:\n\tExpected:\t\t%v\n\tGot:\t\t%v\n", id, data.ExpectedError, err)
+			}
+		} else if err != nil {
+			t.Errorf("Unexpected error %q for sign #%d", err, id)
+		}
+	}
+}

--- a/pkg/plugins/scms/github/main.go
+++ b/pkg/plugins/scms/github/main.go
@@ -106,10 +106,6 @@ func (s *Spec) Validate() (errs []error) {
 		s.VersionFilter.Pattern = s.Version
 	}
 
-	if len(s.GPG.SigningKey) == 0 && s.GPG.Enabled {
-		required = append(required, "gpg.signingKey")
-	}
-
 	if err := s.VersionFilter.Validate(); err != nil {
 		errs = append(errs, err)
 	}

--- a/pkg/plugins/scms/github/main.go
+++ b/pkg/plugins/scms/github/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/shurcooL/githubv4"
 	"github.com/updatecli/updatecli/pkg/core/tmp"
 	"github.com/updatecli/updatecli/pkg/plugins/scms/git/commit"
+	"github.com/updatecli/updatecli/pkg/plugins/scms/git/sign"
 	"github.com/updatecli/updatecli/pkg/plugins/utils/version"
 )
 
@@ -30,6 +31,7 @@ type Spec struct {
 	Username      string          // Username specifies the username used to authenticate with Github API
 	User          string          // User specific the user in git commit messages
 	PullRequest   PullRequestSpec // Deprecated since https://github.com/updatecli/updatecli/issues/260, must be clean up
+	GPG           sign.GPGSpec    // GPG key and passphrased used for commit signing
 }
 
 // Github contains settings to interact with Github
@@ -102,6 +104,10 @@ func (s *Spec) Validate() (errs []error) {
 
 	if len(s.VersionFilter.Pattern) == 0 {
 		s.VersionFilter.Pattern = s.Version
+	}
+
+	if len(s.GPG.SigningKey) == 0 && s.GPG.Enabled {
+		required = append(required, "gpg.signingKey")
 	}
 
 	if err := s.VersionFilter.Validate(); err != nil {

--- a/pkg/plugins/scms/github/scm.go
+++ b/pkg/plugins/scms/github/scm.go
@@ -65,7 +65,13 @@ func (g *Github) Commit(message string) error {
 		return err
 	}
 
-	err = git.Commit(g.Spec.User, g.Spec.Email, commitMessage, g.GetDirectory())
+	gpgSigningKey := g.Spec.GPG.SigningKey
+	gpgPassphrase := g.Spec.GPG.Passphrase
+	if !g.Spec.GPG.Enabled {
+		gpgSigningKey = ""
+	}
+
+	err = git.Commit(g.Spec.User, g.Spec.Email, commitMessage, g.GetDirectory(), gpgSigningKey, gpgPassphrase)
 	if err != nil {
 		return err
 	}

--- a/pkg/plugins/scms/github/scm.go
+++ b/pkg/plugins/scms/github/scm.go
@@ -67,9 +67,6 @@ func (g *Github) Commit(message string) error {
 
 	gpgSigningKey := g.Spec.GPG.SigningKey
 	gpgPassphrase := g.Spec.GPG.Passphrase
-	if !g.Spec.GPG.Enabled {
-		gpgSigningKey = ""
-	}
 
 	err = git.Commit(g.Spec.User, g.Spec.Email, commitMessage, g.GetDirectory(), gpgSigningKey, gpgPassphrase)
 	if err != nil {

--- a/pkg/plugins/scms/github/scm.go
+++ b/pkg/plugins/scms/github/scm.go
@@ -65,10 +65,7 @@ func (g *Github) Commit(message string) error {
 		return err
 	}
 
-	gpgSigningKey := g.Spec.GPG.SigningKey
-	gpgPassphrase := g.Spec.GPG.Passphrase
-
-	err = git.Commit(g.Spec.User, g.Spec.Email, commitMessage, g.GetDirectory(), gpgSigningKey, gpgPassphrase)
+	err = git.Commit(g.Spec.User, g.Spec.Email, commitMessage, g.GetDirectory(), g.Spec.GPG.SigningKey, g.Spec.GPG.Passphrase)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
# Add gpg signing

Fix #274

Add ability to specify gpg key and passphrase to sign commits. No passphrase will be treated as empty passphrase.


## Test

Tested manually with this config for scm:

```yaml
scms:
  default:
    kind: github
    spec:
      user: "{{ .github.user }}"
      email: "{{ .github.email }}"
      owner: "{{ .github.owner }}"
      repository: "{{ .github.repository }}"
      token: "{{ requiredEnv .github.token }}"
      username: "{{ .github.username }}"
      branch: "{{ .github.branch }}"
      gpg:
        signingKey: |
          -----BEGIN PGP PRIVATE KEY BLOCK-----

          Blablabla... this is secret
          -----END PGP PRIVATE KEY BLOCK-----
        enabled: true
```



Also, added a new test for sign package:

```shell
cd updatecli/pkg/plugins/scms/git/sign
go test
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

Any feedback is welcome. I am not familiar with the tool project structure, so if there is a need to change anything in the PR it is cool with me. I am motivated to get it merged.