### PR TITLE
Don't clean temporary updatecli directory by default

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -42,5 +42,5 @@ func init() {
 
 	applyCmd.Flags().BoolVarP(&applyCommit, "commit", "", true, "Record changes to the repository, '--commit=false' (default: true)")
 	applyCmd.Flags().BoolVarP(&applyPush, "push", "", true, "Update remote refs '--push=false' (default: true)")
-	applyCmd.Flags().BoolVarP(&applyClean, "clean", "", true, "Remove updatecli working directory like '--clean=false '(default: true)")
+	applyCmd.Flags().BoolVar(&applyClean, "clean", false, "Remove updatecli working directory like '--clean=true'")
 }

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -18,7 +18,6 @@ var (
 			e.Options.Config.ManifestFile = cfgFile
 			e.Options.Config.ValuesFiles = valuesFiles
 			e.Options.Config.SecretsFiles = secretsFiles
-
 			e.Options.Pipeline.Target.Commit = false
 			e.Options.Pipeline.Target.Push = false
 			e.Options.Pipeline.Target.Clean = diffClean
@@ -37,5 +36,6 @@ func init() {
 	diffCmd.Flags().StringVarP(&cfgFile, "config", "c", "./updatecli.yaml", "Sets config file or directory. (default: './updatecli.yaml')")
 	diffCmd.Flags().StringArrayVarP(&valuesFiles, "values", "v", []string{}, "Sets values file uses for templating")
 	diffCmd.Flags().StringArrayVar(&secretsFiles, "secrets", []string{}, "Sets Sops secrets file uses for templating")
-	diffCmd.Flags().BoolVarP(&diffClean, "clean", "", true, "Remove updatecli working directory like '--clean=false '(default: true)")
+	diffCmd.Flags().BoolVar(&diffClean, "clean", false, "Remove updatecli working directory like '--clean=true'")
+
 }

--- a/cmd/prepare.go
+++ b/cmd/prepare.go
@@ -34,5 +34,5 @@ func init() {
 	prepareCmd.Flags().StringVarP(&cfgFile, "config", "c", "./updatecli.yaml", "Sets config file or directory. (default: './updatecli.yaml')")
 	prepareCmd.Flags().StringArrayVarP(&valuesFiles, "values", "v", []string{}, "Sets values file uses for templating")
 	prepareCmd.Flags().StringArrayVar(&secretsFiles, "secrets", []string{}, "Sets Sops secrets file uses for templating")
-	prepareCmd.Flags().BoolVarP(&prepareClean, "clean", "", false, "Remove updatecli working directory like '--clean=true '(default: false)")
+	prepareCmd.Flags().BoolVar(&prepareClean, "clean", false, "Remove updatecli working directory like '--clean=true")
 }


### PR DESCRIPTION
Signed-off-by: Olblak <me@olblak.com>

Fix #788 

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands `updatecli diff` or `updatecli apply` with scm configuration. At the end of the run, we should still see content in /tmp/updatecli/

## Additional Information

### Tradeoff

Enduser will have to clean the temporary directory on themself which is handle by the system anyway as mentioned @gionn

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
