### PR TITLE
Fix: scm concurrency issue when running git clone

### DIFF
--- a/pkg/core/engine/main.go
+++ b/pkg/core/engine/main.go
@@ -86,7 +86,9 @@ func Clone(
 	hashes *[]uint64,
 	wg *sync.WaitGroup) error {
 
-	hash, err := hashstructure.Hash(s, nil)
+	scmhandler := *s
+
+	hash, err := hashstructure.Hash(scmhandler.GetDirectory(), nil)
 	if err != nil {
 		return err
 	}
@@ -108,7 +110,7 @@ func Clone(
 			if err != nil {
 				logrus.Errorf("err - %s", err)
 			}
-		}(*s)
+		}(scmhandler)
 		<-channel
 
 	}


### PR DESCRIPTION
# Fix: scm concurrency issue when running git clone

Fix #669

Use git directory hash instead of scm spec hash.

## Test

Test with whatever manifest using 1 or multiple scm repository

## Additional Information

### Tradeoff

/
### Potential improvement
/
