### PR TITLE
Do not set github username as required

### DIFF
--- a/pkg/plugins/scms/github/main.go
+++ b/pkg/plugins/scms/github/main.go
@@ -36,7 +36,7 @@ type Spec struct {
 	// URL specifies the default github url in case of GitHub enterprise
 	URL string `yaml:",omitempty"`
 	// Username specifies the username used to authenticate with Github API
-	Username string `yaml:",omitempty" jsonschema:"required"`
+	Username string `yaml:",omitempty"`
 	// User specifies the user of the git commit messages
 	User string `yaml:",omitempty"`
 	// GPG key and passphrased used for commit signing


### PR DESCRIPTION
The Github username parameters is not required

<!-- Describe the changes introduced by this pull request -->

## Test

/

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
