### PR TITLE
Allow strict semantic versioning

### DIFF
--- a/e2e/updatecli.d/success.d/dockerimage.yaml
+++ b/e2e/updatecli.d/success.d/dockerimage.yaml
@@ -129,6 +129,14 @@ conditions:
     spec:
       image: "quay.io/calico/node"
 
+  quayio-semver-strict:
+    name: "Get latest calico image"
+    kind: dockerimage
+    sourceid: quayio-semver
+    spec:
+      image: "quay.io/calico/node"
+      strict: true
+
   quayio-regex:
     name: "Get latest calico image"
     kind: dockerimage


### PR DESCRIPTION
Signed-off-by: Olblak <me@olblak.com>

This pullrequest adds the ability to enforce strict semantic versioning by using a new `versionfilter` parameter named `strict

Differently for the two following version `1.0` and `1.0.0`, with strict enabled, only `1.0.0` will be accepted


<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
cp pkg/plugins/utils/version/
go test
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

While exploring potential solution to allow more granularity in version filtering, I discovered https://github.com/hashicorp/go-version
This library could be useful for non semver version by adding a new `kind` to versionfilter
