### PR TITLE
Avoid directory when fetching updatecli comments

### DIFF
--- a/pkg/core/jsonschema/main.go
+++ b/pkg/core/jsonschema/main.go
@@ -27,7 +27,7 @@ var (
 	updatecliPackageName string = "github.com/updatecli/updatecli/"
 
 	// commentDir defines the temporary directory where
-	commentDir string = path.Join(os.TempDir(), "updatecli/")
+	commentDir string = path.Join(os.TempDir(), "updatecli", "_comments")
 	// commentURL defines the updatecli git url
 	commentURL string = "https://github.com/updatecli/updatecli.git"
 )


### PR DESCRIPTION
Signed-off-by: Olblak <me@olblak.com>

# Avoid directory when fetching updatecli comments

For the command `updatecli jsonschema` to populate the field "description", we cloned the updatecli directory in a temporary location and then we delete the directory once we are done. For some stupid reason I was using "/tmp/updatecli" which is also used by default by the scm resource to manipulate git repository. So I ended up in a situation where I deleted `/tmp/updatecli` 
 before any git operation to happen.

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, I used this configuration https://github.com/updatecli/website/blob/master/updatecli/updatecli.d/jsonschema.yaml

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

In the future, we have a risk of collusion if at some point we have a git repository "github.com/updatecli/_comments"