### PR TITLE
No default crawler when autodiscovery is used with manifest

### DIFF
--- a/e2e/updatecli.d/warning.d/autodiscovery/fleet/git.yaml
+++ b/e2e/updatecli.d/warning.d/autodiscovery/fleet/git.yaml
@@ -1,3 +1,4 @@
+name: Fleet autodiscovery using Git scm
 scms:
   fleet-lab:
     kind: git 
@@ -9,13 +10,9 @@ autodiscovery:
   scmid: fleet-lab
   crawlers:
     helm:
-      # By default enabled
-      enable: true
       # To ignore specific path
       #ignore:
       #  - path: <filepath relative to scm repository>
       #only:
       #  - path: <filepath relative to scm repository>
     rancher/fleet:
-      # By default it's enable 
-      enable: true

--- a/e2e/updatecli.d/warning.d/autodiscovery/fleet/githubPullrequest.yaml
+++ b/e2e/updatecli.d/warning.d/autodiscovery/fleet/githubPullrequest.yaml
@@ -1,3 +1,4 @@
+name: "Fleet Autodiscovery using github scm"
 scms:
   fleet-lab:
     kind: github
@@ -21,17 +22,7 @@ autodiscovery:
   scmid: fleet-lab
   pullrequestid: fleet-lab
   crawlers:
-    helm:
-      # By default enabled
-      enable: true
-      # To ignore specific path
-      #ignore:
-      #  # - path: <filepath relative to scm repository>
-      #only:
-      #  # - path: <filepath relative to scm repository>
     rancher/fleet:
-      # By default it's enable 
-      enable: true
       # To ignore specific path
       #ignore:
       # - path: <filepath relative to scm repository>

--- a/e2e/updatecli.d/warning.d/autodiscovery/helm/example.1.yaml
+++ b/e2e/updatecli.d/warning.d/autodiscovery/helm/example.1.yaml
@@ -1,3 +1,4 @@
+name: "Helm autodiscovery using git scm"
 scms:
   epinio:
     kind: git
@@ -9,8 +10,6 @@ autodiscovery:
   scmid: epinio
   crawlers:
     helm:
-      # Enabled by default
-      enable: true
       # To ignore specific path
       #ignore:
       #  # - path: <filepath relative to scm repository>

--- a/e2e/updatecli.d/warning.d/autodiscovery/maven/git.yaml
+++ b/e2e/updatecli.d/warning.d/autodiscovery/maven/git.yaml
@@ -1,3 +1,4 @@
+name: "Maven autodiscovery using git scm"
 scms:
   default:
     kind: git 
@@ -15,16 +16,9 @@ autodiscovery:
   scmid: default
   crawlers:
     maven:
-      # By default enabled
-      enable: true
       # To ignore specific path
       #ignore:
       #  - path: <filepath relative to scm repository>
       #only:
       #  - path: <filepath relative to scm repository>
-    rancher/fleet:
-      # By default it's enable 
-      enable: false
-    helm:
-      # By default it's enable 
-      enable: false
+

--- a/pkg/core/pipeline/autodiscovery/main.go
+++ b/pkg/core/pipeline/autodiscovery/main.go
@@ -33,7 +33,6 @@ type Options struct {
 }
 type Crawler interface {
 	DiscoverManifests(input discoveryConfig.Input) ([]config.Spec, error)
-	Enabled() bool
 }
 
 type AutoDiscovery struct {
@@ -134,11 +133,7 @@ func New(spec discoveryConfig.Config,
 func (g *AutoDiscovery) Run() ([]config.Spec, error) {
 	var totalDiscoveredManifests []config.Spec
 
-	for id, crawler := range g.crawlers {
-		if !crawler.Enabled() {
-			logrus.Infof("Manifest autodiscovering is disabled for %q", id)
-			continue
-		}
+	for _, crawler := range g.crawlers {
 
 		discoveredManifests, err := crawler.DiscoverManifests(
 			discoveryConfig.Input{

--- a/pkg/core/pipeline/autodiscovery/main.go
+++ b/pkg/core/pipeline/autodiscovery/main.go
@@ -57,14 +57,6 @@ func New(spec discoveryConfig.Config,
 		return &AutoDiscovery{}, err
 	}
 
-	tmpCrawlers := DefaultCrawlerSpecs.Crawlers
-
-	for id, crawlerSpec := range s.Crawlers {
-		tmpCrawlers[id] = crawlerSpec
-	}
-
-	s.Crawlers = tmpCrawlers
-
 	g := AutoDiscovery{
 		spec: s,
 	}
@@ -78,7 +70,7 @@ func New(spec discoveryConfig.Config,
 		g.pullrequestConfig = pullrequestConfig
 	}
 
-	for kind := range DefaultCrawlerSpecs.Crawlers {
+	for kind := range s.Crawlers {
 
 		// Init workDir based on process running directory
 		workDir, err := os.Getwd()

--- a/pkg/plugins/autodiscovery/fleet/main.go
+++ b/pkg/plugins/autodiscovery/fleet/main.go
@@ -15,8 +15,6 @@ import (
 type Spec struct {
 	// RootDir defines the root directory used to recursively search for Fleet bundle
 	RootDir string `yaml:",omitempty"`
-	// Disable allows to disable the Fleet crawler
-	Disable bool `yaml:",omitempty"`
 	// Ignore allows to specify rule to ignore autodiscovery a specific Fleet bundle based on a rule
 	Ignore MatchingRules `yaml:",omitempty"`
 	// Only allows to specify rule to only autodiscover manifest for a specific Fleet bundle based on a rule
@@ -105,9 +103,4 @@ func SetScm(configSpec *config.Spec, scmSpec scm.Config, scmID string) {
 func SetPullrequest(configSpec *config.Spec, pullrequestSpec pullrequest.Config, pullrequestID string) {
 	configSpec.PullRequests = make(map[string]pullrequest.Config)
 	configSpec.PullRequests[pullrequestID] = pullrequestSpec
-}
-
-// RunDisabled returns a bool saying if a run should be done
-func (f Fleet) Enabled() bool {
-	return !f.spec.Disable
 }

--- a/pkg/plugins/autodiscovery/helm/main.go
+++ b/pkg/plugins/autodiscovery/helm/main.go
@@ -16,8 +16,6 @@ import (
 type Spec struct {
 	// RootDir defines the root directory used to recursively search for Helm Chart
 	RootDir string `yaml:",omitempty"`
-	// Disable allows to disable the helm chart crawler
-	Disable bool `yaml:",omitempty"`
 	// Ignore allows to specify rule to ignore autodiscovery a specific Helm based on a rule
 	Ignore MatchingRules `yaml:",omitempty"`
 	// Only allows to specify rule to only autodiscover manifest for a specific Helm based on a rule
@@ -116,9 +114,4 @@ func SetScm(configSpec *config.Spec, scmSpec scm.Config, scmID string) {
 func SetPullrequest(configSpec *config.Spec, pullrequestSpec pullrequest.Config, pullrequestID string) {
 	configSpec.PullRequests = make(map[string]pullrequest.Config)
 	configSpec.PullRequests[pullrequestID] = pullrequestSpec
-}
-
-// RunDisabled returns a bool saying if a run should be done
-func (h Helm) Enabled() bool {
-	return !h.spec.Disable
 }

--- a/pkg/plugins/autodiscovery/helmfile/main.go
+++ b/pkg/plugins/autodiscovery/helmfile/main.go
@@ -16,8 +16,6 @@ import (
 type Spec struct {
 	// RootDir defines the root directory used to recursively search for Helm Chart
 	RootDir string `yaml:",omitempty"`
-	// Disable allows to disable the helm chart crawler
-	Disable bool `yaml:",omitempty"`
 	// Ignore allows to specify rule to ignore autodiscovery a specific Helm based on a rule
 	Ignore MatchingRules `yaml:",omitempty"`
 	// Only allows to specify rule to only autodiscover manifest for a specific Helm based on a rule
@@ -107,9 +105,4 @@ func SetScm(configSpec *config.Spec, scmSpec scm.Config, scmID string) {
 func SetPullrequest(configSpec *config.Spec, pullrequestSpec pullrequest.Config, pullrequestID string) {
 	configSpec.PullRequests = make(map[string]pullrequest.Config)
 	configSpec.PullRequests[pullrequestID] = pullrequestSpec
-}
-
-// RunDisabled returns a bool saying if a run should be done
-func (h Helmfile) Enabled() bool {
-	return !h.spec.Disable
 }

--- a/pkg/plugins/autodiscovery/maven/main.go
+++ b/pkg/plugins/autodiscovery/maven/main.go
@@ -16,8 +16,6 @@ import (
 type Spec struct {
 	// RootDir defines the root directory used to recursively search for Helm Chart
 	RootDir string `yaml:",omitempty"`
-	// Disable allows to disable the helm chart crawler
-	Disable bool `yaml:",omitempty"`
 	// Ignore allows to specify rule to ignore autodiscovery a specific Helm based on a rule
 	Ignore MatchingRules `yaml:",omitempty"`
 	// Only allows to specify rule to only autodiscover manifest for a specific Helm based on a rule
@@ -122,9 +120,4 @@ func SetScm(configSpec *config.Spec, scmSpec scm.Config, scmID string) {
 func SetPullrequest(configSpec *config.Spec, pullrequestSpec pullrequest.Config, pullrequestID string) {
 	configSpec.PullRequests = make(map[string]pullrequest.Config)
 	configSpec.PullRequests[pullrequestID] = pullrequestSpec
-}
-
-// RunDisabled returns a bool saying if a run should be done
-func (m Maven) Enabled() bool {
-	return !m.spec.Disable
 }


### PR DESCRIPTION
As introduced on https://github.com/updatecli/updatecli/discussions/874

I find it very annoying that I have to disable all crawler if I want an autodiscovery manifest handle only one crawler
No default crawler when autodiscovery is used from manifest

Signed-off-by: Olblak <me@olblak.com>

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can test the two following workflow:

```shell
go build -o bin/updatecli .
./bin/updatecli manifest show --config e2e/updatecli.d/warning.d/autodiscovery/fleet --experimental 
# Should only detect rancherl/fleet and helm manifest 
./bin/updatecli manifest show --local-autodiscovery --experimental
# Should display rancher/fleet, helm, and Maven manifest
go test
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
