### PR TITLE
Fix updatecli golangconfig

### DIFF
--- a/updatecli/updatecli.d/golang.yaml
+++ b/updatecli/updatecli.d/golang.yaml
@@ -1,4 +1,4 @@
-title: Bump Golang Version
+name: Bump Golang Version
 
 scms:
   default:
@@ -16,6 +16,7 @@ sources:
   latestGoVersion:
     name: Get Latest Go Release
     kind: githubrelease
+    scmid: default
     spec:
       owner: golang
       repository: go
@@ -29,7 +30,8 @@ sources:
   gomod:
     name: Update go.mod
     kind: shell
-    depends_on:
+    scmid: default
+    dependson:
       - latestGoVersion
     spec:
       command: ./updatecli/scripts/updateGomodGoversion.sh ./go.mod {{ source "latestGoVersion" }}
@@ -41,6 +43,7 @@ conditions:
     name: Ensure GA step is defined in Github Action named release-sandbox
     kind: yaml
     disablesourceinput: true
+    scmid: default
     spec:
       file: .github/workflows/release-sandbox.yaml
       key: jobs.build.steps[3].id
@@ -49,6 +52,7 @@ conditions:
     name: Ensure GA step is defined in Github Action named release
     kind: yaml
     disablesourceinput: true
+    scmid: default
     spec:
       file: .github/workflows/release.yaml
       key: jobs.build.steps[3].id
@@ -57,6 +61,7 @@ conditions:
     name: Ensure GA step is defined in Github Action named go
     kind: yaml
     disablesourceinput: true
+    scmid: default
     spec:
       file: .github/workflows/go.yaml
       key: jobs.build.steps[0].id
@@ -74,6 +79,7 @@ conditions:
     name: 'Is docker image golang:{{ source "latestGoVersion" }} published'
     sourceid: latestGoVersion
     kind: dockerimage
+    scmid: default
     spec:
       image: golang
       tag: '{{ source "latestGoVersion" }}'
@@ -124,11 +130,6 @@ pullrequests:
     title: '[updatecli] Bump Golang version to {{ source "latestGoVersion" }}'
     kind: github
     scmid: default
-    targets:
-      - release-sandbox
-      - release
-      - workflowgo
-      - go.mod
     spec:
       labels:
         - chore

--- a/updatecli/updatecli.d/golang.yaml
+++ b/updatecli/updatecli.d/golang.yaml
@@ -16,7 +16,6 @@ sources:
   latestGoVersion:
     name: Get Latest Go Release
     kind: githubrelease
-    scmid: default
     spec:
       owner: golang
       repository: go

--- a/updatecli/updatecli.d/golangci-lint.yaml
+++ b/updatecli/updatecli.d/golangci-lint.yaml
@@ -1,4 +1,4 @@
-title: "Bump golangci-lint version"
+name: "Bump golangci-lint version"
 
 scms:
   default:
@@ -54,9 +54,8 @@ pullrequests:
     title: '[updatecli] Bump golangci-lint version to {{ source "default" }}'
     kind: github
     scmid: default
-    targets:
-      - default
     spec:
+      automerge: true
       labels:
         - chore
         - dependencies

--- a/updatecli/updatecli.d/updatecli.yaml
+++ b/updatecli/updatecli.d/updatecli.yaml
@@ -1,4 +1,4 @@
-title: Bump udpatecli version
+name: Bump udpatecli version
 
 scms:
   default:
@@ -37,9 +37,8 @@ pullrequests:
     title: '[updatecli] Bump updatecli version to {{ source "latestVersion" }}'
     kind: github
     scmid: default
-    targets:
-      - bugReport
     spec:
+      automerge: true
       labels:
         - chore
         - skip-changelog

--- a/updatecli/updatecli.d/venom.yaml
+++ b/updatecli/updatecli.d/venom.yaml
@@ -1,4 +1,4 @@
-title: Bump venom version
+name: Bump venom version
 
 scms:
   default:
@@ -39,9 +39,8 @@ pullrequests:
     title: '[updatecli] Bump Venom version to {{ source "latestVersion" }}'
     kind: github
     scmid: default
-    targets:
-      - goWorkflow
     spec:
+      automerge: true
       labels:
         - chore
         - skip-changelog


### PR DESCRIPTION
Apparently Updatecli manifest here were too much outdated


## Test

To test this pull request, you can run the following commands:

```shell
cp <to_package_directory>
go test
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
