### PR TITLE
chore: optimize steps order in `go` GitHub Action

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -21,23 +21,6 @@ jobs:
         with:
           go-version: 1.19.1
         id: go
-      # Manage and run your integration tests with efficiency
-      # https://github.com/ovh/venom
-      - name: Install Venom
-        run: |
-          curl -o /usr/local/bin/venom https://github.com/ovh/venom/releases/download/$VENOM_VERSION/venom.linux-amd64 -L
-          sudo chmod +x /usr/local/bin/venom
-          ls -lha /usr/local/bin/venom
-        env:
-          VENOM_VERSION: v1.0.1
-      - name: Show Venom version
-        run: venom version
-      - name: Install GoReleaser
-        uses: goreleaser/goreleaser-action@v3
-        with:
-          install-only: true
-      - name: Show GoReleaser version
-        run: goreleaser --version
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3
       - name: golangci-lint
@@ -47,6 +30,12 @@ jobs:
           # and must be specified without patch version:
           # we always use the latest patch version.
           version: v1.49
+      - name: Install GoReleaser
+        uses: goreleaser/goreleaser-action@v3
+        with:
+          install-only: true
+      - name: Show GoReleaser version
+        run: goreleaser --version
       - name: Build
         run: make build
       - name: Quick Test
@@ -70,6 +59,17 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         if: ${{ github.event_name == 'schedule' }}
+      # Manage and run your integration tests with efficiency
+      # https://github.com/ovh/venom
+      - name: Install Venom
+        run: |
+          curl -o /usr/local/bin/venom https://github.com/ovh/venom/releases/download/$VENOM_VERSION/venom.linux-amd64 -L
+          sudo chmod +x /usr/local/bin/venom
+          ls -lha /usr/local/bin/venom
+        env:
+          VENOM_VERSION: v1.0.1
+      - name: Show Venom version
+        run: venom version
       - name: Run End to End tests
         run: make test-e2e
         env:


### PR DESCRIPTION
No need to install and check version of tools before they're really used. If a previous step fails, it avoid unnecessary downloads and executions.
