### PR TITLE
Deprecate depends_on in favor of dependson

### DIFF
--- a/e2e/updatecli.d/success.d/command.yaml
+++ b/e2e/updatecli.d/success.d/command.yaml
@@ -25,7 +25,7 @@ targets:
 #
 #  4:
 #    name: Should be skipped
-#    depends_on:
+#    dependson:
 #      - "2"
 #    kind: shell
 #    spec:
@@ -34,7 +34,7 @@ targets:
   5:
     name: Should be succeeding
     kind: shell
-    depends_on:
+    dependson:
       - "1"
     spec:
       command: "true"

--- a/pkg/core/pipeline/condition/main.go
+++ b/pkg/core/pipeline/condition/main.go
@@ -138,11 +138,11 @@ func (c *Config) Validate() error {
 	if len(c.DeprecatedDependsOn) > 0 {
 		switch len(c.DependsOn) == 0 {
 		case true:
-			logrus.Warningf("%q is deprecated in favor of %q.", "depends_on", "dependson")
+			logrus.Warningln("\"depends_on\" is deprecated in favor of \"dependson\".")
 			c.DependsOn = c.DeprecatedDependsOn
 			c.DeprecatedDependsOn = []string{}
 		case false:
-			logrus.Warningf("%q is ignored in favor of %q.", "depends_on", "dependson")
+			logrus.Warningln("\"depends_on\" is ignored in favor of \"dependson\".")
 			c.DeprecatedDependsOn = []string{}
 		}
 	}

--- a/pkg/core/pipeline/condition/main.go
+++ b/pkg/core/pipeline/condition/main.go
@@ -134,6 +134,19 @@ func (c *Config) Validate() error {
 		}
 	}
 
+	// Handle depends_on deprecation
+	if len(c.DeprecatedDependsOn) > 0 {
+		switch len(c.DependsOn) == 0 {
+		case true:
+			logrus.Warningf("%q is deprecated in favor of %q.", "depends_on", "dependson")
+			c.DependsOn = c.DeprecatedDependsOn
+			c.DeprecatedDependsOn = []string{}
+		case false:
+			logrus.Warningf("%q is ignored in favor of %q.", "depends_on", "dependson")
+			c.DeprecatedDependsOn = []string{}
+		}
+	}
+
 	// Handle sourceID deprecation
 	if len(c.DeprecatedSourceID) > 0 {
 		switch len(c.SourceID) {

--- a/pkg/core/pipeline/resource/main.go
+++ b/pkg/core/pipeline/resource/main.go
@@ -26,7 +26,7 @@ import (
 )
 
 type ResourceConfig struct {
-	// depends_on specifies which resources must be executed before the current one
+	// dependson specifies which resources must be executed before the current one
 	DependsOn []string `yaml:",omitempty"`
 	// name specifies the resource name
 	Name string `yaml:",omitempty"`

--- a/pkg/core/pipeline/resource/main.go
+++ b/pkg/core/pipeline/resource/main.go
@@ -27,7 +27,7 @@ import (
 
 type ResourceConfig struct {
 	// depends_on specifies which resources must be executed before the current one
-	DependsOn []string `yaml:"depends_on,omitempty"`
+	DependsOn []string `yaml:",omitempty"`
 	// name specifies the resource name
 	Name string `yaml:",omitempty" jsonschema:"required"`
 	// kind specifies the resource kind which defines accepted spec value
@@ -42,6 +42,8 @@ type ResourceConfig struct {
 	SCMID string `yaml:",omitempty"` // SCMID references a uniq scm configuration
 	// !deprecated, please use scmid
 	DeprecatedSCMID string `yaml:"scmID,omitempty" jsonschema:"-"` // SCMID references a uniq scm configuration
+	// !deprecated, please use scmid
+	DeprecatedDependsOn []string `yaml:"depends_on,omitempty" jsonschema:"-"` // SCMID references a uniq scm configuration
 }
 
 // New returns a newly initialized Resource or an error

--- a/pkg/core/pipeline/resource/main.go
+++ b/pkg/core/pipeline/resource/main.go
@@ -42,7 +42,7 @@ type ResourceConfig struct {
 	SCMID string `yaml:",omitempty"` // SCMID references a uniq scm configuration
 	// !deprecated, please use scmid
 	DeprecatedSCMID string `yaml:"scmID,omitempty" jsonschema:"-"` // SCMID references a uniq scm configuration
-	// !deprecated, please use scmid
+	// !deprecated, please use dependson
 	DeprecatedDependsOn []string `yaml:"depends_on,omitempty" jsonschema:"-"` // SCMID references a uniq scm configuration
 }
 

--- a/pkg/core/pipeline/resource/main.go
+++ b/pkg/core/pipeline/resource/main.go
@@ -43,7 +43,7 @@ type ResourceConfig struct {
 	// !deprecated, please use scmid
 	DeprecatedSCMID string `yaml:"scmID,omitempty" jsonschema:"-"` // SCMID references a uniq scm configuration
 	// !deprecated, please use dependson
-	DeprecatedDependsOn []string `yaml:"depends_on,omitempty" jsonschema:"-"` // SCMID references a uniq scm configuration
+	DeprecatedDependsOn []string `yaml:"depends_on,omitempty" jsonschema:"-"` // depends_on specifies which resources must be executed before the current one
 }
 
 // New returns a newly initialized Resource or an error

--- a/pkg/core/pipeline/source/main.go
+++ b/pkg/core/pipeline/source/main.go
@@ -138,6 +138,19 @@ func (c *Config) Validate() error {
 		missingParameters = append(missingParameters, "kind")
 	}
 
+	// Handle depends_on deprecation
+	if len(c.DeprecatedDependsOn) > 0 {
+		switch len(c.DependsOn) == 0 {
+		case true:
+			logrus.Warningf("%q is deprecated in favor of %q.", "depends_on", "dependson")
+			c.DependsOn = c.DeprecatedDependsOn
+			c.DeprecatedDependsOn = []string{}
+		case false:
+			logrus.Warningf("%q is ignored in favor of %q.", "depends_on", "dependson")
+			c.DeprecatedDependsOn = []string{}
+		}
+	}
+
 	// Ensure kind is lowercase
 	if c.Kind != strings.ToLower(c.Kind) {
 		logrus.Warningf("kind value %q must be lowercase", c.Kind)

--- a/pkg/core/pipeline/source/main.go
+++ b/pkg/core/pipeline/source/main.go
@@ -142,11 +142,11 @@ func (c *Config) Validate() error {
 	if len(c.DeprecatedDependsOn) > 0 {
 		switch len(c.DependsOn) == 0 {
 		case true:
-			logrus.Warningf("%q is deprecated in favor of %q.", "depends_on", "dependson")
+			logrus.Warningln("\"depends_on\" is deprecated in favor of \"dependson\".")
 			c.DependsOn = c.DeprecatedDependsOn
 			c.DeprecatedDependsOn = []string{}
 		case false:
-			logrus.Warningf("%q is ignored in favor of %q.", "depends_on", "dependson")
+			logrus.Warningln("\"depends_on\" is ignored in favor of \"dependson\".")
 			c.DeprecatedDependsOn = []string{}
 		}
 	}

--- a/pkg/core/pipeline/target/main.go
+++ b/pkg/core/pipeline/target/main.go
@@ -191,11 +191,11 @@ func (c *Config) Validate() error {
 	if len(c.DeprecatedDependsOn) > 0 {
 		switch len(c.DependsOn) == 0 {
 		case true:
-			logrus.Warningf("%q is deprecated in favor of %q.", "depends_on", "dependson")
+			logrus.Warningln("\"depends_on\" is deprecated in favor of \"dependson\".")
 			c.DependsOn = c.DeprecatedDependsOn
 			c.DeprecatedDependsOn = []string{}
 		case false:
-			logrus.Warningf("%q is ignored in favor of %q.", "depends_on", "dependson")
+			logrus.Warningln("\"depends_on\" is ignored in favor of \"dependson\".")
 			c.DeprecatedDependsOn = []string{}
 		}
 	}

--- a/pkg/core/pipeline/target/main.go
+++ b/pkg/core/pipeline/target/main.go
@@ -187,6 +187,19 @@ func (c *Config) Validate() error {
 		missingParameters = append(missingParameters, "kind")
 	}
 
+	// Handle depends_on deprecation
+	if len(c.DeprecatedDependsOn) > 0 {
+		switch len(c.DependsOn) == 0 {
+		case true:
+			logrus.Warningf("%q is deprecated in favor of %q.", "depends_on", "dependson")
+			c.DependsOn = c.DeprecatedDependsOn
+			c.DeprecatedDependsOn = []string{}
+		case false:
+			logrus.Warningf("%q is ignored in favor of %q.", "depends_on", "dependson")
+			c.DeprecatedDependsOn = []string{}
+		}
+	}
+
 	// Ensure kind is lowercase
 	if c.Kind != strings.ToLower(c.Kind) {
 		logrus.Warningf("kind value %q must be lowercase", c.Kind)


### PR DESCRIPTION
Signed-off-by: Olblak <me@olblak.com>

Align depends_on syntax with the current manifest convention.
This also remove the confusion introduce by jsonschema

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
cp <to_package_directory>
go test
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
