### PR TITLE
Add Helmfile autodiscovery crawler

### DIFF
--- a/e2e/updatecli.d/warning.d/autodiscovery/helmfile/example.1.yaml
+++ b/e2e/updatecli.d/warning.d/autodiscovery/helmfile/example.1.yaml
@@ -1,0 +1,20 @@
+name: Test Helmfile Autodiscovery
+
+scms:
+  default:
+    kind: git
+    spec:
+      url: https://github.com/olblak/k8s-lab.git
+    
+autodiscovery:
+  # scmid is applied to all crawlers
+  scmid: default
+  crawlers:
+    helmfile:
+      # To ignore specific path
+      #ignore:
+      #  # - path: <filepath relative to scm repository>
+      #  # - path: chart/*
+      only:
+        - path: helmfile.d/*
+#

--- a/pkg/core/pipeline/autodiscovery/main.go
+++ b/pkg/core/pipeline/autodiscovery/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
 	"github.com/updatecli/updatecli/pkg/plugins/autodiscovery/fleet"
 	"github.com/updatecli/updatecli/pkg/plugins/autodiscovery/helm"
+	"github.com/updatecli/updatecli/pkg/plugins/autodiscovery/helmfile"
 	"github.com/updatecli/updatecli/pkg/plugins/autodiscovery/maven"
 )
 
@@ -104,6 +105,17 @@ func New(spec discoveryConfig.Config,
 			}
 
 			g.crawlers = append(g.crawlers, helmCrawler)
+
+		case "helmfile":
+
+			helmfileCrawler, err := helmfile.New(g.spec.Crawlers[kind], workDir)
+
+			if err != nil {
+				errs = append(errs, fmt.Errorf("%s - %s", kind, err))
+				continue
+			}
+
+			g.crawlers = append(g.crawlers, helmfileCrawler)
 
 		case "maven":
 			mavenCrawler, err := maven.New(g.spec.Crawlers[kind], workDir)

--- a/pkg/plugins/autodiscovery/helmfile/dependencies.go
+++ b/pkg/plugins/autodiscovery/helmfile/dependencies.go
@@ -1,0 +1,157 @@
+package helmfile
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/sirupsen/logrus"
+	"github.com/updatecli/updatecli/pkg/core/config"
+	"github.com/updatecli/updatecli/pkg/core/pipeline/condition"
+	"github.com/updatecli/updatecli/pkg/core/pipeline/resource"
+	"github.com/updatecli/updatecli/pkg/core/pipeline/source"
+	"github.com/updatecli/updatecli/pkg/core/pipeline/target"
+	"github.com/updatecli/updatecli/pkg/plugins/resources/helm"
+	"github.com/updatecli/updatecli/pkg/plugins/resources/yaml"
+)
+
+var (
+	// ChartValidFiles specifies accepted Helm chart metadata file name
+	ChartValidFiles [2]string = [2]string{"*.yaml", "*.yml"}
+)
+
+// Release specify the release information that we are looking for in Helmfile
+type release struct {
+	Name    string
+	Chart   string
+	Version string
+}
+
+// Repository specify the repository information that we are looking for in Helmfile
+type repository struct {
+	Name string
+	URL  string
+}
+
+// chartMetadata is the information that we need to retrieve from Helm chart files.
+type helmfileMetadata struct {
+	Name         string
+	Repositories []repository
+	Releases     []release
+}
+
+func (h Helmfile) discoverHelmfileManifests() ([]config.Spec, error) {
+
+	var manifests []config.Spec
+
+	foundHelmfileFiles, err := searchHelmfileFiles(
+		h.rootDir,
+		ChartValidFiles[:])
+
+	if err != nil {
+		return nil, err
+	}
+
+	for _, foundHelmfile := range foundHelmfileFiles {
+
+		relativeFoundChartFile, err := filepath.Rel(h.rootDir, foundHelmfile)
+		if err != nil {
+			// Let's try the next chart if one fail
+			logrus.Errorln(err)
+			continue
+		}
+
+		helmfileRelativeMetadataPath := filepath.Dir(relativeFoundChartFile)
+		helmfileFilename := filepath.Base(helmfileRelativeMetadataPath)
+
+		// Test if the ignore rule based on path is respected
+		if len(h.spec.Ignore) > 0 && h.spec.Ignore.isMatchingIgnoreRule(h.rootDir, relativeFoundChartFile) {
+			logrus.Debugf("Ignoring Helmfile %q from %q, as not matching rule(s)\n",
+				helmfileFilename,
+				helmfileRelativeMetadataPath)
+			continue
+		}
+
+		// Test if the only rule based on path is respected
+		if len(h.spec.Only) > 0 && !h.spec.Only.isMatchingOnlyRule(h.rootDir, relativeFoundChartFile) {
+			logrus.Debugf("Ignoring Helmfile %q from %q, as not matching rule(s)\n",
+				helmfileFilename,
+				helmfileRelativeMetadataPath)
+			continue
+		}
+
+		// Retrieve chart dependencies for each chart
+
+		metadata, err := getHelmfileMetadata(foundHelmfile)
+		if err != nil {
+			return nil, err
+		}
+
+		if metadata == nil {
+			continue
+		}
+
+		if len(metadata.Releases) == 0 {
+			continue
+		}
+
+		logrus.Printf("\n\n%+v\n\n", metadata)
+
+		for i, release := range metadata.Releases {
+			manifestName := fmt.Sprintf("Bump %q Helm Chart version for Helmfile %q", release.Name, foundHelmfile)
+
+			chartName, chartURL := getReleaseRepositoryUrl(metadata.Repositories, release)
+
+			if chartName == "" || chartURL == "" {
+				logrus.Infof("repository not identified for release %q", release.Chart)
+				continue
+			}
+
+			manifest := config.Spec{
+				Name: manifestName,
+				Sources: map[string]source.Config{
+					release.Name: {
+						ResourceConfig: resource.ResourceConfig{
+							Name: fmt.Sprintf("Get latest %q Helm Chart Version", release.Name),
+							Kind: "helmchart",
+							Spec: helm.Spec{
+								Name: chartName,
+								URL:  chartURL,
+							},
+						},
+					},
+				},
+				Conditions: map[string]condition.Config{
+					release.Name: {
+						DisableSourceInput: true,
+						ResourceConfig: resource.ResourceConfig{
+							Name: fmt.Sprintf("Ensure release %q is specified", release.Name),
+							Kind: "yaml",
+							Spec: yaml.Spec{
+								File:  foundHelmfile,
+								Key:   fmt.Sprintf("releases[%d].chart", i),
+								Value: release.Chart,
+							},
+						},
+					},
+				},
+				Targets: map[string]target.Config{
+					release.Name: {
+						SourceID: release.Name,
+						ResourceConfig: resource.ResourceConfig{
+							Name: fmt.Sprintf("Bump %q Helm Chart Version for Helmfile %q", release.Name, foundHelmfile),
+							Kind: "yaml",
+							Spec: yaml.Spec{
+								File: foundHelmfile,
+								Key:  fmt.Sprintf("releases[%d].version", i),
+							},
+						},
+					},
+				},
+			}
+			manifests = append(manifests, manifest)
+
+		}
+	}
+
+	return manifests, nil
+}

--- a/pkg/plugins/autodiscovery/helmfile/dependencies.go
+++ b/pkg/plugins/autodiscovery/helmfile/dependencies.go
@@ -94,16 +94,20 @@ func (h Helmfile) discoverHelmfileManifests() ([]config.Spec, error) {
 			continue
 		}
 
-		logrus.Printf("\n\n%+v\n\n", metadata)
-
 		for i, release := range metadata.Releases {
 			manifestName := fmt.Sprintf("Bump %q Helm Chart version for Helmfile %q", release.Name, foundHelmfile)
 
 			chartName, chartURL := getReleaseRepositoryUrl(metadata.Repositories, release)
 
 			if chartName == "" || chartURL == "" {
-				logrus.Infof("repository not identified for release %q", release.Chart)
+				logrus.Debugf("repository not identified for release %q, skipping", release.Chart)
 				continue
+			}
+
+			if release.Version == "" {
+				logrus.Debugf("no version specified for release %q, skipping", release.Chart)
+				continue
+
 			}
 
 			manifest := config.Spec{

--- a/pkg/plugins/autodiscovery/helmfile/main.go
+++ b/pkg/plugins/autodiscovery/helmfile/main.go
@@ -1,0 +1,115 @@
+package helmfile
+
+import (
+	"strings"
+
+	"github.com/mitchellh/mapstructure"
+	"github.com/sirupsen/logrus"
+	"github.com/updatecli/updatecli/pkg/core/config"
+	discoveryConfig "github.com/updatecli/updatecli/pkg/core/pipeline/autodiscovery/config"
+	"github.com/updatecli/updatecli/pkg/core/pipeline/pullrequest"
+	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
+	"github.com/updatecli/updatecli/pkg/plugins/utils/docker/dockerregistry"
+)
+
+// Spec defines the parameters which can be provided to the Helm builder.
+type Spec struct {
+	// RootDir defines the root directory used to recursively search for Helm Chart
+	RootDir string `yaml:",omitempty"`
+	// Disable allows to disable the helm chart crawler
+	Disable bool `yaml:",omitempty"`
+	// Ignore allows to specify rule to ignore autodiscovery a specific Helm based on a rule
+	Ignore MatchingRules `yaml:",omitempty"`
+	// Only allows to specify rule to only autodiscover manifest for a specific Helm based on a rule
+	Only MatchingRules `yaml:",omitempty"`
+	// Auths provides a map of registry credentials where the key is the registry URL without scheme
+	Auths map[string]dockerregistry.RegistryAuth `yaml:",omitempty"`
+}
+
+// Helmfile hold all information needed to generate helmfile manifest.
+type Helmfile struct {
+	// spec defines the settings provided via an updatecli manifest
+	spec Spec
+	// rootDir defines the root directory from where looking for Helm Chart
+	rootDir string
+}
+
+// New return a new valid Helm object.
+func New(spec interface{}, rootDir string) (Helmfile, error) {
+	var s Spec
+
+	err := mapstructure.Decode(spec, &s)
+	if err != nil {
+		return Helmfile{}, err
+	}
+
+	dir := rootDir
+	if len(s.RootDir) > 0 {
+		dir = s.RootDir
+	}
+
+	// If no RootDir have been provided via settings,
+	// then fallback to the current process path.
+	if len(dir) == 0 {
+		logrus.Errorln("no working directrory defined")
+		return Helmfile{}, err
+	}
+
+	return Helmfile{
+		spec:    s,
+		rootDir: dir,
+	}, nil
+
+}
+
+func (h Helmfile) DiscoverManifests(input discoveryConfig.Input) ([]config.Spec, error) {
+
+	logrus.Infof("\n\n%s\n", strings.ToTitle("Helmfile"))
+	logrus.Infof("%s\n", strings.Repeat("=", len("Helmfile")+1))
+
+	manifests, err := h.discoverHelmfileManifests()
+
+	if err != nil {
+		return nil, err
+	}
+
+	// Set scm configuration if specified
+	for i := range manifests {
+		// Set scm configuration if specified
+		if len(input.ScmID) > 0 {
+			SetScm(&manifests[i], *input.ScmSpec, input.ScmID)
+		}
+
+		// Set pullrequest configuration if specified
+		if len(input.PullrequestID) > 0 {
+			SetPullrequest(&manifests[i], *input.PullRequestSpec, input.PullrequestID)
+		}
+	}
+
+	return manifests, nil
+}
+
+func SetScm(configSpec *config.Spec, scmSpec scm.Config, scmID string) {
+	configSpec.SCMs = make(map[string]scm.Config)
+	configSpec.SCMs[scmID] = scmSpec
+
+	for id, condition := range configSpec.Conditions {
+		condition.SCMID = scmID
+		configSpec.Conditions[id] = condition
+	}
+
+	for id, target := range configSpec.Targets {
+		target.SCMID = scmID
+		configSpec.Targets[id] = target
+	}
+}
+
+func SetPullrequest(configSpec *config.Spec, pullrequestSpec pullrequest.Config, pullrequestID string) {
+	configSpec.PullRequests = make(map[string]pullrequest.Config)
+	configSpec.PullRequests[pullrequestID] = pullrequestSpec
+}
+
+// RunDisabled returns a bool saying if a run should be done
+func (h Helmfile) Enabled() bool {
+	return !h.spec.Disable
+}

--- a/pkg/plugins/autodiscovery/helmfile/main.go
+++ b/pkg/plugins/autodiscovery/helmfile/main.go
@@ -67,7 +67,7 @@ func (h Helmfile) DiscoverManifests(input discoveryConfig.Input) ([]config.Spec,
 	logrus.Infof("\n\n%s\n", strings.ToTitle("Helmfile"))
 	logrus.Infof("%s\n", strings.Repeat("=", len("Helmfile")+1))
 
-	manifests, err := h.discoverHelmfileManifests()
+	manifests, err := h.discoverHelmfileReleaseManifests()
 
 	if err != nil {
 		return nil, err

--- a/pkg/plugins/autodiscovery/helmfile/main_test.go
+++ b/pkg/plugins/autodiscovery/helmfile/main_test.go
@@ -1,0 +1,94 @@
+package helmfile
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/updatecli/updatecli/pkg/core/config"
+	discoveryConfig "github.com/updatecli/updatecli/pkg/core/pipeline/autodiscovery/config"
+	"github.com/updatecli/updatecli/pkg/core/pipeline/condition"
+	"github.com/updatecli/updatecli/pkg/core/pipeline/resource"
+	"github.com/updatecli/updatecli/pkg/core/pipeline/source"
+	"github.com/updatecli/updatecli/pkg/core/pipeline/target"
+	"github.com/updatecli/updatecli/pkg/plugins/resources/helm"
+	"github.com/updatecli/updatecli/pkg/plugins/resources/yaml"
+)
+
+func TestDiscoverManifests(t *testing.T) {
+	testdata := []struct {
+		name              string
+		rootDir           string
+		expectedPipelines []config.Spec
+	}{
+		{
+			name:    "Scenario 1",
+			rootDir: "testdata",
+			expectedPipelines: []config.Spec{
+				{
+
+					Name: "Bump \"datadog\" Helm Chart version for Helmfile \"testdata/helmfile.d/cik8s.yaml\"",
+					Sources: map[string]source.Config{
+						"datadog": {
+							ResourceConfig: resource.ResourceConfig{
+								Name: "Get latest \"datadog\" Helm Chart Version",
+								Kind: "helmchart",
+								Spec: helm.Spec{
+									Name: "datadog",
+									URL:  "https://helm.datadoghq.com",
+								},
+							},
+						},
+					},
+					Conditions: map[string]condition.Config{
+						"datadog": {
+							DisableSourceInput: true,
+							ResourceConfig: resource.ResourceConfig{
+								Name: "Ensure release \"datadog\" is specified",
+								Kind: "yaml",
+								Spec: yaml.Spec{
+									File:  "testdata/helmfile.d/cik8s.yaml",
+									Key:   "releases[0].chart",
+									Value: "datadog/datadog",
+								},
+							},
+						},
+					},
+					Targets: map[string]target.Config{
+
+						"datadog": {
+							SourceID: "datadog",
+							ResourceConfig: resource.ResourceConfig{
+								Name: "Bump \"datadog\" Helm Chart Version for Helmfile \"testdata/helmfile.d/cik8s.yaml\"",
+								Kind: "yaml",
+								Spec: yaml.Spec{
+									File: "testdata/helmfile.d/cik8s.yaml",
+									Key:  "releases[0].version",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range testdata {
+
+		t.Run(tt.name, func(t *testing.T) {
+			helmfile, err := New(
+				Spec{
+					RootDir: tt.rootDir,
+				}, "")
+
+			require.NoError(t, err)
+
+			pipelines, err := helmfile.DiscoverManifests(discoveryConfig.Input{})
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedPipelines, pipelines)
+
+		})
+	}
+
+}

--- a/pkg/plugins/autodiscovery/helmfile/main_test.go
+++ b/pkg/plugins/autodiscovery/helmfile/main_test.go
@@ -27,7 +27,7 @@ func TestDiscoverManifests(t *testing.T) {
 			expectedPipelines: []config.Spec{
 				{
 
-					Name: "Bump \"datadog\" Helm Chart version for Helmfile \"testdata/helmfile.d/cik8s.yaml\"",
+					Name: "Bump \"datadog\" Helm Chart version for Helmfile \"helmfile.d/cik8s.yaml\"",
 					Sources: map[string]source.Config{
 						"datadog": {
 							ResourceConfig: resource.ResourceConfig{
@@ -44,7 +44,7 @@ func TestDiscoverManifests(t *testing.T) {
 						"datadog": {
 							DisableSourceInput: true,
 							ResourceConfig: resource.ResourceConfig{
-								Name: "Ensure release \"datadog\" is specified",
+								Name: "Ensure release \"datadog\" is specified for Helmfile \"helmfile.d/cik8s.yaml\"",
 								Kind: "yaml",
 								Spec: yaml.Spec{
 									File:  "testdata/helmfile.d/cik8s.yaml",
@@ -59,11 +59,54 @@ func TestDiscoverManifests(t *testing.T) {
 						"datadog": {
 							SourceID: "datadog",
 							ResourceConfig: resource.ResourceConfig{
-								Name: "Bump \"datadog\" Helm Chart Version for Helmfile \"testdata/helmfile.d/cik8s.yaml\"",
+								Name: "Bump \"datadog\" Helm Chart Version for Helmfile \"helmfile.d/cik8s.yaml\"",
 								Kind: "yaml",
 								Spec: yaml.Spec{
 									File: "testdata/helmfile.d/cik8s.yaml",
 									Key:  "releases[0].version",
+								},
+							},
+						},
+					},
+				},
+				{
+
+					Name: "Bump \"docker-registry-secrets\" Helm Chart version for Helmfile \"helmfile.d/cik8s.yaml\"",
+					Sources: map[string]source.Config{
+						"docker-registry-secrets": {
+							ResourceConfig: resource.ResourceConfig{
+								Name: "Get latest \"docker-registry-secrets\" Helm Chart Version",
+								Kind: "helmchart",
+								Spec: helm.Spec{
+									Name: "docker-registry-secrets",
+									URL:  "https://jenkins-infra.github.io/helm-charts",
+								},
+							},
+						},
+					},
+					Conditions: map[string]condition.Config{
+						"docker-registry-secrets": {
+							DisableSourceInput: true,
+							ResourceConfig: resource.ResourceConfig{
+								Name: "Ensure release \"docker-registry-secrets\" is specified for Helmfile \"helmfile.d/cik8s.yaml\"",
+								Kind: "yaml",
+								Spec: yaml.Spec{
+									File:  "testdata/helmfile.d/cik8s.yaml",
+									Key:   "releases[1].chart",
+									Value: "jenkins-infra/docker-registry-secrets",
+								},
+							},
+						},
+					},
+					Targets: map[string]target.Config{
+						"docker-registry-secrets": {
+							SourceID: "docker-registry-secrets",
+							ResourceConfig: resource.ResourceConfig{
+								Name: "Bump \"docker-registry-secrets\" Helm Chart Version for Helmfile \"helmfile.d/cik8s.yaml\"",
+								Kind: "yaml",
+								Spec: yaml.Spec{
+									File: "testdata/helmfile.d/cik8s.yaml",
+									Key:  "releases[1].version",
 								},
 							},
 						},

--- a/pkg/plugins/autodiscovery/helmfile/matchingRule.go
+++ b/pkg/plugins/autodiscovery/helmfile/matchingRule.go
@@ -1,0 +1,76 @@
+package helmfile
+
+import (
+	"path/filepath"
+
+	"github.com/sirupsen/logrus"
+)
+
+// MatchingRule allows to specifies rules to identify manifest
+type MatchingRule struct {
+	// Path specifies a Helm chart path pattern, the pattern requires to match all of name, not just a substring.
+	Path string
+}
+
+type MatchingRules []MatchingRule
+
+func (m MatchingRules) isMatchingIgnoreRule(rootDir, relativePath string) bool {
+	// Test if the ignore rule based on path is respected
+	result := false
+
+	if len(m) > 0 {
+		for _, rule := range m {
+			logrus.Infof("Rule: %q\n", rule.Path)
+			logrus.Infof("Relative Found: %q\n", relativePath)
+			switch filepath.IsAbs(rule.Path) {
+			case true:
+				match, err := filepath.Match(rule.Path, filepath.Join(rootDir, relativePath))
+				if err != nil {
+					logrus.Errorf("%s - %q", err, rule.Path)
+				}
+				if match {
+					result = true
+				}
+			case false:
+				match, err := filepath.Match(rule.Path, relativePath)
+				if err != nil {
+					logrus.Errorf("%s - %q", err, rule.Path)
+				}
+				if match {
+					result = true
+				}
+			}
+		}
+	}
+
+	return result
+}
+
+func (m MatchingRules) isMatchingOnlyRule(rootDir, relativePath string) bool {
+	// Test if the only rule based on path is respected
+	result := false
+	if len(m) > 0 {
+		for _, rule := range m {
+			switch filepath.IsAbs(rule.Path) {
+			case true:
+				match, err := filepath.Match(rule.Path, filepath.Join(rootDir, relativePath))
+				if err != nil {
+					logrus.Errorf("%s - %q", err, rule.Path)
+				}
+				if match {
+					result = true
+				}
+			case false:
+				match, err := filepath.Match(rule.Path, relativePath)
+				if err != nil {
+					logrus.Errorf("%s - %q", err, rule.Path)
+				}
+				if match {
+					result = true
+				}
+			}
+		}
+	}
+
+	return result
+}

--- a/pkg/plugins/autodiscovery/helmfile/releases.go
+++ b/pkg/plugins/autodiscovery/helmfile/releases.go
@@ -15,8 +15,8 @@ import (
 )
 
 var (
-	// ChartValidFiles specifies accepted Helm chart metadata file name
-	ChartValidFiles [2]string = [2]string{"*.yaml", "*.yml"}
+	// DefaultFilePattern specifies accepted Helm chart metadata file name
+	DefaultFilePattern [2]string = [2]string{"*.yaml", "*.yml"}
 )
 
 // Release specify the release information that we are looking for in Helmfile
@@ -39,13 +39,13 @@ type helmfileMetadata struct {
 	Releases     []release
 }
 
-func (h Helmfile) discoverHelmfileManifests() ([]config.Spec, error) {
+func (h Helmfile) discoverHelmfileReleaseManifests() ([]config.Spec, error) {
 
 	var manifests []config.Spec
 
 	foundHelmfileFiles, err := searchHelmfileFiles(
 		h.rootDir,
-		ChartValidFiles[:])
+		DefaultFilePattern[:])
 
 	if err != nil {
 		return nil, err
@@ -95,7 +95,7 @@ func (h Helmfile) discoverHelmfileManifests() ([]config.Spec, error) {
 		}
 
 		for i, release := range metadata.Releases {
-			manifestName := fmt.Sprintf("Bump %q Helm Chart version for Helmfile %q", release.Name, foundHelmfile)
+			manifestName := fmt.Sprintf("Bump %q Helm Chart version for Helmfile %q", release.Name, relativeFoundChartFile)
 
 			chartName, chartURL := getReleaseRepositoryUrl(metadata.Repositories, release)
 
@@ -128,7 +128,7 @@ func (h Helmfile) discoverHelmfileManifests() ([]config.Spec, error) {
 					release.Name: {
 						DisableSourceInput: true,
 						ResourceConfig: resource.ResourceConfig{
-							Name: fmt.Sprintf("Ensure release %q is specified", release.Name),
+							Name: fmt.Sprintf("Ensure release %q is specified for Helmfile %q", release.Name, relativeFoundChartFile),
 							Kind: "yaml",
 							Spec: yaml.Spec{
 								File:  foundHelmfile,
@@ -142,7 +142,7 @@ func (h Helmfile) discoverHelmfileManifests() ([]config.Spec, error) {
 					release.Name: {
 						SourceID: release.Name,
 						ResourceConfig: resource.ResourceConfig{
-							Name: fmt.Sprintf("Bump %q Helm Chart Version for Helmfile %q", release.Name, foundHelmfile),
+							Name: fmt.Sprintf("Bump %q Helm Chart Version for Helmfile %q", release.Name, relativeFoundChartFile),
 							Kind: "yaml",
 							Spec: yaml.Spec{
 								File: foundHelmfile,

--- a/pkg/plugins/autodiscovery/helmfile/testdata/helmfile.d/cik8s.yaml
+++ b/pkg/plugins/autodiscovery/helmfile/testdata/helmfile.d/cik8s.yaml
@@ -1,0 +1,57 @@
+helmDefaults:
+  atomic: true
+  force: false
+  timeout: 300
+  wait: true
+repositories:
+  - name: autoscaler
+    url: https://kubernetes.github.io/autoscaler
+  - name: datadog
+    url: https://helm.datadoghq.com
+  - name: eks
+    url: https://aws.github.io/eks-charts
+  - name: jenkins-infra
+    url: https://jenkins-infra.github.io/helm-charts
+releases:
+  - name: datadog
+    needs:
+      - default/docker-registry-secrets
+    namespace: datadog
+    chart: datadog/datadog
+    version: 3.1.3
+    values:
+      - "../config/ext_datadog.yaml.gotmpl"
+      - "../config/ext_datadog_cik8s.yaml"
+    secrets:
+      - "../secrets/config/datadog/cik8s-secrets.yaml"
+#  - name: docker-registry-secrets
+#    #this helmchart doesn't create any resources within the namespace specified below.
+#    #specifying a namespace is required by the "needs" feature of helmfile (to allow referencing to this release from others)
+#    namespace: default
+#    chart: jenkins-infra/docker-registry-secrets
+#    version: 0.1.0
+#    values:
+#      - "../config/docker-registry-secrets.yaml"
+#    secrets:
+#      - "../secrets/config/docker-registry-secrets/secrets.yaml"
+#  - name: jenkins-agents
+#    needs:
+#      - default/docker-registry-secrets
+#    namespace: jenkins-agents
+#    chart: jenkins-infra/jenkins-kubernetes-agents
+#    version: 0.2.1
+#    secrets:
+#      - "../secrets/config/jenkins-kubernetes-agents/secrets.yaml"
+#  - name: autoscaler
+#    namespace: autoscaler
+#    chart: autoscaler/cluster-autoscaler
+#    version: 9.21.0
+#    values:
+#      - "../config/ext_autoscaler.yaml"
+#  - name: aws-node-termination-handler
+#    namespace: eks
+#    chart: eks/aws-node-termination-handler
+#    version: 0.19.3
+#    values:
+#      - "../config/ext_aws-node-termination-handler.yaml"
+

--- a/pkg/plugins/autodiscovery/helmfile/testdata/helmfile.d/cik8s.yaml
+++ b/pkg/plugins/autodiscovery/helmfile/testdata/helmfile.d/cik8s.yaml
@@ -24,34 +24,22 @@ releases:
       - "../config/ext_datadog_cik8s.yaml"
     secrets:
       - "../secrets/config/datadog/cik8s-secrets.yaml"
-#  - name: docker-registry-secrets
-#    #this helmchart doesn't create any resources within the namespace specified below.
-#    #specifying a namespace is required by the "needs" feature of helmfile (to allow referencing to this release from others)
-#    namespace: default
-#    chart: jenkins-infra/docker-registry-secrets
-#    version: 0.1.0
-#    values:
-#      - "../config/docker-registry-secrets.yaml"
-#    secrets:
-#      - "../secrets/config/docker-registry-secrets/secrets.yaml"
-#  - name: jenkins-agents
-#    needs:
-#      - default/docker-registry-secrets
-#    namespace: jenkins-agents
-#    chart: jenkins-infra/jenkins-kubernetes-agents
-#    version: 0.2.1
-#    secrets:
-#      - "../secrets/config/jenkins-kubernetes-agents/secrets.yaml"
-#  - name: autoscaler
-#    namespace: autoscaler
-#    chart: autoscaler/cluster-autoscaler
-#    version: 9.21.0
-#    values:
-#      - "../config/ext_autoscaler.yaml"
-#  - name: aws-node-termination-handler
-#    namespace: eks
-#    chart: eks/aws-node-termination-handler
-#    version: 0.19.3
-#    values:
-#      - "../config/ext_aws-node-termination-handler.yaml"
+  - name: docker-registry-secrets
+    #this helmchart doesn't create any resources within the namespace specified below.
+    #specifying a namespace is required by the "needs" feature of helmfile (to allow referencing to this release from others)
+    namespace: default
+    chart: jenkins-infra/docker-registry-secrets
+    version: 0.1.0
+    values:
+      - "../config/docker-registry-secrets.yaml"
+    secrets:
+      - "../secrets/config/docker-registry-secrets/secrets.yaml"
+  # Should not be pick up as no version specified
+  - name: jenkins-agents
+    needs:
+      - default/docker-registry-secrets
+    namespace: jenkins-agents
+    chart: jenkins-infra/jenkins-kubernetes-agents
+    secrets:
+      - "../secrets/config/jenkins-kubernetes-agents/secrets.yaml"
 

--- a/pkg/plugins/autodiscovery/helmfile/utils.go
+++ b/pkg/plugins/autodiscovery/helmfile/utils.go
@@ -2,8 +2,8 @@ package helmfile
 
 import (
 	"fmt"
+	"io"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -63,7 +63,7 @@ func getHelmfileMetadata(filename string) (*helmfileMetadata, error) {
 
 	defer v.Close()
 
-	content, err := ioutil.ReadAll(v)
+	content, err := io.ReadAll(v)
 	if err != nil {
 		return &helmfileMetadata{}, err
 	}

--- a/pkg/plugins/autodiscovery/helmfile/utils.go
+++ b/pkg/plugins/autodiscovery/helmfile/utils.go
@@ -1,0 +1,96 @@
+package helmfile
+
+import (
+	"fmt"
+	"io/fs"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	goyaml "gopkg.in/yaml.v3"
+)
+
+// searchHelmfileFiles will look, recursively, for every files named Chart.yaml from a root directory.
+func searchHelmfileFiles(rootDir string, files []string) ([]string, error) {
+
+	helmfiles := []string{}
+
+	// To do switch to WalkDir which is more efficient, introduced in 1.16
+	err := filepath.Walk(rootDir, func(path string, info fs.FileInfo, err error) error {
+		if err != nil {
+			fmt.Printf("prevent panic by handling failure accessing a path %q: %v\n", path, err)
+			return err
+		}
+
+		for _, f := range files {
+			match, err := filepath.Match(f, info.Name())
+			if err != nil {
+				logrus.Errorln(err)
+				continue
+			}
+			if match {
+				helmfiles = append(helmfiles, path)
+			}
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	logrus.Debugf("%d potential helmfile(s) found", len(helmfiles))
+
+	return helmfiles, nil
+}
+
+// getHelmfileMetadata reads a Chart.yaml for information that could be automated
+func getHelmfileMetadata(filename string) (*helmfileMetadata, error) {
+
+	var helmfile helmfileMetadata
+
+	if _, err := os.Stat(filename); err != nil {
+		return &helmfileMetadata{}, err
+	}
+
+	v, err := os.Open(filename)
+	if err != nil {
+		return &helmfileMetadata{}, err
+	}
+
+	defer v.Close()
+
+	content, err := ioutil.ReadAll(v)
+	if err != nil {
+		return &helmfileMetadata{}, err
+	}
+
+	err = goyaml.Unmarshal(content, &helmfile)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if len(helmfile.Releases) == 0 {
+		return &helmfileMetadata{}, nil
+	}
+
+	for _, value := range helmfile.Releases {
+		logrus.Debugf("Name: %q\n", value.Name)
+		logrus.Debugf("Version: %q\n", value.Version)
+	}
+
+	return &helmfile, nil
+}
+
+func getReleaseRepositoryUrl(repositories []repository, release release) (name, url string) {
+	for i := range repositories {
+		if strings.HasPrefix(release.Chart, repositories[i].Name+"/") {
+			return strings.TrimPrefix(release.Chart, repositories[i].Name+"/"), repositories[i].URL
+		}
+	}
+	return "", ""
+}

--- a/pkg/plugins/autodiscovery/helmfile/utils_test.go
+++ b/pkg/plugins/autodiscovery/helmfile/utils_test.go
@@ -2,16 +2,18 @@ package helmfile
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestSearchFiles(t *testing.T) {
 
 	gotFiles, err := searchHelmfileFiles(
-		"testdata/chart", ChartValidFiles[:])
+		"testdata/helmfile.d", DefaultFilePattern[:])
 	if err != nil {
 		t.Errorf("%s\n", err)
 	}
-	expectedFile := "testdata/chart/epinio/Chart.yaml"
+	expectedFile := "testdata/helmfile.d/cik8s.yaml"
 
 	if len(gotFiles) == 0 {
 		t.Errorf("Expecting file %q but got none", expectedFile)
@@ -25,13 +27,48 @@ func TestSearchFiles(t *testing.T) {
 
 func TestListChartDependency(t *testing.T) {
 
-	gotChartMetadata, err := getHelmfileMetadata(
-		"testdata/chart/epinio/Chart.yaml")
+	gotMetadata, err := getHelmfileMetadata(
+		"testdata/helmfile.d/cik8s.yaml")
 	if err != nil {
 		t.Errorf("%s\n", err)
 	}
-	expectedChartName := "epinio"
-	if gotChartMetadata.Name != expectedChartName {
-		t.Errorf("Expecting Chart Name %q but got %q", expectedChartName, gotChartMetadata.Name)
+	expectedReleases := []release{
+		{
+			Name:    "datadog",
+			Chart:   "datadog/datadog",
+			Version: "3.1.3",
+		},
+		{
+			Name:    "docker-registry-secrets",
+			Chart:   "jenkins-infra/docker-registry-secrets",
+			Version: "0.1.0",
+		},
+		{
+			Name:    "jenkins-agents",
+			Chart:   "jenkins-infra/jenkins-kubernetes-agents",
+			Version: "",
+		},
 	}
+
+	expectedRepositories := []repository{
+		{
+			Name: "autoscaler",
+			URL:  "https://kubernetes.github.io/autoscaler",
+		},
+		{
+			Name: "datadog",
+			URL:  "https://helm.datadoghq.com",
+		},
+		{
+			Name: "eks",
+			URL:  "https://aws.github.io/eks-charts",
+		},
+		{
+			Name: "jenkins-infra",
+			URL:  "https://jenkins-infra.github.io/helm-charts",
+		},
+	}
+
+	assert.Equal(t, expectedReleases, gotMetadata.Releases)
+	assert.Equal(t, expectedRepositories, gotMetadata.Repositories)
 }

--- a/pkg/plugins/autodiscovery/helmfile/utils_test.go
+++ b/pkg/plugins/autodiscovery/helmfile/utils_test.go
@@ -1,0 +1,37 @@
+package helmfile
+
+import (
+	"testing"
+)
+
+func TestSearchFiles(t *testing.T) {
+
+	gotFiles, err := searchHelmfileFiles(
+		"testdata/chart", ChartValidFiles[:])
+	if err != nil {
+		t.Errorf("%s\n", err)
+	}
+	expectedFile := "testdata/chart/epinio/Chart.yaml"
+
+	if len(gotFiles) == 0 {
+		t.Errorf("Expecting file %q but got none", expectedFile)
+		return
+	}
+
+	if gotFiles[0] != expectedFile {
+		t.Errorf("Expecting file %q but got %q", expectedFile, gotFiles[0])
+	}
+}
+
+func TestListChartDependency(t *testing.T) {
+
+	gotChartMetadata, err := getHelmfileMetadata(
+		"testdata/chart/epinio/Chart.yaml")
+	if err != nil {
+		t.Errorf("%s\n", err)
+	}
+	expectedChartName := "epinio"
+	if gotChartMetadata.Name != expectedChartName {
+		t.Errorf("Expecting Chart Name %q but got %q", expectedChartName, gotChartMetadata.Name)
+	}
+}


### PR DESCRIPTION
Signed-off-by: Olblak <me@olblak.com>

Fix #409 

This pullrquest add the helmfile autodiscovery crawler.
By default it searches for all files matching ["*.yaml", "*.yml"] if the crawler identify the following pattern in the file 

```
repositories:
 - ...
releases:
 - ...
```

So it assumes that the repository used by a release is defined in the same file.

## Test

To test this pull request, you can run the following commands:

```shell
# Unit Test
cd pkg/plugins/autodiscovery/helmfile
go test

## End to End test
go build -o bin/updatecli .
./bin/updatecli diff --config e2e/updatecli.d/warning.d/autodiscovery/helmfile --experimental --debug
```

## Additional Information

### Tradeoff
In order to be detected by Updatecli helmfile releases requires the following rules

1. A release and its repository must be located in the same file
2. A version must be specified for a release

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
