### PR TITLE
Remove github dependency from jenkins plugin

### DIFF
--- a/pkg/plugins/resources/jenkins/main.go
+++ b/pkg/plugins/resources/jenkins/main.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/mitchellh/mapstructure"
 	"github.com/sirupsen/logrus"
-	"github.com/updatecli/updatecli/pkg/plugins/scms/github"
 	"github.com/updatecli/updatecli/pkg/plugins/utils/mavenmetadata"
 )
 
@@ -18,8 +17,6 @@ type Spec struct {
 	Release string `yaml:",omitempty"`
 	// Defines a specific release version (condition only)
 	Version string `yaml:",omitempty"`
-	// Github Parameter used to retrieve a Jenkins changelog
-	Github github.Spec `yaml:",omitempty"`
 }
 
 // Jenkins defines a resource of kind "githubrelease"


### PR DESCRIPTION
Signed-off-by: Olblak <me@olblak.com>

Fix #789 

Historically we fetch Jenkins changelog from GitHub but it isn't the case anymore. This PR is especially needed as we automatically mention Github settings in IDE auto completion and documentation on https://www.updatecli.io/docs/plugins/resource/jenkins/

## Test

Nothing to test as it's not used anyway

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
