### PR TITLE
Fix updatecli manifest for golang update

### DIFF
--- a/updatecli/updatecli.d/golang.yaml
+++ b/updatecli/updatecli.d/golang.yaml
@@ -65,7 +65,7 @@ conditions:
     disablesourceinput: true
     spec:
       file: .github/workflows/updatecli.yaml
-      key: jobs.build.steps[2].id
+      key: jobs.updatecli.steps[2].id
       value: go
     scmid: default
   dockerTag:
@@ -107,7 +107,7 @@ targets:
     sourceid: latestGoVersion
     spec:
       file: .github/workflows/updatecli.yaml
-      key: jobs.build.steps[2].with.go-version
+      key: jobs.updatecli.steps[2].with.go-version
     scmid: default
   go.mod:
     name: '[go.mod] Update Golang version to {{ source "latestGoVersion" }}'


### PR DESCRIPTION
Signed-off-by: Olblak <me@olblak.com>

# Fix updatecli manifest for golang update

I noticed that the pipeline that update Golang version is broken 
This PR is the fix needed to get it back on track
```
 - GOLANG.YAML:
	Sources:
		✔ [gomod] Update go.mod (kind: shell)
		✔ [latestGoVersion] Get Latest Go Release (kind: githubrelease)
	Condition:
		✔ [dockerTag] Is docker image golang:1.18.3 published (kind: dockerimage)
		✔ [workflowgo] Ensure GA step is defined in Github Action named go (kind: yaml)
		✔ [workflowrelease] Ensure GA step is defined in Github Action named release (kind: yaml)
		✔ [workflowrelease-sandbox] Ensure GA step is defined in Github Action named release-sandbox (kind: yaml)
		✗ [workflowupdatecli] [release.yaml] Update Golang version to 1.18.3 (kind: yaml)
	Target:
		- [go.mod] [go.mod] Update Golang version to {{ source "latestGoVersion" }} (kind: file)
		- [release] [release-sandbox.yaml] Update Golang version to {{ source "latestGoVersion" }} (kind: yaml)
		- [release-sandbox] [release.yaml] Update Golang version to {{ source "latestGoVersion" }} (kind: yaml)
		- [workflowgo] [release.yaml] Update Golang version to {{ source "latestGoVersion" }} (kind: yaml)
		- [workflowupdatecli] [release.yaml] Update Golang version to {{ source "latestGoVersion" }} (kind: yaml)
```

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
updatecli diff --config updatecli/updatecli.d/golang.yaml 
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
