### PR TITLE
Add path env to golang updatecli manifest

### DIFF
--- a/updatecli/updatecli.d/golang.yaml
+++ b/updatecli/updatecli.d/golang.yaml
@@ -33,6 +33,8 @@ sources:
       - latestGoVersion
     spec:
       command: ./updatecli/scripts/updateGomodGoversion.sh ./go.mod {{ source "latestGoVersion" }}
+      environments:
+        - name: PATH
 
 conditions:
   workflowrelease-sandbox:


### PR DESCRIPTION
#  Add path env to golang updatecli manifest

Fix broken updatecli manifest
With release 0.28.0, the resource "shell" used in a source must specify environment variable(s) inherited from the updatecli process

<!-- Describe the changes introduced by this pull request -->

## Test

/

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
