### PR TITLE
Feat: add an experimental flag and use it to define the versionFilter behavior

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,6 +4,7 @@ import (
 	"os"
 
 	"github.com/sirupsen/logrus"
+	"github.com/updatecli/updatecli/pkg/core/cmdoptions"
 	"github.com/updatecli/updatecli/pkg/core/log"
 
 	"github.com/updatecli/updatecli/pkg/core/engine"
@@ -18,6 +19,7 @@ var (
 	secretsFiles []string
 	e            engine.Engine
 	verbose      bool
+	experimental bool
 
 	rootCmd = &cobra.Command{
 		Use:   "updatecli",
@@ -45,9 +47,14 @@ func Execute() {
 
 func init() {
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "debug", "", false, "Debug Output")
+	rootCmd.PersistentFlags().BoolVarP(&experimental, "experimental", "", false, "Enable Experimental mode")
 	rootCmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
 		if verbose {
 			logrus.SetLevel(logrus.DebugLevel)
+		}
+		if experimental {
+			cmdoptions.Experimental = true
+			logrus.Infof("Experimental Mode Enabled")
 		}
 	}
 	rootCmd.AddCommand(

--- a/pkg/core/cmdoptions/main.go
+++ b/pkg/core/cmdoptions/main.go
@@ -1,0 +1,3 @@
+package cmdoptions
+
+var Experimental bool = false

--- a/pkg/core/reports/report.go
+++ b/pkg/core/reports/report.go
@@ -74,7 +74,6 @@ type Report struct {
 }
 
 // Init initializes a new report for a specific configuration
-//func (config *Config) InitReport() (report *Report) {
 func (r *Report) Init(name string, sourceNbr, conditionNbr, targetNbr int) {
 
 	r.Name = name

--- a/pkg/core/transformer/main.go
+++ b/pkg/core/transformer/main.go
@@ -16,7 +16,7 @@ var (
 	ErrEmptyInput = errors.New("validation error: transformer input is empty")
 )
 
-//Transformer holds a tranformer rule
+// Transformer holds a tranformer rule
 type Transformer struct {
 	// AddPrefix adds a prefix to the transformer input value
 	AddPrefix           string `yaml:",omitempty"`
@@ -44,7 +44,7 @@ type Transformer struct {
 	DeprecatedSemVerInc string `yaml:"semverInc,omitempty" jsonschema:"-"`
 }
 
-//Transformers defines a list of transformer applied in order
+// Transformers defines a list of transformer applied in order
 type Transformers []Transformer
 
 // Apply applies a single transformation based on a key

--- a/pkg/plugins/resources/dockerimage/source.go
+++ b/pkg/plugins/resources/dockerimage/source.go
@@ -38,7 +38,7 @@ searchTag:
 
 		// Todo: validate that result is valid for architecture
 
-		tag = di.foundVersion.OriginalVersion
+		tag = di.foundVersion.GetVersion()
 
 		img := di.image
 		img.Tag = tag

--- a/pkg/plugins/resources/gitea/branch/source.go
+++ b/pkg/plugins/resources/gitea/branch/source.go
@@ -33,7 +33,7 @@ func (g *Gitea) Source(workingDir string) (string, error) {
 		}
 	}
 
-	value := g.foundVersion.OriginalVersion
+	value := g.foundVersion.GetVersion()
 
 	if len(value) == 0 {
 		logrus.Infof("%s No Gitea branches found matching pattern %q", result.FAILURE, g.versionFilter.Pattern)

--- a/pkg/plugins/resources/gitea/release/source.go
+++ b/pkg/plugins/resources/gitea/release/source.go
@@ -34,9 +34,9 @@ func (g *Gitea) Source(workingDir string) (string, error) {
 		}
 	}
 
-	value := g.foundVersion.OriginalVersion
+	value := g.foundVersion.GetVersion()
 
-	logrus.Infof("Latest Release found: %v", g.foundVersion.OriginalVersion)
+	logrus.Infof("Latest Release found: %v", g.foundVersion.GetVersion())
 
 	if len(value) == 0 {
 		logrus.Infof("%s No Gitea Release tag found matching pattern %q", result.FAILURE, g.versionFilter.Pattern)

--- a/pkg/plugins/resources/gitea/tag/source.go
+++ b/pkg/plugins/resources/gitea/tag/source.go
@@ -34,7 +34,7 @@ func (g *Gitea) Source(workingDir string) (string, error) {
 		}
 	}
 
-	value := g.foundVersion.OriginalVersion
+	value := g.foundVersion.GetVersion()
 
 	if len(value) == 0 {
 		logrus.Infof("%s No Gitea tags found matching pattern %q", result.FAILURE, g.versionFilter.Pattern)

--- a/pkg/plugins/resources/githubrelease/source.go
+++ b/pkg/plugins/resources/githubrelease/source.go
@@ -33,7 +33,7 @@ func (gr *GitHubRelease) Source(workingDir string) (value string, err error) {
 	if err != nil {
 		return "", err
 	}
-	value = gr.foundVersion.OriginalVersion
+	value = gr.foundVersion.GetVersion()
 
 	if len(value) == 0 {
 		logrus.Infof("%s No Github Release version found matching pattern %q", result.FAILURE, gr.versionFilter.Pattern)

--- a/pkg/plugins/resources/gittag/condition.go
+++ b/pkg/plugins/resources/gittag/condition.go
@@ -48,7 +48,7 @@ func (gt *GitTag) condition(source string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	tag := gt.foundVersion.OriginalVersion
+	tag := gt.foundVersion.GetVersion()
 
 	if len(tag) == 0 {
 		err = fmt.Errorf("no git tag matching pattern %q, found", gt.versionFilter.Pattern)

--- a/pkg/plugins/resources/gittag/source.go
+++ b/pkg/plugins/resources/gittag/source.go
@@ -29,7 +29,7 @@ func (gt *GitTag) Source(workingDir string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	value := gt.foundVersion.OriginalVersion
+	value := gt.foundVersion.GetVersion()
 
 	if len(value) == 0 {
 		logrus.Infof("%s No git tag found matching pattern %q", result.FAILURE, gt.versionFilter.Pattern)

--- a/pkg/plugins/resources/gittag/target.go
+++ b/pkg/plugins/resources/gittag/target.go
@@ -72,7 +72,7 @@ func (gt *GitTag) target(source string, dryRun bool) (bool, []string, string, er
 		// Something went wrong during the tag search.
 		return false, files, message, err
 	}
-	if gt.foundVersion.OriginalVersion == source {
+	if gt.foundVersion.GetVersion() == source {
 		// No error, but no change
 		logrus.Printf("%s The Git Tag %q already exists, nothing else to do.",
 			result.SUCCESS,

--- a/pkg/plugins/resources/helm/validate.go
+++ b/pkg/plugins/resources/helm/validate.go
@@ -13,7 +13,7 @@ var (
 	ErrWrongConfig = errors.New("wrong helm configuration")
 )
 
-//ValidateTarget ensure that target required parameter are set
+// ValidateTarget ensure that target required parameter are set
 func (c *Chart) ValidateTarget() error {
 
 	var errs []error

--- a/pkg/plugins/resources/shell/command.go
+++ b/pkg/plugins/resources/shell/command.go
@@ -39,7 +39,7 @@ func (nce *nativeCommandExecutor) ExecuteCommand(inputCmd command) (commandResul
 	command.Env = append(command.Env, inputCmd.Env...)
 	err := command.Run()
 
-	// Display environment variables in debug mode
+	// Display environment variables in mode
 	logrus.Debugf("Environment variables\n")
 	for _, env := range command.Env {
 		logrus.Debugf("\t* %s\n", env)

--- a/pkg/plugins/resources/shell/target.go
+++ b/pkg/plugins/resources/shell/target.go
@@ -26,11 +26,11 @@ func (s *Shell) TargetFromSCM(source string, scm scm.ScmHandler, dryRun bool) (b
 	return changed, files, message, err
 }
 
-// Target executes the provided command (concatenated with the source) to apply the change.
-//	The command is expected, if it changes something, to print the new value to the stdout
-//	- An exit code of 0 and an empty stdout means: "successful command and no change"
-//	- An exit code of 0 and something on the stdout means: "successful command with a changed value"
-//	- Any other exit code means "failed command with no change"
+// target executes the provided command (concatenated with the source) to apply the change.
+// The command is expected, if it changes something, to print the new value to the stdout:
+// - An exit code of 0 and an empty stdout means: "successful command and no change"
+// - An exit code of 0 and something on the stdout means: "successful command with a changed value"
+// - Any other exit code means "failed command with no change"
 // The environment variable 'DRY_RUN' is set to true or false based on the input parameter (e.g. 'updatecli diff' or 'apply'?)
 func (s *Shell) target(source, workingDir string, dryRun bool) (bool, string, error) {
 

--- a/pkg/plugins/utils/version/main.go
+++ b/pkg/plugins/utils/version/main.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/sirupsen/logrus"
+	"github.com/updatecli/updatecli/pkg/core/cmdoptions"
 )
 
 // Filter defines parameters to apply different kind of version matching based on a list of versions
@@ -21,6 +22,13 @@ type Filter struct {
 type Version struct {
 	ParsedVersion   string
 	OriginalVersion string
+}
+
+func (v Version) GetVersion() string {
+	if cmdoptions.Experimental {
+		return v.OriginalVersion
+	}
+	return v.ParsedVersion
 }
 
 const (


### PR DESCRIPTION
This PR introduces a new flag `--experimental` for all subcommands, which sets a global boolean variable `experimental` in a new package `cmdoptions`.

It also reverts indirectly #802 but allows the new behavior (e.g. returning the original version) for #803 if the `--experimental` flag is used.

The goal is to avoid a breaking change while allowing the new behavior to be used for testing autodiscovery. This feature flag would allows us to ship feature without enabling it.

## Test

To test this pull request, you can run the following commands:

```shell
cp <to_package_directory>
go test
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
