### PR TITLE
Bump golanci-lint version used in Github Action

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -46,7 +46,7 @@ jobs:
           # Required: the version of golangci-lint is required
           # and must be specified without patch version:
           # we always use the latest patch version.
-          version: v1.29
+          version: v1.45
       - name: Build
         run: make build
       - name: Quick Test

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ DOCKER_BUILDKIT=1
 export DOCKER_BUILDKIT
 
 # Used by the test-e2e system
-VENOM_VAR_binpath ?= $(CURDIR)/dist/updatecli_$(shell go env GOOS)_$(shell go env GOARCH)
+VENOM_VAR_binpath ?= $(CURDIR)/dist/updatecli_$(shell go env GOOS)_$(shell go env GOARCH)_v1
 export VENOM_VAR_binpath
 
 local_bin=./dist/updatecli_$(shell go env GOHOSTOS)_$(shell go env GOHOSTARCH)/updatecli
@@ -57,6 +57,7 @@ test-short: ## Execute the Golang's tests for updatecli
 test-e2e: ## Execute updatecli end to end tests
 	echo $$VENOM_VAR_binpath
 	time venom run e2e/venom.d/* --output-dir ./e2e --format yaml
+
 
 .PHONY: lint
 lint: ## Execute the Golang's linters on updatecli's source code

--- a/updatecli/updatecli.d/golangci-lint.yaml
+++ b/updatecli/updatecli.d/golangci-lint.yaml
@@ -61,3 +61,4 @@ pullrequests:
         - chore
         - dependencies
         - skip-changelog
+

--- a/updatecli/updatecli.d/golangci-lint.yaml
+++ b/updatecli/updatecli.d/golangci-lint.yaml
@@ -1,0 +1,63 @@
+title: "Bump golangci-lint version"
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: updatecli
+      email: me@olblak.com
+      owner: updatecli
+      repository: updatecli
+      token: '{{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}'
+      username: '{{ requiredEnv "UPDATECLI_GITHUB_ACTOR" }}'
+      branch: main
+
+sources:
+  default:
+    name: Get latest updatecli release
+    kind: githubrelease
+    spec:
+      owner: golangci
+      repository: golangci-lint
+      token: '{{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}'
+      username: '{{ requiredEnv "UPDATECLI_GITHUB_ACTOR" }}'
+    
+
+conditions:
+  default:
+    name: 'Update updatecli version to {{ source "default" }}'
+    kind: yaml
+    disablesourceinput: true
+    spec:
+      file: .github/workflows/go.yaml
+      key: jobs.build.steps[6].name
+      value: "golangci-lint"
+    scmid: default
+
+targets:
+  default:
+    name: 'Update updatecli version to {{ source "default" }}'
+    kind: yaml
+    spec:
+      file: .github/workflows/go.yaml
+      key: jobs.build.steps[6].with.version
+    scmid: default
+    # Required: the version of golangci-lint is required
+    # and must be specified without patch version:
+    # we always use the latest patch version.
+    transformers:
+      - findSubMatch:
+          pattern: 'v(\d*)\.(\d*)'
+
+pullrequests:
+  default:
+    title: '[updatecli] Bump golangci-lint version to {{ source "default" }}'
+    kind: github
+    scmid: default
+    targets:
+      - default
+    spec:
+      labels:
+        - chore
+        - dependencies
+        - skip-changelog


### PR DESCRIPTION
Fix #651 

* Bump golangci-lint version
* Add updatecli manifest to automate version update

## Test

To test this pull request, you can run the following commands:

```shell
updatecli diff --config updatecli/updatecli.d/golangci-lint.yaml
```

## Additional Information

### Tradeoff
/

### Potential improvement

/
