### PR TITLE
Cleanup Updatecli manifest

### DIFF
--- a/updatecli/updatecli.d/golang.yaml
+++ b/updatecli/updatecli.d/golang.yaml
@@ -1,117 +1,115 @@
 name: Bump Golang Version
-
-scms:
-  default:
-    kind: github
-    spec:
-      user: updatecli
-      email: me@olblak.com
-      owner: updatecli
-      repository: updatecli
-      token: '{{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}'
-      username: '{{ requiredEnv "UPDATECLI_GITHUB_ACTOR" }}'
-      branch: main
-
-sources:
-  latestGoVersion:
-    name: Get Latest Go Release
-    kind: githubrelease
-    spec:
-      owner: golang
-      repository: go
-      token: '{{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}'
-      username: '{{ requiredEnv "UPDATECLI_GITHUB_ACTOR" }}'
-      versionfilter:
-        kind: regex
-        pattern: 'go1\.(\d*)\.(\d*)$'
-    transformers:
-      - trimprefix: go
-  gomod:
-    name: Update go.mod
-    kind: shell
-    scmid: default
-    depends_on:
-      - latestGoVersion
-    spec:
-      command: ./updatecli/scripts/updateGomodGoversion.sh ./go.mod {{ source "latestGoVersion" }}
-      environments:
-        - name: PATH
-
-conditions:
-  workflowrelease-sandbox:
-    name: Ensure GA step is defined in Github Action named release-sandbox
-    kind: yaml
-    disablesourceinput: true
-    scmid: default
-    spec:
-      file: .github/workflows/release-sandbox.yaml
-      key: jobs.build.steps[3].id
-      value: go
-  workflowrelease:
-    name: Ensure GA step is defined in Github Action named release
-    kind: yaml
-    disablesourceinput: true
-    scmid: default
-    spec:
-      file: .github/workflows/release.yaml
-      key: jobs.build.steps[3].id
-      value: go
-  workflowgo:
-    name: Ensure GA step is defined in Github Action named go
-    kind: yaml
-    disablesourceinput: true
-    scmid: default
-    spec:
-      file: .github/workflows/go.yaml
-      key: jobs.build.steps[0].id
-      value: go
-  dockerTag:
-    name: 'Is docker image golang:{{ source "latestGoVersion" }} published'
-    sourceid: latestGoVersion
-    kind: dockerimage
-    scmid: default
-    spec:
-      image: golang
-      tag: '{{ source "latestGoVersion" }}'
-
-targets:
-  release-sandbox:
-    name: '[release.yaml] Update Golang version to {{ source "latestGoVersion" }}'
-    sourceid: latestGoVersion
-    kind: yaml
-    spec:
-      file: .github/workflows/release.yaml
-      key: jobs.build.steps[3].with.go-version
-    scmid: default
-  release:
-    name: '[release-sandbox.yaml] Update Golang version to {{ source "latestGoVersion" }}'
-    sourceid: latestGoVersion
-    kind: yaml
-    spec:
-      file: .github/workflows/release-sandbox.yaml
-      key: jobs.build.steps[3].with.go-version
-    scmid: default
-  workflowgo:
-    name: '[release.yaml] Update Golang version to {{ source "latestGoVersion" }}'
-    kind: yaml
-    sourceid: latestGoVersion
-    spec:
-      file: .github/workflows/go.yaml
-      key: jobs.build.steps[0].with.go-version
-    scmid: default
-  go.mod:
-    name: '[go.mod] Update Golang version to {{ source "latestGoVersion" }}'
-    sourceid: gomod
-    kind: file
-    spec:
-      file: go.mod
-    scmid: default
-
+pipelineid: 5ba938aaacf1b88e3db4076b2a7a7db6ee1e00eb19dbe2469abf35c96f008e8d
 pullrequests:
-  default:
-    title: '[updatecli] Bump Golang version to {{ source "latestGoVersion" }}'
-    kind: github
-    scmid: default
-    spec:
-      labels:
-        - chore
+    default:
+        title: '[updatecli] Bump Golang version to {{ source "latestGoVersion" }}'
+        kind: github
+        spec:
+            labels:
+                - chore
+        scmid: default
+scms:
+    default:
+        kind: github
+        spec:
+            branch: main
+            email: me@olblak.com
+            owner: updatecli
+            repository: updatecli
+            token: '{{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}'
+            user: updatecli
+            username: '{{ requiredEnv "UPDATECLI_GITHUB_ACTOR" }}'
+        disabled: false
+sources:
+    gomod:
+        dependson:
+            - latestGoVersion
+        name: Update go.mod
+        kind: shell
+        spec:
+            command: ./updatecli/scripts/updateGomodGoversion.sh ./go.mod {{ source "latestGoVersion" }}
+            environments:
+                - name: PATH
+        scmid: default
+    latestGoVersion:
+        name: Get Latest Go Release
+        kind: githubrelease
+        transformers:
+            - trimprefix: go
+        spec:
+            owner: golang
+            repository: go
+            token: '{{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}'
+            username: '{{ requiredEnv "UPDATECLI_GITHUB_ACTOR" }}'
+            versionfilter:
+                kind: regex
+                pattern: go1\.(\d*)\.(\d*)$
+conditions:
+    dockerTag:
+        name: Is docker image golang:{{ source "latestGoVersion" }} published
+        kind: dockerimage
+        spec:
+            image: golang
+            tag: '{{ source "latestGoVersion" }}'
+        scmid: default
+        sourceid: latestGoVersion
+    workflowgo:
+        name: Ensure GA step is defined in Github Action named go
+        kind: yaml
+        spec:
+            file: .github/workflows/go.yaml
+            key: jobs.build.steps[0].id
+            value: go
+        scmid: default
+        disablesourceinput: true
+    workflowrelease:
+        name: Ensure GA step is defined in Github Action named release
+        kind: yaml
+        spec:
+            file: .github/workflows/release.yaml
+            key: jobs.build.steps[3].id
+            value: go
+        scmid: default
+        disablesourceinput: true
+    workflowrelease-sandbox:
+        name: Ensure GA step is defined in Github Action named release-sandbox
+        kind: yaml
+        spec:
+            file: .github/workflows/release-sandbox.yaml
+            key: jobs.build.steps[3].id
+            value: go
+        scmid: default
+        disablesourceinput: true
+targets:
+    go.mod:
+        name: '[go.mod] Update Golang version to {{ source "latestGoVersion" }}'
+        kind: file
+        spec:
+            file: go.mod
+        scmid: default
+        sourceid: gomod
+    release:
+        name: '[release-sandbox.yaml] Update Golang version to {{ source "latestGoVersion" }}'
+        kind: yaml
+        spec:
+            file: .github/workflows/release-sandbox.yaml
+            key: jobs.build.steps[3].with.go-version
+        scmid: default
+        sourceid: latestGoVersion
+    release-sandbox:
+        name: '[release.yaml] Update Golang version to {{ source "latestGoVersion" }}'
+        kind: yaml
+        spec:
+            file: .github/workflows/release.yaml
+            key: jobs.build.steps[3].with.go-version
+        scmid: default
+        sourceid: latestGoVersion
+    workflowgo:
+        name: '[release.yaml] Update Golang version to {{ source "latestGoVersion" }}'
+        kind: yaml
+        spec:
+            file: .github/workflows/go.yaml
+            key: jobs.build.steps[0].with.go-version
+        scmid: default
+        sourceid: latestGoVersion
+version: 0.34.0

--- a/updatecli/updatecli.d/golangci-lint.yaml
+++ b/updatecli/updatecli.d/golangci-lint.yaml
@@ -1,62 +1,59 @@
-name: "Bump golangci-lint version"
-
-scms:
-  default:
-    kind: github
-    spec:
-      user: updatecli
-      email: me@olblak.com
-      owner: updatecli
-      repository: updatecli
-      token: '{{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}'
-      username: '{{ requiredEnv "UPDATECLI_GITHUB_ACTOR" }}'
-      branch: main
-
-sources:
-  default:
-    name: Get latest golangci-lint version
-    kind: githubrelease
-    spec:
-      owner: golangci
-      repository: golangci-lint
-      token: '{{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}'
-      username: '{{ requiredEnv "UPDATECLI_GITHUB_ACTOR" }}'
-    
-
-conditions:
-  default:
-    name: 'Test golangci-lint is used in workflow go.yaml'
-    kind: yaml
-    disablesourceinput: true
-    spec:
-      file: .github/workflows/go.yaml
-      key: jobs.build.steps[6].name
-      value: "golangci-lint"
-    scmid: default
-
-targets:
-  default:
-    name: 'Update Golangci-lint version to {{ source "default" }}'
-    kind: yaml
-    spec:
-      file: .github/workflows/go.yaml
-      key: jobs.build.steps[6].with.version
-    scmid: default
-    # Required: the version of golangci-lint is required
-    # and must be specified without patch version:
-    # we always use the latest patch version.
-    transformers:
-      - findsubmatch:
-          pattern: 'v(\d*)\.(\d*)'
-
+name: Bump golangci-lint version
+pipelineid: e6d141666bd851d4bac9467b898b5e908012a53932de7a805c0767c9e7aeb532
 pullrequests:
-  default:
-    title: '[updatecli] Bump golangci-lint version to {{ source "default" }}'
-    kind: github
-    scmid: default
-    spec:
-      automerge: true
-      labels:
-        - chore
-        - dependencies
-        - skip-changelog
+    default:
+        title: '[updatecli] Bump golangci-lint version to {{ source "default" }}'
+        kind: github
+        spec:
+            automerge: true
+            labels:
+                - chore
+                - dependencies
+                - skip-changelog
+        scmid: default
+scms:
+    default:
+        kind: github
+        spec:
+            branch: main
+            email: me@olblak.com
+            owner: updatecli
+            repository: updatecli
+            token: '{{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}'
+            user: updatecli
+            username: '{{ requiredEnv "UPDATECLI_GITHUB_ACTOR" }}'
+        disabled: false
+sources:
+    default:
+        name: Get latest golangci-lint version
+        kind: githubrelease
+        spec:
+            owner: golangci
+            repository: golangci-lint
+            token: '{{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}'
+            username: '{{ requiredEnv "UPDATECLI_GITHUB_ACTOR" }}'
+conditions:
+    default:
+        name: Test golangci-lint is used in workflow go.yaml
+        kind: yaml
+        spec:
+            file: .github/workflows/go.yaml
+            key: jobs.build.steps[2].name
+            value: golangci-lint
+        scmid: default
+        disablesourceinput: true
+targets:
+    default:
+        name: Update Golangci-lint version to {{ source "default" }}
+        kind: yaml
+        transformers:
+            - findsubmatch:
+                pattern: v(\d*)\.(\d*)
+                captureIndex: 0
+                captureindex: 0
+        spec:
+            file: .github/workflows/go.yaml
+            key: jobs.build.steps[2].with.version
+        scmid: default
+        sourceid: default
+version: 0.34.0

--- a/updatecli/updatecli.d/updatecli.yaml
+++ b/updatecli/updatecli.d/updatecli.yaml
@@ -1,44 +1,44 @@
 name: Bump udpatecli version
-
-scms:
-  default:
-    kind: github
-    spec:
-      user: updatecli
-      email: me@olblak.com
-      owner: updatecli
-      repository: updatecli
-      token: '{{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}'
-      username: '{{ requiredEnv "UPDATECLI_GITHUB_ACTOR" }}'
-      branch: main
-
-sources:
-  latestVersion:
-    name: Get latest updatecli release
-    kind: githubrelease
-    spec:
-      owner: updatecli
-      repository: updatecli
-      token: '{{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}'
-      username: '{{ requiredEnv "UPDATECLI_GITHUB_ACTOR" }}'
-
-targets:
-  bugReport:
-    name: '[bug-report] Update updatecli version to {{ source "latestVersion" }}'
-    kind: file
-    spec:
-      file: .github/ISSUE_TEMPLATE/1-bug-report.yml
-      matchpattern: '\*\*updatecli\*\*: .*'
-      content: '**updatecli**: {{ source `latestVersion` }}'
-    scmid: default
-
+pipelineid: cac467f9bdc931266038f8cf363edc865370121deb3954b93e70d0588827a04f
 pullrequests:
-  default:
-    title: '[updatecli] Bump updatecli version to {{ source "latestVersion" }}'
-    kind: github
-    scmid: default
-    spec:
-      automerge: true
-      labels:
-        - chore
-        - skip-changelog
+    default:
+        title: '[updatecli] Bump updatecli version to {{ source "latestVersion" }}'
+        kind: github
+        spec:
+            automerge: true
+            labels:
+                - chore
+                - skip-changelog
+        scmid: default
+scms:
+    default:
+        kind: github
+        spec:
+            branch: main
+            email: me@olblak.com
+            owner: updatecli
+            repository: updatecli
+            token: '{{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}'
+            user: updatecli
+            username: '{{ requiredEnv "UPDATECLI_GITHUB_ACTOR" }}'
+        disabled: false
+sources:
+    latestVersion:
+        name: Get latest updatecli release
+        kind: githubrelease
+        spec:
+            owner: updatecli
+            repository: updatecli
+            token: '{{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}'
+            username: '{{ requiredEnv "UPDATECLI_GITHUB_ACTOR" }}'
+targets:
+    bugReport:
+        name: '[bug-report] Update updatecli version to {{ source "latestVersion" }}'
+        kind: file
+        spec:
+            content: '**updatecli**: {{ source `latestVersion` }}'
+            file: .github/ISSUE_TEMPLATE/1-bug-report.yml
+            matchpattern: '\*\*updatecli\*\*: .*'
+        scmid: default
+        sourceid: latestVersion
+version: 0.34.0

--- a/updatecli/updatecli.d/venom.yaml
+++ b/updatecli/updatecli.d/venom.yaml
@@ -1,46 +1,48 @@
 name: Bump venom version
-
-scms:
-  default:
-    kind: github
-    spec:
-      user: updatecli
-      email: me@olblak.com
-      owner: updatecli
-      repository: updatecli
-      token: '{{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}'
-      username: '{{ requiredEnv "UPDATECLI_GITHUB_ACTOR" }}'
-      branch: main
-
-sources:
-  latestVersion:
-    name: Get latest Venom release
-    kind: githubrelease
-    spec:
-      owner: ovh
-      repository: venom
-      token: '{{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}'
-      username: '{{ requiredEnv "UPDATECLI_GITHUB_ACTOR" }}'
-      versionfilter:
-        kind: semver
-    
-targets:
-  goWorkflow:
-    name: 'Bump Venom version to {{ source "latestVersion" }}'
-    kind: file
-    spec:
-      file: .github/workflows/go.yaml
-      matchpattern: 'VENOM_VERSION: .*'
-      content: 'VENOM_VERSION: {{ source `latestVersion` }}'
-    scmid: default
-
+pipelineid: 6a1c726e25648f93a45aa3b540ba8fd6307a62f92830404f55259bfbbc1b3c6f
 pullrequests:
-  default:
-    title: '[updatecli] Bump Venom version to {{ source "latestVersion" }}'
-    kind: github
-    scmid: default
-    spec:
-      automerge: true
-      labels:
-        - chore
-        - skip-changelog
+    default:
+        title: '[updatecli] Bump Venom version to {{ source "latestVersion" }}'
+        kind: github
+        spec:
+            automerge: true
+            labels:
+                - chore
+                - skip-changelog
+        scmid: default
+scms:
+    default:
+        kind: github
+        spec:
+            branch: main
+            email: me@olblak.com
+            owner: updatecli
+            repository: updatecli
+            token: '{{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}'
+            user: updatecli
+            username: '{{ requiredEnv "UPDATECLI_GITHUB_ACTOR" }}'
+        disabled: false
+sources:
+    latestVersion:
+        name: Get latest Venom release
+        kind: githubrelease
+        spec:
+            owner: ovh
+            repository: venom
+            token: '{{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}'
+            username: '{{ requiredEnv "UPDATECLI_GITHUB_ACTOR" }}'
+            versionfilter:
+                kind: semver
+        transformers:
+          - addprefix: "v"
+targets:
+    goWorkflow:
+        name: Bump Venom version to {{ source "latestVersion" }}
+        kind: file
+        spec:
+            content: 'VENOM_VERSION: {{ source `latestVersion` }}'
+            file: .github/workflows/go.yaml
+            matchpattern: 'VENOM_VERSION: .*'
+        scmid: default
+        sourceid: latestVersion
+version: 0.34.0


### PR DESCRIPTION
Fix the venom pipeline until https://github.com/updatecli/updatecli/issues/803 is fixed
Run `updatecli manifest upgrade` to fix deprecated syntax

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
updatecli diff --config updatecli/updatecli.d 
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
