### PR TITLE
fix: truncate pull request body

### DIFF
--- a/pkg/plugins/scms/github/pullrequest.go
+++ b/pkg/plugins/scms/github/pullrequest.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/shurcooL/githubv4"
 	"github.com/sirupsen/logrus"
+	"github.com/updatecli/updatecli/pkg/plugins/utils/truncate"
 )
 
 // PULLREQUESTBODY is the pull request template used as pull request description
@@ -218,7 +219,13 @@ func (p *PullRequest) generatePullRequestBody() (string, error) {
 		return "", err
 	}
 
-	return buffer.String(), nil
+	// GitHub Issues/PRs messages have a max size limit on the
+	// message body payload.
+	// `body is too long (maximum is 65536 characters)`.
+	// To avoid that, we ensure to cap the message to 60k chars.
+	const MAX_CHARACTERS_PER_MESSAGE = 60000
+
+	return truncate.String(buffer.String(), MAX_CHARACTERS_PER_MESSAGE), nil
 }
 
 // updatePullRequest updates an existing pull request.

--- a/pkg/plugins/scms/github/pullrequest.go
+++ b/pkg/plugins/scms/github/pullrequest.go
@@ -222,8 +222,8 @@ func (p *PullRequest) generatePullRequestBody() (string, error) {
 	// GitHub Issues/PRs messages have a max size limit on the
 	// message body payload.
 	// `body is too long (maximum is 65536 characters)`.
-	// To avoid that, we ensure to cap the message to 60k chars.
-	const MAX_CHARACTERS_PER_MESSAGE = 60000
+	// To avoid that, we ensure to cap the message to 65k chars.
+	const MAX_CHARACTERS_PER_MESSAGE = 65000
 
 	return truncate.String(buffer.String(), MAX_CHARACTERS_PER_MESSAGE), nil
 }

--- a/pkg/plugins/utils/truncate/main.go
+++ b/pkg/plugins/utils/truncate/main.go
@@ -1,0 +1,16 @@
+package truncate
+
+import "unicode/utf8"
+
+// String safely truncate a string
+func String(str string, length int) string {
+	if length <= 0 {
+		return ""
+	}
+
+	if utf8.RuneCountInString(str) < length {
+		return str
+	}
+
+	return string([]rune(str)[:length])
+}

--- a/pkg/plugins/utils/truncate/main.go
+++ b/pkg/plugins/utils/truncate/main.go
@@ -1,6 +1,9 @@
 package truncate
 
-import "unicode/utf8"
+import (
+	"fmt"
+	"unicode/utf8"
+)
 
 // String safely truncate a string
 func String(str string, length int) string {
@@ -12,5 +15,5 @@ func String(str string, length int) string {
 		return str
 	}
 
-	return string([]rune(str)[:length])
+	return fmt.Sprint(string([]rune(str)[:length]), "...")
 }

--- a/pkg/plugins/utils/truncate/main_test.go
+++ b/pkg/plugins/utils/truncate/main_test.go
@@ -1,13 +1,46 @@
 package truncate
 
 import (
+	"fmt"
 	"testing"
 )
 
 func TestString(t *testing.T) {
-	str := String("This is a really long PR body", 24)
+	// small string
+	smallStr := "This is a small PR body"
+	truncatedSmallStr := "This is a small PR"
 
-	if got, want := str, "This is a really long PR"; got != want {
-		t.Fatalf(`str = %q, want %q`, got, want)
+	// too large string
+	const REPEAT = 2500
+	str := "This is a really long PR body"
+
+	longStr := ""
+	for i := 0; i < REPEAT; i++ {
+		longStr += str
+	}
+
+	truncatedLongStr := ""
+	for i := 0; i < REPEAT-1; i++ {
+		truncatedLongStr += str
+	}
+
+	// execute test cases
+	tests := []struct {
+		s             string
+		truncatedSLen int
+		want          string
+	}{
+		{smallStr, len(truncatedSmallStr), truncatedSmallStr},
+		{longStr, len(truncatedLongStr), truncatedLongStr},
+	}
+
+	for i, test := range tests {
+		testname := fmt.Sprintf("test case: %d, length: %d", i+1, test.truncatedSLen)
+		t.Run(testname, func(t *testing.T) {
+			res := String(test.s, test.truncatedSLen)
+			if res != fmt.Sprint(test.want, "...") {
+				t.Fatalf(`str = %q, want %q`, res, test.want)
+			}
+		})
 	}
 }

--- a/pkg/plugins/utils/truncate/main_test.go
+++ b/pkg/plugins/utils/truncate/main_test.go
@@ -1,0 +1,13 @@
+package truncate
+
+import (
+	"testing"
+)
+
+func TestString(t *testing.T) {
+	str := String("This is a really long PR body", 24)
+
+	if got, want := str, "This is a really long PR"; got != want {
+		t.Fatalf(`str = %q, want %q`, got, want)
+	}
+}


### PR DESCRIPTION
Fix #873 

<!-- Describe the changes introduced by this pull request -->

Truncate long PR message to avoid `body is too long` error. 

## Test

To test this pull request, you can run the following commands:

```shell
go test -timeout 30s -run ^TestString$ github.com/updatecli/updatecli/pkg/plugins/utils/truncate
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->
_No response_

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->

_No response_