### PR TITLE
Allow multiple query combined with versionfilter to toml source

### DIFF
--- a/e2e/updatecli.d/success.d/toml.yaml
+++ b/e2e/updatecli.d/success.d/toml.yaml
@@ -7,11 +7,20 @@ sources:
     spec:
       file: pkg/plugins/resources/toml/testdata/data.toml
       key: owner.firstName
+  ports:
+    name: Get sorted ports
+    kind: toml
+    spec:
+      file: pkg/plugins/resources/toml/testdata/data.toml
+      query: database.ports.[*]
+      versionfilter:
+        kind: semver
 
 conditions:
   local:
     name: Test value from toml
     kind: toml
+    sourceid: local
     spec:
       file: pkg/plugins/resources/toml/testdata/data.toml
       key: owner.firstName
@@ -23,11 +32,20 @@ conditions:
       file: pkg/plugins/resources/toml/testdata/data.toml
       key: ".employees.(address=AU).role"
       value: "M"
+  ports:
+    name: Get sorted ports
+    kind: toml
+    disablesourceinput: true
+    spec:
+      file: pkg/plugins/resources/toml/testdata/data.toml
+      query: ".employees.(address=AU).role"
+      value: "M"
 
 targets:
   local:
     name: Test value from toml
     kind: toml
+    sourceid: local
     spec:
       file: pkg/plugins/resources/toml/testdata/data.toml
       key: owner.firstName

--- a/pkg/plugins/resources/toml/condition.go
+++ b/pkg/plugins/resources/toml/condition.go
@@ -32,9 +32,9 @@ func (t *Toml) ConditionFromSCM(source string, scm scm.ScmHandler) (bool, error)
 		var queryResults []string
 		var err error
 
-		switch t.spec.Multiple {
+		switch len(t.spec.Query) > 0 {
 		case true:
-			queryResults, err = t.contents[i].MultipleQuery(t.spec.Key)
+			queryResults, err = t.contents[i].MultipleQuery(t.spec.Query)
 
 			if err != nil {
 				return false, err

--- a/pkg/plugins/resources/toml/condition_test.go
+++ b/pkg/plugins/resources/toml/condition_test.go
@@ -18,7 +18,7 @@ func TestCondition(t *testing.T) {
 		wantErr          bool
 	}{
 		{
-			name: "Default successful multiple update workflow",
+			name: "Deprecated - Default successful multiple update workflow",
 			spec: Spec{
 				File:     "testdata/data.toml",
 				Key:      ".employees.[*].role",
@@ -27,20 +27,26 @@ func TestCondition(t *testing.T) {
 			expectedResult: false,
 		},
 		{
+			name: "Default successful multiple update workflow",
+			spec: Spec{
+				File:  "testdata/data.toml",
+				Query: ".employees.[*].role",
+			},
+			expectedResult: false,
+		},
+		{
 			name: "Successful conditional multiple update workflow",
 			spec: Spec{
-				File:     "testdata/data.toml",
-				Key:      ".employees.(address=AU).role",
-				Multiple: true,
+				File:  "testdata/data.toml",
+				Query: ".employees.(address=AU).role",
 			},
 			expectedResult: false,
 		},
 		{
 			name: "Successful multiple map update workflow",
 			spec: Spec{
-				File:     "testdata/data.toml",
-				Key:      ".benefits.[0].country.(country=UK).name",
-				Multiple: true,
+				File:  "testdata/data.toml",
+				Query: ".benefits.[0].country.(country=UK).name",
 			},
 			expectedResult: false,
 		},
@@ -76,10 +82,9 @@ func TestCondition(t *testing.T) {
 		{
 			name: "Test key do not exist",
 			spec: Spec{
-				File:     "testdata/data.toml",
-				Key:      ".doNotExist.[*]",
-				Value:    "",
-				Multiple: true,
+				File:  "testdata/data.toml",
+				Query: ".doNotExist.[*]",
+				Value: "",
 			},
 			expectedResult:   false,
 			wantErr:          true,

--- a/pkg/plugins/resources/toml/main.go
+++ b/pkg/plugins/resources/toml/main.go
@@ -5,8 +5,10 @@ import (
 	"strings"
 
 	"github.com/mitchellh/mapstructure"
+	"github.com/sirupsen/logrus"
 	"github.com/updatecli/updatecli/pkg/core/text"
 	"github.com/updatecli/updatecli/pkg/plugins/utils/dasel"
+	"github.com/updatecli/updatecli/pkg/plugins/utils/version"
 )
 
 var (
@@ -18,6 +20,10 @@ var (
 type Toml struct {
 	spec     Spec
 	contents []dasel.FileContent
+	// Holds both parsed version and original version (to allow retrieving metadata such as changelog)
+	foundVersion version.Version
+	// Holds the "valid" version.filter, that might be different than the user-specified filter (Spec.VersionFilter)
+	versionFilter version.Filter
 }
 
 func New(spec interface{}) (*Toml, error) {
@@ -31,10 +37,32 @@ func New(spec interface{}) (*Toml, error) {
 
 	err = newSpec.Validate()
 
+	if err != nil {
+		return nil, err
+	}
+
+	// Deprecate message to remove in a futur updatelci version
+	// cfr https://github.com/updatecli/updatecli/pull/944
+	if newSpec.Multiple {
+		logrus.Warningln("the setting 'multiple' is now deprecated. you shoul be be using the parameter \"query\" which allows you to specify an advanced query.")
+		if len(newSpec.Key) > 0 && len(newSpec.Query) == 0 {
+			logrus.Printf("Instead of using the parameter key %q combined with multiple, we converted your setting to use the parameter query %q", newSpec.Key, newSpec.Query)
+			newSpec.Query = newSpec.Key
+			newSpec.Key = ""
+			newSpec.Multiple = false
+		}
+	}
+
 	newSpec.File = strings.TrimPrefix(newSpec.File, "file://")
 
+	newFilter, err := newSpec.VersionFilter.Init()
+	if err != nil {
+		return nil, err
+	}
+
 	j := Toml{
-		spec: newSpec,
+		spec:          newSpec,
+		versionFilter: newFilter,
 	}
 
 	// Init currentContents

--- a/pkg/plugins/resources/toml/source_test.go
+++ b/pkg/plugins/resources/toml/source_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/updatecli/updatecli/pkg/plugins/utils/version"
 	"gotest.tools/assert"
 )
 
@@ -51,6 +52,18 @@ func TestSource(t *testing.T) {
 				Key:  ".database.ports.[1]",
 			},
 			expectedResult: "8001",
+		},
+		{
+			name: "Test Query exist",
+			spec: Spec{
+				File:  "testdata/data.toml",
+				Query: ".employees.[*].role",
+				VersionFilter: version.Filter{
+					Kind:    "regex",
+					Pattern: "I(.*)",
+				},
+			},
+			expectedResult: "IC",
 		},
 	}
 

--- a/pkg/plugins/resources/toml/spec.go
+++ b/pkg/plugins/resources/toml/spec.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 
 	"github.com/sirupsen/logrus"
+	"github.com/updatecli/updatecli/pkg/plugins/utils/version"
 )
 
 type Spec struct {
@@ -11,19 +12,23 @@ type Spec struct {
 	File string `yaml:",omitempty"`
 	// [c][t] Files specifies a list of Json file to manipuate
 	Files []string `yaml:",omitempty"`
+	// [s][c][t] Query allows to used advanced query. Override the parameter key
+	Query string `yaml:",omitempty"`
 	// [s][c][t] Key specifies the query to retrieve an information from a toml file
 	Key string `yaml:",omitempty"`
 	// [s][c][t] Value specifies the value for a specific key. Default to source output
 	Value string `yaml:",omitempty"`
-	// [c][t] Multiple allows to query multiple values at once
-	Multiple bool `yaml:",omitempty"`
+	// [c][t] *Deprecated* Please look at query parameter to achieve similar objective
+	Multiple bool `yaml:",omitempty" jsonschema:"-"`
+	// [s]VersionFilter provides parameters to specify version pattern and its type like regex, semver, or just latest.
+	VersionFilter version.Filter `yaml:",omitempty"`
 }
 
 var (
 	// ErrSpecFileUndefined is returned if a file wasn't specified
 	ErrSpecFileUndefined = errors.New("toml file undefined")
 	// ErrSpecKeyUndefined is returned if a key wasn't specified
-	ErrSpecKeyUndefined = errors.New("toml key undefined")
+	ErrSpecKeyUndefined = errors.New("toml key or query undefined")
 	// ErrSpecFileAndFilesDefines when we both spec File and Files have been specified
 	ErrSpecFileAndFilesDefined = errors.New("parameter \"file\" and \"files\" are mutually exclusive")
 	// ErrWrongSpec is returned when the Spec has wrong content
@@ -36,7 +41,7 @@ func (s *Spec) Validate() error {
 	if len(s.File) == 0 && len(s.Files) == 0 {
 		errs = append(errs, ErrSpecFileUndefined)
 	}
-	if len(s.Key) == 0 {
+	if len(s.Key) == 0 && len(s.Query) == 0 {
 		errs = append(errs, ErrSpecKeyUndefined)
 	}
 

--- a/pkg/plugins/resources/toml/target.go
+++ b/pkg/plugins/resources/toml/target.go
@@ -55,9 +55,9 @@ func (t *Toml) TargetFromSCM(source string, scm scm.ScmHandler, dryRun bool) (ch
 		var queryResults []string
 		var err error
 
-		switch t.spec.Multiple {
+		switch len(t.spec.Query) > 0 {
 		case true:
-			queryResults, err = t.contents[i].MultipleQuery(t.spec.Key)
+			queryResults, err = t.contents[i].MultipleQuery(t.spec.Query)
 
 			if err != nil {
 				return false, files, message, err
@@ -99,9 +99,9 @@ func (t *Toml) TargetFromSCM(source string, scm scm.ScmHandler, dryRun bool) (ch
 		}
 
 		// Update the target file with the new value
-		switch t.spec.Multiple {
+		switch len(t.spec.Query) > 0 {
 		case true:
-			err = t.contents[i].PutMultiple(t.spec.Key, t.spec.Value)
+			err = t.contents[i].PutMultiple(t.spec.Query, t.spec.Value)
 
 			if err != nil {
 				return false, files, message, err

--- a/pkg/plugins/resources/toml/target_test.go
+++ b/pkg/plugins/resources/toml/target_test.go
@@ -19,12 +19,24 @@ func TestTarget(t *testing.T) {
 		wantErr          bool
 	}{
 		{
-			name: "Test key do not exist",
+			name: "Deprecated multiple Test key do not exist",
 			spec: Spec{
 				File:     "testdata/data.toml",
 				Key:      ".doNotExist.[*]",
 				Value:    "",
 				Multiple: true,
+			},
+			expectedResult:   false,
+			sourceInput:      "M",
+			wantErr:          true,
+			expectedErrorMsg: errors.New("could not find multiple value for query \".doNotExist.[*]\" from file \"testdata/data.toml\""),
+		},
+		{
+			name: "Test key do not exist",
+			spec: Spec{
+				File:  "testdata/data.toml",
+				Query: ".doNotExist.[*]",
+				Value: "",
 			},
 			expectedResult:   false,
 			sourceInput:      "M",
@@ -46,9 +58,8 @@ func TestTarget(t *testing.T) {
 		{
 			name: "Default successful multiple update workflow",
 			spec: Spec{
-				File:     "testdata/data.toml",
-				Key:      ".employees.[*].role",
-				Multiple: true,
+				File:  "testdata/data.toml",
+				Query: ".employees.[*].role",
 			},
 			sourceInput:    "M",
 			expectedResult: true,
@@ -56,9 +67,8 @@ func TestTarget(t *testing.T) {
 		{
 			name: "Successful conditional multiple update workflow",
 			spec: Spec{
-				File:     "testdata/data.toml",
-				Key:      ".employees.(address=AU).role",
-				Multiple: true,
+				File:  "testdata/data.toml",
+				Query: ".employees.(address=AU).role",
 			},
 			sourceInput:    "M",
 			expectedResult: false,
@@ -66,9 +76,8 @@ func TestTarget(t *testing.T) {
 		{
 			name: "Successful multiple map update workflow",
 			spec: Spec{
-				File:     "testdata/data.toml",
-				Key:      ".benefits.[0].country.(country=UK).name",
-				Multiple: true,
+				File:  "testdata/data.toml",
+				Query: ".benefits.[0].country.(country=UK).name",
 			},
 			sourceInput:    "all",
 			expectedResult: true,


### PR DESCRIPTION
Signed-off-by: Olblak <me@olblak.com>
As discussed on https://github.com/updatecli/updatecli/issues/942#issuecomment-1284561424
I realized that it would be super usefull to be able to do a multiple query combined with versionfilter on the toml resource

This pullrequest allows the following manifest to work 

<!-- Describe the changes introduced by this pull request -->
Example 

```
sources:
  ports:
    name: Get sorted ports
    kind: toml
    spec:
      file: pkg/plugins/resources/toml/testdata/data.toml
      query: database.ports.[*]
      versionfilter:
        kind: semver
```

## Example 

```
++++++++++++
+ PIPELINE +
++++++++++++



######################
# BASIC TOML EXAMPLE #
######################


SOURCES
=======

ports
-----
Searching for version matching pattern "*"
✔ Value "8002", found in file "/home/olblak/Projects/Updatecli/updatecli/pkg/plugins/resources/toml/testdata/data.toml", for key "database.ports.[*]"'

```
## Test

To test this pull request, you can run the following commands:

```shell
cd pkg/plugins/resources/toml
go test
```

## Additional Information

### Tradeoff

Similar to the Json approach, I am deprecating the parameter multiple in favor of query

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
