### PR TITLE
Improve reporting of pipeline with wrong configuration

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -74,7 +74,7 @@ func run(command string) error {
 		err := e.Prepare()
 		if err != nil {
 			logrus.Errorf("%s %s", result.FAILURE, err)
-			logrus.Errorln("Continuing and trying to go as far as possible")
+			return err
 		}
 
 		err = e.Run()
@@ -94,7 +94,7 @@ func run(command string) error {
 		err := e.Prepare()
 		if err != nil {
 			logrus.Errorf("%s %s", result.FAILURE, err)
-			logrus.Errorln("Continuing and trying to go as far as possible")
+			return err
 		}
 
 		err = e.Run()

--- a/pkg/core/config/main.go
+++ b/pkg/core/config/main.go
@@ -131,8 +131,6 @@ func (config *Config) Display() error {
 // Validate run various validation test on the configuration and update fields if necessary
 func (config *Config) Validate() error {
 
-	logrus.Infof("Validating %q", config.Name)
-
 	if config.Source.Kind != "" && (len(config.Sources) > 0) {
 		logrus.Errorf("Source and Sources can't be defined at the same time, please use the 'Sources' syntax")
 		return ErrBadConfig

--- a/pkg/core/engine/main.go
+++ b/pkg/core/engine/main.go
@@ -154,9 +154,12 @@ func (e *Engine) LoadConfigurations() error {
 
 		loadedConfiguration, err := config.New(cfgFile, e.Options.ValuesFiles, e.Options.SecretsFiles)
 
-		if err == config.ErrConfigFileTypeNotSupported {
+		switch {
+		case err == config.ErrConfigFileTypeNotSupported:
+			// Updatecli accepts either a single configuration file or a directory containing multiple configurations.
+			// When browsing files from a directory, we don't want to record error due to unsupported files.
 			continue
-		} else if err != nil && err != config.ErrConfigFileTypeNotSupported {
+		case err != nil && err != config.ErrConfigFileTypeNotSupported:
 			err = fmt.Errorf("%q - %s", cfgFile, err)
 			errs = append(errs, err)
 			continue

--- a/pkg/core/engine/main.go
+++ b/pkg/core/engine/main.go
@@ -178,7 +178,6 @@ func (e *Engine) LoadConfigurations() error {
 			err := fmt.Errorf("%q - %s", cfgFile, err)
 			errs = append(errs, err)
 		}
-
 	}
 
 	if len(errs) > 0 {

--- a/pkg/core/engine/main.go
+++ b/pkg/core/engine/main.go
@@ -154,12 +154,14 @@ func (e *Engine) LoadConfigurations() error {
 
 		loadedConfiguration, err := config.New(cfgFile, e.Options.ValuesFiles, e.Options.SecretsFiles)
 
-		switch {
-		case err == config.ErrConfigFileTypeNotSupported:
+		switch err {
+		case config.ErrConfigFileTypeNotSupported:
 			// Updatecli accepts either a single configuration file or a directory containing multiple configurations.
 			// When browsing files from a directory, we don't want to record error due to unsupported files.
 			continue
-		case err != nil && err != config.ErrConfigFileTypeNotSupported:
+		case nil:
+			// nothing to do
+		default:
 			err = fmt.Errorf("%q - %s", cfgFile, err)
 			errs = append(errs, err)
 			continue


### PR DESCRIPTION
# Improve reporting of pipeline with wrong configuration

Fix #552 
This pull request allows to better identify which pipeline is failing due to a bad configuration. 
Now It would show

```
+++++++++++
+ PREPARE +
+++++++++++

Loading Pipeline "updatecli/updatecli.d/golang.yaml"
Loading Pipeline "updatecli/updatecli.d/updatecli.yaml"
Loading Pipeline "updatecli/updatecli.d/venom.yaml"
ERROR: failed loading pipeline(s)
	* "updatecli/updatecli.d/golang.yaml" - scms ID "default2" referenced by pullrequest ID "default", doesn't exist
	* "updatecli/updatecli.d/updatecli.yaml" - scm id "default222" doesn't exist

```
instead of the old 
```
+++++++++++
+ PREPARE +
+++++++++++

Loading Pipeline "updatecli/updatecli.d/golang.yaml"
Validating ""
Validating "GOLANG.YAML"
ERROR: ✗ scms ID "default2" referenced by pullrequest ID "default", doesn't exist
ERROR: Continuing and trying to go as far as possible

```
## Test

To test this pull request, we needs updatecli configuration with wrong content and good content.

```shell
cp <to_package_directory>
go test
```

This pullrequest introduces a behavior change during the "prepare" stage.
Previously , it would just try to load as much configuration as possible and clone as much git repository as possible without failing. But now we exit if we couldn't load any pipeline or if something wrong happened with one of the git clones.

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

Implement the same behavior for git clones where it tries to clones as much repository as possible
