### PR TITLE
pullrequest correctly search linked targets based on pullrequestID

### DIFF
--- a/e2e/updatecli.d/success.d/githubPullrequest.yaml
+++ b/e2e/updatecli.d/success.d/githubPullrequest.yaml
@@ -11,18 +11,15 @@ scms:
       branch: main
 
 sources:
-  jenkins: 
+  jenkins:
     name: Get updatecli config title
-    kind: yaml 
+    kind: jenkins
     scmid: default
-    spec:
-      file: "updatecli/updatecli.d/updatecli.yaml"
-      key: "title"
 
 targets:
-  jenkins: 
+  jenkins:
     name: Update updatecli config title
-    kind: yaml 
+    kind: yaml
     scmid: default
     spec:
       file: "updatecli/updatecli.d/updatecli.yaml"

--- a/e2e/updatecli.d/success.d/githubPullrequest.yaml
+++ b/e2e/updatecli.d/success.d/githubPullrequest.yaml
@@ -1,0 +1,34 @@
+name: Test Github Pullrequest
+
+scms:
+  default:
+    kind: github
+    spec:
+      owner: updatecli
+      repository: updatecli
+      username: '{{ requiredEnv "GITHUB_ACTOR"}}'
+      token: '{{ requiredEnv "GITHUB_TOKEN" }}'
+      branch: main
+
+sources:
+  jenkins: 
+    name: Get updatecli config title
+    kind: yaml 
+    scmid: default
+    spec:
+      file: "updatecli/updatecli.d/updatecli.yaml"
+      key: "title"
+
+targets:
+  jenkins: 
+    name: Update updatecli config title
+    kind: yaml 
+    scmid: default
+    spec:
+      file: "updatecli/updatecli.d/updatecli.yaml"
+      key: "title"
+
+pullrequests:
+  prID1:
+    scmid: default
+    kind: github


### PR DESCRIPTION
Signed-off-by: Olblak <me@olblak.com>

Fix #836 
In release 0.30.0, Updatecli automatically detects which targets are related to a pullrequest spec, for generating the pullrequest body. 

So 
```
pullrequests:
  jenkins:
    title: Bump Jenkins Version to {{ source "jenkins" }}
    kind: github
    scmid: github2
    targets:
      - jenkins
```

becomes 
```
pullrequests:
  jenkins:
    title: Bump Jenkins Version to {{ source "jenkins" }}
    kind: github
    scmid: github2
```

But in the code I passed the wrong id value the pullrequest scmID instead of the pullrequets ID
I didn't detect this issue because in my tests environment, it's usually the same value.

## Test

To test this pull request, you can run the following commands:

```shell
cp <to_package_directory>
go test
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
