### PR TITLE
fix: Empty changelog message shouldn't display source object even in debug mode

### DIFF
--- a/pkg/core/pipeline/source/main.go
+++ b/pkg/core/pipeline/source/main.go
@@ -87,7 +87,7 @@ func (s *Source) Run() (err error) {
 	// Any error means an empty changelog
 	s.Changelog = source.Changelog()
 	if s.Changelog == "" {
-		logrus.Debugf("empty changelog found for the source %v", s)
+		logrus.Debugln("empty changelog found for the source")
 	}
 
 	if len(s.Config.Transformers) > 0 {


### PR DESCRIPTION
Signed-off-by: Olblak <me@olblak.com>

# Empty changelog message shouldn't display source object even in debug mode

Fix #XXX

Empty changelog message shouldn't display source object even in debug mode. It had little value and is a risk for leaking information

## Test

To test this pull request, you can run the following commands:

```shell
cp <to_package_directory>
go test
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
