### PR TITLE
Always use the latest Go version available when updating the go.mod from Updatecli GA

### DIFF
--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -17,8 +17,7 @@ jobs:
         uses: "updatecli/updatecli-action@v2.6.1"
       - name: Set up Go
         uses: actions/setup-go@v3
-        with:
-          go-version: 1.19.1
+        check-latest: true
         id: go
       - name: "Run updatecli in dryrun"
         run: "updatecli diff --config ./updatecli/updatecli.d"

--- a/updatecli/updatecli.d/golang.yaml
+++ b/updatecli/updatecli.d/golang.yaml
@@ -65,15 +65,6 @@ conditions:
       file: .github/workflows/go.yaml
       key: jobs.build.steps[0].id
       value: go
-  workflowupdatecli:
-    name: '[release.yaml] Update Golang version to {{ source "latestGoVersion" }}'
-    kind: yaml
-    disablesourceinput: true
-    spec:
-      file: .github/workflows/updatecli.yaml
-      key: jobs.updatecli.steps[2].id
-      value: go
-    scmid: default
   dockerTag:
     name: 'Is docker image golang:{{ source "latestGoVersion" }} published'
     sourceid: latestGoVersion
@@ -107,14 +98,6 @@ targets:
     spec:
       file: .github/workflows/go.yaml
       key: jobs.build.steps[0].with.go-version
-    scmid: default
-  workflowupdatecli:
-    name: '[release.yaml] Update Golang version to {{ source "latestGoVersion" }}'
-    kind: yaml
-    sourceid: latestGoVersion
-    spec:
-      file: .github/workflows/updatecli.yaml
-      key: jobs.updatecli.steps[2].with.go-version
     scmid: default
   go.mod:
     name: '[go.mod] Update Golang version to {{ source "latestGoVersion" }}'


### PR DESCRIPTION
Signed-off-by: Olblak <me@olblak.com>
Fix broken Updatecli pipeline when bumping Golang major version

During Golang 1.19.1 update, I noticed that the Updatecli GA workflow went into a deadlock.
When Updatecli bump the major version of a Golang, the Golang version used by the workflow would update go.mod and then fail to clean dependencies as the Golang version used in an older one.

I don't see any downside to always use the latest Golang version available

## Test

To test this pull request, you can run the following commands:

```shell
cp <to_package_directory>
go test
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
