### PR TITLE
By default Use temporary working branch with git scm

### DIFF
--- a/pkg/core/pipeline/scm/main.go
+++ b/pkg/core/pipeline/scm/main.go
@@ -116,7 +116,7 @@ func (s *Scm) GenerateSCM() error {
 			return err
 		}
 
-		g, err := git.New(gitSpec)
+		g, err := git.New(gitSpec, s.PipelineID)
 
 		if err != nil {
 			return err

--- a/pkg/plugins/scms/git/scm.go
+++ b/pkg/plugins/scms/git/scm.go
@@ -23,7 +23,7 @@ func (g *Git) Checkout() error {
 		g.spec.Username,
 		g.spec.Password,
 		g.spec.Branch,
-		g.remoteBranch,
+		g.HeadBranch,
 		g.GetDirectory())
 	if err != nil {
 		return err
@@ -59,7 +59,7 @@ func (g *Git) Clone() (string, error) {
 		return "", err
 	}
 
-	if len(g.remoteBranch) > 0 && len(g.GetDirectory()) > 0 {
+	if len(g.HeadBranch) > 0 && len(g.GetDirectory()) > 0 {
 		err = g.Checkout()
 		if err != nil {
 			logrus.Errorf("err - %s", err)

--- a/pkg/plugins/scms/github/main.go
+++ b/pkg/plugins/scms/github/main.go
@@ -32,6 +32,8 @@ type Spec struct {
 	Repository string `yaml:",omitempty" jsonschema:"required"`
 	// Token specifies the credential used to authenticate with
 	Token string `yaml:",omitempty" jsonschema:"required"`
+	// DisableWorkingBranch disables temporary working branch such as updatecli_xxx
+	DisableWorkingBranch bool `yaml:",omitempty"`
 	// URL specifies the default github url in case of GitHub enterprise
 	URL string `yaml:",omitempty"`
 	// Username specifies the username used to authenticate with Github API
@@ -84,8 +86,14 @@ func New(s Spec, pipelineID string) (*Github, error) {
 	httpClient := oauth2.NewClient(context.Background(), src)
 
 	g := Github{
-		Spec:       s,
-		HeadBranch: git.SanitizeBranchName(fmt.Sprintf("updatecli_%v", pipelineID)),
+		Spec: s,
+	}
+
+	switch s.DisableWorkingBranch {
+	case true:
+		g.HeadBranch = git.SanitizeBranchName(s.Branch)
+	case false:
+		g.HeadBranch = git.SanitizeBranchName(fmt.Sprintf("updatecli_%s", pipelineID))
 	}
 
 	if strings.HasSuffix(s.URL, "github.com") {


### PR DESCRIPTION
Signed-off-by: Olblak <me@olblak.com>

# By default Use temporary working branch with git scm

Requirement for https://github.com/updatecli/updatecli/pull/744

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, I used the following manifest to manifest that in one case we have a temporary branch and not in the second situation

```shell
title: "Test git scm resource"

scms:  
  tmpDir:
    kind: git 
    spec:
      url: https://github.com/updatecli/updatecli.git
      disableworkingbranch: true
      branch: main
  noneTmpDir:
    kind: git 
    spec:
      url: https://github.com/updatecli/website.git
      branch: master

sources:
  default:
    kind: jenkins

targets: 
  tmpDir:
    name: "tmpdir"
    kind: file
    scmid: tmpDir
    spec:
      file: README.adoc
  noneTmpDir:
    name: "testnonetmpdir"
    kind: file
    scmid: noneTmpDir
    spec:
      file: README.md

```

## Additional Information

### Tradeoff

Up to know the default behavior for git scm was to not use a temporary branch such as "updatecli_xxxx". To keep the current manifest working we could provide an ugprade path where automatically set "disableworkingbranch: true" for version older than 0.27, and we had a warning message

### Potential improvement

Now that I am experimentation with gitea support, I realize that scm of type other than "svn, or mercurial" doesn't add any value and quite the opposite make the code more difficult to maintain. On mid term, I am considering deprecating the github scm kind
