### PR TITLE
Fix: yaml source workdir relying on scm

### DIFF
--- a/e2e/updatecli.d/success.d/githubPullrequest.yaml
+++ b/e2e/updatecli.d/success.d/githubPullrequest.yaml
@@ -13,13 +13,16 @@ scms:
 sources:
   jenkins:
     name: Get updatecli config title
-    kind: jenkins
+    kind: yaml
     scmid: default
+    spec:
+      file: "updatecli/updatecli.d/updatecli.yaml"
+      key: "title"
 
 targets:
-  jenkins:
+  jenkins: 
     name: Update updatecli config title
-    kind: yaml
+    kind: yaml 
     scmid: default
     spec:
       file: "updatecli/updatecli.d/updatecli.yaml"

--- a/pkg/plugins/resources/yaml/source.go
+++ b/pkg/plugins/resources/yaml/source.go
@@ -2,6 +2,7 @@ package yaml
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/sirupsen/logrus"
@@ -13,6 +14,10 @@ import (
 // Source return the latest version
 func (y *Yaml) Source(workingDir string) (string, error) {
 	// By default workingDir is set to local directory
+
+	if len(workingDir) > 0 {
+		y.spec.File = filepath.Join(workingDir, y.spec.File)
+	}
 
 	// Test at runtime if a file exist
 	if !y.contentRetriever.FileExists(y.spec.File) {


### PR DESCRIPTION
Signed-off-by: Olblak <me@olblak.com>

Spot while testing https://github.com/updatecli/updatecli/pull/838
This appears to be a regression where the source yaml didn't use the correct scmID

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
go build -o bin/updatecli .
./bin/updatecli diff --config e2e/updatecli.d/success.d/githubPullrequest.yaml
```

## Additional Information

### Tradeoff

/

### Potential improvement

This part should deserve better UT, but I don't really have the time atm 
