### PR TITLE
Resource "File" correctly uses scmID

### DIFF
--- a/pkg/plugins/resources/file/source.go
+++ b/pkg/plugins/resources/file/source.go
@@ -28,7 +28,7 @@ func (f *File) Source(workingDir string) (string, error) {
 		return "", fmt.Errorf("Validation error: the provided manifest configuration had the following validation errors:\n%s", strings.Join(validationErrors, "\n\n"))
 	}
 
-        # Relative path is used when an SCM is associated with the file resource: means the file is on a remote SCM (hence relative path)
+        // Relative path is used when an SCM is associated with the file resource: means the file is on a remote SCM (hence relative path)
 	if !filepath.IsAbs(f.spec.File) {
 		f.spec.File = filepath.Join(workingDir, f.spec.File)
 		logrus.Debugf("Relative path detected: changing to absolute path from working directory: %q", f.spec.File)

--- a/pkg/plugins/resources/file/source.go
+++ b/pkg/plugins/resources/file/source.go
@@ -2,6 +2,7 @@ package file
 
 import (
 	"fmt"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -25,6 +26,11 @@ func (f *File) Source(workingDir string) (string, error) {
 	// Return all the validation errors if found any
 	if len(validationErrors) > 0 {
 		return "", fmt.Errorf("Validation error: the provided manifest configuration had the following validation errors:\n%s", strings.Join(validationErrors, "\n\n"))
+	}
+
+	if !filepath.IsAbs(f.spec.File) {
+		f.spec.File = filepath.Join(workingDir, f.spec.File)
+		logrus.Debugf("Relative path detected: changing to absolute path from working directory: %q", f.spec.File)
 	}
 
 	if err := f.Read(); err != nil {

--- a/pkg/plugins/resources/file/source.go
+++ b/pkg/plugins/resources/file/source.go
@@ -28,7 +28,7 @@ func (f *File) Source(workingDir string) (string, error) {
 		return "", fmt.Errorf("Validation error: the provided manifest configuration had the following validation errors:\n%s", strings.Join(validationErrors, "\n\n"))
 	}
 
-        // Relative path is used when an SCM is associated with the file resource: means the file is on a remote SCM (hence relative path)
+	// Relative path is used when an SCM is associated with the file resource: means the file is on a remote SCM (hence relative path)
 	if !filepath.IsAbs(f.spec.File) {
 		f.spec.File = filepath.Join(workingDir, f.spec.File)
 		logrus.Debugf("Relative path detected: changing to absolute path from working directory: %q", f.spec.File)

--- a/pkg/plugins/resources/file/source.go
+++ b/pkg/plugins/resources/file/source.go
@@ -28,6 +28,7 @@ func (f *File) Source(workingDir string) (string, error) {
 		return "", fmt.Errorf("Validation error: the provided manifest configuration had the following validation errors:\n%s", strings.Join(validationErrors, "\n\n"))
 	}
 
+        # Relative path is used when an SCM is associated with the file resource: means the file is on a remote SCM (hence relative path)
 	if !filepath.IsAbs(f.spec.File) {
 		f.spec.File = filepath.Join(workingDir, f.spec.File)
 		logrus.Debugf("Relative path detected: changing to absolute path from working directory: %q", f.spec.File)

--- a/pkg/plugins/resources/file/source_test.go
+++ b/pkg/plugins/resources/file/source_test.go
@@ -15,10 +15,23 @@ func TestFile_Source(t *testing.T) {
 		spec                Spec
 		wantSource          string
 		wantErr             bool
+		workingDir          string
 		mockReturnedContent string
 		mockReturnedError   error
 		wantMockState       text.MockTextRetriever
 	}{
+		{
+			name: "Relative file",
+			spec: Spec{
+				File: "example.yaml",
+			},
+			wantErr:    false,
+			workingDir: "/tmp/updatecli/",
+			wantSource: "",
+			wantMockState: text.MockTextRetriever{
+				Location: "/tmp/updatecli/example.yaml",
+			},
+		},
 		{
 			name: "Normal Case",
 			spec: Spec{
@@ -130,7 +143,7 @@ d3cab7d777eec230b67eb9723f3b271cd43e29c688439e4c67e3398cdaf6406b  terraform_0.14
 				spec:             tt.spec,
 				contentRetriever: &mockText,
 			}
-			source, gotErr := f.Source(f.spec.File)
+			source, gotErr := f.Source(tt.workingDir)
 			if tt.wantErr {
 				assert.Error(t, gotErr)
 				return


### PR DESCRIPTION
Fix #558 

If a relative file path is provided with a scmID, then like for condition and target, we want to use the git repository directory as the file root directory

## Test

To test this pull request, I used the following updatecli configuration:

.updatecli.yaml
```
---
title: "Test Git scm"

scms:
  scenario-1:
    kind: git 
    spec:
      username: '{{ requiredEnv "UPDATECLI_GITHUB_ACTOR" }}'
      password: '{{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}'
      url: "https://github.com/updatecli/experiment.git"
      branch: "main"

sources:
  scenario-1:
    name: "Scenario 1"
    kind: file
    scmID: scenario-1
    spec:
      file: README.md
      line: 1
```

```shell
updatecli diff --config updatecli.yaml
```

## Additional Information

### Tradeoff
/
### Potential improvement

/
