### PR TITLE
fix(github) initialize the headbranch 

### DIFF
--- a/pkg/core/pipeline/main.go
+++ b/pkg/core/pipeline/main.go
@@ -72,7 +72,7 @@ func (p *Pipeline) Init(config *config.Config, options Options) error {
 		// avoid gosec G601: Reassign the loop iteration variable to a local variable so the pointer address is correct
 		scmConfig := scmConfig
 
-		p.SCMs[id], err = scm.New(&scmConfig, &config.PipelineID)
+		p.SCMs[id], err = scm.New(&scmConfig, config.PipelineID)
 		if err != nil {
 			return err
 		}

--- a/pkg/core/pipeline/scm/main.go
+++ b/pkg/core/pipeline/scm/main.go
@@ -17,9 +17,9 @@ type Config struct {
 }
 
 type Scm struct {
-	Config      *Config
-	Handler     ScmHandler
-	PipeplineID *string
+	Config     *Config
+	Handler    ScmHandler
+	PipelineID string
 }
 
 var (
@@ -58,11 +58,11 @@ func (c *Config) Validate() error {
 	return nil
 }
 
-func New(config *Config, pipelineID *string) (Scm, error) {
+func New(config *Config, pipelineID string) (Scm, error) {
 
 	s := Scm{
-		Config:      config,
-		PipeplineID: pipelineID,
+		Config:     config,
+		PipelineID: pipelineID,
 	}
 
 	err := s.GenerateSCM()
@@ -85,7 +85,7 @@ func (s *Scm) GenerateSCM() error {
 			return err
 		}
 
-		g, err := github.New(githubSpec, *s.PipeplineID)
+		g, err := github.New(githubSpec, s.PipelineID)
 
 		if err != nil {
 			return err

--- a/pkg/plugins/scms/github/main.go
+++ b/pkg/plugins/scms/github/main.go
@@ -83,17 +83,15 @@ func New(s Spec, pipelineID string) (*Github, error) {
 	)
 	httpClient := oauth2.NewClient(context.Background(), src)
 
-	if strings.HasSuffix(s.URL, "github.com") {
-		return &Github{
-			Spec:   s,
-			client: githubv4.NewClient(httpClient),
-		}, nil
-	}
-
 	g := Github{
 		Spec:       s,
-		client:     githubv4.NewEnterpriseClient(os.Getenv(s.URL), httpClient),
 		HeadBranch: git.SanitizeBranchName(fmt.Sprintf("updatecli_%v", pipelineID)),
+	}
+
+	if strings.HasSuffix(s.URL, "github.com") {
+		g.client = githubv4.NewClient(httpClient)
+	} else {
+		g.client = githubv4.NewEnterpriseClient(os.Getenv(s.URL), httpClient)
 	}
 
 	g.setDirectory()

--- a/pkg/plugins/scms/github/main_test.go
+++ b/pkg/plugins/scms/github/main_test.go
@@ -11,13 +11,15 @@ import (
 
 func TestNew(t *testing.T) {
 	tests := []struct {
-		name    string
-		spec    Spec
-		want    Github
-		wantErr bool
+		name       string
+		spec       Spec
+		pipelineID string
+		want       Github
+		wantErr    bool
 	}{
 		{
-			name: "Nominal case",
+			name:       "Nominal case",
+			pipelineID: "12345",
 			spec: Spec{
 				Branch:     "main",
 				Repository: "updatecli",
@@ -28,6 +30,7 @@ func TestNew(t *testing.T) {
 				URL:        "github.com",
 			},
 			want: Github{
+				HeadBranch: "updatecli_12345",
 				Spec: Spec{
 					Branch:     "main",
 					Repository: "updatecli",
@@ -40,7 +43,8 @@ func TestNew(t *testing.T) {
 			},
 		},
 		{
-			name: "Nominal case with empty directory",
+			name:       "Nominal case with empty directory",
+			pipelineID: "12345",
 			spec: Spec{
 				Branch:     "main",
 				Repository: "updatecli",
@@ -50,6 +54,7 @@ func TestNew(t *testing.T) {
 				URL:        "github.com",
 			},
 			want: Github{
+				HeadBranch: "updatecli_12345",
 				Spec: Spec{
 					Branch:     "main",
 					Repository: "updatecli",
@@ -62,7 +67,8 @@ func TestNew(t *testing.T) {
 			},
 		},
 		{
-			name: "Nominal case with empty URL",
+			name:       "Nominal case with empty URL",
+			pipelineID: "12345",
 			spec: Spec{
 				Branch:     "main",
 				Repository: "updatecli",
@@ -72,6 +78,7 @@ func TestNew(t *testing.T) {
 				Directory:  "/home/updatecli",
 			},
 			want: Github{
+				HeadBranch: "updatecli_12345",
 				Spec: Spec{
 					Branch:     "main",
 					Repository: "updatecli",
@@ -84,7 +91,8 @@ func TestNew(t *testing.T) {
 			},
 		},
 		{
-			name: "Validation Error (missing token)",
+			name:       "Validation Error (missing token)",
+			pipelineID: "12345",
 			spec: Spec{
 				Branch:     "main",
 				Repository: "updatecli",
@@ -97,7 +105,7 @@ func TestNew(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := New(tt.spec, "")
+			got, err := New(tt.spec, tt.pipelineID)
 			if tt.wantErr {
 				assert.Error(t, err)
 				return
@@ -105,6 +113,7 @@ func TestNew(t *testing.T) {
 
 			require.NoError(t, err)
 			assert.Equal(t, tt.want.Spec, got.Spec)
+			assert.Equal(t, tt.want.HeadBranch, got.HeadBranch)
 			assert.NotNil(t, got.client)
 		})
 	}


### PR DESCRIPTION
Fix the issue introduced in #700 (ref. https://github.com/updatecli/updatecli/pull/700#issuecomment-1153273824)

## Test

To test this pull request, you can run the following commands:

```shell
make test
make test-e2e
```

Also tested on jenkins-infra/kubernetes-management

## Additional Information

- Added unit tests to underline the error before fixing
- Fixed a typo
- Removed the pointer/references to the pipelineID string. Not sure the reason why pointer was used?
