### PR TITLE
fix: Report shouldn't show source and target if none were configured

### DIFF
--- a/pkg/core/reports/main.go
+++ b/pkg/core/reports/main.go
@@ -20,10 +20,12 @@ REPORTS:
 {{ "\t"}}Error: {{ .Err}}
 {{ else }}
 {{- .Result }} {{ .Name -}}:{{"\n"}}
-{{- "\t"}}Sources:
+{{- if .Sources -}}
+{{- "\t"}}Source:
 {{ range $ID,$source := .Sources }}
 {{- "\t" }}{{"\t"}}{{- $source.Result }} [{{ $ID }}] {{ $source.Name }} (kind: {{ $source.Kind -}}){{"\n"}}
-{{- end }}
+{{- end -}}
+{{- end -}}
 
 {{- if .Conditions -}}
 {{- "\t" }}Condition:
@@ -31,12 +33,13 @@ REPORTS:
 {{- "\t" }}{{"\t"}}{{- $condition.Result }} [{{ $ID }}] {{ $condition.Name }} (kind: {{ $condition.Kind -}}){{"\n"}}
 {{- end -}}
 {{- end -}}
-
+{{- if .Targets -}}
 {{- "\t" -}}Target:
 {{ range $ID, $target := .Targets }}
 {{- "\t" }}{{"\t"}}{{- $target.Result }} [{{ $ID }}] {{ $target.Name }} (kind: {{ $target.Kind -}}){{"\n"}}
 {{- end }}
 {{ end }}
+{{- end -}}
 {{ end }}
 `
 


### PR DESCRIPTION
Signed-off-by: Olblak <me@olblak.com>

#  Report shouldn't show source and target if none were configured

Fix a small UI bug where we always display the word "source" and "target" in the report information.
For example running updatecli against the following manifest 

```
scms:
  default:
    kind: git 
    spec:
      url: https://github.com/updatecli/updatecli.git
```
shows
```
=============================

REPORTS:


- EXAMPLE.YAML:
	Sources:
	Target:



Run Summary
===========
Pipeline(s) run:
  * Changed:	0
  * Failed:	0
  * Skipped:	1
  * Succeeded:	0
  * Total:	1
```
and should return
```
=============================

REPORTS:


- EXAMPLE.YAML:

Run Summary
===========
Pipeline(s) run:
  * Changed:	0
  * Failed:	0
  * Skipped:	1
  * Succeeded:	0
  * Total:	1
```

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run updatecli using the manifest mentioned above

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
