### PR TITLE
fix: redact token or password in scm config error logs

### DIFF
--- a/pkg/core/pipeline/condition/main.go
+++ b/pkg/core/pipeline/condition/main.go
@@ -84,9 +84,10 @@ func (c *Condition) Run(source string) (err error) {
 			return err
 		}
 	} else {
-		var i interface{} = c.Config.Scm
-		scm := i.(scm.ScmHandler)
-		return fmt.Errorf("something went wrong while looking at the scm configuration: %s", scm.ToString())
+		for key := range c.Config.Scm {
+			scm := c.Config.Scm[key].(scm.ScmHandler)
+			return fmt.Errorf("something went wrong while looking at the scm configuration: %s", scm.ToString())
+		}
 	}
 
 	if ok {

--- a/pkg/core/pipeline/condition/main.go
+++ b/pkg/core/pipeline/condition/main.go
@@ -2,7 +2,6 @@ package condition
 
 import (
 	"fmt"
-	"reflect"
 
 	jschema "github.com/invopop/jsonschema"
 	"github.com/sirupsen/logrus"
@@ -85,25 +84,7 @@ func (c *Condition) Run(source string) (err error) {
 			return err
 		}
 	} else {
-		var scmKind string
-		for key := range c.Config.Scm {
-			scmKind = key
-		}
-		switch scmKind {
-		case "github":
-			interf := reflect.ValueOf(c.Config.Scm["github"]).Interface()
-			redacted := interf.(map[string]interface{})
-			redacted["token"] = "********"
-			return fmt.Errorf("something went wrong while looking at the scm configuration: %+v", redacted)
-		case "git":
-			interf := reflect.ValueOf(c.Config.Scm["git"]).Interface()
-			redacted := interf.(map[string]interface{})
-			redacted["password"] = "********"
-			return fmt.Errorf("something went wrong while looking at the scm configuration: %+v", redacted)
-		default:
-			logrus.Errorf("scm of kind %q is not supported", scmKind)
-			return fmt.Errorf("something went wrong while looking at the scm configuration: %+v", c.Config.Scm)
-		}
+		return fmt.Errorf("something went wrong while looking at the scm configuration: %s", c.Config.Scm.ToString())
 	}
 
 	if ok {

--- a/pkg/core/pipeline/condition/main.go
+++ b/pkg/core/pipeline/condition/main.go
@@ -2,6 +2,7 @@ package condition
 
 import (
 	"fmt"
+	"reflect"
 
 	jschema "github.com/invopop/jsonschema"
 	"github.com/sirupsen/logrus"
@@ -84,7 +85,25 @@ func (c *Condition) Run(source string) (err error) {
 			return err
 		}
 	} else {
-		return fmt.Errorf("something went wrong while looking at the scm configuration: %v", c.Config.Scm)
+		var scmKind string
+		for key := range c.Config.Scm {
+			scmKind = key
+		}
+		switch scmKind {
+		case "github":
+			interf := reflect.ValueOf(c.Config.Scm["github"]).Interface()
+			redacted := interf.(map[string]interface{})
+			redacted["token"] = "********"
+			return fmt.Errorf("something went wrong while looking at the scm configuration: %+v", redacted)
+		case "git":
+			interf := reflect.ValueOf(c.Config.Scm["git"]).Interface()
+			redacted := interf.(map[string]interface{})
+			redacted["password"] = "********"
+			return fmt.Errorf("something went wrong while looking at the scm configuration: %+v", redacted)
+		default:
+			logrus.Errorf("scm of kind %q is not supported", scmKind)
+			return fmt.Errorf("something went wrong while looking at the scm configuration: %+v", c.Config.Scm)
+		}
 	}
 
 	if ok {

--- a/pkg/core/pipeline/condition/main.go
+++ b/pkg/core/pipeline/condition/main.go
@@ -84,7 +84,9 @@ func (c *Condition) Run(source string) (err error) {
 			return err
 		}
 	} else {
-		return fmt.Errorf("something went wrong while looking at the scm configuration: %s", c.Config.Scm.ToString())
+		var i interface{} = c.Config.Scm
+		scm := i.(scm.ScmHandler)
+		return fmt.Errorf("something went wrong while looking at the scm configuration: %s", scm.ToString())
 	}
 
 	if ok {

--- a/pkg/core/pipeline/scm/main.go
+++ b/pkg/core/pipeline/scm/main.go
@@ -38,6 +38,7 @@ type ScmHandler interface {
 	Clean() error
 	PushTag(tag string) error
 	GetChangedFiles(workingDir string) ([]string, error)
+	ToString() string
 }
 
 func (c *Config) Validate() error {

--- a/pkg/plugins/scms/git/scm.go
+++ b/pkg/plugins/scms/git/scm.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/sirupsen/logrus"
@@ -143,4 +144,23 @@ func (g *Git) PushTag(tag string) error {
 
 func (g *Git) GetChangedFiles(workingDir string) ([]string, error) {
 	return git.GetChangedFiles(workingDir)
+}
+
+func (g *Git) ToString() string {
+	redacted := Git{
+		URL:           g.URL,
+		Username:      g.Username,
+		Password:      "******",
+		Branch:        g.Branch,
+		remoteBranch:  g.remoteBranch,
+		User:          g.User,
+		Email:         g.Email,
+		Directory:     g.Directory,
+		Version:       g.Version,
+		Force:         g.Force,
+		CommitMessage: g.CommitMessage,
+		GPG:           g.GPG,
+	}
+
+	return fmt.Sprintf("%+v", redacted)
 }

--- a/pkg/plugins/scms/github/scm.go
+++ b/pkg/plugins/scms/github/scm.go
@@ -115,3 +115,21 @@ func (g *Github) PushTag(tag string) error {
 func (g *Github) GetChangedFiles(workingDir string) ([]string, error) {
 	return git.GetChangedFiles(workingDir)
 }
+
+func (g *Github) ToString() string {
+	redacted := Spec{
+		Branch:      g.Spec.Branch,
+		Directory:   g.Spec.Directory,
+		Email:       g.Spec.Email,
+		Owner:       g.Spec.Owner,
+		Repository:  g.Spec.Repository,
+		Token:       "******",
+		URL:         g.Spec.URL,
+		Username:    g.Spec.Username,
+		User:        g.Spec.User,
+		PullRequest: g.Spec.PullRequest,
+		GPG:         g.Spec.GPG,
+	}
+
+	return fmt.Sprintf("%+v", redacted)
+}


### PR DESCRIPTION
# fix: redact token or password in scm config error logs

Fixes #644

Replace github token or git password by `********` in updatecli values before dumping them in error logs.

## Test

To test this pull request, remove the block `sources` from https://github.com/updatecli/updatecli/blob/main/examples/updatecli.d/updatecli.yaml then run the following commands:

```shell
./dist/updatecli diff --values examples/values.yaml --config examples/updatecli.d/updatecli.yaml
```

<details>
<summary>Error logs before:</summary>

```shell
CONDITIONS:
===========

dockerFile
----------
ERROR: something went wrong while looking at the scm configuration: map[github:map[branch:main email:updatecli@olblak.com owner:olblak repository:updatecli token:ghp_ABCDEFEGHIJKLMNOPQRSTUVWXYZabcdeffghijklmnopqrstuvwxyz user:updatecli username:olblak]]

✗ condition not met, skipping pipeline
```

</details>

<details>
<summary>Error logs after:</summary>

```shell
CONDITIONS:
===========

dockerFile
----------
ERROR: something went wrong while looking at the scm configuration: map[branch:main email:updatecli@olblak.com owner:olblak repository:updatecli token:******** user:updatecli username:olblak]

✗ condition not met, skipping pipeline
```

</details>

## Additional Information

### Tradeoff

I assume there is only one scm in values.yaml

### Potential improvement

Add tests