### PR TITLE
feat: revert #802 and use experimental to control the returned filtered version

### DIFF
--- a/e2e/updatecli.d/success.d/source/gitTag.yaml
+++ b/e2e/updatecli.d/success.d/source/gitTag.yaml
@@ -18,7 +18,10 @@ sources:
     name: Get latest updatecli test
     kind: gittag
     spec:
-      versionfilter:
-        kind: semver
-        pattern: "~0.1"
+      # comment following test until dockerimage and semver versionfilter move out from experimental
+      # more ctx on https://github.com/updatecli/updatecli/pull/816
+
+      #versionfilter:
+      #  kind: semver
+      #  pattern: "~0.1"
     scmid: updatecli

--- a/e2e/updatecli.d/warning.d/dockerimage.yaml
+++ b/e2e/updatecli.d/warning.d/dockerimage.yaml
@@ -15,23 +15,25 @@ sources:
     spec:
       image: "ghcr.io/updatecli/updatecli"
       architecture: amd64
-  ## Dockerhub return an alphabetically ordered list of docker image tag
-  # semver doesn't work in the current state
-  dockerhub-semver:
-    name: Get Latest semver Tag for Dockerhub
-    kind: dockerimage
-    spec:
-      image: "updatecli/updatecli"
-      architecture: amd64
-      versionFilter:
-        kind: semver
-  # Ghcr return an created time ordered list of container image tag
-  # semver doesn't work in the current state
-  ghcr.io-semver:
-    name: Get Latest semver Tag from ghcr
-    kind: dockerimage
-    spec:
-      image: "ghcr.io/updatecli/updatecli"
-      architecture: amd64
-      versionFilter:
-        kind: semver
+  # comment following test until dockerimage and semver versionfilter move out from experimental
+  # more ctx on https://github.com/updatecli/updatecli/pull/816
+  ### Dockerhub return an alphabetically ordered list of docker image tag
+  ## semver doesn't work in the current state
+  #dockerhub-semver:
+  #  name: Get Latest semver Tag for Dockerhub
+  #  kind: dockerimage
+  #  spec:
+  #    image: "updatecli/updatecli"
+  #    architecture: amd64
+  #    versionFilter:
+  #      kind: semver
+  ## Ghcr return an created time ordered list of container image tag
+  ## semver doesn't work in the current state
+  #ghcr.io-semver:
+  #  name: Get Latest semver Tag from ghcr
+  #  kind: dockerimage
+  #  spec:
+  #    image: "ghcr.io/updatecli/updatecli"
+  #    architecture: amd64
+  #    versionFilter:
+  #      kind: semver

--- a/pkg/plugins/resources/dockerimage/source.go
+++ b/pkg/plugins/resources/dockerimage/source.go
@@ -38,7 +38,7 @@ searchTag:
 
 		// Todo: validate that result is valid for architecture
 
-		tag = di.foundVersion.OriginalVersion
+		tag = di.foundVersion.GetVersion()
 
 		img := di.image
 		img.Tag = tag

--- a/pkg/plugins/resources/gitea/branch/source.go
+++ b/pkg/plugins/resources/gitea/branch/source.go
@@ -33,7 +33,7 @@ func (g *Gitea) Source(workingDir string) (string, error) {
 		}
 	}
 
-	value := g.foundVersion.OriginalVersion
+	value := g.foundVersion.GetVersion()
 
 	if len(value) == 0 {
 		logrus.Infof("%s No Gitea branches found matching pattern %q", result.FAILURE, g.versionFilter.Pattern)

--- a/pkg/plugins/resources/gitea/release/source.go
+++ b/pkg/plugins/resources/gitea/release/source.go
@@ -34,9 +34,9 @@ func (g *Gitea) Source(workingDir string) (string, error) {
 		}
 	}
 
-	value := g.foundVersion.OriginalVersion
+	value := g.foundVersion.GetVersion()
 
-	logrus.Infof("Latest Release found: %v", g.foundVersion.OriginalVersion)
+	logrus.Infof("Latest Release found: %v", g.foundVersion.GetVersion())
 
 	if len(value) == 0 {
 		logrus.Infof("%s No Gitea Release tag found matching pattern %q", result.FAILURE, g.versionFilter.Pattern)

--- a/pkg/plugins/resources/gitea/tag/source.go
+++ b/pkg/plugins/resources/gitea/tag/source.go
@@ -34,7 +34,7 @@ func (g *Gitea) Source(workingDir string) (string, error) {
 		}
 	}
 
-	value := g.foundVersion.OriginalVersion
+	value := g.foundVersion.GetVersion()
 
 	if len(value) == 0 {
 		logrus.Infof("%s No Gitea tags found matching pattern %q", result.FAILURE, g.versionFilter.Pattern)

--- a/pkg/plugins/resources/githubrelease/source.go
+++ b/pkg/plugins/resources/githubrelease/source.go
@@ -33,7 +33,7 @@ func (gr *GitHubRelease) Source(workingDir string) (value string, err error) {
 	if err != nil {
 		return "", err
 	}
-	value = gr.foundVersion.OriginalVersion
+	value = gr.foundVersion.GetVersion()
 
 	if len(value) == 0 {
 		logrus.Infof("%s No Github Release version found matching pattern %q", result.FAILURE, gr.versionFilter.Pattern)

--- a/pkg/plugins/resources/gittag/condition.go
+++ b/pkg/plugins/resources/gittag/condition.go
@@ -48,7 +48,7 @@ func (gt *GitTag) condition(source string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	tag := gt.foundVersion.OriginalVersion
+	tag := gt.foundVersion.GetVersion()
 
 	if len(tag) == 0 {
 		err = fmt.Errorf("no git tag matching pattern %q, found", gt.versionFilter.Pattern)

--- a/pkg/plugins/resources/gittag/source.go
+++ b/pkg/plugins/resources/gittag/source.go
@@ -29,7 +29,7 @@ func (gt *GitTag) Source(workingDir string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	value := gt.foundVersion.OriginalVersion
+	value := gt.foundVersion.GetVersion()
 
 	if len(value) == 0 {
 		logrus.Infof("%s No git tag found matching pattern %q", result.FAILURE, gt.versionFilter.Pattern)

--- a/pkg/plugins/resources/gittag/target.go
+++ b/pkg/plugins/resources/gittag/target.go
@@ -72,7 +72,7 @@ func (gt *GitTag) target(source string, dryRun bool) (bool, []string, string, er
 		// Something went wrong during the tag search.
 		return false, files, message, err
 	}
-	if gt.foundVersion.OriginalVersion == source {
+	if gt.foundVersion.GetVersion() == source {
 		// No error, but no change
 		logrus.Printf("%s The Git Tag %q already exists, nothing else to do.",
 			result.SUCCESS,

--- a/pkg/plugins/utils/version/semver.go
+++ b/pkg/plugins/utils/version/semver.go
@@ -52,8 +52,8 @@ func (s *Semver) Search(versions []string) error {
 	// We need to be sure that at least one version exist
 	if len(versions) == 0 {
 		return ErrNoVersionsFound
-
 	}
+
 	err := s.Init(versions)
 	if err != nil {
 		logrus.Error(err)


### PR DESCRIPTION
Requires #815 
Related to #803
Reverts #802 

Closes #810 


This PR reverts the behavior of #802 by default, but allow it to be used when the new `--experimental` from #815 is used.

It also adds a warning to end user when the parsed version is different than the original, which means there is `v` prefix that was dropped. 

The warning message (see below):

- Gives instructions to end user on how to edit their manifest if they need to keep the "dropping `v` prefix" and how to test it (by adding the `--experimental` flag)
- Is not shown if the experimental flag is enabled

## Test

To test this pull request, you can run the following commands:

```shell
$ go build -o dist/updatecli
```

Then

```shell
$ ./dist/updatecli diff --config ./updatecli/updatecli.d/venom.yaml

./dist/updatecli diff --config ./updatecli/updatecli.d/venom.yaml


+++++++++++
+ PREPARE +
+++++++++++

Loading Pipeline "./updatecli/updatecli.d/venom.yaml"

SCM repository retrieved: 1


++++++++++++
+ PIPELINE +
++++++++++++



######################
# BUMP VENOM VERSION #
######################


SOURCES
=======

latestVersion
-------------
Searching for version matching pattern "*"
WARNING: Updatecli will soon stop removing the 'v' prefix of 'semver' version filters to keep the original retrieved version as per https://github.com/updatecli/updatecli/issues/803.
  If you need to keep the old behavior, please add a transformer (https://www.updatecli.io/docs/core/transformer/) of type "trimprefix" to remove the "v" prefix:

  sources:
    latestVersion:
      name: Get latest version
      kind: githubrelease
      spec:
        # ...
        versionfilter:
          kind: semver
      transformers:
        - trimprefix: 'v'

  You can try the new behavior (to verify your updated manifests) by adding the flag "--experimental" when executing the "updatecli" command line.
✔ Github Release version "1.0.1" found matching pattern "*"


CHANGELOG:
----------

Release published on the 2021-12-13 16:52:12 +0000 UTC at the url https://github.com/ovh/venom/releases/tag/v1.0.1

# Venom v1.0.1

## What's Changed
* fix: handle json number is assertions (#460) https://github.com/ovh/venom/pull/464

**Full Changelog**: https://github.com/ovh/venom/compare/v1.0.0...v1.0.1


TARGETS
========

goWorkflow
----------

**Dry Run enabled**

⚠ updated the [dry run] content of the file "/var/folders/2s/09szbrgn22l2tcvxz1_k34g40000gn/T/updatecli/github/updatecli/updatecli/.github/workflows/go.yaml"

--- /var/folders/2s/09szbrgn22l2tcvxz1_k34g40000gn/T/updatecli/github/updatecli/updatecli/.github/workflows/go.yaml
+++ /var/folders/2s/09szbrgn22l2tcvxz1_k34g40000gn/T/updatecli/github/updatecli/updatecli/.github/workflows/go.yaml
@@ -29,7 +29,7 @@
           sudo chmod +x /usr/local/bin/venom
           ls -lha /usr/local/bin/venom
         env:
-          VENOM_VERSION: v1.0.1
+          VENOM_VERSION: 1.0.1
       - name: Show Venom version
         run: venom version
       - name: Install GoReleaser



PULL REQUESTS
=============

[Dry Run] A pull request with kind "github" and title "[updatecli] Bump Venom version to 1.0.1" is expected.

=============================

REPORTS:


⚠ VENOM.YAML:
        Source:
                ✔ [latestVersion] Get latest Venom release (kind: githubrelease)
        Target:
                ⚠ [goWorkflow] Bump Venom version to 1.0.1 (kind: file)


Run Summary
===========
Pipeline(s) run:
  * Changed:    1
  * Failed:     0
  * Skipped:    0
  * Succeeded:  0
  * Total:      1
```

```shell



====

./dist/updatecli --experimental diff --config ./updatecli/updatecli.d/venom.yaml
Experimental Mode Enabled


+++++++++++
+ PREPARE +
+++++++++++

Loading Pipeline "./updatecli/updatecli.d/venom.yaml"

SCM repository retrieved: 1


++++++++++++
+ PIPELINE +
++++++++++++



######################
# BUMP VENOM VERSION #
######################


SOURCES
=======

latestVersion
-------------
Searching for version matching pattern "*"
✔ Github Release version "v1.0.1" found matching pattern "*"


CHANGELOG:
----------

Release published on the 2021-12-13 16:52:12 +0000 UTC at the url https://github.com/ovh/venom/releases/tag/v1.0.1

# Venom v1.0.1

## What's Changed
* fix: handle json number is assertions (#460) https://github.com/ovh/venom/pull/464

**Full Changelog**: https://github.com/ovh/venom/compare/v1.0.0...v1.0.1


TARGETS
========

goWorkflow
----------

**Dry Run enabled**

✔ Content from file "/var/folders/2s/09szbrgn22l2tcvxz1_k34g40000gn/T/updatecli/github/updatecli/updatecli/.github/workflows/go.yaml" already up to date
✔ All contents from 'file' and 'files' combined already up to date


PULL REQUESTS
=============


=============================

REPORTS:


✔ VENOM.YAML:
        Source:
                ✔ [latestVersion] Get latest Venom release (kind: githubrelease)
        Target:
                ✔ [goWorkflow] Bump Venom version to v1.0.1 (kind: file)


Run Summary
===========
Pipeline(s) run:
  * Changed:    0
  * Failed:     0
  * Skipped:    0
  * Succeeded:  1
  * Total:      1
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
