### PR TITLE
feat: add a new 'experimental' flag

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,6 +4,7 @@ import (
 	"os"
 
 	"github.com/sirupsen/logrus"
+	"github.com/updatecli/updatecli/pkg/core/cmdoptions"
 	"github.com/updatecli/updatecli/pkg/core/log"
 
 	"github.com/updatecli/updatecli/pkg/core/engine"
@@ -18,6 +19,7 @@ var (
 	secretsFiles []string
 	e            engine.Engine
 	verbose      bool
+	experimental bool
 
 	rootCmd = &cobra.Command{
 		Use:   "updatecli",
@@ -45,9 +47,14 @@ func Execute() {
 
 func init() {
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "debug", "", false, "Debug Output")
+	rootCmd.PersistentFlags().BoolVarP(&experimental, "experimental", "", false, "Enable Experimental mode")
 	rootCmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
 		if verbose {
 			logrus.SetLevel(logrus.DebugLevel)
+		}
+		if experimental {
+			cmdoptions.Experimental = true
+			logrus.Infof("Experimental Mode Enabled")
 		}
 	}
 	rootCmd.AddCommand(

--- a/pkg/core/cmdoptions/main.go
+++ b/pkg/core/cmdoptions/main.go
@@ -1,0 +1,3 @@
+package cmdoptions
+
+var Experimental bool = false


### PR DESCRIPTION
Signed-off-by: Damien Duportal <damien.duportal@gmail.com>

Related to #803 and #813

This pull request introduces a new flag `--experimental`, available for ALL subcommands (like `--debug`).

This flag sets a global variable `cmdoptions.Experimental` so that any package can use it.

## Test

To test this pull request, you can run the following commands:

```shell
./dist/updatecli --debug --experimental diff --config ./updatecli/updatecli.d/updatecli.yaml
```

should print `Experimental mode enabled`.
