### PR TITLE
Adds support for new OCI registries

### DIFF
--- a/pkg/plugins/utils/docker/dockerregistry/main.go
+++ b/pkg/plugins/utils/docker/dockerregistry/main.go
@@ -133,7 +133,7 @@ func (dgr DockerGenericRegistry) Digest(image dockerimage.Image) (string, error)
 	// manifests (a container image is supplied for multiple architectures).
 	// This format is backward compatible with the Docker Registry V2.
 
-	case "application/vnd.oci.image.index.v1+json",
+	case "application/vnd.oci.image.index.v1+json":
 		fallthrough
 	// Standard Registry v2 API (nominal case) such as DockerHub or GHCR
 

--- a/pkg/plugins/utils/docker/dockerregistry/main.go
+++ b/pkg/plugins/utils/docker/dockerregistry/main.go
@@ -68,7 +68,7 @@ func (dgr DockerGenericRegistry) Digest(image dockerimage.Image) (string, error)
 	}
 
 	req.Header.Add("Accept", "application/vnd.docker.distribution.manifest.list.v2+json")
-	req.Header.Add("Accept", "application/vnd.docker.distribution.manifest.v2+json")
+	req.Header.Add("Accept", "application/vnd.oci.image.index.v1+json")
 
 	// Retrieve a bearer token to authenticate further requests
 	token, err := dgr.login(image)
@@ -114,12 +114,9 @@ func (dgr DockerGenericRegistry) Digest(image dockerimage.Image) (string, error)
 	}
 
 	switch res.Header.Get("content-type") {
-	// Case of images not having a multi-architecture manifest, or wrapping a v1 API answer (backward compatible registries).
-	// For instance: quay.io
-	case "application/vnd.docker.distribution.manifest.v2+json":
-		// Note that there are no check against the image's architecture
-		return strings.TrimPrefix(res.Header.Get("Docker-Content-Digest"), "sha256:"), nil
-
+	// Newer registries that are OCI compliant
+	case "application/vnd.oci.image.index.v1+json":
+		fallthrough
 	// Standard Registry v2 API (nominal case) such as DockerHub or GHCR
 	case "application/vnd.docker.distribution.manifest.list.v2+json":
 		type response struct {

--- a/pkg/plugins/utils/docker/dockerregistry/main_test.go
+++ b/pkg/plugins/utils/docker/dockerregistry/main_test.go
@@ -87,7 +87,7 @@ func TestRegistry_Digest(t *testing.T) {
 			want:     "c74f1b1166784193ea6c8f9440263b9be6cae07dfe35e32a5df7a31358ac2060",
 		},
 		{
-			name: "Normal case on quay.io (new OCI format)",
+			name: "Normal case on quay.io (new OCI format: manifest list)",
 			image: dockerimage.Image{
 				Registry:     "quay.io",
 				Namespace:    "ansible",
@@ -99,6 +99,21 @@ func TestRegistry_Digest(t *testing.T) {
 				"Content-Type": {"application/vnd.oci.image.index.v1+json"},
 			},
 			want: "c74f1b1166784193ea6c8f9440263b9be6cae07dfe35e32a5df7a31358ac2060",
+		},
+		{
+			name: "Normal case on quay.io (new OCI format: standalone manifest)",
+			image: dockerimage.Image{
+				Registry:     "quay.io",
+				Namespace:    "ansible",
+				Repository:   "ansible-runner",
+				Tag:          "latest",
+				Architecture: "arm64",
+			},
+			mockAPIResHeaders: http.Header{
+				"Content-Type":          {"application/vnd.oci.image.manifest.v1+json"},
+				"Docker-Content-Digest": {"sha256:abb5ef7d2825f8ca4927f406cce339ca3b66d29f6267c26234255546680642c3"},
+			},
+			want: "abb5ef7d2825f8ca4927f406cce339ca3b66d29f6267c26234255546680642c3",
 		},
 		{
 			name: "Image does not exist",

--- a/pkg/plugins/utils/docker/dockerregistry/main_test.go
+++ b/pkg/plugins/utils/docker/dockerregistry/main_test.go
@@ -87,7 +87,7 @@ func TestRegistry_Digest(t *testing.T) {
 			want:     "c74f1b1166784193ea6c8f9440263b9be6cae07dfe35e32a5df7a31358ac2060",
 		},
 		{
-			name: "Normal case with no architecture support (quay.io)",
+			name: "Normal case on quay.io (new OCI format)",
 			image: dockerimage.Image{
 				Registry:     "quay.io",
 				Namespace:    "ansible",
@@ -96,10 +96,9 @@ func TestRegistry_Digest(t *testing.T) {
 				Architecture: "arm64",
 			},
 			mockAPIResHeaders: http.Header{
-				"Content-Type":          {"application/vnd.docker.distribution.manifest.v2+json"},
-				"Docker-Content-Digest": {"sha256:abb5ef7d2825f8ca4927f406cce339ca3b66d29f6267c26234255546680642c3"},
+				"Content-Type": {"application/vnd.oci.image.index.v1+json"},
 			},
-			want: "abb5ef7d2825f8ca4927f406cce339ca3b66d29f6267c26234255546680642c3",
+			want: "c74f1b1166784193ea6c8f9440263b9be6cae07dfe35e32a5df7a31358ac2060",
 		},
 		{
 			name: "Image does not exist",


### PR DESCRIPTION
# Adds support for new OCI registries

Fix #605 

- add the "application/vnd.oci.image.index.v1+json" content type in the Accept headers of the requests made to the registries
- process the "application/vnd.oci.image.index.v1+json" responses just like "application/vnd.docker.distribution.manifest.list.v2+json" ones
- remove support for "application/vnd.docker.distribution.manifest.v2+json"
- update the quay.io unit test case to be an OCI unit test case

## Test

To test this pull request, you can run the following commands:

```shell
go test -v ./pkg/plugins/utils/docker/dockerregistry
```

I also made sure to test a real pipeline such as: 

```yaml
title: Miniflux
sources:
  miniflux:
    name: Miniflux Release
    kind: githubRelease
    spec:
      owner: miniflux
      repository: v2
      token: REDACTED
      versionFilter:
        kind: semver
        pattern: ~2
conditions:
  miniflux_docker:
    name: Container image of Miniflux is available on Docker
    kind: dockerImage
    sourceID: miniflux
    spec:
      hostname: ghcr.io
      image: docker.io/miniflux/miniflux
      architecture: amd64
targets:
  miniflux:
    name: Update YAML
    kind: yaml
    sourceID: miniflux
    spec:
      file: tests/out.yaml
      key: miniflux.docker
```

I tested such a pipeline with the following images:
- docker.io/miniflux/miniflux
- ghcr.io/miniflux/miniflux
- quay.io/itix/tic-tsdb
- quay.io/itix/photo-bot
