### PR TITLE
Revert "Enable default autodiscovery if no valid configuration have b…

### DIFF
--- a/pkg/core/engine/main.go
+++ b/pkg/core/engine/main.go
@@ -339,14 +339,8 @@ func GenerateSchema(baseSchemaID, schemaDir string) error {
 // LoadAutoDiscovery will try to guess available pipelines based on specific directory
 func (e *Engine) LoadAutoDiscovery() error {
 
-	// Load default Autodiscovery pipeline if flag is enabled or no pipeline are scheduled
-	if e.Options.Pipeline.AutoDiscovery.Enabled || len(e.Pipelines) == 0 {
-
-		if !e.Options.Pipeline.AutoDiscovery.Enabled && len(e.Pipelines) == 0 {
-			// Introduce extra space to highlight the warning message
-			logrus.Infof("\n\n")
-			logrus.Warningf("Default Autodiscovery crawlers has been enabled as zero Updatecli configuration were specified and we didn't detected default configuration.\n")
-		}
+	// Default Autodiscovery pipeline
+	if e.Options.Pipeline.AutoDiscovery.Enabled {
 
 		// To remove once not experimental
 		if !cmdoptions.Experimental {


### PR DESCRIPTION
I revert this PR as after a quick pre-release check, I noticed edge cases that I didn't consider.
I don't have the time to fix it now, so it will be part of a next release