### PR TITLE
fix:  Support different XML path format 

### DIFF
--- a/e2e/updatecli.d/success.d/xml.yaml
+++ b/e2e/updatecli.d/success.d/xml.yaml
@@ -1,6 +1,6 @@
 ---
 
-title: Show a set of xml resources as a generic example
+name: Show a set of xml resources as a generic example
 
 scms:
   ircbot:
@@ -19,6 +19,22 @@ sources:
       file: pom.xml
       path: "/project/parent/version"
 
+  parentVersionFromFileScheme:
+    name: Get parent version from pom.xml
+    scmid: ircbot
+    kind: xml
+    spec:
+      file: file://pom.xml
+      path: "/project/parent/version"
+
+  parentVersionFromURLScheme:
+    name: Get parent version from pom.xml
+    scmid: ircbot
+    kind: xml
+    spec:
+      file: https://raw.githubusercontent.com/olblak/ircbot/master/pom.xml
+      path: "/project/parent/version"
+
 conditions:
   parent-version:
     name: Test if parent version is set to source output
@@ -27,6 +43,23 @@ conditions:
     scmid: ircbot
     spec:
       file: pom.xml
+      path: "/project/parent/version"
+  parentVersionFromScheme:
+    name: Test if parent version is set to source output
+    kind: xml
+    sourceid: parentVersion
+    scmid: ircbot
+    spec:
+      file: file://pom.xml
+      path: "/project/parent/version"
+
+  parentVersionFromURLScheme:
+    name: Get parent version from pom.xml
+    scmid: ircbot
+    sourceid: parentVersion
+    kind: xml
+    spec:
+      file: https://raw.githubusercontent.com/olblak/ircbot/master/pom.xml
       path: "/project/parent/version"
   artifactid:
     name: Test if parent artifactId is set to jenkins

--- a/pkg/plugins/resources/xml/condition.go
+++ b/pkg/plugins/resources/xml/condition.go
@@ -15,7 +15,9 @@ func (x *XML) Condition(source string) (bool, error) {
 
 func (x *XML) ConditionFromSCM(source string, scm scm.ScmHandler) (bool, error) {
 
-	x.spec.File = joinPathWithWorkingDirectoryPath(x.spec.File, scm.GetDirectory())
+	if scm != nil {
+		x.spec.File = joinPathWithWorkingDirectoryPath(x.spec.File, scm.GetDirectory())
+	}
 
 	// Test at runtime if a file exist
 	if !x.contentRetriever.FileExists(x.spec.File) {

--- a/pkg/plugins/resources/xml/condition_test.go
+++ b/pkg/plugins/resources/xml/condition_test.go
@@ -1,101 +1,101 @@
 package xml
 
 import (
-	"errors"
 	"testing"
-)
 
-type ConditionDataset []ConditionData
-
-type ConditionData struct {
-	data           XML
-	expectedResult bool
-	expectedError  error
-}
-
-var (
-	conditionDataset = ConditionDataset{
-		{
-			data: XML{
-				spec: Spec{
-					File: "testdata/data_0.xml",
-					Path: "/name/firstname",
-				},
-			},
-			expectedResult: false,
-		},
-		{
-			data: XML{
-				spec: Spec{
-					File:  "testdata/data_0.xml",
-					Path:  "/name/firstname",
-					Value: "John",
-				},
-			},
-			expectedResult: true,
-		},
-		{
-			data: XML{
-				spec: Spec{
-					File:  "testdata/data_0.xml",
-					Path:  "/name/firstname",
-					Value: "wrongValue",
-				},
-			},
-			expectedResult: false,
-		},
-		{
-			data: XML{
-				spec: Spec{
-					File: "testdata/data_0.xml",
-					Path: ".name.donotExit",
-				},
-			},
-			expectedResult: false,
-		},
-		{
-			data: XML{
-				spec: Spec{
-					File: "testdata/data_1.xml",
-					Path: "/breakfast_menu/food[0]/name",
-				},
-			},
-			expectedResult: false,
-		},
-		{
-			data: XML{
-				spec: Spec{
-					File:  "testdata/data_1.xml",
-					Path:  "/breakfast_menu/food[0]/name",
-					Value: "Belgian Waffles",
-				},
-			},
-			expectedResult: true,
-		},
-		{
-			data: XML{
-				spec: Spec{
-					File:  "testdata/data_1.xml",
-					Path:  "/breakfast_menu.food[0]/name",
-					Value: "wrongValue",
-				},
-			},
-			expectedResult: false,
-		},
-	}
+	"github.com/stretchr/testify/require"
+	"gotest.tools/assert"
 )
 
 func TestCondition(t *testing.T) {
 
-	for id, c := range conditionDataset {
-		got, err := c.data.Condition("")
-		if !errors.Is(c.expectedError, err) {
-			t.Errorf("Wrong error for %v:\nGot:\n\t%q\nExpected:\n\t%q\n",
-				id, err.Error(), c.expectedError.Error())
-		}
-		if c.expectedResult != got {
-			t.Errorf("Wrong source result for %v:\n\tExpected:\t%t\n\tGot:\t%t",
-				id, c.expectedResult, got)
-		}
+	testData := []struct {
+		name             string
+		spec             Spec
+		expectedResult   bool
+		expectedErrorMsg error
+		wantErr          bool
+	}{
+		{
+			spec: Spec{
+				File: "testdata/data_0.xml",
+				Path: "/name/firstname",
+			},
+			expectedResult: false,
+		},
+		{
+			spec: Spec{
+				File:  "testdata/data_0.xml",
+				Path:  "/name/firstname",
+				Value: "John",
+			},
+			expectedResult: true,
+		},
+		{
+			spec: Spec{
+				File:  "https://raw.githubusercontent.com/updatecli/updatecli/main/pkg/plugins/resources/xml/testdata/data_0.xml",
+				Path:  "/name/firstname",
+				Value: "John",
+			},
+			expectedResult: true,
+		},
+		{
+			spec: Spec{
+				File:  "testdata/data_0.xml",
+				Path:  "/name/firstname",
+				Value: "wrongValue",
+			},
+			expectedResult: false,
+		},
+		{
+			spec: Spec{
+				File: "testdata/data_0.xml",
+				Path: ".name.donotExit",
+			},
+			expectedResult: false,
+		},
+		{
+			spec: Spec{
+				File: "testdata/data_1.xml",
+				Path: "/breakfast_menu/food[0]/name",
+			},
+			expectedResult: false,
+		},
+		{
+			spec: Spec{
+				File:  "testdata/data_1.xml",
+				Path:  "/breakfast_menu/food[0]/name",
+				Value: "Belgian Waffles",
+			},
+			expectedResult: true,
+		},
+		{
+			spec: Spec{
+				File:  "testdata/data_1.xml",
+				Path:  "/breakfast_menu.food[0]/name",
+				Value: "wrongValue",
+			},
+			expectedResult: false,
+		},
 	}
+
+	for _, tt := range testData {
+
+		t.Run(tt.name, func(t *testing.T) {
+			x, err := New(tt.spec)
+
+			require.NoError(t, err)
+
+			gotResult, err := x.Condition("")
+
+			if tt.wantErr {
+				assert.Equal(t, tt.expectedErrorMsg.Error(), err.Error())
+			} else {
+				require.NoError(t, err)
+			}
+
+			assert.Equal(t, tt.expectedResult, gotResult)
+		})
+	}
+
 }

--- a/pkg/plugins/resources/xml/source.go
+++ b/pkg/plugins/resources/xml/source.go
@@ -1,7 +1,7 @@
 package xml
 
 import (
-	"path/filepath"
+	"fmt"
 
 	"github.com/beevik/etree"
 	"github.com/sirupsen/logrus"
@@ -10,8 +10,21 @@ import (
 
 func (x *XML) Source(workingDir string) (string, error) {
 
+	// To merge File path with current working dire, unless file is an http url
+	x.spec.File = joinPathWithWorkingDirectoryPath(x.spec.File, workingDir)
+
+	// Test at runtime if a file exist
+	if !x.contentRetriever.FileExists(x.spec.File) {
+		return "", fmt.Errorf("the XML file %q does not exist", x.spec.File)
+	}
+
+	if err := x.Read(); err != nil {
+		return "", err
+	}
+
 	doc := etree.NewDocument()
-	if err := doc.ReadFromFile(filepath.Join(workingDir, x.spec.File)); err != nil {
+
+	if err := doc.ReadFromString(x.currentContent); err != nil {
 		return "", err
 	}
 

--- a/pkg/plugins/resources/xml/source_test.go
+++ b/pkg/plugins/resources/xml/source_test.go
@@ -1,55 +1,65 @@
 package xml
 
-import "testing"
+import (
+	"testing"
 
-type SourceDataset []SourceData
-
-type SourceData struct {
-	data           XML
-	expectedResult string
-}
-
-var (
-	sourceDataset = SourceDataset{
-		{
-			data: XML{
-				spec: Spec{
-					File: "testdata/data_0.xml",
-					Path: "//name/firstname",
-				},
-			},
-			expectedResult: "John",
-		},
-		{
-			data: XML{
-				spec: Spec{
-					File: "testdata/data_1.xml",
-					Path: "doNotExist",
-				},
-			},
-			expectedResult: "",
-		},
-		{
-			data: XML{
-				spec: Spec{
-					File: "testdata/data_1.xml",
-					Path: "//breakfast_menu[0]/name",
-				},
-			},
-			expectedResult: "",
-		},
-	}
+	"github.com/stretchr/testify/require"
+	"gotest.tools/assert"
 )
 
 func TestSource(t *testing.T) {
 
-	for _, s := range sourceDataset {
-		got, err := s.data.Source("")
-		if err != nil {
-			t.Errorf("error: %s", err.Error())
-		}
-		if s.expectedResult != got {
-			t.Errorf("Wrong source result:\n\tExpected:\t%q\n\tGot:\t%q", s.expectedResult, got)
-		}
+	testData := []struct {
+		name           string
+		spec           Spec
+		expectedResult string
+	}{
+		{
+			name: "scenario 1",
+			spec: Spec{
+				File: "testdata/data_0.xml",
+				Path: "//name/firstname",
+			},
+			expectedResult: "John",
+		},
+		{
+			name: "scenario 1.1 - http",
+			spec: Spec{
+				File: "https://raw.githubusercontent.com/updatecli/updatecli/main/pkg/plugins/resources/xml/testdata/data_0.xml",
+				Path: "//name/firstname",
+			},
+			expectedResult: "John",
+		},
+		{
+			name: "scenario 2",
+			spec: Spec{
+				File: "testdata/data_1.xml",
+				Path: "doNotExist",
+			},
+			expectedResult: "",
+		},
+		{
+			name: "scenario 3",
+			spec: Spec{
+				File: "testdata/data_1.xml",
+				Path: "//breakfast_menu[0]/name",
+			},
+			expectedResult: "",
+		},
+	}
+
+	for _, tt := range testData {
+
+		t.Run(tt.name, func(t *testing.T) {
+			x, err := New(tt.spec)
+
+			require.NoError(t, err)
+
+			gotResult, err := x.Source("")
+
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.expectedResult, gotResult)
+		})
 	}
 }

--- a/pkg/plugins/resources/xml/target.go
+++ b/pkg/plugins/resources/xml/target.go
@@ -30,7 +30,9 @@ func (x *XML) TargetFromSCM(source string, scm scm.ScmHandler, dryRun bool) (cha
 		return false, files, message, fmt.Errorf("URL scheme is not supported for XML target: %q", x.spec.File)
 	}
 
-	x.spec.File = joinPathWithWorkingDirectoryPath(x.spec.File, scm.GetDirectory())
+	if scm != nil {
+		x.spec.File = joinPathWithWorkingDirectoryPath(x.spec.File, scm.GetDirectory())
+	}
 
 	// Test at runtime if a file exist
 	if !x.contentRetriever.FileExists(x.spec.File) {

--- a/pkg/plugins/resources/xml/target_test.go
+++ b/pkg/plugins/resources/xml/target_test.go
@@ -8,105 +8,102 @@ import (
 	"gotest.tools/assert"
 )
 
-type TargetDataset []TargetData
+func TestTarget(t *testing.T) {
 
-type TargetData struct {
-	name         string
-	data         XML
-	wantResult   bool
-	wantErrorMsg error
-	wantErr      bool
-}
-
-var (
-	targetDataset = TargetDataset{
+	testData := []struct {
+		name             string
+		spec             Spec
+		expectedResult   bool
+		expectedErrorMsg error
+		wantErr          bool
+	}{
 		{
 			name: "Test 1",
-			data: XML{
-				spec: Spec{
-					File:  "testdata/data_0.xml",
-					Path:  "/name/firstname",
-					Value: "Bob",
-				},
+			spec: Spec{
+				File:  "testdata/data_0.xml",
+				Path:  "/name/firstname",
+				Value: "Bob",
 			},
-			wantResult: true,
+			expectedResult: true,
 		},
 		{
 			name: "Test 2",
-			data: XML{
-				spec: Spec{
-					File:  "testdata/data_0.xml",
-					Path:  "/name/firstname",
-					Value: "John",
-				},
+			spec: Spec{
+				File:  "testdata/data_0.xml",
+				Path:  "/name/firstname",
+				Value: "John",
 			},
-			wantResult: false,
+			expectedResult: false,
 		},
 		{
 			name: "Test 3",
-			data: XML{
-				spec: Spec{
-					File:  "testdata/data_2.xml",
-					Path:  "/name/firstname",
-					Value: "Bob",
-				},
+			spec: Spec{
+				File:  "testdata/data_2.xml",
+				Path:  "/name/firstname",
+				Value: "Bob",
 			},
-			wantResult: true,
+			expectedResult: true,
 		},
 		{
 			name: "Test 4",
-			data: XML{
-				spec: Spec{
-					File:  "testdata/doNotExist.xml",
-					Path:  "/name/firstname",
-					Value: "Alice",
-				},
+			spec: Spec{
+				File:  "testdata/doNotExist.xml",
+				Path:  "/name/firstname",
+				Value: "Alice",
 			},
-			wantResult:   false,
-			wantErrorMsg: errors.New("open testdata/doNotExist.xml: no such file or directory"),
-			wantErr:      true,
+			expectedResult:   false,
+			expectedErrorMsg: errors.New("the XML file \"testdata/doNotExist.xml\" does not exist"),
+			wantErr:          true,
 		},
 		{
-			data: XML{
-				spec: Spec{
-					File:  "testdata/data_2.xml",
-					Path:  "/name/donotexist",
-					Value: "Bob",
-				},
+			name: "Test 5",
+			spec: Spec{
+				File:  "testdata/data_2.xml",
+				Path:  "/name/donotexist",
+				Value: "Bob",
 			},
-			wantResult:   false,
-			wantErr:      true,
-			wantErrorMsg: errors.New("✗ nothing found at path \"/name/donotexist\" from file \"testdata/data_2.xml\""),
+			expectedResult:   false,
+			wantErr:          true,
+			expectedErrorMsg: errors.New("✗ nothing found at path \"/name/donotexist\" from file \"testdata/data_2.xml\""),
 		},
 		{
-			data: XML{
-				spec: Spec{
-					File:  "testdata/data_2.xml",
-					Path:  "/name/firstname",
-					Value: "John",
-				},
+			name: "Test 6",
+			spec: Spec{
+				File:  "testdata/data_2.xml",
+				Path:  "/name/firstname",
+				Value: "John",
 			},
-			wantResult: false,
+			expectedResult: false,
+		},
+		{
+			name: "Test 7",
+			spec: Spec{
+				File:  "https://raw.githubusercontent.com/updatecli/updatecli/main/pkg/plugins/resources/xml/testdata/data_2.xml",
+				Path:  "/name/firstname",
+				Value: "John",
+			},
+			wantErr:          true,
+			expectedResult:   false,
+			expectedErrorMsg: errors.New("URL scheme is not supported for XML target: \"https://raw.githubusercontent.com/updatecli/updatecli/main/pkg/plugins/resources/xml/testdata/data_2.xml\""),
 		},
 	}
-)
 
-func TestTarget(t *testing.T) {
-
-	for _, tt := range targetDataset {
+	for _, tt := range testData {
 
 		t.Run(tt.name, func(t *testing.T) {
+			x, err := New(tt.spec)
 
-			gotResult, gotErr := tt.data.Target("", true)
+			require.NoError(t, err)
+
+			gotResult, err := x.Target("", true)
 
 			if tt.wantErr {
-				require.Error(t, gotErr)
+				assert.Equal(t, tt.expectedErrorMsg.Error(), err.Error())
 			} else {
-				require.NoError(t, gotErr)
+				require.NoError(t, err)
 			}
 
-			assert.Equal(t, tt.wantResult, gotResult)
-
+			assert.Equal(t, tt.expectedResult, gotResult)
 		})
 	}
 

--- a/pkg/plugins/resources/xml/utils.go
+++ b/pkg/plugins/resources/xml/utils.go
@@ -7,12 +7,12 @@ import (
 
 // joinPathwithworkingDirectoryPath To merge File path with current working dire, unless file is an http url
 func joinPathWithWorkingDirectoryPath(fileName, workingDir string) string {
-	if workingDir != "" &&
-		!filepath.IsAbs(fileName) &&
-		!strings.HasPrefix(fileName, "https://") &&
-		!strings.HasPrefix(fileName, "http://") {
-		fileName = filepath.Join(workingDir, fileName)
+	if workingDir == "" ||
+		filepath.IsAbs(fileName) ||
+		strings.HasPrefix(fileName, "https://") ||
+		strings.HasPrefix(fileName, "http://") {
+		return fileName
 	}
 
-	return fileName
+	return filepath.Join(workingDir, fileName)
 }

--- a/pkg/plugins/resources/xml/utils.go
+++ b/pkg/plugins/resources/xml/utils.go
@@ -1,0 +1,18 @@
+package xml
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// joinPathwithworkingDirectoryPath To merge File path with current working dire, unless file is an http url
+func joinPathWithWorkingDirectoryPath(fileName, workingDir string) string {
+	if workingDir != "" &&
+		!filepath.IsAbs(fileName) &&
+		!strings.HasPrefix(fileName, "https://") &&
+		!strings.HasPrefix(fileName, "http://") {
+		fileName = filepath.Join(workingDir, fileName)
+	}
+
+	return fileName
+}

--- a/pkg/plugins/resources/xml/utils_test.go
+++ b/pkg/plugins/resources/xml/utils_test.go
@@ -1,0 +1,63 @@
+package xml
+
+import (
+	"testing"
+
+	"gotest.tools/assert"
+)
+
+func TestJoinPathWithWorkingDirectoryPath(t *testing.T) {
+
+	testData := []struct {
+		name           string
+		fileName       string
+		workingDir     string
+		expectedResult string
+	}{
+		{
+			name:           "scenario 1",
+			fileName:       "test.xml",
+			workingDir:     "/tmp",
+			expectedResult: "/tmp/test.xml",
+		},
+		{
+			name:           "scenario 2",
+			fileName:       "/tmp/test.xml",
+			workingDir:     "/opt",
+			expectedResult: "/tmp/test.xml",
+		},
+		{
+			name:           "scenario 3",
+			fileName:       "https://test.xml",
+			workingDir:     "/opt",
+			expectedResult: "https://test.xml",
+		},
+		{
+			name:           "scenario 4",
+			fileName:       "http://test.xml",
+			workingDir:     "/opt",
+			expectedResult: "http://test.xml",
+		},
+		{
+			name:           "scenario 5",
+			fileName:       "test.xml",
+			workingDir:     "",
+			expectedResult: "test.xml",
+		},
+		{
+			name:           "scenario 6",
+			fileName:       "./test.xml",
+			workingDir:     "/opt",
+			expectedResult: "/opt/test.xml",
+		},
+	}
+
+	for _, tt := range testData {
+		t.Run(tt.name, func(t *testing.T) {
+
+			gotResult := joinPathWithWorkingDirectoryPath(tt.fileName, tt.workingDir)
+
+			assert.Equal(t, tt.expectedResult, gotResult)
+		})
+	}
+}


### PR DESCRIPTION
Fix #XXX

While looking in https://github.com/updatecli/updatecli/pull/650
I noticed that while we should be able to support different path URL such as ["https://","http://","file://","absolutePath", "relativePath"], it wasn't the case anymore.

This pullrqeuest add e2e test on the xml resource + address the source/conditoin/target.

As similar pullrequest will come for the yaml resource as well

## Test

To test this pull request, you can run the following commands:

```shell
cp <to_package_directory>
go test
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
