### PR TITLE
fix: check if the extension is not `yaml` and not `yml`

### DIFF
--- a/pkg/core/config/template.go
+++ b/pkg/core/config/template.go
@@ -104,9 +104,8 @@ func ReadFile(filename string, values *map[string]interface{}, encrypted bool) (
 
 	baseFilename := filepath.Base(filename)
 
-	if extension := filepath.Ext(baseFilename); strings.Compare(extension, ".yaml") != 0 ||
-		strings.Compare(extension, ".yml") != 0 &&
-			strings.Compare(extension, ".yaml") != 0 {
+	if extension := filepath.Ext(baseFilename); strings.Compare(extension, ".yml") != 0 &&
+		strings.Compare(extension, ".yaml") != 0 {
 		err = fmt.Errorf("wrong file extension %q for file %q", extension, baseFilename)
 		logrus.Errorln(err)
 		return err


### PR DESCRIPTION
# check if the extension is not `yaml` and not `yml`

Fix https://github.com/updatecli/updatecli/issues/731

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
cat >EOF > pipeline.yml 
---
title: Update test values
sources:
  dummy:
    name: "Dummy"
    kind: shell
    spec:
      command: echo {{ .Value }}
targets:
  dummy:
    name: "Dummy"
    kind: shell
    spec:
      command: echo {{ .Value }}
EOF
cat <EOF > values.yml
Value: "foo"
EOF
cp pipeline.yml pipeline.yaml
cp values.yml values.yaml 
go run main.go diff --config pipeline.yml --values values.yml
go run main.go diff --config pipeline.yaml --values values.yml
go run main.go diff --config pipeline.yml --values values.yaml
go run main.go diff --config pipeline.yaml --values values.yaml
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
