### PR TITLE
fix: use the URL instead of the token to initialize GitHub Enterprise client

### DIFF
--- a/pkg/plugins/scms/github/main.go
+++ b/pkg/plugins/scms/github/main.go
@@ -75,7 +75,7 @@ func New(s Spec) (*Github, error) {
 
 	return &Github{
 		Spec:   s,
-		client: githubv4.NewEnterpriseClient(os.Getenv(s.Token), httpClient),
+		client: githubv4.NewEnterpriseClient(os.Getenv(s.URL), httpClient),
 	}, nil
 }
 


### PR DESCRIPTION
# fix: use the URL instead of the token to initialize GitHub Enterprise client

Fix #XXX

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
cp <to_package_directory>
go test
```

## Additional Information

Saw this while working on #644, quick fix as it is.

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
