### PR TITLE
Fix: Autodiscovery groupBy correctly applied

### DIFF
--- a/pkg/core/pipeline/autodiscovery/main.go
+++ b/pkg/core/pipeline/autodiscovery/main.go
@@ -170,7 +170,12 @@ func (g *AutoDiscovery) Run() ([]config.Spec, error) {
 
 	// We use a sha256 hash to avoid colusion between pipelineID
 	hash := sha256.New()
-	io.WriteString(hash, "updatecli/autodiscovery/batch")
+	_, err := io.WriteString(hash, "updatecli/autodiscovery/batch")
+
+	if err != nil {
+		logrus.Errorln(err)
+	}
+
 	batchPipelineID := fmt.Sprintf("%x", hash.Sum(nil))
 
 	for i := range totalDiscoveredManifests {
@@ -179,7 +184,10 @@ func (g *AutoDiscovery) Run() ([]config.Spec, error) {
 			totalDiscoveredManifests[i].PipelineID = batchPipelineID[0:32]
 
 		case discoveryConfig.GROUPEBYINDIVIDUAL, "":
-			io.WriteString(hash, totalDiscoveredManifests[i].Name)
+			_, err := io.WriteString(hash, totalDiscoveredManifests[i].Name)
+			if err != nil {
+				logrus.Errorln(err)
+			}
 			pipelineID := fmt.Sprintf("%x", hash.Sum(nil))
 
 			totalDiscoveredManifests[i].PipelineID = pipelineID[0:32]

--- a/pkg/core/pipeline/autodiscovery/main.go
+++ b/pkg/core/pipeline/autodiscovery/main.go
@@ -3,6 +3,7 @@ package autodiscovery
 import (
 	"crypto/sha256"
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/mitchellh/mapstructure"
@@ -169,7 +170,8 @@ func (g *AutoDiscovery) Run() ([]config.Spec, error) {
 
 	// We use a sha256 hash to avoid colusion between pipelineID
 	hash := sha256.New()
-	batchPipelineID := fmt.Sprintf("%x", hash.Sum([]byte("updatecli/autodiscovery/batch")))
+	io.WriteString(hash, "updatecli/autodiscovery/batch")
+	batchPipelineID := fmt.Sprintf("%x", hash.Sum(nil))
 
 	for i := range totalDiscoveredManifests {
 		switch g.spec.GroupBy {
@@ -177,7 +179,8 @@ func (g *AutoDiscovery) Run() ([]config.Spec, error) {
 			totalDiscoveredManifests[i].PipelineID = batchPipelineID[0:32]
 
 		case discoveryConfig.GROUPEBYINDIVIDUAL, "":
-			pipelineID := fmt.Sprintf("%x", hash.Sum([]byte(totalDiscoveredManifests[i].Name)))
+			io.WriteString(hash, totalDiscoveredManifests[i].Name)
+			pipelineID := fmt.Sprintf("%x", hash.Sum(nil))
 
 			totalDiscoveredManifests[i].PipelineID = pipelineID[0:32]
 


### PR DESCRIPTION
Signed-off-by: Olblak <me@olblak.com>

In this pullrquest https://github.com/olblak/fleet-lab/pull/1, I noticed that the groupby wasn't correctly handle.
And the pipelineID was always the same no matter what

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
