### PR TITLE
Allow multiple query combined with versionfilter to csv source

### DIFF
--- a/e2e/updatecli.d/success.d/csv.yaml
+++ b/e2e/updatecli.d/success.d/csv.yaml
@@ -8,6 +8,16 @@ sources:
       files:
         - pkg/plugins/resources/csv/testdata/data.csv
       key: .[0].firstname
+  versionfilter:
+    name: Test Version filter`
+    kind: csv
+    spec:
+      files: 
+        - pkg/plugins/resources/csv/testdata/data.csv
+      query: ".[*].firstname"
+      versionfilter:
+        kind: regex
+        pattern: "^Jo"
 
 conditions:
   single:
@@ -25,19 +35,20 @@ targets:
   single:
     name: Basic target update
     kind: csv
+    sourceid: default
     spec:
       files: 
         - pkg/plugins/resources/csv/testdata/data.csv
         - pkg/plugins/resources/csv/testdata/data.csv
-      key: .[1].firstname
+      query: .[1].firstname
       value: John
 
   multiple:
     name: Mulitple target update
     kind: csv
+    sourceid: default
     spec:
       files:
         - pkg/plugins/resources/csv/testdata/data.csv
         - pkg/plugins/resources/csv/testdata/data.csv
-      key: .[*].firstname
-      multiple: true
+      query: .[*].firstname

--- a/pkg/plugins/resources/csv/condition.go
+++ b/pkg/plugins/resources/csv/condition.go
@@ -32,9 +32,9 @@ func (c *CSV) ConditionFromSCM(source string, scm scm.ScmHandler) (bool, error) 
 		var queryResults []string
 		var err error
 
-		switch c.spec.Multiple {
+		switch len(c.spec.Query) > 0 {
 		case true:
-			queryResults, err = c.contents[i].MultipleQuery(c.spec.Key)
+			queryResults, err = c.contents[i].MultipleQuery(c.spec.Query)
 
 			if err != nil {
 				return false, err

--- a/pkg/plugins/resources/csv/condition_test.go
+++ b/pkg/plugins/resources/csv/condition_test.go
@@ -27,7 +27,7 @@ func TestCondition(t *testing.T) {
 			expectedResult: true,
 		},
 		{
-			name: "Multiple query scenario",
+			name: "Deprecated Multiple query scenario",
 			spec: Spec{
 				File:     "testdata/data.csv",
 				Key:      ".[*].firstname",
@@ -37,12 +37,20 @@ func TestCondition(t *testing.T) {
 			expectedResult: false,
 		},
 		{
+			name: "Query scenario",
+			spec: Spec{
+				File:  "testdata/data.csv",
+				Query: ".[*].firstname",
+				Value: "John",
+			},
+			expectedResult: false,
+		},
+		{
 			name: "Multiple query scenario",
 			spec: Spec{
-				File:     "testdata/data.csv",
-				Key:      ".[*].surname",
-				Value:    "",
-				Multiple: true,
+				File:  "testdata/data.csv",
+				Query: ".[*].surname",
+				Value: "",
 			},
 			expectedResult: false,
 		},

--- a/pkg/plugins/resources/csv/source_test.go
+++ b/pkg/plugins/resources/csv/source_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/updatecli/updatecli/pkg/plugins/utils/version"
 	"gotest.tools/assert"
 )
 
@@ -24,6 +25,18 @@ func TestSource(t *testing.T) {
 				Key:     ".[0].firstname",
 				Comma:   ',',
 				Comment: '#',
+			},
+			expectedResult: "John",
+		},
+		{
+			name: "Regex versionFilter successful workflow",
+			spec: Spec{
+				File:  "testdata/data.csv",
+				Query: ".[*].firstname",
+				VersionFilter: version.Filter{
+					Kind:    "regex",
+					Pattern: "^Jo",
+				},
 			},
 			expectedResult: "John",
 		},
@@ -54,7 +67,7 @@ func TestSource(t *testing.T) {
 			},
 			expectedResult:   "",
 			wantErr:          true,
-			expectedErrorMsg: errors.New("could not find value for path \".doNotExist\" from file \"testdata/data.csv\""),
+			expectedErrorMsg: errors.New("✗ cannot find value for path \".doNotExist\" from file \"testdata/data.csv\""),
 		},
 	}
 

--- a/pkg/plugins/resources/csv/spec.go
+++ b/pkg/plugins/resources/csv/spec.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 
 	"github.com/sirupsen/logrus"
+	"github.com/updatecli/updatecli/pkg/plugins/utils/version"
 )
 
 type Spec struct {
@@ -13,19 +14,23 @@ type Spec struct {
 	Files []string `yaml:",omitempty"`
 	// [s][c][t] Key specifies the csv query
 	Key string `yaml:",omitempty"`
+	// [s][c][t] Query allows to used advanced query. Override the parameter key
+	Query string `yaml:",omitempty"`
 	// [s][c][t] Key specifies the csv value, default to source output
 	Value string `yaml:",omitempty"`
 	// [s][c][t] Comma specifies the csv separator character, default ","
 	Comma rune `yaml:",omitempty"`
 	// [s][c][t] Comma specifies the csv comment character, default "#"
 	Comment rune `yaml:",omitempty"`
-	// [c][t] Multiple allows to query multiple values at once
-	Multiple bool `yaml:",omitempty"`
+	// [c][t] *Deprecated* Please look at query parameter to achieve similar objective
+	Multiple bool `yaml:",omitempty" jsonschema:"-"`
+	// [s]VersionFilter provides parameters to specify version pattern and its type like regex, semver, or just latest.
+	VersionFilter version.Filter `yaml:",omitempty"`
 }
 
 var (
 	ErrSpecFileUndefined       = errors.New("csv file undefined")
-	ErrSpecKeyUndefined        = errors.New("csv key undefined")
+	ErrSpecKeyUndefined        = errors.New("csv key or query undefined")
 	ErrSpecFileAndFilesDefined = errors.New("parameter \"file\" and \"files\" are mutually exclusive")
 	// ErrWrongSpec is returned when the Spec has wrong content
 	ErrWrongSpec error = errors.New("wrong spec content")
@@ -36,7 +41,7 @@ func (s *Spec) Validate() error {
 	if len(s.File) == 0 && len(s.Files) == 0 {
 		errs = append(errs, ErrSpecFileUndefined)
 	}
-	if len(s.Key) == 0 {
+	if len(s.Key) == 0 && len(s.Query) == 0 {
 		errs = append(errs, ErrSpecKeyUndefined)
 	}
 

--- a/pkg/plugins/resources/csv/target.go
+++ b/pkg/plugins/resources/csv/target.go
@@ -55,9 +55,9 @@ func (c *CSV) TargetFromSCM(source string, scm scm.ScmHandler, dryRun bool) (cha
 		var queryResults []string
 		var err error
 
-		switch c.spec.Multiple {
+		switch len(c.spec.Query) > 0 {
 		case true:
-			queryResults, err = c.contents[i].MultipleQuery(c.spec.Key)
+			queryResults, err = c.contents[i].MultipleQuery(c.spec.Query)
 
 			if err != nil {
 				return false, files, message, err
@@ -99,9 +99,9 @@ func (c *CSV) TargetFromSCM(source string, scm scm.ScmHandler, dryRun bool) (cha
 		}
 
 		// Update the target file with the new value
-		switch c.spec.Multiple {
+		switch len(c.spec.Query) > 0 {
 		case true:
-			err = c.contents[i].PutMultiple(c.spec.Key, c.spec.Value)
+			err = c.contents[i].PutMultiple(c.spec.Query, c.spec.Value)
 
 			if err != nil {
 				return false, files, message, err

--- a/pkg/plugins/resources/csv/target_test.go
+++ b/pkg/plugins/resources/csv/target_test.go
@@ -30,6 +30,15 @@ func TestTarget(t *testing.T) {
 		{
 			name: "Default successful workflow",
 			spec: Spec{
+				File:  "testdata/data.csv",
+				Query: ".[*].firstname",
+			},
+			sourceInput:    "Tom",
+			expectedResult: true,
+		},
+		{
+			name: "Default successful workflow",
+			spec: Spec{
 				File:  "testdata/data.2.csv",
 				Key:   ".[0].firstname",
 				Comma: ';',


### PR DESCRIPTION
Signed-off-by: Olblak <me@olblak.com>

As discussed on https://github.com/updatecli/updatecli/issues/942#issuecomment-1284561424
I realized that it would be super usefull to be able to do a multiple query combined with versionfilter on the csv resource

This pullrequest allows the following manifest to work 

```
sources:
    name: Test Version filter
    kind: csv 
    spec:
      files: 
        - pkg/plugins/resources/csv/testdata/data.csv
      query: ".[*].firstname"
      versionfilter:
        kind: regex
        pattern: "^Jo"

```

## Example 

```
#############################
# CSV MANIPULATION EXAMPLES #
#############################


SOURCES
=======

versionfilter
-------------
Searching for version matching pattern "^Jo"
✔ Value "John", found in file "/home/olblak/Projects/Updatecli/updatecli/pkg/plugins/resources/csv/testdata/data.csv", for key ".[*].firstname"'

default
-------
✔ Value "John", found in file "/home/olblak/Projects/Updatecli/updatecli/pkg/plugins/resources/csv/testdata/data.csv", for key ".[0].firstname"'

```

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
cp <to_package_directory>
go test
```

## Additional Information

### Tradeoff

Similar to the Json approach, I am deprecating the parameter multiple in favor of query

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
