### PR TITLE
Enable default autodiscovery if no valid configuration have been loaded

### DIFF
--- a/pkg/core/engine/main.go
+++ b/pkg/core/engine/main.go
@@ -339,8 +339,14 @@ func GenerateSchema(baseSchemaID, schemaDir string) error {
 // LoadAutoDiscovery will try to guess available pipelines based on specific directory
 func (e *Engine) LoadAutoDiscovery() error {
 
-	// Default Autodiscovery pipeline
-	if e.Options.Pipeline.AutoDiscovery.Enabled {
+	// Load default Autodiscovery pipeline if flag is enabled or no pipeline are scheduled
+	if e.Options.Pipeline.AutoDiscovery.Enabled || len(e.Pipelines) == 0 {
+
+		if !e.Options.Pipeline.AutoDiscovery.Enabled && len(e.Pipelines) == 0 {
+			// Introduce extra space to highlight the warning message
+			logrus.Infof("\n\n")
+			logrus.Warningf("Default Autodiscovery crawlers has been enabled as zero Updatecli configuration were specified and we didn't detected default configuration.\n")
+		}
 
 		// To remove once not experimental
 		if !cmdoptions.Experimental {


### PR DESCRIPTION
Signed-off-by: Olblak <me@olblak.com>

I propose to load default crawlers, if we no valid pipeline could  be loaded.
Either because no valid manifest were provided by `--config` argument, or because no default configuration such as `updatecli.yaml` or `updatecli.d` could be found.

So if we run `updatecli diff` then it would display following output
```
Experimental Mode Enabled


+++++++++++
+ PREPARE +
+++++++++++


SCM repository retrieved: 0


WARNING: Default Autodiscovery crawlers enabled as no Updatecli configuration have been specified nor default configuration detected



++++++++++++++++++
+ AUTO DISCOVERY +
++++++++++++++++++



#######################
# LOCAL AUTODISCOVERY #
#######################


HELM
=====
Manifest detected: 0


RANCHER FLEET
==============
Manifest detected: 0


MAVEN
======
Manifest detected: 0

```
<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
cp <to_package_directory>
go test
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
