### PR TITLE
Add graphql path when creating client

### DIFF
--- a/pkg/plugins/scms/github/main.go
+++ b/pkg/plugins/scms/github/main.go
@@ -3,6 +3,7 @@ package github
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"os"
 	"path"
 	"strings"
@@ -99,7 +100,11 @@ func New(s Spec, pipelineID string) (*Github, error) {
 		g.client = githubv4.NewClient(httpClient)
 	} else {
 		// Based on official documentation, for GH enterprise, the GraphQL API path is /api/graphql
-		g.client = githubv4.NewEnterpriseClient(s.URL+"api/graphql", httpClient)
+		graphqlURL, err := url.JoinPath(s.URL, "/api/graphql")
+		if err != nil {
+			return nil, err
+		}
+		g.client = githubv4.NewEnterpriseClient(graphqlURL, httpClient)
 	}
 
 	g.setDirectory()

--- a/pkg/plugins/scms/github/main.go
+++ b/pkg/plugins/scms/github/main.go
@@ -100,7 +100,7 @@ func New(s Spec, pipelineID string) (*Github, error) {
 		g.client = githubv4.NewClient(httpClient)
 	} else {
 		// For GH enterprise the GraphQL API path is /api/graphql
-		// Cf https://docs.github.com/en/enterprise-cloud@latest/graphql/guides/managing-enterprise-accounts#3-setting-up-insomnia-to-use-the-github-graphql-api-with-enterprise-accounts)
+		// Cf https://docs.github.com/en/enterprise-cloud@latest/graphql/guides/managing-enterprise-accounts#3-setting-up-insomnia-to-use-the-github-graphql-api-with-enterprise-accounts
 		graphqlURL, err := url.JoinPath(s.URL, "/api/graphql")
 		if err != nil {
 			return nil, err

--- a/pkg/plugins/scms/github/main.go
+++ b/pkg/plugins/scms/github/main.go
@@ -99,7 +99,8 @@ func New(s Spec, pipelineID string) (*Github, error) {
 	if strings.HasSuffix(s.URL, "github.com") {
 		g.client = githubv4.NewClient(httpClient)
 	} else {
-		// Based on official documentation, for GH enterprise, the GraphQL API path is /api/graphql
+		// For GH enterprise the GraphQL API path is /api/graphql
+		// Cf https://docs.github.com/en/enterprise-cloud@latest/graphql/guides/managing-enterprise-accounts#3-setting-up-insomnia-to-use-the-github-graphql-api-with-enterprise-accounts)
 		graphqlURL, err := url.JoinPath(s.URL, "/api/graphql")
 		if err != nil {
 			return nil, err

--- a/pkg/plugins/scms/github/main.go
+++ b/pkg/plugins/scms/github/main.go
@@ -98,7 +98,8 @@ func New(s Spec, pipelineID string) (*Github, error) {
 	if strings.HasSuffix(s.URL, "github.com") {
 		g.client = githubv4.NewClient(httpClient)
 	} else {
-		g.client = githubv4.NewEnterpriseClient(s.URL, httpClient)
+		// Based on official documentation, for GH enterprise, the GraphQL API path is /api/graphql
+		g.client = githubv4.NewEnterpriseClient(s.URL+"api/graphql", httpClient)
 	}
 
 	g.setDirectory()


### PR DESCRIPTION
Fix [862](https://github.com/updatecli/updatecli/issues/862)

After investigating for a while, I found that the problem is that shurcooL/githubv4 [expects a graphql url](https://github.com/shurcooL/githubv4/blob/234843c633fadff9694210ce7ab97948c9148a14/githubv4.go#L22).

Just adding the graphql path to the URL parameter doesn't work (as that same url is used to pull the repo), but just by appending /api/graphql to [the s.URL](https://github.com/updatecli/updatecli/blob/main/pkg/plugins/scms/github/main.go#L101) when initiating the client, fixes it.

Based on official [documentation](https://docs.github.com/en/enterprise-cloud@latest/graphql/guides/managing-enterprise-accounts#3-setting-up-insomnia-to-use-the-github-graphql-api-with-enterprise-accounts), the enterprise url for GraphQL is `https://<HOST>/api/graphql`.

## Additional Information

### Tradeoff


### Potential improvement

Tests are missing for all the custom URLs.
