### PR TITLE
Feat: By default githubrelease and gittag combined with semver shouldn't return original version

### DIFF
--- a/e2e/updatecli.d/success.d/githubrelease.yaml
+++ b/e2e/updatecli.d/success.d/githubrelease.yaml
@@ -1,0 +1,12 @@
+sources:
+  latestVersion:
+    name: Get latest Venom release
+    kind: githubrelease
+    spec:
+      owner: updatecli
+      repository: updatecli
+      token: '{{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}'
+      username: '{{ requiredEnv "UPDATECLI_GITHUB_ACTOR" }}'
+      originalVersion: true
+      versionfilter:
+        kind: semver

--- a/e2e/updatecli.d/success.d/githubrelease.yaml
+++ b/e2e/updatecli.d/success.d/githubrelease.yaml
@@ -1,6 +1,6 @@
 sources:
   latestVersion:
-    name: Get latest Venom release
+    name: Get latest Updatecli release
     kind: githubrelease
     spec:
       owner: updatecli

--- a/e2e/updatecli.d/success.d/githubrelease.yaml
+++ b/e2e/updatecli.d/success.d/githubrelease.yaml
@@ -10,3 +10,13 @@ sources:
       keeporiginalversion: true
       versionfilter:
         kind: semver
+  regex:
+    name: Get latest Venom release
+    kind: githubrelease
+    spec:
+      owner: updatecli
+      repository: updatecli
+      token: '{{ requiredEnv "GITHUB_TOKEN" }}'
+      username: '{{ requiredEnv "GITHUB_ACTOR" }}'
+      versionfilter:
+        kind: regex

--- a/e2e/updatecli.d/success.d/githubrelease.yaml
+++ b/e2e/updatecli.d/success.d/githubrelease.yaml
@@ -11,7 +11,7 @@ sources:
       versionfilter:
         kind: semver
   regex:
-    name: Get latest Venom release
+    name: Get latest Updatecli release
     kind: githubrelease
     spec:
       owner: updatecli

--- a/e2e/updatecli.d/success.d/githubrelease.yaml
+++ b/e2e/updatecli.d/success.d/githubrelease.yaml
@@ -5,8 +5,8 @@ sources:
     spec:
       owner: updatecli
       repository: updatecli
-      token: '{{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}'
-      username: '{{ requiredEnv "UPDATECLI_GITHUB_ACTOR" }}'
+      token: '{{ requiredEnv "GITHUB_TOKEN" }}'
+      username: '{{ requiredEnv "GITHUB_ACTOR" }}'
       originalVersion: true
       versionfilter:
         kind: semver

--- a/e2e/updatecli.d/success.d/githubrelease.yaml
+++ b/e2e/updatecli.d/success.d/githubrelease.yaml
@@ -7,6 +7,6 @@ sources:
       repository: updatecli
       token: '{{ requiredEnv "GITHUB_TOKEN" }}'
       username: '{{ requiredEnv "GITHUB_ACTOR" }}'
-      originalVersion: true
+      keeporiginalversion: true
       versionfilter:
         kind: semver

--- a/e2e/updatecli.d/success.d/gittag.yaml
+++ b/e2e/updatecli.d/success.d/gittag.yaml
@@ -1,0 +1,14 @@
+scms:
+  default:
+    kind: git
+    spec:
+      url: https://github.com/updatecli/updatecli.git
+
+sources:
+  default:
+    kind: gittag
+    scmid: default
+    spec:
+      originalVersion: true
+      versionFilter:
+        kind: semver

--- a/e2e/updatecli.d/success.d/gittag.yaml
+++ b/e2e/updatecli.d/success.d/gittag.yaml
@@ -12,3 +12,9 @@ sources:
       keeporiginalVersion: true
       versionFilter:
         kind: semver
+  regex:
+    kind: gittag
+    scmid: default
+    spec:
+      versionFilter:
+        kind: regex

--- a/e2e/updatecli.d/success.d/gittag.yaml
+++ b/e2e/updatecli.d/success.d/gittag.yaml
@@ -9,6 +9,6 @@ sources:
     kind: gittag
     scmid: default
     spec:
-      originalVersion: true
+      keeporiginalVersion: true
       versionFilter:
         kind: semver

--- a/e2e/updatecli.d/success.d/source/gitTag.yaml
+++ b/e2e/updatecli.d/success.d/source/gitTag.yaml
@@ -21,4 +21,5 @@ sources:
       versionfilter:
         kind: semver
         pattern: "~0.1"
+      keeporiginalversion: true
     scmid: updatecli

--- a/e2e/updatecli.d/warning.d/githubrelease.yaml
+++ b/e2e/updatecli.d/warning.d/githubrelease.yaml
@@ -1,6 +1,6 @@
 sources:
   latestVersion:
-    name: Get latest Venom release
+    name: Get latest Updatecli release
     kind: githubrelease
     spec:
       owner: updatecli

--- a/e2e/updatecli.d/warning.d/githubrelease.yaml
+++ b/e2e/updatecli.d/warning.d/githubrelease.yaml
@@ -1,0 +1,12 @@
+sources:
+  latestVersion:
+    name: Get latest Venom release
+    kind: githubrelease
+    spec:
+      owner: updatecli
+      repository: updatecli
+      token: '{{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}'
+      username: '{{ requiredEnv "UPDATECLI_GITHUB_ACTOR" }}'
+      versionfilter:
+        kind: semver
+

--- a/e2e/updatecli.d/warning.d/githubrelease.yaml
+++ b/e2e/updatecli.d/warning.d/githubrelease.yaml
@@ -5,8 +5,8 @@ sources:
     spec:
       owner: updatecli
       repository: updatecli
-      token: '{{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}'
-      username: '{{ requiredEnv "UPDATECLI_GITHUB_ACTOR" }}'
+      token: '{{ requiredEnv "GITHUB_TOKEN" }}'
+      username: '{{ requiredEnv "GITHUB_ACTOR" }}'
       versionfilter:
         kind: semver
 

--- a/e2e/updatecli.d/warning.d/gittag.yaml
+++ b/e2e/updatecli.d/warning.d/gittag.yaml
@@ -1,0 +1,14 @@
+scms:
+  default:
+    kind: git
+    spec:
+      url: https://github.com/updatecli/updatecli.git
+
+sources:
+  default:
+    kind: gittag
+    scmid: default
+    spec:
+      versionFilter:
+        kind: semver
+

--- a/pkg/plugins/resources/githubrelease/deprecation.go
+++ b/pkg/plugins/resources/githubrelease/deprecation.go
@@ -1,7 +1,7 @@
 package githubrelease
 
 var (
-	DeprecatedSemverVersionVersion string = `Deprecated behavior detected
+	DeprecatedSemverVersionMessage string = `Deprecated behavior detected
 |++++
 | If the Github Release you are interacting with, doesn't prepend the retrieved version with the character "v" such as "v1.0.0",
 | then feel free to add the parameter 'originalVersion: true' to hide this message such as in the following example.

--- a/pkg/plugins/resources/githubrelease/deprecation.go
+++ b/pkg/plugins/resources/githubrelease/deprecation.go
@@ -1,0 +1,37 @@
+package githubrelease
+
+var (
+	DeprecatedSemverVersionVersion string = `Deprecated behavior detected
+|++++
+| If the Github Release you are interacting with, doesn't prepend the retrieved version with the character "v" such as "v1.0.0",
+| then feel free to add the parameter 'originalVersion: true' to hide this message such as in the following example.
+| Otherwise please read this message carefully.
+| 
+| ----
+| sources:
+|  		example:
+|    		name: Get latest Updatecli release
+|    		kind: githubrelease
+|    		spec:
+|      			owner: updatecli
+|      			repository: updatecli
+|      			token: '{{ requiredEnv "GITHUB_TOKEN" }}'
+|      			username: '{{ requiredEnv "GITHUB_ACTOR" }}'
+|      			originalVersion: true
+|      			versionfilter:
+|        			kind: semver
+| ----
+| 
+| In Updatecli, we consider that information retrieved from a "Source" shouldn't be altered.
+| Instead, it should be the role of a "Transformer" rule to modify it.
+|
+| The Github Release version retrieve using the semantic version rule will stop dropping the "v" if one is specified in the GitHub release tag such as v1.0.0.
+| This bug has been around for so long that we saw a significant amount of Updateclli manifest written in a way that we can't automatically fix by running "updatecli manifest upgrade"
+| 
+| As we take seriously backward compatibility for Updatecli manifest, we introduce the parameter "originalVersion" to keep the current deprecated behavior until all manifests are updated.
+| 
+| Please adapt your manifest to this new behavior and then set originalVersion to true to validate that you are manifest is compatible with the new behavior.
+| More information on https://github.com/updatecli/updatecli/issues/803
+|++++
+`
+)

--- a/pkg/plugins/resources/githubrelease/deprecation.go
+++ b/pkg/plugins/resources/githubrelease/deprecation.go
@@ -7,19 +7,37 @@ var (
 | then feel free to add the parameter 'originalVersion: true' to hide this message such as in the following example.
 | Otherwise please read this message carefully.
 | 
+| Before:
 | ----
-| sources:
-|  		example:
-|    		name: Get latest Updatecli release
-|    		kind: githubrelease
-|    		spec:
-|      			owner: updatecli
-|      			repository: updatecli
-|      			token: '{{ requiredEnv "GITHUB_TOKEN" }}'
-|      			username: '{{ requiredEnv "GITHUB_ACTOR" }}'
-|      			originalVersion: true
-|      			versionfilter:
-|        			kind: semver
+| < sources:
+| <     example:
+| <         name: Get latest Updatecli release
+| <         kind: githubrelease
+| <         spec:
+| <             owner: updatecli
+| <             repository: updatecli
+| <             token: '{{ requiredEnv "GITHUB_TOKEN" }}'
+| <             username: '{{ requiredEnv "GITHUB_ACTOR" }}'
+| <             versionfilter:
+| <                 kind: semver
+| ----
+|
+| After:
+| ----
+| > sources:
+| >     example:
+| >         name: Get latest Updatecli release
+| >         kind: githubrelease
+| >         spec:
+| >             owner: updatecli
+| >             repository: updatecli
+| >             token: '{{ requiredEnv "GITHUB_TOKEN" }}'
+| >             username: '{{ requiredEnv "GITHUB_ACTOR" }}'
+| >             originalVersion: true
+| >             versionfilter:
+| >                 kind: semver
+| >             transformers:
+| >                 - trimprefix: v
 | ----
 | 
 | In Updatecli, we consider that information retrieved from a "Source" shouldn't be altered.

--- a/pkg/plugins/resources/githubrelease/deprecation.go
+++ b/pkg/plugins/resources/githubrelease/deprecation.go
@@ -33,7 +33,7 @@ var (
 | >             repository: updatecli
 | >             token: '{{ requiredEnv "GITHUB_TOKEN" }}'
 | >             username: '{{ requiredEnv "GITHUB_ACTOR" }}'
-| >             originalVersion: true
+| >             keeporiginalversion: true
 | >             versionfilter:
 | >                 kind: semver
 | >             transformers:

--- a/pkg/plugins/resources/githubrelease/deprecation.go
+++ b/pkg/plugins/resources/githubrelease/deprecation.go
@@ -48,7 +48,7 @@ var (
 | 
 | As we take seriously backward compatibility for Updatecli manifest, we introduce the parameter "keeporiginalversion" to keep the current deprecated behavior until all manifests are updated.
 | 
-| Please adapt your manifest to this new behavior and then set originalVersion to true to validate that you are manifest is compatible with the new behavior.
+| Please adapt your manifest to this new behavior and then set "keeporiginalversion" to true to validate that you are manifest is compatible with the new behavior.
 | More information on https://github.com/updatecli/updatecli/issues/803
 |++++
 `

--- a/pkg/plugins/resources/githubrelease/deprecation.go
+++ b/pkg/plugins/resources/githubrelease/deprecation.go
@@ -4,7 +4,7 @@ var (
 	DeprecatedSemverVersionMessage string = `Deprecated behavior detected
 |++++
 | If the Github Release you are interacting with, doesn't prepend the retrieved version with the character "v" such as "v1.0.0",
-| then feel free to add the parameter 'originalVersion: true' to hide this message such as in the following example.
+| then feel free to add the parameter 'keeporiginalVersion: true' to hide this message such as in the following example.
 | Otherwise please read this message carefully.
 | 
 | Before:

--- a/pkg/plugins/resources/githubrelease/deprecation.go
+++ b/pkg/plugins/resources/githubrelease/deprecation.go
@@ -46,7 +46,7 @@ var (
 | The Github Release version retrieve using the semantic version rule will stop dropping the "v" if one is specified in the GitHub release tag such as v1.0.0.
 | This bug has been around for so long that we saw a significant amount of Updateclli manifest written in a way that we can't automatically fix by running "updatecli manifest upgrade"
 | 
-| As we take seriously backward compatibility for Updatecli manifest, we introduce the parameter "originalVersion" to keep the current deprecated behavior until all manifests are updated.
+| As we take seriously backward compatibility for Updatecli manifest, we introduce the parameter "keeporiginalversion" to keep the current deprecated behavior until all manifests are updated.
 | 
 | Please adapt your manifest to this new behavior and then set originalVersion to true to validate that you are manifest is compatible with the new behavior.
 | More information on https://github.com/updatecli/updatecli/issues/803

--- a/pkg/plugins/resources/githubrelease/deprecation.go
+++ b/pkg/plugins/resources/githubrelease/deprecation.go
@@ -44,7 +44,7 @@ var (
 | Instead, it should be the role of a "Transformer" rule to modify it.
 |
 | The Github Release version retrieve using the semantic version rule will stop dropping the "v" if one is specified in the GitHub release tag such as v1.0.0.
-| This bug has been around for so long that we saw a significant amount of Updateclli manifest written in a way that we can't automatically fix by running "updatecli manifest upgrade"
+| This bug has been around for so long that we saw a significant amount of Updatecli manifest written in a way that we can't automatically fix by running "updatecli manifest upgrade"
 | 
 | As we take seriously backward compatibility for Updatecli manifest, we introduce the parameter "keeporiginalversion" to keep the current deprecated behavior until all manifests are updated.
 | 

--- a/pkg/plugins/resources/githubrelease/main.go
+++ b/pkg/plugins/resources/githubrelease/main.go
@@ -22,7 +22,7 @@ type Spec struct {
 	Username string `yaml:",omitempty" jsonschema:"required"`
 	// VersionFilter provides parameters to specify version pattern and its type like regex, semver, or just latest.
 	VersionFilter version.Filter `yaml:",omitempty"`
-	// KeepOriginalVersion is an ephemeral parameters. cfr https://github.com/updatecli/updatecli/issues/803
+	// [S] KeepOriginalVersion is an ephemeral parameters. cfr https://github.com/updatecli/updatecli/issues/803
 	KeepOriginalVersion bool `yaml:",omitempty"`
 }
 

--- a/pkg/plugins/resources/githubrelease/main.go
+++ b/pkg/plugins/resources/githubrelease/main.go
@@ -22,16 +22,16 @@ type Spec struct {
 	Username string `yaml:",omitempty" jsonschema:"required"`
 	// VersionFilter provides parameters to specify version pattern and its type like regex, semver, or just latest.
 	VersionFilter version.Filter `yaml:",omitempty"`
-	// OriginalVersion is an ephemeral parameters. cfr https://github.com/updatecli/updatecli/issues/803
-	OriginalVersion bool
+	// KeepOriginalVersion is an ephemeral parameters. cfr https://github.com/updatecli/updatecli/issues/803
+	KeepOriginalVersion bool
 }
 
 // GitHubRelease defines a resource of kind "githubrelease"
 type GitHubRelease struct {
-	ghHandler       github.GithubHandler
-	versionFilter   version.Filter // Holds the "valid" version.filter, that might be different than the user-specified filter (Spec.VersionFilter)
-	foundVersion    version.Version
-	OriginalVersion bool
+	ghHandler           github.GithubHandler
+	versionFilter       version.Filter // Holds the "valid" version.filter, that might be different than the user-specified filter (Spec.VersionFilter)
+	foundVersion        version.Version
+	keepOriginalVersion bool
 }
 
 // New returns a new valid GitHubRelease object.
@@ -54,7 +54,7 @@ func New(spec interface{}) (*GitHubRelease, error) {
 		return &GitHubRelease{}, err
 	}
 
-	if !newSpec.OriginalVersion {
+	if !newSpec.KeepOriginalVersion && newSpec.VersionFilter.Kind == version.SEMVERVERSIONKIND {
 		logrus.Warningf("%s\n\n", DeprecatedSemverVersionVersion)
 	}
 
@@ -64,8 +64,8 @@ func New(spec interface{}) (*GitHubRelease, error) {
 	}
 
 	return &GitHubRelease{
-		ghHandler:       newHandler,
-		versionFilter:   newFilter,
-		OriginalVersion: newSpec.OriginalVersion,
+		ghHandler:           newHandler,
+		versionFilter:       newFilter,
+		keepOriginalVersion: newSpec.KeepOriginalVersion,
 	}, nil
 }

--- a/pkg/plugins/resources/githubrelease/main.go
+++ b/pkg/plugins/resources/githubrelease/main.go
@@ -55,7 +55,7 @@ func New(spec interface{}) (*GitHubRelease, error) {
 	}
 
 	if !newSpec.KeepOriginalVersion && newSpec.VersionFilter.Kind == version.SEMVERVERSIONKIND {
-		logrus.Warningf("%s\n\n", DeprecatedSemverVersionVersion)
+		logrus.Warningf("%s\n\n", DeprecatedSemverVersionMessage)
 	}
 
 	newFilter, err := newSpec.VersionFilter.Init()

--- a/pkg/plugins/resources/githubrelease/main.go
+++ b/pkg/plugins/resources/githubrelease/main.go
@@ -23,7 +23,7 @@ type Spec struct {
 	// VersionFilter provides parameters to specify version pattern and its type like regex, semver, or just latest.
 	VersionFilter version.Filter `yaml:",omitempty"`
 	// KeepOriginalVersion is an ephemeral parameters. cfr https://github.com/updatecli/updatecli/issues/803
-	KeepOriginalVersion bool
+	KeepOriginalVersion bool `yaml:",omitempty"`
 }
 
 // GitHubRelease defines a resource of kind "githubrelease"

--- a/pkg/plugins/resources/githubrelease/source.go
+++ b/pkg/plugins/resources/githubrelease/source.go
@@ -33,7 +33,14 @@ func (gr *GitHubRelease) Source(workingDir string) (value string, err error) {
 	if err != nil {
 		return "", err
 	}
+
 	value = gr.foundVersion.OriginalVersion
+
+	// To remove after transition is over
+	// cfr https://github.com/updatecli/updatecli/issues/803
+	if !gr.OriginalVersion {
+		value = gr.foundVersion.ParsedVersion
+	}
 
 	if len(value) == 0 {
 		logrus.Infof("%s No Github Release version found matching pattern %q", result.FAILURE, gr.versionFilter.Pattern)

--- a/pkg/plugins/resources/githubrelease/source.go
+++ b/pkg/plugins/resources/githubrelease/source.go
@@ -38,7 +38,7 @@ func (gr *GitHubRelease) Source(workingDir string) (value string, err error) {
 
 	// To remove after transition is over
 	// cfr https://github.com/updatecli/updatecli/issues/803
-	if !gr.OriginalVersion {
+	if !gr.keepOriginalVersion {
 		value = gr.foundVersion.ParsedVersion
 	}
 

--- a/pkg/plugins/resources/gittag/deprecation.go
+++ b/pkg/plugins/resources/gittag/deprecation.go
@@ -23,7 +23,7 @@ var (
 | > sources:
 | >     example:
 | >         name: Get latest Updatecli release
-| >    	    kind: gittag
+| >         kind: gittag
 | >    	    spec:
 | >             originalVersion: true
 | >             versionfilter:

--- a/pkg/plugins/resources/gittag/deprecation.go
+++ b/pkg/plugins/resources/gittag/deprecation.go
@@ -40,7 +40,7 @@ var (
 | 
 | As we take seriously backward compatibility for Updatecli manifest, we introduce the parameter "originalVersion" to keep the current deprecated behavior until all manifests are updated.
 | 
-| Please adapt your manifest to this new behavior by adding a transformer and then set originalVersion to true to validate that you are manifest is compatible with the new behavior.
+| Please adapt your manifest to this new behavior by adding a transformer and then set keeporiginalVersion to true to validate that you are manifest is compatible with the new behavior.
 | More information on https://github.com/updatecli/updatecli/issues/803
 |++++
 `

--- a/pkg/plugins/resources/gittag/deprecation.go
+++ b/pkg/plugins/resources/gittag/deprecation.go
@@ -25,7 +25,7 @@ var (
 | >         name: Get latest Updatecli release
 | >         kind: gittag
 | >    	    spec:
-| >             originalVersion: true
+| >             keeporiginalversion: true
 | >             versionfilter:
 | >             kind: semver
 | >             transformers:

--- a/pkg/plugins/resources/gittag/deprecation.go
+++ b/pkg/plugins/resources/gittag/deprecation.go
@@ -7,15 +7,29 @@ var (
 | then feel free to add the parameter 'originalVersion: true' to hide this message such as in the following example.
 | Otherwise please keep reading this message carefully.
 | 
+| Before:
 | ----
-| sources:
-|  		example:
-|    		name: Get latest Updatecli release
-|    		kind: gittag
-|    		spec:
-|      			originalVersion: true
-|      			versionfilter:
-|        			kind: semver
+| < sources:
+| <     example:
+| <         name: Get latest Updatecli release
+| <         kind: gittag
+| <    	    spec:
+| <             versionfilter:
+| <             kind: semver
+| ----
+|
+| After:
+| ----
+| > sources:
+| >     example:
+| >         name: Get latest Updatecli release
+| >    	    kind: gittag
+| >    	    spec:
+| >             originalVersion: true
+| >             versionfilter:
+| >             kind: semver
+| >             transformers:
+| >                 - trimprefix: v
 | ----
 | 
 | In Updatecli, we consider that information retrieved from a "Source" shouldn't be altered.

--- a/pkg/plugins/resources/gittag/deprecation.go
+++ b/pkg/plugins/resources/gittag/deprecation.go
@@ -1,7 +1,7 @@
 package gittag
 
 var (
-	DeprecatedSemverVersionVersion string = `Deprecated behavior detected
+	DeprecatedSemverVersionMessage string = `Deprecated behavior detected
 |++++
 | If the GitTag resource you are interacting with, doesn't prepend the retrieved version with the character "v" such as "v1.0.0",
 | then feel free to add the parameter 'originalVersion: true' to hide this message such as in the following example.

--- a/pkg/plugins/resources/gittag/deprecation.go
+++ b/pkg/plugins/resources/gittag/deprecation.go
@@ -1,0 +1,33 @@
+package gittag
+
+var (
+	DeprecatedSemverVersionVersion string = `Deprecated behavior detected
+|++++
+| If the GitTag resource you are interacting with, doesn't prepend the retrieved version with the character "v" such as "v1.0.0",
+| then feel free to add the parameter 'originalVersion: true' to hide this message such as in the following example.
+| Otherwise please keep reading this message carefully.
+| 
+| ----
+| sources:
+|  		example:
+|    		name: Get latest Updatecli release
+|    		kind: gittag
+|    		spec:
+|      			originalVersion: true
+|      			versionfilter:
+|        			kind: semver
+| ----
+| 
+| In Updatecli, we consider that information retrieved from a "Source" shouldn't be altered.
+| Instead, it should be the role of a "Transformer" rule to modify it.
+|
+| The Git Tag version retrieve using the semantic version rule will stop dropping the "v" if one is specified in the Git tag such as v1.0.0.
+| This bug has been around for so long that we saw a significant amount of Updateclli manifest written in a way that we can't automatically fix by running "updatecli manifest upgrade"
+| 
+| As we take seriously backward compatibility for Updatecli manifest, we introduce the parameter "originalVersion" to keep the current deprecated behavior until all manifests are updated.
+| 
+| Please adapt your manifest to this new behavior and then set originalVersion to true to validate that you are manifest is compatible with the new behavior.
+| More information on https://github.com/updatecli/updatecli/issues/803
+|++++
+`
+)

--- a/pkg/plugins/resources/gittag/deprecation.go
+++ b/pkg/plugins/resources/gittag/deprecation.go
@@ -4,7 +4,7 @@ var (
 	DeprecatedSemverVersionMessage string = `Deprecated behavior detected
 |++++
 | If the GitTag resource you are interacting with doesn't prepend the retrieved version with the character "v" such as "v1.0.0",
-| then feel free to add the parameter 'originalVersion: true' to hide this message such as in the following example.
+| then feel free to add the parameter 'keeporiginalVersion: true' to hide this message such as in the following example.
 | Otherwise please keep reading this message carefully.
 | 
 | Before:
@@ -38,7 +38,7 @@ var (
 | The Git Tag version retrieval using the semantic version rule will stop dropping the "v" if one is specified in the Git tag such as v1.0.0.
 | This bug has been around for so long that we saw a significant amount of Updateclli manifest written in a way that we can't automatically fix by running "updatecli manifest upgrade"
 | 
-| As we take seriously backward compatibility for Updatecli manifest, we introduce the parameter "originalVersion" to keep the current deprecated behavior until all manifests are updated.
+| As we take seriously backward compatibility for Updatecli manifest, we introduce the parameter "keeporiginalversion" to keep the current deprecated behavior until all manifests are updated.
 | 
 | Please adapt your manifest to this new behavior by adding a transformer and then set keeporiginalVersion to true to validate that you are manifest is compatible with the new behavior.
 | More information on https://github.com/updatecli/updatecli/issues/803

--- a/pkg/plugins/resources/gittag/main.go
+++ b/pkg/plugins/resources/gittag/main.go
@@ -19,7 +19,7 @@ type Spec struct {
 	VersionFilter version.Filter `yaml:",omitempty"`
 	// Message associated to the git tag
 	Message string `yaml:",omitempty"`
-	// Keeporiginalversion is an ephemeral parameters. cfr https://github.com/updatecli/updatecli/issues/803
+	// [S] Keeporiginalversion is an ephemeral parameters. cfr https://github.com/updatecli/updatecli/issues/803
 	KeepOriginalVersion bool `yaml:",omitempty"`
 }
 

--- a/pkg/plugins/resources/gittag/main.go
+++ b/pkg/plugins/resources/gittag/main.go
@@ -19,8 +19,8 @@ type Spec struct {
 	VersionFilter version.Filter `yaml:",omitempty"`
 	// Message associated to the git tag
 	Message string `yaml:",omitempty"`
-	// OriginalVersion is an ephemeral parameters to smooth the transition. cfg https://github.com/updatecli/updatecli/issues/803
-	OriginalVersion bool
+	// Keeporiginalversion is an ephemeral parameters. cfr https://github.com/updatecli/updatecli/issues/803
+	KeepOriginalVersion bool
 }
 
 // GitTag defines a resource of kind "gittag"
@@ -49,10 +49,6 @@ func New(spec interface{}) (*GitTag, error) {
 		return &GitTag{}, err
 	}
 
-	if !newSpec.OriginalVersion {
-		logrus.Warningf("%s\n\n", DeprecatedSemverVersionVersion)
-	}
-
 	newResource := &GitTag{
 		spec:             newSpec,
 		versionFilter:    newFilter,
@@ -67,6 +63,10 @@ func (gt *GitTag) Validate() error {
 	validationErrors := []string{}
 	if gt.spec.Path == "" {
 		validationErrors = append(validationErrors, "Git working directory path is empty while it must be specified. Did you specify an `scmID` or a `spec.path`?")
+	}
+
+	if !gt.spec.KeepOriginalVersion && gt.spec.VersionFilter.Kind == version.SEMVERVERSIONKIND {
+		logrus.Warningf("%s\n\n", DeprecatedSemverVersionVersion)
 	}
 
 	// Return all the validation errors if found any

--- a/pkg/plugins/resources/gittag/main.go
+++ b/pkg/plugins/resources/gittag/main.go
@@ -20,7 +20,7 @@ type Spec struct {
 	// Message associated to the git tag
 	Message string `yaml:",omitempty"`
 	// Keeporiginalversion is an ephemeral parameters. cfr https://github.com/updatecli/updatecli/issues/803
-	KeepOriginalVersion bool
+	KeepOriginalVersion bool  `yaml:",omitempty"`
 }
 
 // GitTag defines a resource of kind "gittag"

--- a/pkg/plugins/resources/gittag/main.go
+++ b/pkg/plugins/resources/gittag/main.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/mitchellh/mapstructure"
+	"github.com/sirupsen/logrus"
 	"github.com/updatecli/updatecli/pkg/plugins/utils/gitgeneric"
 	"github.com/updatecli/updatecli/pkg/plugins/utils/version"
 )
@@ -18,6 +19,8 @@ type Spec struct {
 	VersionFilter version.Filter `yaml:",omitempty"`
 	// Message associated to the git tag
 	Message string `yaml:",omitempty"`
+	// OriginalVersion is an ephemeral parameters to smooth the transition. cfg https://github.com/updatecli/updatecli/issues/803
+	OriginalVersion bool
 }
 
 // GitTag defines a resource of kind "gittag"
@@ -44,6 +47,10 @@ func New(spec interface{}) (*GitTag, error) {
 	newFilter, err := newSpec.VersionFilter.Init()
 	if err != nil {
 		return &GitTag{}, err
+	}
+
+	if !newSpec.OriginalVersion {
+		logrus.Warningf("%s\n\n", DeprecatedSemverVersionVersion)
 	}
 
 	newResource := &GitTag{

--- a/pkg/plugins/resources/gittag/main.go
+++ b/pkg/plugins/resources/gittag/main.go
@@ -20,7 +20,7 @@ type Spec struct {
 	// Message associated to the git tag
 	Message string `yaml:",omitempty"`
 	// Keeporiginalversion is an ephemeral parameters. cfr https://github.com/updatecli/updatecli/issues/803
-	KeepOriginalVersion bool  `yaml:",omitempty"`
+	KeepOriginalVersion bool `yaml:",omitempty"`
 }
 
 // GitTag defines a resource of kind "gittag"

--- a/pkg/plugins/resources/gittag/main.go
+++ b/pkg/plugins/resources/gittag/main.go
@@ -66,7 +66,7 @@ func (gt *GitTag) Validate() error {
 	}
 
 	if !gt.spec.KeepOriginalVersion && gt.spec.VersionFilter.Kind == version.SEMVERVERSIONKIND {
-		logrus.Warningf("%s\n\n", DeprecatedSemverVersionVersion)
+		logrus.Warningf("%s\n\n", DeprecatedSemverVersionMessage)
 	}
 
 	// Return all the validation errors if found any

--- a/pkg/plugins/resources/gittag/source.go
+++ b/pkg/plugins/resources/gittag/source.go
@@ -31,9 +31,9 @@ func (gt *GitTag) Source(workingDir string) (string, error) {
 	}
 
 	value := gt.foundVersion.OriginalVersion
-	// To remove after transition
+	// To remove after transition is over
 	// cfg https://github.com/updatecli/updatecli/issues/803
-	if !gt.spec.OriginalVersion {
+	if !gt.spec.KeepOriginalVersion {
 		value = gt.foundVersion.ParsedVersion
 	}
 

--- a/pkg/plugins/resources/gittag/source.go
+++ b/pkg/plugins/resources/gittag/source.go
@@ -29,7 +29,13 @@ func (gt *GitTag) Source(workingDir string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+
 	value := gt.foundVersion.OriginalVersion
+	// To remove after transition
+	// cfg https://github.com/updatecli/updatecli/issues/803
+	if !gt.spec.OriginalVersion {
+		value = gt.foundVersion.ParsedVersion
+	}
 
 	if len(value) == 0 {
 		logrus.Infof("%s No git tag found matching pattern %q", result.FAILURE, gt.versionFilter.Pattern)

--- a/updatecli/updatecli.d/venom.yaml
+++ b/updatecli/updatecli.d/venom.yaml
@@ -21,6 +21,7 @@ sources:
       repository: venom
       token: '{{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}'
       username: '{{ requiredEnv "UPDATECLI_GITHUB_ACTOR" }}'
+      originalVersion: true
       versionfilter:
         kind: semver
     

--- a/updatecli/updatecli.d/venom.yaml
+++ b/updatecli/updatecli.d/venom.yaml
@@ -21,7 +21,7 @@ sources:
       repository: venom
       token: '{{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}'
       username: '{{ requiredEnv "UPDATECLI_GITHUB_ACTOR" }}'
-      originalVersion: true
+      keeporiginalversion: true
       versionfilter:
         kind: semver
     


### PR DESCRIPTION
Fix #803 

As Herve suggested, I propose a new flag "originalversion" set to false by default. such as

```
sources:
  latestVersion:
    name: Get latest Updatecli release
    kind: githubrelease
    spec:
      owner: updatecli
      repository: updatecli
      token: '{{ requiredEnv "GITHUB_TOKEN" }}'
      username: '{{ requiredEnv "GITHUB_ACTOR" }}'
      keeporiginalversion: true
      versionfilter:
        kind: semver
```

```

SOURCES
=======

latestVersion
-------------
WARNING: Deprecated behavior detected
|++++
| If the Github Release you are interacting with, doesn't prepend the retrieved version with the character "v" such as "v1.0.0",
| then feel free to add the parameter 'originalVersion: true' to hide this message such as in the following example.
| Otherwise please read this message carefully.
| 
| ----
| sources:
|  		example:
|    		name: Get latest Updatecli release
|    		kind: githubrelease
|    		spec:
|      			owner: updatecli
|      			repository: updatecli
|      			token: '{{ requiredEnv "GITHUB_TOKEN" }}'
|      			username: '{{ requiredEnv "GITHUB_ACTOR" }}'
|      			originalVersion: true
|      			versionfilter:
|        			kind: semver
| ----
| 
| In Updatecli, we consider that information retrieved from a "Source" shouldn't be altered.
| Instead, it should be the role of a "Transformer" rule to modify it.
|
| The Github Release version retrieve using the semantic version rule will stop dropping the "v" if one is specified in the GitHub release tag such as v1.0.0.
| This bug has been around for so long that we saw a significant amount of Updateclli manifest written in a way that we can't automatically fix by running "updatecli manifest upgrade"
| 
| As we take seriously backward compatibility for Updatecli manifest, we introduce the parameter "originalVersion" to keep the current deprecated behavior until all manifests are updated.
| 
| Please adapt your manifest to this new behavior and then set originalVersion to true to validate that you are manifest is compatible with the new behavior.
| More information on https://github.com/updatecli/updatecli/issues/803
|++++


Searching for version matching pattern "*"
✔ Github Release version "1.0.1" found matching pattern "*"

...
```

This warning will only be displayed for "gittag" and "githubreleas" as those two resources are the only one being affected by this change. the "dockerimage" and "gitea/*" haven't be released yet.

## Test

To test this pull request, you can run the following commands:

```shell
go build -o bin/updatecli
./bin/updatecli diff --config e2e/updatecli.d/success.d/gittag.yaml
./bin/updatecli diff --config e2e/updatecli.d/success.d/githubrelease.yaml

./bin/updatecli diff --config e2e/updatecli.d/warning.d/gittag.yaml
./bin/updatecli diff --config e2e/updatecli.d/warning.d/githubrelease.yaml
go test
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
