### PR TITLE
cleanup(pipeline) remove deprecated code for prefix and postfix

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -148,10 +148,11 @@ targets:
   idName:
     name: "updatecli"
     kind: "yaml"
-    prefix: "olblak/polls@256:"
     spec:
       file: "..."
       key:  "..."
+    transformers:
+      - addPrefix: "olblak/polls@256:"
 ```
 
 

--- a/examples/updatecli.d/docker-compose.yaml
+++ b/examples/updatecli.d/docker-compose.yaml
@@ -9,9 +9,10 @@ targets:
   imageTag:
     name: "updatecli docker image tag"
     kind: "yaml"
-    prefix: "olblak/polls@256:"
     spec:
       #file: "/home/olblak/Project/Jenkins-infra/polls/docker-compose.yaml"
       file: "../../Jenkins-infra/polls/docker-compose.yamli"
       #file: "docker-compose.yamli"
       key: "services.api.image"
+    transformers:
+      - addPrefix: "olblak/polls@256:"

--- a/examples/updatecli.d/jenkins.yaml
+++ b/examples/updatecli.d/jenkins.yaml
@@ -2,13 +2,14 @@ sources:
   lastMavenRelease:
     kind: maven
     name: "Get latest jenkins weekly version from maven repository"
-    postfix: "-jdk11"
     spec:
       owner: "maven"
       url: "repo.jenkins-ci.org"
       repository: "releases"
       groupID: "org.jenkins-ci.main"
       artifactID: "jenkins-war"
+    transformers:
+      - addSuffix: "-jdk11"
 conditions:
   docker:
     name: "Is Docker Image Published on Registry?"
@@ -19,8 +20,6 @@ targets:
   imageTag:
     name: "Update Jenkins docker image tag"
     kind: yaml
-    #prefix: "test-"
-    #postfix: "-jdk13"
     spec:
       file: "charts/jenkins/values.yaml"
       key: "jenkins.controller.imageTag"

--- a/examples/updatecli.d/updatecli.yaml
+++ b/examples/updatecli.d/updatecli.yaml
@@ -30,12 +30,13 @@ targets:
   dockerFile:
     name: "isDockerfileCorrect"
     kind: dockerfile
-    prefix: "olblak/updatecli:"
     spec:
       file: Dockerfile
       Instruction:
         keyword: "FROM"
         matcher: "golang:1.14"
+    transformers:
+      - addPrefix: "olblak/updatecli:"
     scm:
       github:
         user: "updatecli"

--- a/pkg/core/pipeline/condition/main.go
+++ b/pkg/core/pipeline/condition/main.go
@@ -3,7 +3,6 @@ package condition
 import (
 	"fmt"
 
-	"github.com/sirupsen/logrus"
 	"github.com/updatecli/updatecli/pkg/core/pipeline/resource"
 	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
 	"github.com/updatecli/updatecli/pkg/core/result"
@@ -42,16 +41,6 @@ func (c *Condition) Run(source string) (err error) {
 		}
 	}
 
-	// Announce deprecation on 2021/01/31
-	if len(c.Config.Prefix) > 0 {
-		logrus.Warnf("Key 'prefix' deprecated in favor of 'transformers', it will be delete in a future release")
-	}
-
-	// Announce deprecation on 2021/01/31
-	if len(c.Config.Postfix) > 0 {
-		logrus.Warnf("Key 'postfix' deprecated in favor of 'transformers', it will be delete in a future release")
-	}
-
 	// If scm is defined then clone the repository
 	if c.Scm != nil {
 		s := *c.Scm
@@ -72,14 +61,14 @@ func (c *Condition) Run(source string) (err error) {
 			return err
 		}
 
-		ok, err = condition.ConditionFromSCM(c.Config.Prefix+source+c.Config.Postfix, s)
+		ok, err = condition.ConditionFromSCM(source, s)
 		if err != nil {
 			c.Result = result.FAILURE
 			return err
 		}
 
 	} else if len(c.Config.Scm) == 0 {
-		ok, err = condition.Condition(c.Config.Prefix + source + c.Config.Postfix)
+		ok, err = condition.Condition(source)
 		if err != nil {
 			c.Result = result.FAILURE
 			return err

--- a/pkg/core/pipeline/conditions.go
+++ b/pkg/core/pipeline/conditions.go
@@ -39,10 +39,7 @@ func (p *Pipeline) RunConditions() (globalResult bool, err error) {
 		logrus.Infof("\n%s\n", id)
 		logrus.Infof("%s\n", strings.Repeat("-", len(id)))
 
-		err := condition.Run(
-			p.Sources[condition.Config.SourceID].Config.Prefix +
-				p.Sources[condition.Config.SourceID].Output +
-				p.Sources[condition.Config.SourceID].Config.Postfix)
+		err := condition.Run(p.Sources[condition.Config.SourceID].Output)
 		if err != nil {
 			// Show error to end user if any but continue the flow execution
 			logrus.Error(err)

--- a/pkg/core/pipeline/resource/main.go
+++ b/pkg/core/pipeline/resource/main.go
@@ -21,13 +21,9 @@ import (
 )
 
 type ResourceConfig struct {
-	DependsOn []string `yaml:"depends_on"`
-	Name      string
-	Kind      string
-	// Deprecated in favor of Transformers on 2021/01/3
-	Prefix string
-	// Deprecated in favor of Transformers on 2021/01/3
-	Postfix      string
+	DependsOn    []string `yaml:"depends_on"`
+	Name         string
+	Kind         string
 	Transformers transformer.Transformers
 	Spec         interface{}
 	// Deprecated field on version [1.17.0]

--- a/pkg/core/pipeline/source/main.go
+++ b/pkg/core/pipeline/source/main.go
@@ -92,16 +92,6 @@ func (s *Source) Run() (err error) {
 		}
 	}
 
-	// Announce deprecation on 2021/01/31
-	if len(s.Config.Prefix) > 0 {
-		logrus.Warnf("Key 'prefix' deprecated in favor of 'transformers', it will be delete in a future release\n")
-	}
-
-	// Announce deprecation on 2021/01/31
-	if len(s.Config.Postfix) > 0 {
-		logrus.Warnf("Key 'postfix' deprecated in favor of 'transformers', it will be delete in a future release\n")
-	}
-
 	if len(s.Output) == 0 {
 		s.Result = result.ATTENTION
 	}

--- a/pkg/core/pipeline/target/main.go
+++ b/pkg/core/pipeline/target/main.go
@@ -60,16 +60,6 @@ func (t *Target) Run(source string, o *Options) (err error) {
 		}
 	}
 
-	// Announce deprecation on 2021/01/31
-	if len(t.Config.Prefix) > 0 {
-		logrus.Warnf("Key 'prefix' deprecated in favor of 'transformers', it will be delete in a future release")
-	}
-
-	// Announce deprecation on 2021/01/31
-	if len(t.Config.Postfix) > 0 {
-		logrus.Warnf("Key 'postfix' deprecated in favor of 'transformers', it will be delete in a future release")
-	}
-
 	if o.DryRun {
 		logrus.Infof("\n**Dry Run enabled**\n\n")
 	}
@@ -83,7 +73,7 @@ func (t *Target) Run(source string, o *Options) (err error) {
 	// If no scm configuration provided then stop early
 	if t.Scm == nil {
 
-		changed, err = target.Target(t.Config.Prefix+source+t.Config.Postfix, o.DryRun)
+		changed, err = target.Target(source, o.DryRun)
 		if err != nil {
 			t.Result = result.FAILURE
 			return err
@@ -119,7 +109,7 @@ func (t *Target) Run(source string, o *Options) (err error) {
 		return err
 	}
 
-	changed, files, message, err = target.TargetFromSCM(t.Config.Prefix+source+t.Config.Postfix, s, o.DryRun)
+	changed, files, message, err = target.TargetFromSCM(source, s, o.DryRun)
 	if err != nil {
 		t.Result = result.FAILURE
 		return err

--- a/pkg/core/pipeline/targets.go
+++ b/pkg/core/pipeline/targets.go
@@ -42,17 +42,7 @@ func (p *Pipeline) RunTargets() error {
 		// Update report name as the target configuration might has been updated (templated values)
 		rpt.Name = target.Config.Name
 
-		if target.Config.Prefix == "" && p.Sources[target.Config.SourceID].Config.Prefix != "" {
-			target.Config.Prefix = p.Sources[target.Config.SourceID].Config.Prefix
-		}
-
-		if target.Config.Postfix == "" && p.Sources[target.Config.SourceID].Config.Postfix != "" {
-			target.Config.Postfix = p.Sources[target.Config.SourceID].Config.Postfix
-		}
-
-		err = target.Run(
-			p.Sources[target.Config.SourceID].Output,
-			&p.Options.Target)
+		err = target.Run(p.Sources[target.Config.SourceID].Output, &p.Options.Target)
 
 		rpt.Result = target.Result
 


### PR DESCRIPTION
This PR removes the deprecated code for "prefix" and "postfix" (which have been replaced by transformers more than 1 year ago).

Depends on #590 (as there is a common change on the signature of a call to `ScmHandler.Init()`)

Associated documentation PR: https://github.com/updatecli/website/pull/264

## Test

To test this pull request, you can run the following commands:

```shell
make test
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
