### PR TITLE
Add disablesourceinput to target

### DIFF
--- a/pkg/core/config/main.go
+++ b/pkg/core/config/main.go
@@ -268,14 +268,18 @@ func (config *Config) Validate() error {
 				return ErrBadConfig
 			}
 		}
-		// Try to guess SourceID
-		if len(t.SourceID) == 0 && len(config.Sources) > 1 {
 
-			logrus.Errorf("empty 'sourceID' for target %q", id)
-			return ErrBadConfig
-		} else if len(t.SourceID) == 0 && len(config.Sources) == 1 {
-			for id := range config.Sources {
-				t.SourceID = id
+		// Only check/guess the sourceID if the user did not disable it (default is enabled)
+		if !t.DisableSourceInput {
+			// Try to guess SourceID
+			if len(t.SourceID) == 0 && len(config.Sources) > 1 {
+
+				logrus.Errorf("empty 'sourceID' for target %q", id)
+				return ErrBadConfig
+			} else if len(t.SourceID) == 0 && len(config.Sources) == 1 {
+				for id := range config.Sources {
+					t.SourceID = id
+				}
 			}
 		}
 

--- a/pkg/core/pipeline/condition/main.go
+++ b/pkg/core/pipeline/condition/main.go
@@ -1,6 +1,7 @@
 package condition
 
 import (
+	"errors"
 	"fmt"
 
 	jschema "github.com/invopop/jsonschema"
@@ -9,6 +10,11 @@ import (
 	"github.com/updatecli/updatecli/pkg/core/pipeline/resource"
 	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
 	"github.com/updatecli/updatecli/pkg/core/result"
+)
+
+var (
+	// ErrWrongConfig is returned when a condition spec has missing attributes which are mandatory
+	ErrWrongConfig = errors.New("wrong condition configuration")
 )
 
 // Condition defines which condition needs to be met
@@ -107,6 +113,8 @@ func (c Config) JSONSchema() *jschema.Schema {
 }
 
 func (c *Config) Validate() error {
+	gotError := false
+
 	// Handle scmID deprecation
 	if len(c.DeprecatedSCMID) > 0 {
 		switch len(c.SCMID) {
@@ -131,6 +139,15 @@ func (c *Config) Validate() error {
 			logrus.Warningf("%q and %q are mutually exclusif, ignoring %q",
 				"sourceID", "sourceid", "sourceID")
 		}
+	}
+
+	if len(c.SourceID) > 0 && c.DisableSourceInput {
+		logrus.Errorln("disablesourceinput is incompatible with sourceid, ignoring the latter")
+		gotError = true
+	}
+
+	if gotError {
+		return ErrWrongConfig
 	}
 
 	return nil

--- a/pkg/core/pipeline/target/main.go
+++ b/pkg/core/pipeline/target/main.go
@@ -1,6 +1,7 @@
 package target
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -10,6 +11,11 @@ import (
 	"github.com/updatecli/updatecli/pkg/core/pipeline/resource"
 	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
 	"github.com/updatecli/updatecli/pkg/core/result"
+)
+
+var (
+	// ErrWrongConfig is returned when a target spec has missing attributes which are mandatory
+	ErrWrongConfig = errors.New("wrong target configuration")
 )
 
 // Target defines which file needs to be updated based on source output
@@ -36,6 +42,8 @@ type Config struct {
 	// ! Deprecated - please use all lowercase `sourceid`
 	// sourceid specifies where retrieving the default value
 	DeprecatedSourceID string `yaml:"sourceID"`
+	// disablesourceinput disables the mechanism to retrieve a default value from a source.
+	DisableSourceInput bool
 	// sourceid specifies where retrieving the default value
 	SourceID string
 	// disablesourceinput
@@ -177,6 +185,9 @@ func (Config) JSONSchema() *jschema.Schema {
 
 func (c *Config) Validate() error {
 	// Handle scmID deprecation
+
+	gotError := false
+
 	if len(c.DeprecatedSCMID) > 0 {
 		switch len(c.SCMID) {
 		case 0:
@@ -200,6 +211,15 @@ func (c *Config) Validate() error {
 			logrus.Warningf("%q and %q are mutually exclusif, ignoring %q",
 				"sourceID", "sourceid", "sourceID")
 		}
+	}
+
+	if len(c.SourceID) > 0 && c.DisableSourceInput {
+		logrus.Errorln("disablesourceinput is incompatible with sourceid, ignoring the latter")
+		gotError = true
+	}
+
+	if gotError {
+		return ErrWrongConfig
 	}
 
 	return nil


### PR DESCRIPTION
# Add disablesourceinput to target

Fix #675 

Today I noticed that we don't have the ability to `disablesourceinput` for target.
Similarly to condition, they are cases where a target rely on templating instead of source input  

<!-- Describe the changes introduced by this pull request -->

## Test

I tested this pullrequest with manifest containing two sources and one target

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
