### PR TITLE
Fix scm resource initialization

### DIFF
--- a/pkg/core/pipeline/condition/main.go
+++ b/pkg/core/pipeline/condition/main.go
@@ -65,12 +65,6 @@ func (c *Condition) Run(source string) (err error) {
 			return err
 		}
 
-		err = s.Init(c.Config.Name)
-		if err != nil {
-			c.Result = result.FAILURE
-			return err
-		}
-
 		err = s.Checkout()
 		if err != nil {
 			c.Result = result.FAILURE

--- a/pkg/core/pipeline/main.go
+++ b/pkg/core/pipeline/main.go
@@ -72,7 +72,7 @@ func (p *Pipeline) Init(config *config.Config, options Options) error {
 		// avoid gosec G601: Reassign the loop iteration variable to a local variable so the pointer address is correct
 		scmConfig := scmConfig
 
-		p.SCMs[id], err = scm.New(&scmConfig)
+		p.SCMs[id], err = scm.New(&scmConfig, &config.PipelineID)
 		if err != nil {
 			return err
 		}

--- a/pkg/core/pipeline/scm/main.go
+++ b/pkg/core/pipeline/scm/main.go
@@ -94,7 +94,7 @@ func (s *Scm) GenerateSCM() error {
 		s.Handler = g
 
 	case "git":
-		gitSpec := git.Git{}
+		gitSpec := git.Spec{}
 
 		err := mapstructure.Decode(s.Config.Spec, &gitSpec)
 		if err != nil {
@@ -121,7 +121,7 @@ func (Config) JSONSchema() *jschema.Schema {
 	type configAlias Config
 
 	anyOfSpec := map[string]interface{}{
-		"git":    &git.Git{},
+		"git":    &git.Spec{},
 		"github": &github.Spec{},
 	}
 

--- a/pkg/core/pipeline/scm/main.go
+++ b/pkg/core/pipeline/scm/main.go
@@ -17,8 +17,9 @@ type Config struct {
 }
 
 type Scm struct {
-	Config  *Config
-	Handler ScmHandler
+	Config      *Config
+	Handler     ScmHandler
+	PipeplineID *string
 }
 
 var (
@@ -32,7 +33,6 @@ type ScmHandler interface {
 	Clone() (string, error)
 	Checkout() error
 	GetDirectory() (directory string)
-	Init(pipelineID string) error
 	Push() error
 	Commit(message string) error
 	Clean() error
@@ -58,10 +58,11 @@ func (c *Config) Validate() error {
 	return nil
 }
 
-func New(config *Config) (Scm, error) {
+func New(config *Config, pipelineID *string) (Scm, error) {
 
 	s := Scm{
-		Config: config,
+		Config:      config,
+		PipeplineID: pipelineID,
 	}
 
 	err := s.GenerateSCM()
@@ -84,7 +85,7 @@ func (s *Scm) GenerateSCM() error {
 			return err
 		}
 
-		g, err := github.New(githubSpec)
+		g, err := github.New(githubSpec, *s.PipeplineID)
 
 		if err != nil {
 			return err
@@ -93,14 +94,20 @@ func (s *Scm) GenerateSCM() error {
 		s.Handler = g
 
 	case "git":
-		g := git.Git{}
+		gitSpec := git.Git{}
 
-		err := mapstructure.Decode(s.Config.Spec, &g)
+		err := mapstructure.Decode(s.Config.Spec, &gitSpec)
 		if err != nil {
 			return err
 		}
 
-		s.Handler = &g
+		g, err := git.New(gitSpec)
+
+		if err != nil {
+			return err
+		}
+
+		s.Handler = g
 	default:
 		logrus.Errorf("scm of kind %q is not supported", s.Config.Kind)
 	}

--- a/pkg/core/pipeline/source/main.go
+++ b/pkg/core/pipeline/source/main.go
@@ -49,13 +49,6 @@ func (s *Source) Run() (err error) {
 			return err
 		}
 
-		err = SCM.Init(workingDir)
-
-		if err != nil {
-			s.Result = result.FAILURE
-			return err
-		}
-
 		err = SCM.Checkout()
 
 		if err != nil {

--- a/pkg/core/pipeline/target/main.go
+++ b/pkg/core/pipeline/target/main.go
@@ -118,11 +118,6 @@ func (t *Target) Run(source string, o *Options) (err error) {
 
 	s := *t.Scm
 
-	if err = s.Init(t.Config.PipelineID); err != nil {
-		t.Result = result.FAILURE
-		return err
-	}
-
 	if err = s.Checkout(); err != nil {
 		t.Result = result.FAILURE
 		return err

--- a/pkg/plugins/resources/githubrelease/main.go
+++ b/pkg/plugins/resources/githubrelease/main.go
@@ -39,7 +39,7 @@ func New(spec interface{}) (*GitHubRelease, error) {
 		Token:      newSpec.Token,
 		URL:        newSpec.URL,
 		Username:   newSpec.Username,
-	})
+	}, "")
 	if err != nil {
 		return &GitHubRelease{}, err
 	}

--- a/pkg/plugins/scms/git/main.go
+++ b/pkg/plugins/scms/git/main.go
@@ -13,39 +13,56 @@ import (
 	git "github.com/updatecli/updatecli/pkg/plugins/utils/gitgeneric"
 )
 
-// Git contains settings to manipulate a git repository.
-type Git struct {
-	URL           string
-	Username      string
-	Password      string
-	Branch        string
-	remoteBranch  string
-	User          string
-	Email         string
-	Directory     string
-	Version       string
-	Force         bool          // Force is used during the git push phase to run `git push --force`.
-	CommitMessage commit.Commit // CommitMessage contains conventional commit metadata as type or scope, used to generate the final commit message.
-	GPG           sign.GPGSpec  // GPG key and passphrased used for commit signing
+// Spec contains settings to manipulate a git repository.
+type Spec struct {
+	// URL specifies the git url
+	URL string
+	// Username specifies the username for http authentication
+	Username string
+	// Password specifies the password for http authentication
+	Password string
+	// Branch specifies the git branch
+	Branch string
+	// User specifies the git commit author
+	User string
+	// Email specifies the git commit email
+	Email string
+	// Directory specifies the directory to use for cloning the repository
+	Directory string
+	// Force is used during the git push phase to run `git push --force`.
+	Force bool
+	// CommitMessage contains conventional commit metadata as type or scope, used to generate the final commit message.
+	CommitMessage commit.Commit
+	// GPG key and passphrased used for commit signing
+	GPG sign.GPGSpec
 }
 
-func New(g Git) (*Git, error) {
+type Git struct {
+	spec         Spec
+	remoteBranch string
+}
+
+// New returns a new git object
+func New(s Spec) (*Git, error) {
 	var err error
-	if len(g.Directory) == 0 {
-		g.Directory, err = newDirectory(g.URL)
+	if len(s.Directory) == 0 {
+		s.Directory, err = newDirectory(s.URL)
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	if len(g.Branch) == 0 {
-		g.Branch = "main"
+	if len(s.Branch) == 0 {
+		s.Branch = "main"
 	}
 
-	g.remoteBranch = git.SanitizeBranchName(g.Branch)
-	return &g, nil
+	return &Git{
+		spec:         s,
+		remoteBranch: git.SanitizeBranchName(s.Branch),
+	}, nil
 
 }
+
 func newDirectory(URL string) (string, error) {
 
 	directory := path.Join(

--- a/pkg/plugins/scms/git/main.go
+++ b/pkg/plugins/scms/git/main.go
@@ -16,7 +16,7 @@ import (
 // Spec contains settings to manipulate a git repository.
 type Spec struct {
 	// URL specifies the git url
-	URL string
+	URL string `jsonschema:"required"`
 	// Username specifies the username for http authentication
 	Username string
 	// Password specifies the password for http authentication

--- a/pkg/plugins/scms/git/main.go
+++ b/pkg/plugins/scms/git/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/updatecli/updatecli/pkg/core/tmp"
 	"github.com/updatecli/updatecli/pkg/plugins/scms/git/commit"
 	"github.com/updatecli/updatecli/pkg/plugins/scms/git/sign"
+	git "github.com/updatecli/updatecli/pkg/plugins/utils/gitgeneric"
 )
 
 // Git contains settings to manipulate a git repository.
@@ -28,6 +29,23 @@ type Git struct {
 	GPG           sign.GPGSpec  // GPG key and passphrased used for commit signing
 }
 
+func New(g Git) (*Git, error) {
+	var err error
+	if len(g.Directory) == 0 {
+		g.Directory, err = newDirectory(g.URL)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if len(g.Branch) == 0 {
+		g.Branch = "main"
+	}
+
+	g.remoteBranch = git.SanitizeBranchName(g.Branch)
+	return &g, nil
+
+}
 func newDirectory(URL string) (string, error) {
 
 	directory := path.Join(

--- a/pkg/plugins/scms/git/main_test.go
+++ b/pkg/plugins/scms/git/main_test.go
@@ -8,46 +8,46 @@ import (
 type DataSet []Data
 
 type Data struct {
-	g                     Git
+	s                     Spec
 	expectedDirectoryName string
 }
 
 var (
 	Dataset DataSet = DataSet{
 		{
-			g: Git{
+			s: Spec{
 				URL:      "https://github.com/updatecli/updatecli.git",
 				Username: "git",
 				Password: "password",
 			}, expectedDirectoryName: "github_com_updatecli_updatecli_git",
 		},
 		{
-			g: Git{
+			s: Spec{
 				URL:      "https://github.com/updatecli/updatecli.git",
 				Username: "git",
 				Password: "password",
 			}, expectedDirectoryName: "github_com_updatecli_updatecli_git",
 		},
 		{
-			g: Git{
+			s: Spec{
 				URL:      "https://github.com/updatecli/updatecli.git",
 				Password: "password",
 			}, expectedDirectoryName: "github_com_updatecli_updatecli_git",
 		},
 		{
-			g: Git{
+			s: Spec{
 				URL:      "https://github.com/updatecli/updatecli.git",
 				Username: "git",
 			}, expectedDirectoryName: "github_com_updatecli_updatecli_git",
 		},
 		{
-			g: Git{
+			s: Spec{
 				URL:      "https://@github.com/updatecli/updatecli.git",
 				Username: "git",
 			}, expectedDirectoryName: "github_com_updatecli_updatecli_git",
 		},
 		{
-			g: Git{
+			s: Spec{
 				URL:      "ssh://server:project.git",
 				Username: "bob",
 			}, expectedDirectoryName: "server_project_git",
@@ -57,7 +57,7 @@ var (
 
 func TestSanitizeDirectoryName(t *testing.T) {
 	for _, data := range Dataset {
-		got := sanitizeDirectoryName(data.g.URL)
+		got := sanitizeDirectoryName(data.s.URL)
 
 		if strings.Compare(got, data.expectedDirectoryName) != 0 {
 			t.Errorf("got sanitize directory name %q, expected %q", got, data.expectedDirectoryName)

--- a/pkg/plugins/scms/git/scm.go
+++ b/pkg/plugins/scms/git/scm.go
@@ -19,7 +19,12 @@ func (g *Git) Add(files []string) error {
 
 // Checkout create and then uses a temporary git branch.
 func (g *Git) Checkout() error {
-	err := git.Checkout(g.Username, g.Password, g.Branch, g.remoteBranch, g.GetDirectory())
+	err := git.Checkout(
+		g.spec.Username,
+		g.spec.Password,
+		g.spec.Branch,
+		g.remoteBranch,
+		g.GetDirectory())
 	if err != nil {
 		return err
 	}
@@ -28,12 +33,12 @@ func (g *Git) Checkout() error {
 
 // GetDirectory returns the working git directory.
 func (g *Git) GetDirectory() (directory string) {
-	return g.Directory
+	return g.spec.Directory
 }
 
 // Clean removes the current git repository from local storage.
 func (g *Git) Clean() error {
-	err := os.RemoveAll(g.Directory) // clean up
+	err := os.RemoveAll(g.spec.Directory) // clean up
 	if err != nil {
 		return err
 	}
@@ -44,9 +49,9 @@ func (g *Git) Clean() error {
 func (g *Git) Clone() (string, error) {
 
 	err := git.Clone(
-		g.Username,
-		g.Password,
-		g.URL,
+		g.spec.Username,
+		g.spec.Password,
+		g.spec.URL,
 		g.GetDirectory())
 
 	if err != nil {
@@ -62,25 +67,25 @@ func (g *Git) Clone() (string, error) {
 		}
 	}
 
-	return g.Directory, nil
+	return g.spec.Directory, nil
 }
 
 // Commit run `git commit`.
 func (g *Git) Commit(message string) error {
 
 	// Generate the conventional commit message
-	commitMessage, err := g.CommitMessage.Generate(message)
+	commitMessage, err := g.spec.CommitMessage.Generate(message)
 	if err != nil {
 		return err
 	}
 
 	err = git.Commit(
-		g.User,
-		g.Email,
+		g.spec.User,
+		g.spec.Email,
 		commitMessage,
 		g.GetDirectory(),
-		g.GPG.SigningKey,
-		g.GPG.Passphrase,
+		g.spec.GPG.SigningKey,
+		g.spec.GPG.Passphrase,
 	)
 	if err != nil {
 		return err
@@ -92,10 +97,10 @@ func (g *Git) Commit(message string) error {
 // Push run `git push`.
 func (g *Git) Push() error {
 	err := git.Push(
-		g.Username,
-		g.Password,
+		g.spec.Username,
+		g.spec.Password,
 		g.GetDirectory(),
-		g.Force)
+		g.spec.Force)
 
 	if err != nil {
 		return err
@@ -108,7 +113,12 @@ func (g *Git) Push() error {
 // PushTag push tags
 func (g *Git) PushTag(tag string) error {
 
-	err := git.PushTag(tag, g.Username, g.Password, g.GetDirectory(), g.Force)
+	err := git.PushTag(
+		tag,
+		g.spec.Username,
+		g.spec.Password,
+		g.GetDirectory(),
+		g.spec.Force)
 	if err != nil {
 		return err
 	}

--- a/pkg/plugins/scms/git/scm.go
+++ b/pkg/plugins/scms/git/scm.go
@@ -43,14 +43,7 @@ func (g *Git) Clean() error {
 // Clone run `git clone`.
 func (g *Git) Clone() (string, error) {
 
-	err := g.Init("")
-
-	if err != nil {
-		logrus.Errorf("err - %s", err)
-		return "", err
-	}
-
-	err = git.Clone(
+	err := git.Clone(
 		g.Username,
 		g.Password,
 		g.URL,
@@ -91,24 +84,6 @@ func (g *Git) Commit(message string) error {
 	)
 	if err != nil {
 		return err
-	}
-
-	return nil
-}
-
-// Init set Git parameters if needed.
-func (g *Git) Init(pipelineID string) (err error) {
-	if len(g.Directory) == 0 {
-		g.Directory, err = newDirectory(g.URL)
-		if err != nil {
-			return err
-		}
-	}
-
-	g.remoteBranch = git.SanitizeBranchName(g.Branch)
-
-	if len(g.Branch) == 0 {
-		g.Branch = "main"
 	}
 
 	return nil

--- a/pkg/plugins/scms/github/main.go
+++ b/pkg/plugins/scms/github/main.go
@@ -14,6 +14,8 @@ import (
 	"github.com/updatecli/updatecli/pkg/core/tmp"
 	"github.com/updatecli/updatecli/pkg/plugins/scms/git/commit"
 	"github.com/updatecli/updatecli/pkg/plugins/scms/git/sign"
+
+	git "github.com/updatecli/updatecli/pkg/plugins/utils/gitgeneric"
 )
 
 // Spec represents the configuration input
@@ -41,7 +43,7 @@ type Github struct {
 }
 
 // New returns a new valid Github object.
-func New(s Spec) (*Github, error) {
+func New(s Spec, pipelineID string) (*Github, error) {
 	errs := s.Validate()
 
 	if len(errs) > 0 {
@@ -73,10 +75,15 @@ func New(s Spec) (*Github, error) {
 		}, nil
 	}
 
-	return &Github{
-		Spec:   s,
-		client: githubv4.NewEnterpriseClient(os.Getenv(s.URL), httpClient),
-	}, nil
+	g := Github{
+		Spec:       s,
+		client:     githubv4.NewEnterpriseClient(os.Getenv(s.URL), httpClient),
+		HeadBranch: git.SanitizeBranchName(fmt.Sprintf("updatecli_%v", pipelineID)),
+	}
+
+	g.setDirectory()
+
+	return &g, nil
 }
 
 // Validate verifies if mandatory Github parameters are provided and return false if not.

--- a/pkg/plugins/scms/github/main.go
+++ b/pkg/plugins/scms/github/main.go
@@ -42,6 +42,10 @@ type Spec struct {
 	PullRequest PullRequestSpec
 	// GPG key and passphrased used for commit signing
 	GPG sign.GPGSpec
+	// Force is used during the git push phase to run `git push --force`.
+	Force bool
+	// CommitMessage represents conventional commit metadata as type or scope, used to generate the final commit message.
+	CommitMessage commit.Commit
 }
 
 // Github contains settings to interact with Github
@@ -50,11 +54,7 @@ type Github struct {
 	Spec Spec
 	// HeadBranch is used when creating a temporary branch before opening a PR
 	HeadBranch string
-	// Force is used during the git push phase to run `git push --force`.
-	Force bool
-	// CommitMessage represents conventional commit metadata as type or scope, used to generate the final commit message.
-	CommitMessage commit.Commit
-	client        GitHubClient
+	client     GitHubClient
 }
 
 // New returns a new valid Github object.

--- a/pkg/plugins/scms/github/main.go
+++ b/pkg/plugins/scms/github/main.go
@@ -20,25 +20,40 @@ import (
 
 // Spec represents the configuration input
 type Spec struct {
-	Branch      string          // Branch specifies which github branch to work on
-	Directory   string          // Directory specifies where the github repository is cloned on the local disk
-	Email       string          // Email specifies which emails to use when creating commits
-	Owner       string          // Owner specifies repository owner
-	Repository  string          // Repository specifies the name of a repository for a specific owner
-	Token       string          // Token specifies the credential used to authenticate with
-	URL         string          // URL specifies the default github url in case of GitHub enterprise
-	Username    string          // Username specifies the username used to authenticate with Github API
-	User        string          // User specifies the user of the git commit messages
-	PullRequest PullRequestSpec // Deprecated since https://github.com/updatecli/updatecli/issues/260, must be clean up
-	GPG         sign.GPGSpec    // GPG key and passphrased used for commit signing
+	// Branch specifies which github branch to work on
+	Branch string
+	// Directory specifies where the github repository is cloned on the local disk
+	Directory string
+	// Email specifies which emails to use when creating commits
+	Email string
+	// Owner specifies repository owner
+	Owner string
+	// Repository specifies the name of a repository for a specific owner
+	Repository string
+	// Token specifies the credential used to authenticate with
+	Token string
+	// URL specifies the default github url in case of GitHub enterprise
+	URL string
+	// Username specifies the username used to authenticate with Github API
+	Username string
+	// User specifies the user of the git commit messages
+	User string
+	// Deprecated since https://github.com/updatecli/updatecli/issues/260, must be clean up
+	PullRequest PullRequestSpec
+	// GPG key and passphrased used for commit signing
+	GPG sign.GPGSpec
 }
 
 // Github contains settings to interact with Github
 type Github struct {
-	Spec          Spec          // Spec contains inputs coming from updatecli configuration
-	HeadBranch    string        // remoteBranch is used when creating a temporary branch before opening a PR
-	Force         bool          // Force is used during the git push phase to run `git push --force`.
-	CommitMessage commit.Commit // CommitMessage represents conventional commit metadata as type or scope, used to generate the final commit message.
+	// Spec contains inputs coming from updatecli configuration
+	Spec Spec
+	// HeadBranch is used when creating a temporary branch before opening a PR
+	HeadBranch string
+	// Force is used during the git push phase to run `git push --force`.
+	Force bool
+	// CommitMessage represents conventional commit metadata as type or scope, used to generate the final commit message.
+	CommitMessage commit.Commit
 	client        GitHubClient
 }
 

--- a/pkg/plugins/scms/github/main.go
+++ b/pkg/plugins/scms/github/main.go
@@ -27,15 +27,15 @@ type Spec struct {
 	// Email specifies which emails to use when creating commits
 	Email string
 	// Owner specifies repository owner
-	Owner string
+	Owner string `jsonschema:"required"`
 	// Repository specifies the name of a repository for a specific owner
-	Repository string
+	Repository string `jsonschema:"required"`
 	// Token specifies the credential used to authenticate with
-	Token string
+	Token string `jsonschema:"required"`
 	// URL specifies the default github url in case of GitHub enterprise
 	URL string
 	// Username specifies the username used to authenticate with Github API
-	Username string
+	Username string `jsonschema:"required"`
 	// User specifies the user of the git commit messages
 	User string
 	// Deprecated since https://github.com/updatecli/updatecli/issues/260, must be clean up

--- a/pkg/plugins/scms/github/main_test.go
+++ b/pkg/plugins/scms/github/main_test.go
@@ -97,7 +97,7 @@ func TestNew(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := New(tt.spec)
+			got, err := New(tt.spec, "")
 			if tt.wantErr {
 				assert.Error(t, err)
 				return

--- a/pkg/plugins/scms/github/scm.go
+++ b/pkg/plugins/scms/github/scm.go
@@ -51,7 +51,7 @@ func (g *Github) Clone() (string, error) {
 func (g *Github) Commit(message string) error {
 
 	// Generate the conventional commit message
-	commitMessage, err := g.CommitMessage.Generate(message)
+	commitMessage, err := g.Spec.CommitMessage.Generate(message)
 	if err != nil {
 		return err
 	}
@@ -85,7 +85,7 @@ func (g *Github) Add(files []string) error {
 // Push run `git push` then open a pull request on Github if not already created.
 func (g *Github) Push() error {
 
-	err := git.Push(g.Spec.Username, g.Spec.Token, g.GetDirectory(), g.Force)
+	err := git.Push(g.Spec.Username, g.Spec.Token, g.GetDirectory(), g.Spec.Force)
 	if err != nil {
 		return err
 	}
@@ -96,7 +96,7 @@ func (g *Github) Push() error {
 // PushTag push tags
 func (g *Github) PushTag(tag string) error {
 
-	err := git.PushTag(tag, g.Spec.Username, g.Spec.Token, g.GetDirectory(), g.Force)
+	err := git.PushTag(tag, g.Spec.Username, g.Spec.Token, g.GetDirectory(), g.Spec.Force)
 	if err != nil {
 		return err
 	}

--- a/pkg/plugins/scms/github/scm.go
+++ b/pkg/plugins/scms/github/scm.go
@@ -7,14 +7,6 @@ import (
 	git "github.com/updatecli/updatecli/pkg/plugins/utils/gitgeneric"
 )
 
-// Init set default Github parameters if not set.
-func (g *Github) Init(pipelineID string) error {
-	g.HeadBranch = git.SanitizeBranchName(fmt.Sprintf("updatecli_%v", pipelineID))
-	g.setDirectory()
-
-	return nil
-}
-
 // GetDirectory returns the local git repository path.
 func (g *Github) GetDirectory() (directory string) {
 	return g.Spec.Directory


### PR DESCRIPTION
Signed-off-by: Olblak <me@olblak.com>

# Fix scm resource initialization

Fix #699 

The code base evolved in a situation where `scm.Init` was called in different places. That led to have some variable not set in some cases. Instead I move that logic in the `New` function that create SCM spec. I also fix a configuration bug where we couldn't configure GitHub commit behavior. 

In summary:
* Fix git/github scm initialization
* Add comment on git spec and GitHub spec to generate description in Jsonschema
* Expose commit configuration for GitHub SCM resource


## Test

To test this pull request, you can run the following commands:

```shell
./bin/updatecli diff --config e2e/updatecli.d/success.d/source --values e2e/values.yaml --debug --clean=false 
ls /tmp/updatecli/github_com_updatecli_updatecli_git
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
