### PR TITLE
pkg/core/config: replace deprecated `strings.Title` with `cases.Title`

### DIFF
--- a/pkg/core/config/main.go
+++ b/pkg/core/config/main.go
@@ -13,6 +13,9 @@ import (
 	"text/template"
 
 	"github.com/sirupsen/logrus"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+	"gopkg.in/yaml.v3"
 
 	"github.com/updatecli/updatecli/pkg/core/pipeline/condition"
 	"github.com/updatecli/updatecli/pkg/core/pipeline/pullrequest"
@@ -20,7 +23,6 @@ import (
 	"github.com/updatecli/updatecli/pkg/core/pipeline/source"
 	"github.com/updatecli/updatecli/pkg/core/pipeline/target"
 	"github.com/updatecli/updatecli/pkg/core/result"
-	"gopkg.in/yaml.v3"
 )
 
 var (
@@ -433,13 +435,14 @@ func getFieldValueByQuery(conf interface{}, query []string) (value string, err e
 	ValueIface := reflect.ValueOf(conf)
 
 	Field := reflect.Value{}
+	titleCaser := cases.Title(language.English, cases.NoLower)
 
 	// We want to be able to use case insensitive key
 	insensitiveQuery := []string{
 		query[0],
 		strings.ToLower(query[0]),
-		strings.Title(strings.ToLower(query[0])),
-		strings.Title(query[0]),
+		titleCaser.String(strings.ToLower(query[0])),
+		titleCaser.String(query[0]),
 		strings.ToTitle(query[0]),
 	}
 


### PR DESCRIPTION
# Replace deprecated calls to `strings.Title` with `cases.Title`

Fixes #668

This PR replaces [all the callsites of `strings.Title`](https://github.com/updatecli/updatecli/search?q=strings.Title) with the recommended `cases.Title` method, configured for 'English', with the `cases.NoLower` option to get as close as possible from the behavior of `strings.Title` (https://go.dev/play/p/0lQ9iHPi_Ro)

This change doesn't seem to break the test suite, so that's a first step. I'm unsure how to properly test this though.

## Test

To test this pull request, you can run the following commands:

```shell
go test ./pkg/core/config/
```

## Additional Information

### Tradeoff

None

### Potential improvement

None
