### PR TITLE
fix(pullrequest): default title with the source output instead of its result '✔'

### DIFF
--- a/pkg/core/pipeline/pullRequests.go
+++ b/pkg/core/pipeline/pullRequests.go
@@ -58,7 +58,7 @@ func (p *Pipeline) RunPullRequests() error {
 		if len(pr.Title) == 0 {
 			pr.Title = p.Config.GetChangelogTitle(
 				firstTargetID,
-				p.Sources[firstTargetSourceID].Result,
+				p.Sources[firstTargetSourceID].Output,
 			)
 		}
 


### PR DESCRIPTION
Fix 
![image](https://user-images.githubusercontent.com/91831478/198349999-4ccb0504-80e5-4e29-bfe7-55c5dd3f9856.png)


<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
cp <to_package_directory>
go test
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

I intend to improve this pull request default title by including the name of what's updated, and maybe also the type.

Something like

> [updatecli] Bump `<name>` <helm chart|docker image|...> version to <source-output>

The easiest way I found to retrieve the name would be to use sources[0].name, implying the change of (jenkins infra) manifests (they almost all have a description in the `name` field)