### PR TITLE
Add new parameter "repositories" to Maven resource

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yml
@@ -38,7 +38,7 @@ body:
     description: |
       examples:
         - **OS**: Ubuntu 20.04
-        - **updatecli**: v0.30.0
+        - **updatecli**: v0.32.0
     value: |
         - OS:
         - updatecli:

--- a/e2e/updatecli.d/success.d/maven.yaml
+++ b/e2e/updatecli.d/success.d/maven.yaml
@@ -69,12 +69,3 @@ conditions:
       groupid: "junit"
       artifactid: "junit"
       version: "4.3.1"
-
-  checkIfOlderJunitExist5:
-    kind: maven
-    name: Is there a version 4.3.1 of junit/junit
-    disablesourceinput: true
-    spec:
-      groupid: "junit"
-      artifactid: "junit"
-      version: "4.3.2"

--- a/e2e/updatecli.d/success.d/maven.yaml
+++ b/e2e/updatecli.d/success.d/maven.yaml
@@ -9,15 +9,21 @@ sources:
   getLatestJenkinsWarVersion:
     kind: maven
     spec:
-      url: "repo.jenkins-ci.org"
-      repository: "releases"
+      repository: "http://repo.jenkins-ci.org/releases"
       groupid: "org.jenkins-ci.main"
       artifactid: "jenkins-war"
   getLatestJunitVersion:
     kind: maven
     spec:
-      url: "repo.maven.apache.org"
-      repository: "maven2"
+      repository: "repo.maven.apache.org/maven2"
+      groupid: "junit"
+      artifactid: "junit"
+  getLatestJunitVersionfromRepositories:
+    kind: maven
+    spec:
+      repositories:
+        - "repo.maven.apache.org/maven2"
+        - "https://repo.maven.apache.org/maven2"
       groupid: "junit"
       artifactid: "junit"
 
@@ -27,8 +33,48 @@ conditions:
     name: Is there a version 4.3.1 of junit/junit at https://repo.maven.apache.org/maven2
     disablesourceinput: true
     spec:
-      url: "repo.maven.apache.org"
-      repository: "maven2"
+      repository: "repo.maven.apache.org/maven2"
       groupid: "junit"
       artifactid: "junit"
       version: "4.3.1"
+
+  checkIfOlderJunitExistr2:
+    kind: maven
+    name: Is there a version 4.3.1 of junit/junit at https://repo.maven.apache.org/maven2
+    disablesourceinput: true
+    spec:
+      repository: "https://repo.maven.apache.org/maven2"
+      groupid: "junit"
+      artifactid: "junit"
+      version: "4.3.1"
+
+  checkIfOlderJunitExist3:
+    kind: maven
+    name: Is there a version 4.3.1 of junit/junit at https://repo.maven.apache.org/maven2
+    disablesourceinput: true
+    spec:
+      repositories:
+        - "repo.maven.apache.org/maven2"
+      groupid: "junit"
+      artifactid: "junit"
+      version: "4.3.1"
+
+  checkIfOlderJunitExist4:
+    kind: maven
+    name: Is there a version 4.3.1 of junit/junit at https://repo.maven.apache.org/maven2
+    disablesourceinput: true
+    spec:
+      repositories:
+        - "https://repo.maven.apache.org/maven2"
+      groupid: "junit"
+      artifactid: "junit"
+      version: "4.3.1"
+
+  checkIfOlderJunitExist5:
+    kind: maven
+    name: Is there a version 4.3.1 of junit/junit
+    disablesourceinput: true
+    spec:
+      groupid: "junit"
+      artifactid: "junit"
+      version: "4.3.2"

--- a/e2e/updatecli.d/warning.d/maven.yaml
+++ b/e2e/updatecli.d/warning.d/maven.yaml
@@ -1,0 +1,34 @@
+---
+title: Show a set of maven resources as a generic example
+
+scms:
+  local:
+    disabled: true
+
+sources:
+  getLatestJenkinsWarVersion:
+    kind: maven
+    spec:
+      url: "http://repo.jenkins-ci.org"
+      repository: "releases"
+      groupid: "org.jenkins-ci.main"
+      artifactid: "jenkins-war"
+  getLatestJunitVersion:
+    kind: maven
+    spec:
+      url: "repo.maven.apache.org"
+      repository: "maven2"
+      groupid: "junit"
+      artifactid: "junit"
+
+conditions:
+  checkIfOlderJunitExist:
+    kind: maven
+    name: Is there a version 4.3.1 of junit/junit at https://repo.maven.apache.org/maven2
+    disablesourceinput: true
+    spec:
+      url: "repo.maven.apache.org"
+      repository: "maven2"
+      groupid: "junit"
+      artifactid: "junit"
+      version: "4.3.1"

--- a/pkg/plugins/resources/maven/condition.go
+++ b/pkg/plugins/resources/maven/condition.go
@@ -16,6 +16,12 @@ func (m *Maven) Condition(source string) (bool, error) {
 	}
 
 	for _, metadataHandler := range m.metadataHandlers {
+		// metadataURL contains the URL without username/password
+		metadataURL, err := trimUsernamePasswordFromURL(metadataHandler.GetMetadataURL())
+		if err != nil {
+			logrus.Errorf("Trying to parse Maven metadatal url: %s", err)
+		}
+
 		versions, err := metadataHandler.GetVersions()
 		if err != nil {
 			return false, err
@@ -24,7 +30,7 @@ func (m *Maven) Condition(source string) (bool, error) {
 		for _, version := range versions {
 			if version == m.spec.Version {
 				logrus.Infof("%s Version %s is available on the Maven Repository (%s)",
-					result.SUCCESS, m.spec.Version, metadataHandler.GetMetadataURL())
+					result.SUCCESS, m.spec.Version, metadataURL)
 				return true, nil
 			}
 		}

--- a/pkg/plugins/resources/maven/condition.go
+++ b/pkg/plugins/resources/maven/condition.go
@@ -15,21 +15,24 @@ func (m *Maven) Condition(source string) (bool, error) {
 		m.spec.Version = source
 	}
 
-	versions, err := m.metadataHandler.GetVersions()
-	if err != nil {
-		return false, err
-	}
-
-	for _, version := range versions {
-		if version == m.spec.Version {
-			logrus.Infof("%s Version %s is available on the Maven Repository (%s)",
-				result.SUCCESS, m.spec.Version, m.metadataHandler.GetMetadataURL())
-			return true, nil
+	for _, metadataHandler := range m.metadataHandlers {
+		versions, err := metadataHandler.GetVersions()
+		if err != nil {
+			return false, err
 		}
+
+		for _, version := range versions {
+			if version == m.spec.Version {
+				logrus.Infof("%s Version %s is available on the Maven Repository (%s)",
+					result.SUCCESS, m.spec.Version, metadataHandler.GetMetadataURL())
+				return true, nil
+			}
+		}
+
 	}
 
-	logrus.Infof("%s Version %s is not available on the Maven Repository (%s)",
-		result.FAILURE, m.spec.Version, m.metadataHandler.GetMetadataURL())
+	logrus.Infof("%s Version %s is not found for Maven artifact (%s/%s)",
+		result.FAILURE, m.spec.Version, m.spec.GroupID, m.spec.ArtifactID)
 	return false, nil
 }
 

--- a/pkg/plugins/resources/maven/condition_test.go
+++ b/pkg/plugins/resources/maven/condition_test.go
@@ -79,8 +79,10 @@ func TestCondition(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			sut := Maven{
-				spec:            tt.spec,
-				metadataHandler: tt.mockedMetadataHandler,
+				spec: tt.spec,
+				metadataHandlers: []mavenmetadata.Handler{
+					tt.mockedMetadataHandler,
+				},
 			}
 
 			got, gotErr := sut.Condition(tt.source)

--- a/pkg/plugins/resources/maven/condition_test.go
+++ b/pkg/plugins/resources/maven/condition_test.go
@@ -22,8 +22,7 @@ func TestCondition(t *testing.T) {
 			name:   "Passing case with input source for org.eclipse.mylyn.wikitext.wikitext.core on repo.jenkins-ci.org/releases",
 			source: "1.7.4.v20130429",
 			spec: Spec{
-				URL:        "repo.jenkins-ci.org",
-				Repository: "releases",
+				Repository: "repo.jenkins-ci.org/releases",
 				GroupID:    "org.eclipse.mylyn.wikitext",
 				ArtifactID: "wikitext.core",
 			},
@@ -35,8 +34,7 @@ func TestCondition(t *testing.T) {
 		{
 			name: "Passing case with specified version for org.eclipse.mylyn.wikitext.wikitext.core on repo.jenkins-ci.org/releases",
 			spec: Spec{
-				URL:        "repo.jenkins-ci.org",
-				Repository: "releases",
+				Repository: "repo.jenkins-ci.org/releases",
 				GroupID:    "org.eclipse.mylyn.wikitext",
 				ArtifactID: "wikitext.core",
 				Version:    "1.7.3",
@@ -50,8 +48,7 @@ func TestCondition(t *testing.T) {
 			name:   "Failing case with input source for org.eclipse.mylyn.wikitext.wikitext.core on repo.jenkins-ci.org/releases",
 			source: "1.6.0",
 			spec: Spec{
-				URL:        "repo.jenkins-ci.org",
-				Repository: "releases",
+				Repository: "repo.jenkins-ci.org/releases",
 				GroupID:    "org.eclipse.mylyn.wikitext",
 				ArtifactID: "wikitext.core",
 			},
@@ -64,8 +61,7 @@ func TestCondition(t *testing.T) {
 			name:   "Error case with an error returned by the handler",
 			source: "1.7.4.v20130429",
 			spec: Spec{
-				URL:        "repo.jenkins-ci.org",
-				Repository: "releases",
+				Repository: "repo.jenkins-ci.org/releases",
 				GroupID:    "org.eclipse.mylyn.wikitext",
 				ArtifactID: "wikitext.core",
 			},

--- a/pkg/plugins/resources/maven/main.go
+++ b/pkg/plugins/resources/maven/main.go
@@ -1,11 +1,22 @@
 package maven
 
 import (
+	"errors"
 	"fmt"
+	"net/url"
+	"path"
 	"strings"
 
 	"github.com/mitchellh/mapstructure"
+	"github.com/sirupsen/logrus"
 	"github.com/updatecli/updatecli/pkg/plugins/utils/mavenmetadata"
+)
+
+var (
+	// ErrWrongSpec is returned when the Spec has wrong content
+	ErrWrongSpec error = errors.New("wrong spec content")
+
+	MavenCentralRepository string = "repo1.maven.org/maven2/"
 )
 
 // Spec defines a specification for a "maven" resource
@@ -15,6 +26,8 @@ type Spec struct {
 	URL string `yaml:",omitempty"`
 	// Specifies the maven repository name
 	Repository string `yaml:",omitempty"`
+	// Repositories specifies a list of Maven repository
+	Repositories []string `yaml:",omitempty"`
 	// Specifies the maven artifact groupID
 	GroupID string `yaml:",omitempty"`
 	// Specifies the maven artifact artifactID
@@ -25,8 +38,8 @@ type Spec struct {
 
 // Maven defines a resource of kind "maven"
 type Maven struct {
-	spec            Spec
-	metadataHandler mavenmetadata.Handler
+	spec             Spec
+	metadataHandlers []mavenmetadata.Handler
 }
 
 // New returns a reference to a newly initialized Maven object from a Spec
@@ -40,13 +53,66 @@ func New(spec interface{}) (*Maven, error) {
 
 	newResource := &Maven{
 		spec: newSpec,
-		metadataHandler: mavenmetadata.New(
-			fmt.Sprintf("https://%s/%s/%s/%s/maven-metadata.xml",
-				newSpec.URL,
-				newSpec.Repository,
-				strings.ReplaceAll(newSpec.GroupID, ".", "/"),
-				newSpec.ArtifactID),
-		),
+	}
+
+	if len(newSpec.Repository) > 0 {
+
+		URL := strings.TrimPrefix(newSpec.URL, "https://")
+
+		URL = strings.TrimPrefix(URL, "http://")
+
+		u, err := url.Parse("https://" + URL)
+		if err != nil {
+			return &Maven{}, err
+		}
+
+		u.Path = path.Join(
+			u.Path,
+			newSpec.Repository,
+			strings.ReplaceAll(newSpec.GroupID, ".", "/"),
+			newSpec.ArtifactID,
+			"maven-metadata.xml")
+
+		newResource.metadataHandlers = append(
+			newResource.metadataHandlers,
+			mavenmetadata.New(u.String()))
+
+		return newResource, nil
+	}
+
+	for _, repository := range newSpec.Repositories {
+		URL := strings.TrimPrefix(repository, "https://")
+		URL = strings.TrimPrefix(URL, "http://")
+
+		u, err := url.Parse("https://" + URL)
+		if err != nil {
+			return &Maven{}, err
+		}
+
+		u.Path = path.Join(u.Path, strings.ReplaceAll(newSpec.GroupID, ".", "/"), newSpec.ArtifactID, "maven-metadata.xml")
+
+		newResource.metadataHandlers = append(
+			newResource.metadataHandlers,
+			mavenmetadata.New(u.String()))
+	}
+
+	mavenCentrallNotFound, err := isRepositoriesContainsMavenCentral(newSpec.Repositories)
+
+	if err != nil {
+		return &Maven{}, err
+	}
+
+	if !mavenCentrallNotFound {
+		u, err := url.Parse("https://" + MavenCentralRepository)
+		if err != nil {
+			return &Maven{}, err
+		}
+
+		u.Path = path.Join(u.Path, strings.ReplaceAll(newSpec.GroupID, ".", "/"), newSpec.ArtifactID, "maven-metadata.xml")
+
+		newResource.metadataHandlers = append(
+			newResource.metadataHandlers,
+			mavenmetadata.New(u.String()))
 	}
 
 	return newResource, nil
@@ -55,4 +121,23 @@ func New(spec interface{}) (*Maven, error) {
 // Changelog returns the changelog for this resource, or an empty string if not supported
 func (m *Maven) Changelog() string {
 	return ""
+}
+
+func (m Maven) Validate() error {
+	errs := []error{}
+
+	if len(m.spec.Repository) > 0 && len(m.spec.Repositories) > 0 {
+		errs = append(errs, fmt.Errorf("parameter %q and %q are mutually exclusif",
+			"repository",
+			"repositories"))
+	}
+
+	if len(errs) > 0 {
+		for _, e := range errs {
+			logrus.Errorf(e.Error())
+		}
+		return ErrWrongSpec
+	}
+	return nil
+
 }

--- a/pkg/plugins/resources/maven/main_test.go
+++ b/pkg/plugins/resources/maven/main_test.go
@@ -18,15 +18,31 @@ func TestNew(t *testing.T) {
 		{
 			name: "Normal Maven case",
 			spec: Spec{
-				URL:        "repo.jenkins-ci.org",
-				Repository: "releases",
+				Repository: "repo.jenkins-ci.org/releases",
 				GroupID:    "org.eclipse.mylyn.wikitext",
 				ArtifactID: "wikitext.core",
 			},
 			want: &Maven{
 				spec: Spec{
-					URL:        "repo.jenkins-ci.org",
-					Repository: "releases",
+					Repository: "https://repo.jenkins-ci.org/releases",
+					GroupID:    "org.eclipse.mylyn.wikitext",
+					ArtifactID: "wikitext.core",
+				},
+				metadataHandlers: []mavenmetadata.Handler{
+					&mavenmetadata.DefaultHandler{},
+				},
+			},
+		},
+		{
+			name: "Normal Maven case",
+			spec: Spec{
+				Repository: "https://repo.jenkins-ci.org/releases",
+				GroupID:    "org.eclipse.mylyn.wikitext",
+				ArtifactID: "wikitext.core",
+			},
+			want: &Maven{
+				spec: Spec{
+					Repository: "https://repo.jenkins-ci.org/releases",
 					GroupID:    "org.eclipse.mylyn.wikitext",
 					ArtifactID: "wikitext.core",
 				},

--- a/pkg/plugins/resources/maven/main_test.go
+++ b/pkg/plugins/resources/maven/main_test.go
@@ -30,7 +30,9 @@ func TestNew(t *testing.T) {
 					GroupID:    "org.eclipse.mylyn.wikitext",
 					ArtifactID: "wikitext.core",
 				},
-				metadataHandler: &mavenmetadata.DefaultHandler{},
+				metadataHandlers: []mavenmetadata.Handler{
+					&mavenmetadata.DefaultHandler{},
+				},
 			},
 		},
 	}
@@ -45,7 +47,7 @@ func TestNew(t *testing.T) {
 
 			require.NoError(t, err)
 			assert.Equal(t, tt.want.spec, got.spec)
-			assert.IsType(t, tt.want.metadataHandler, tt.want.metadataHandler)
+			assert.IsType(t, tt.want.metadataHandlers, tt.want.metadataHandlers)
 		})
 	}
 }

--- a/pkg/plugins/resources/maven/source.go
+++ b/pkg/plugins/resources/maven/source.go
@@ -11,6 +11,12 @@ import (
 func (m *Maven) Source(workingDir string) (string, error) {
 
 	for _, metadataHandler := range m.metadataHandlers {
+		// metadataURL contains the URL without username/password
+		metadataURL, err := trimUsernamePasswordFromURL(metadataHandler.GetMetadataURL())
+		if err != nil {
+			logrus.Errorf("Trying to parse Maven metadatal url: %s", err)
+		}
+
 		latestVersion, err := metadataHandler.GetLatestVersion()
 		if err != nil {
 			return "", err
@@ -21,7 +27,7 @@ func (m *Maven) Source(workingDir string) (string, error) {
 				"%s Latest version is %s on the Maven repository at %s",
 				result.SUCCESS,
 				latestVersion,
-				metadataHandler.GetMetadataURL(),
+				metadataURL,
 			)
 			return latestVersion, nil
 		}

--- a/pkg/plugins/resources/maven/source.go
+++ b/pkg/plugins/resources/maven/source.go
@@ -10,20 +10,23 @@ import (
 // Source return the latest version
 func (m *Maven) Source(workingDir string) (string, error) {
 
-	latestVersion, err := m.metadataHandler.GetLatestVersion()
-	if err != nil {
-		return "", err
+	for _, metadataHandler := range m.metadataHandlers {
+		latestVersion, err := metadataHandler.GetLatestVersion()
+		if err != nil {
+			return "", err
+		}
+
+		if latestVersion != "" {
+			logrus.Infof(
+				"%s Latest version is %s on the Maven repository at %s",
+				result.SUCCESS,
+				latestVersion,
+				metadataHandler.GetMetadataURL(),
+			)
+			return latestVersion, nil
+		}
+
 	}
 
-	if latestVersion != "" {
-		logrus.Infof(
-			"%s Latest version is %s on the Maven repository at %s",
-			result.SUCCESS,
-			latestVersion,
-			m.metadataHandler.GetMetadataURL(),
-		)
-		return latestVersion, nil
-	}
-
-	return "", fmt.Errorf("%s No latest version on the Maven Repository at %s", result.FAILURE, m.metadataHandler.GetMetadataURL())
+	return "", fmt.Errorf("%s No latest version for the Maven Artifact %s/%s", result.FAILURE, m.spec.GroupID, m.spec.ArtifactID)
 }

--- a/pkg/plugins/resources/maven/source_test.go
+++ b/pkg/plugins/resources/maven/source_test.go
@@ -21,8 +21,7 @@ func TestSource(t *testing.T) {
 		{
 			name: "Normal case with org.eclipse.mylyn.wikitext.wikitext.core on repo.jenkins-ci.org/releases",
 			spec: Spec{
-				URL:        "repo.jenkins-ci.org",
-				Repository: "releases",
+				Repository: "repo.jenkins-ci.org/releases",
 				GroupID:    "org.eclipse.mylyn.wikitext",
 				ArtifactID: "wikitext.core",
 			},
@@ -34,8 +33,7 @@ func TestSource(t *testing.T) {
 		{
 			name: "Error case with an error returned by the handler",
 			spec: Spec{
-				URL:        "repo.jenkins-ci.org",
-				Repository: "releases",
+				Repository: "repo.jenkins-ci.org/releases",
 				GroupID:    "org.eclipse.mylyn.wikitext",
 				ArtifactID: "wikitext.core",
 			},
@@ -47,8 +45,7 @@ func TestSource(t *testing.T) {
 		{
 			name: "Error case with empty latest version returned by the handler",
 			spec: Spec{
-				URL:        "repo.jenkins-ci.org",
-				Repository: "releases",
+				Repository: "repo.jenkins-ci.org/releases",
 				GroupID:    "org.eclipse.mylyn.wikitext",
 				ArtifactID: "wikitext.core",
 			},

--- a/pkg/plugins/resources/maven/source_test.go
+++ b/pkg/plugins/resources/maven/source_test.go
@@ -61,8 +61,10 @@ func TestSource(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			sut := Maven{
-				spec:            tt.spec,
-				metadataHandler: tt.mockedMetadataHandler,
+				spec: tt.spec,
+				metadataHandlers: []mavenmetadata.Handler{
+					tt.mockedMetadataHandler,
+				},
 			}
 
 			got, gotErr := sut.Source(tt.workingDir)

--- a/pkg/plugins/resources/maven/utils.go
+++ b/pkg/plugins/resources/maven/utils.go
@@ -30,17 +30,17 @@ func isRepositoriesContainsMavenCentral(repositories []string) (bool, error) {
 	return false, nil
 }
 
-// trimUsernamePasswordFromURL parse a maven URL to only return the hostname
+// trimUsernamePasswordFromURL parse a maven URL then remove the username/password component from it
 func trimUsernamePasswordFromURL(URL string) (string, error) {
 	u, err := url.Parse(URL)
 	if err != nil {
 		return "", err
 	}
 
-	result := u.Hostname()
+	result := u.Scheme + "://" + u.Hostname()
 
 	if len(u.Path) > 0 {
-		result = u.Scheme + "://" + result + u.Path
+		result = result + u.Path
 	}
 
 	return result, nil

--- a/pkg/plugins/resources/maven/utils.go
+++ b/pkg/plugins/resources/maven/utils.go
@@ -2,23 +2,22 @@ package maven
 
 import (
 	"net/url"
+	"path"
 	"strings"
+
+	"github.com/sirupsen/logrus"
 )
 
 // isRepositoriesContainsMavenCentral return if the repositories list contains the maven central url
 func isRepositoriesContainsMavenCentral(repositories []string) (bool, error) {
 
-	mcu, err := url.Parse("https://" + MavenCentralRepository)
+	mcu, err := url.Parse(MavenCentralRepository)
 	if err != nil {
 		return false, err
 	}
 
-	for i := range repositories {
-		// Ensure we only interact with https repositories
-		u := strings.TrimPrefix(repositories[i], "https://")
-		u = strings.TrimPrefix(u, "http://")
-
-		r, err := url.Parse("https://" + u)
+	for _, repository := range repositories {
+		r, err := url.Parse(repository)
 		if err != nil {
 			return false, err
 		}
@@ -29,4 +28,55 @@ func isRepositoriesContainsMavenCentral(repositories []string) (bool, error) {
 	}
 
 	return false, nil
+}
+
+// trimUsernamePasswordFromURL parse a maven URL to only return the hostname
+func trimUsernamePasswordFromURL(URL string) (string, error) {
+	u, err := url.Parse(URL)
+	if err != nil {
+		return "", err
+	}
+
+	result := u.Hostname()
+
+	if len(u.Path) > 0 {
+		result = u.Scheme + "://" + result + u.Path
+	}
+
+	return result, nil
+}
+
+// joinURL returns an url
+func joinURL(elems []string) (string, error) {
+
+	var URL string
+
+	if len(elems) == 0 {
+		return "", nil
+	}
+
+	URL = elems[0]
+	if !(strings.HasPrefix(elems[0], "https://") || strings.HasPrefix(elems[0], "http://")) {
+		URL = "https://" + elems[0]
+	}
+	URL = strings.TrimSuffix(URL, "/")
+
+	if len(elems) == 1 {
+		return URL, nil
+	}
+
+	u, err := url.Parse(URL)
+	if err != nil {
+		return "", err
+	}
+
+	URL = u.String()
+
+	remainingElements := elems[1:]
+
+	args := path.Join(remainingElements...)
+
+	logrus.Printf(URL)
+
+	return URL + "/" + args, nil
 }

--- a/pkg/plugins/resources/maven/utils.go
+++ b/pkg/plugins/resources/maven/utils.go
@@ -1,0 +1,32 @@
+package maven
+
+import (
+	"net/url"
+	"strings"
+)
+
+// isRepositoriesContainsMavenCentral return if the repositories list contains the maven central url
+func isRepositoriesContainsMavenCentral(repositories []string) (bool, error) {
+
+	mcu, err := url.Parse("https://" + MavenCentralRepository)
+	if err != nil {
+		return false, err
+	}
+
+	for i := range repositories {
+		// Ensure we only interact with https repositories
+		u := strings.TrimPrefix(repositories[i], "https://")
+		u = strings.TrimPrefix(u, "http://")
+
+		r, err := url.Parse("https://" + u)
+		if err != nil {
+			return false, err
+		}
+
+		if r.Hostname() == mcu.Hostname() {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}

--- a/pkg/plugins/resources/maven/utils_test.go
+++ b/pkg/plugins/resources/maven/utils_test.go
@@ -1,0 +1,57 @@
+package maven
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsRepositoriesContainsMavenCentral(t *testing.T) {
+	testData := []struct {
+		Name           string
+		Repositories   []string
+		ExpectedResult bool
+		WantErr        bool
+	}{
+		{
+			Name: "1",
+			Repositories: []string{
+				"repo.jenkins-ci.org",
+			},
+			ExpectedResult: false,
+		},
+		{
+			Name: "1",
+			Repositories: []string{
+				"repo.jenkins-ci.org",
+				"example.com",
+			},
+			ExpectedResult: false,
+		},
+		{
+			Name: "1",
+			Repositories: []string{
+				"repo.jenkins-ci.org",
+				"repo1.maven.org",
+			},
+			ExpectedResult: true,
+		},
+	}
+
+	for _, tt := range testData {
+		t.Run(tt.Name, func(t *testing.T) {
+			gotResult, gotError := isRepositoriesContainsMavenCentral(tt.Repositories)
+
+			if tt.WantErr {
+				require.Error(t, gotError)
+			} else {
+				require.NoError(t, gotError)
+			}
+
+			assert.Equal(t, tt.ExpectedResult, gotResult)
+
+		})
+	}
+
+}

--- a/pkg/plugins/resources/maven/utils_test.go
+++ b/pkg/plugins/resources/maven/utils_test.go
@@ -17,23 +17,23 @@ func TestIsRepositoriesContainsMavenCentral(t *testing.T) {
 		{
 			Name: "1",
 			Repositories: []string{
-				"repo.jenkins-ci.org",
+				"https://repo.jenkins-ci.org",
 			},
 			ExpectedResult: false,
 		},
 		{
 			Name: "1",
 			Repositories: []string{
-				"repo.jenkins-ci.org",
-				"example.com",
+				"https://repo.jenkins-ci.org",
+				"https://example.com",
 			},
 			ExpectedResult: false,
 		},
 		{
 			Name: "1",
 			Repositories: []string{
-				"repo.jenkins-ci.org",
-				"repo1.maven.org",
+				"https://repo.jenkins-ci.org",
+				"https://repo1.maven.org",
 			},
 			ExpectedResult: true,
 		},
@@ -51,6 +51,124 @@ func TestIsRepositoriesContainsMavenCentral(t *testing.T) {
 
 			assert.Equal(t, tt.ExpectedResult, gotResult)
 
+		})
+	}
+
+}
+
+func TestGetURLHostname(t *testing.T) {
+	testData := []struct {
+		Name           string
+		Repository     string
+		ExpectedResult string
+		WantErr        bool
+	}{
+		{
+			Name:           "test 1",
+			Repository:     "https://username:password@example.com",
+			ExpectedResult: "https://example.com",
+		},
+		{
+			Name:           "test 1",
+			Repository:     "https://username:password@example.com",
+			ExpectedResult: "https://example.com",
+		},
+		{
+			Name:           "test 1",
+			Repository:     "https://username:password@example.com/registry",
+			ExpectedResult: "https://example.com/registry",
+		},
+	}
+
+	for _, tt := range testData {
+		t.Run(tt.Name, func(t *testing.T) {
+			gotResult, gotError := trimUsernamePasswordFromURL(tt.Repository)
+
+			if tt.WantErr {
+				require.Error(t, gotError)
+			} else {
+				require.NoError(t, gotError)
+			}
+
+			assert.Equal(t, tt.ExpectedResult, gotResult)
+		})
+	}
+
+}
+
+func TestJoinURLElem(t *testing.T) {
+	testData := []struct {
+		Name           string
+		Repository     []string
+		ExpectedResult string
+		WantErr        bool
+	}{
+		{
+			Name:           "test 0",
+			ExpectedResult: "",
+		},
+		{
+			Name: "test 1",
+			Repository: []string{
+				"username:password@example.com",
+				"registry",
+			},
+			ExpectedResult: "https://username:password@example.com/registry",
+		},
+		{
+			Name: "test 2",
+			Repository: []string{
+				"username:password@example.com/",
+				"registry",
+			},
+			ExpectedResult: "https://username:password@example.com/registry",
+		},
+		{
+			Name: "test 3",
+			Repository: []string{
+				"https://username:password@example.com/",
+				"registry",
+			},
+			ExpectedResult: "https://username:password@example.com/registry",
+		},
+		{
+
+			Name: "test 4",
+			Repository: []string{
+				"http://username:password@example.com/",
+				"registry",
+			},
+			ExpectedResult: "http://username:password@example.com/registry",
+		},
+		{
+
+			Name: "test 5",
+			Repository: []string{
+				"username:password@example.com/",
+				"registry",
+			},
+			ExpectedResult: "https://username:password@example.com/registry",
+		},
+		{
+			Name: "test 6",
+			Repository: []string{
+				"username:password@example.com",
+			},
+			ExpectedResult: "https://username:password@example.com",
+		},
+	}
+
+	for _, tt := range testData {
+		t.Run(tt.Name, func(t *testing.T) {
+			gotResult, gotError := joinURL(tt.Repository)
+
+			if tt.WantErr {
+				require.Error(t, gotError)
+			} else {
+				require.NoError(t, gotError)
+			}
+
+			assert.Equal(t, tt.ExpectedResult, gotResult)
 		})
 	}
 

--- a/pkg/plugins/resources/maven/utils_test.go
+++ b/pkg/plugins/resources/maven/utils_test.go
@@ -56,7 +56,7 @@ func TestIsRepositoriesContainsMavenCentral(t *testing.T) {
 
 }
 
-func TestGetURLHostname(t *testing.T) {
+func TestTrimUsernamePasswordFromURL(t *testing.T) {
 	testData := []struct {
 		Name           string
 		Repository     string
@@ -69,14 +69,19 @@ func TestGetURLHostname(t *testing.T) {
 			ExpectedResult: "https://example.com",
 		},
 		{
-			Name:           "test 1",
+			Name:           "test 2",
 			Repository:     "https://username:password@example.com",
 			ExpectedResult: "https://example.com",
 		},
 		{
-			Name:           "test 1",
+			Name:           "test 3",
 			Repository:     "https://username:password@example.com/registry",
 			ExpectedResult: "https://example.com/registry",
+		},
+		{
+			Name:           "test 4",
+			Repository:     "https://username:password@example.com",
+			ExpectedResult: "https://example.com",
 		},
 	}
 


### PR DESCRIPTION
Signed-off-by: Olblak <me@olblak.com>

The purpose of this Pullrequest is to mimic how Maven decides which repository to use when retrieving the latest version of an artifact by providing a list of repositories. Similarly to Maven, we fallback to Maven Central if we can't find any valid artifact.

This pullrequest is a requirement for https://github.com/updatecli/updatecli/pull/833

- [x] Ensure no leak when using usenrame/password directly in the URL 

An example of the new `repositories` parameter:
```
sources:
    org.mockito/mockito-core:
        name: 'Get latest Maven Artifact version: "org.mockito/mockito-core"'
        kind: maven
        spec:
            repositories:
                - http://repo.jenkins-ci.org/public/
            groupid: org.mockito
            artifactid: mockito-core

```


While the current behavior with the singe repository hasn't been modified. I am deprecating the parameter `URL` as it has no added value than merging it in the field `repository` 

```
sources:
    org.mockito/mockito-core:
        name: 'Get latest Maven Artifact version: "org.mockito/mockito-core"'
        kind: maven
        spec:
            url: http://repo.jenkins-ci..org
            repository: public
            groupid: org.mockito
            artifactid: mockito-core
```

we would have 

```
sources:
    org.mockito/mockito-core:
        name: 'Get latest Maven Artifact version: "org.mockito/mockito-core"'
        kind: maven
        spec:
            repository: http://repo.jenkins-ci..org/public
            groupid: org.mockito
            artifactid: mockito-core
```

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
cd ./pkg/plugins/resources/maven/
go test
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->