### PR TITLE
cleanup(sources): remove deprecated syntax 'source:' (singular source)

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -60,7 +60,7 @@ In the `main.go`, you need to define the `struct` that you'll use to configure y
 ```
 type Capitalized_package_name struct {
 	Field1        string
-	Field2        string 
+	Field2        string
 	Field3        string
 	Field4        string
 }
@@ -138,11 +138,12 @@ config.value
 ```
 # updatecli diff --config config.value
 
-source:
-  kind: packageName
-  spec:
-    field1: "value"
-    field3: "value"
+sources:
+  default:
+    kind: packageName
+    spec:
+      field1: "value"
+      field3: "value"
 targets:
   idName:
     name: "updatecli"

--- a/examples/updatecli.d/docker-compose.yaml
+++ b/examples/updatecli.d/docker-compose.yaml
@@ -1,9 +1,10 @@
-source:
-  name: "Get docker image digest for olblak/polls:latest"
-  kind: dockerDigest
-  spec:
-    image: "olblak/polls"
-    tag: "latest"
+sources:
+  lastDigest:
+    name: "Get docker image digest for olblak/polls:latest"
+    kind: dockerDigest
+    spec:
+      image: "olblak/polls"
+      tag: "latest"
 targets:
   imageTag:
     name: "updatecli docker image tag"

--- a/examples/updatecli.d/dockerfile.yaml
+++ b/examples/updatecli.d/dockerfile.yaml
@@ -1,14 +1,15 @@
 ---
-source:
-  name: Get Latest helm release version
-  kind: githubRelease
-  spec:
-    owner: "helm"
-    repository: "helm"
-    token: {{ requiredEnv .github.token }}
-    username: olblak
-    versionFilter:
-      kind: latest
+sources:
+  lastHelmRelease:
+    name: Get Latest helm release version
+    kind: githubRelease
+    spec:
+      owner: "helm"
+      repository: "helm"
+      token: {{ requiredEnv .github.token }}
+      username: olblak
+      versionFilter:
+        kind: latest
 conditions:
   isENVSet:
     name: Is the 2nd ENV instruction having a "keyword" set to "HELM_VERSION"

--- a/examples/updatecli.d/grafana-loki.yaml
+++ b/examples/updatecli.d/grafana-loki.yaml
@@ -1,9 +1,10 @@
-source:
-  kind: helmChart
-  name: "Get latest loki helm chart version"
-  spec:
-    url: https://grafana.github.io/loki/charts
-    name: loki
+sources:
+  lastHelmRelease:
+    kind: helmChart
+    name: "Get latest loki helm chart version"
+    spec:
+      url: https://grafana.github.io/loki/charts
+      name: loki
 
 conditions:
   exist:

--- a/examples/updatecli.d/jenkins-chart.yaml
+++ b/examples/updatecli.d/jenkins-chart.yaml
@@ -1,9 +1,10 @@
-source:
-  kind: helmChart
-  name: "Get latest jenkins helm chart version"
-  spec:
-    url: https://charts.jenkins.io
-    name: jenkins
+sources:
+  lastHelmRelease:
+    kind: helmChart
+    name: "Get latest jenkins helm chart version"
+    spec:
+      url: https://charts.jenkins.io
+      name: jenkins
 
 conditions:
   exist:

--- a/examples/updatecli.d/jenkins-wiki-exporter.yaml
+++ b/examples/updatecli.d/jenkins-wiki-exporter.yaml
@@ -1,13 +1,14 @@
-source:
-  kind: githubRelease
-  name: "Get jenkins-wiki-exporter latest version"
-  spec:
-    owner: "jenkins-infra"
-    repository: "jenkins-wiki-exporter"
-    token: {{ requiredEnv "GITHUB_TOKEN" }}
-    username: "olblak"
-    versionFilter:
-      kind: latest
+sources:
+  lastRelease:
+    kind: githubRelease
+    name: "Get jenkins-wiki-exporter latest version"
+    spec:
+      owner: "jenkins-infra"
+      repository: "jenkins-wiki-exporter"
+      token: {{ requiredEnv "GITHUB_TOKEN" }}
+      username: "olblak"
+      versionFilter:
+        kind: latest
 conditions:
   docker:
     name: "Is Docker Image Published on Registry?"

--- a/examples/updatecli.d/jenkins.yaml
+++ b/examples/updatecli.d/jenkins.yaml
@@ -1,13 +1,14 @@
-source:
-  kind: maven
-  name: "Get latest jenkins weekly version from maven repository"
-  postfix: "-jdk11"
-  spec:
-    owner: "maven"
-    url: "repo.jenkins-ci.org"
-    repository: "releases"
-    groupID: "org.jenkins-ci.main"
-    artifactID: "jenkins-war"
+sources:
+  lastMavenRelease:
+    kind: maven
+    name: "Get latest jenkins weekly version from maven repository"
+    postfix: "-jdk11"
+    spec:
+      owner: "maven"
+      url: "repo.jenkins-ci.org"
+      repository: "releases"
+      groupID: "org.jenkins-ci.main"
+      artifactID: "jenkins-war"
 conditions:
   docker:
     name: "Is Docker Image Published on Registry?"

--- a/examples/updatecli.d/jenkinsio.yaml
+++ b/examples/updatecli.d/jenkinsio.yaml
@@ -1,9 +1,10 @@
-source:
-  kind: dockerDigest
-  name: "Get latest nginx:1.17 from dockerhub"
-  spec:
-    image: "library/nginx"
-    tag: "1.17"
+sources:
+  lastDockerDigest:
+    kind: dockerDigest
+    name: "Get latest nginx:1.17 from dockerhub"
+    spec:
+      image: "library/nginx"
+      tag: "1.17"
 targets:
   jenkinsio:
     name: "Update to latest nginx:1.17"

--- a/examples/updatecli.d/nginx.yaml
+++ b/examples/updatecli.d/nginx.yaml
@@ -1,9 +1,10 @@
-source:
-  kind: dockerDigest
-  name: "Get latest nginx:1.17 from dockerhub"
-  spec:
-    image: "library/nginx"
-    tag: "1.17"
+sources:
+  lastDockerDigest:
+    kind: dockerDigest
+    name: "Get latest nginx:1.17 from dockerhub"
+    spec:
+      image: "library/nginx"
+      tag: "1.17"
 targets:
   jenkinsioNginxDigest:
     name: "Jenkins.io nginx"

--- a/examples/updatecli.d/noYamlConditionScm.yaml
+++ b/examples/updatecli.d/noYamlConditionScm.yaml
@@ -1,8 +1,9 @@
-source:
-  kind: helmChart
-  spec:
-    url: https://grafana.github.io/loki/charts
-    name: loki
+sources:
+  lastHelmRelease:
+    kind: helmChart
+    spec:
+      url: https://grafana.github.io/loki/charts
+      name: loki
 
 conditions:
   isKeyExistWithCorrectValue:

--- a/examples/updatecli.d/pluginsite-api.yaml
+++ b/examples/updatecli.d/pluginsite-api.yaml
@@ -1,13 +1,14 @@
-source:
-  kind: githubRelease
-  name: "Get latest pluginsite version"
-  spec:
-    owner: "jenkins-infra"
-    repository: "plugin-site-api"
-    token: {{ requiredEnv "GITHUB_TOKEN" }}
-    username: "olblak"
-    versionFilter:
-      kind: latest
+sources:
+  lastGitHubRelease:
+    kind: githubRelease
+    name: "Get latest pluginsite version"
+    spec:
+      owner: "jenkins-infra"
+      repository: "plugin-site-api"
+      token: {{ requiredEnv "GITHUB_TOKEN" }}
+      username: "olblak"
+      versionFilter:
+        kind: latest
 targets:
   imageTag:
     name: "Is Docker Image published on dockerhub"

--- a/examples/updatecli.d/prometheus.yalm
+++ b/examples/updatecli.d/prometheus.yalm
@@ -1,9 +1,10 @@
-source:
-  kind: helmChart
-  name
-  spec:
-    name: prometheus
-    url: https://prometheus-community.github.io/helm-charts
+sources:
+  lastHelmRelease:
+    kind: helmChart
+    name
+    spec:
+      name: prometheus
+      url: https://prometheus-community.github.io/helm-charts
 conditions:
   isNamePrometheus:
     kind: yaml

--- a/examples/updatecli.d/updatecli.yaml
+++ b/examples/updatecli.d/updatecli.yaml
@@ -1,12 +1,13 @@
-source:
-  kind: githubRelease
-  spec:
-    owner: olblak
-    repository: updatecli
-    token: {{ requiredEnv "GITHUB_TOKEN" }}
-    username: olblak
-    versionFilter:
-      kind: latest
+sources:
+  lastGitHubRelease:
+    kind: githubRelease
+    spec:
+      owner: olblak
+      repository: updatecli
+      token: {{ requiredEnv "GITHUB_TOKEN" }}
+      username: olblak
+      versionFilter:
+        kind: latest
 conditions:
   dockerFile:
     name: isDockerfileCorrect

--- a/examples/updatecli.generic/helmChart/SCM.deprecated.yaml
+++ b/examples/updatecli.generic/helmChart/SCM.deprecated.yaml
@@ -1,12 +1,10 @@
 title: Bump Jenkins controller docker image tag
-source:
-  kind: jenkins
-  name: Get Latest Jenkins Stable version
-  spec:
-    release: stable
-    github:
-      token: {{ requiredEnv .github.token }}
-      username: {{ .github.username }}
+sources:
+  lastJenkinsStableVersion:
+    kind: jenkins
+    name: Get Latest Jenkins Stable version
+    spec:
+      release: stable
 targets:
   chartjenkins2:
     name: Bump Jenkins controller docker image tag

--- a/examples/updatecli.generic/helmChart/noSCM.yaml
+++ b/examples/updatecli.generic/helmChart/noSCM.yaml
@@ -1,11 +1,12 @@
 # To work
-# cd /tmp 
+# cd /tmp
 # git clone https://github.com/jenkinsci/helm-charts.git
 
-source:
-  kind: jenkins
-  spec:
-    release: stable
+sources:
+  lastJenkinsStableVersion:
+    kind: jenkins
+    spec:
+      release: stable
 targets:
   chartjenkins:
     name: "jenkinsci/jenkins Helm Chart"

--- a/examples/updatecli.generic/helmChart/requirement.yaml
+++ b/examples/updatecli.generic/helmChart/requirement.yaml
@@ -1,10 +1,11 @@
 title: Bump Jenkins Upstream Chart Version
-source:
-  kind: helmChart
-  name: Get official Jenkins Chart Version
-  spec:
-    url: https://charts.jenkins.io
-    name: jenkins
+sources:
+  lastHelmRelease:
+    kind: helmChart
+    name: Get official Jenkins Chart Version
+    spec:
+      url: https://charts.jenkins.io
+      name: jenkins
 targets:
   chartjenkins:
     name: Bump Jenkins Upstream Chart Version

--- a/examples/updatecli.generic/helmRelease.yaml
+++ b/examples/updatecli.generic/helmRelease.yaml
@@ -30,11 +30,12 @@
 #
 ###
 
-source:
-  kind: helmChart
-  spec:
-    url: https://charts.jenkins.io
-    name: jenkins
+sources:
+  lastHelmRelease:
+    kind: helmChart
+    spec:
+      url: https://charts.jenkins.io
+      name: jenkins
 conditions:
   isPrometheuseHelmChartVersionAvailable:
     name: "Test if the prometheus helm chart is available"

--- a/examples/updatecli.generic/transformers/jenkins.yaml
+++ b/examples/updatecli.generic/transformers/jenkins.yaml
@@ -1,19 +1,20 @@
-source:
-  name: "Get latest jenkins weekly version"
-  kind: jenkins
-  transformers:
-    - addPrefix: "alpha-"
-    - addSuffix: "-jdk11"
-    - trimSuffix: "-jdk11"
-    - addSuffix: "-jdk11"
-    - replacer:
-        from: "-jdk11"
-        to: "-jdk15"
-    - replacers:
-        - from: "-jdk15"
-          to: "-jdk17"
-  spec:
-    release: weekly
+sources:
+  lastJenkinsWeeklyVersion:
+    name: "Get latest jenkins weekly version"
+    kind: jenkins
+    transformers:
+      - addPrefix: "alpha-"
+      - addSuffix: "-jdk11"
+      - trimSuffix: "-jdk11"
+      - addSuffix: "-jdk11"
+      - replacer:
+          from: "-jdk11"
+          to: "-jdk15"
+      - replacers:
+          - from: "-jdk15"
+            to: "-jdk17"
+    spec:
+      release: weekly
 targets:
   targetID:
     name: "Update file file"

--- a/pkg/core/config/main.go
+++ b/pkg/core/config/main.go
@@ -43,8 +43,6 @@ var (
 	// ErrNotAllowedTemplatedKey is returned when
 	// we are planning to template at runtime unauthorized keys such map key
 	ErrNotAllowedTemplatedKey = errors.New("not allowed templated key")
-
-	defaultSourceID = "default"
 )
 
 // Config contains cli configuration
@@ -52,7 +50,6 @@ type Config struct {
 	Name         string
 	PipelineID   string                        // PipelineID allows to identify a full pipeline run, this value is propagated into each target if not defined at that level
 	Title        string                        // Title is used for the full pipeline
-	Source       source.Config                 // **Deprecated** 2021/02/18 Is replaced by Sources, this setting will be deleted in a future release
 	PullRequests map[string]pullrequest.Config // PullRequests defines the list of Pull Request configuration which need to be managed
 	SCMs         map[string]scm.Config         `yaml:"scms"` // SCMs defines the list of repository configuration used to fetch content from.
 	Sources      map[string]source.Config      // Sources defines the list of source configuration
@@ -130,20 +127,6 @@ func (config *Config) Display() error {
 
 // Validate run various validation test on the configuration and update fields if necessary
 func (config *Config) Validate() error {
-
-	if config.Source.Kind != "" && (len(config.Sources) > 0) {
-		logrus.Errorf("Source and Sources can't be defined at the same time, please use the 'Sources' syntax")
-		return ErrBadConfig
-
-	} else if config.Source.Kind != "" && len(config.Sources) == 0 {
-
-		logrus.Warning("Since version 0.2.0, the single source definition is **Deprecated**  and replaced by Sources. This parameter will be deleted in a future release")
-
-		config.Sources = make(map[string]source.Config)
-		config.Sources[defaultSourceID] = config.Source
-		config.Source = source.Config{}
-	}
-
 	for id, scm := range config.SCMs {
 		if err := scm.Validate(); err != nil {
 			logrus.Errorf("bad parameter(s) for scmIDs %q", id)
@@ -477,7 +460,6 @@ func getFieldValueByQuery(conf interface{}, query []string) (value string, err e
 // GetChangelogTitle try to guess a specific target based on various information available for
 // a specific job
 func (config *Config) GetChangelogTitle(ID string, fallback string) (title string) {
-
 	if len(config.Title) > 0 {
 		// If a pipeline title has been defined, then use it for pull request title
 		title = fmt.Sprintf("[updatecli] %s",

--- a/pkg/core/config/main_test.go
+++ b/pkg/core/config/main_test.go
@@ -207,10 +207,12 @@ var (
 			ID: "3",
 			Config: Config{
 				Name: `{{ pipeline "Source.kindd" }}`,
-				Source: source.Config{
-					ResourceConfig: resource.ResourceConfig{
-						Name: "Get Version",
-						Kind: "jenkins",
+				Sources: map[string]source.Config{
+					"default": {
+						ResourceConfig: resource.ResourceConfig{
+							Name: "Get Version",
+							Kind: "jenkins",
+						},
 					},
 				},
 			},


### PR DESCRIPTION
This PR removes the deprecated syntax `source:` (singular source).

Depends on #588 

Associated documentation PR: https://github.com/updatecli/website/pull/264

## Test

To test this pull request, you can run the following commands:

```shell
make test
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
