### PR TITLE
cleanup(yaml) remove deprecated code for attribute path

### DIFF
--- a/examples/updatecli.d/docker-compose.yaml
+++ b/examples/updatecli.d/docker-compose.yaml
@@ -10,7 +10,6 @@ targets:
     kind: "yaml"
     prefix: "olblak/polls@256:"
     spec:
-      #path: "/tt"
       #file: "/home/olblak/Project/Jenkins-infra/polls/docker-compose.yaml"
       file: "../../Jenkins-infra/polls/docker-compose.yamli"
       #file: "docker-compose.yamli"

--- a/pkg/plugins/resources/yaml/main.go
+++ b/pkg/plugins/resources/yaml/main.go
@@ -20,10 +20,8 @@ var (
 // Spec defines a specification for a "yaml" resource
 // parsed from an updatecli manifest file
 type Spec struct {
-	File string
-	Key  string
-	// Deprecated: use File instead
-	Path    string
+	File    string
+	Key     string
 	Value   string
 	KeyOnly bool // [condition] allow checking for only the existence of a key (not its value)
 }
@@ -66,9 +64,6 @@ func (y *Yaml) Validate() error {
 	var validationErrors []string
 
 	// Check for all validation
-	if len(y.spec.Path) > 0 {
-		validationErrors = append(validationErrors, "Invalid spec for yaml resource: Key 'path' is deprecated, use 'file' instead.")
-	}
 	if y.spec.File == "" {
 		validationErrors = append(validationErrors, "Invalid spec for yaml resource: 'file' is empty.")
 	}

--- a/pkg/plugins/resources/yaml/main_test.go
+++ b/pkg/plugins/resources/yaml/main_test.go
@@ -408,16 +408,6 @@ func Test_Validate(t *testing.T) {
 			mockFileExist: true,
 			wantErr:       true,
 		},
-		{
-			name: "raises an error when 'Path' is defined (deprecated)",
-			spec: Spec{
-				Path: "/tmp/bar.yaml",
-				File: "/tmp/toto.yaml",
-				Key:  "foo.bar",
-			},
-			mockFileExist: true,
-			wantErr:       true,
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
This PR removes the deprecated code for the attribute `path` in the specification for YAML plugins.

Use the attribute `file:` instead.

Associated documentation PR: https://github.com/updatecli/website/pull/264

## Test

To test this pull request, you can run the following commands:

```shell
make test
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
