### PR TITLE
Remove limitation for multiple files in condition and fix tests

### DIFF
--- a/pkg/plugins/resources/file/condition.go
+++ b/pkg/plugins/resources/file/condition.go
@@ -53,9 +53,6 @@ func (f *File) checkCondition(source string) (bool, error) {
 func (f *File) condition(source string) (bool, error) {
 	var validationErrors []string
 
-	if len(f.files) > 1 {
-		validationErrors = append(validationErrors, "Validation error in conditions of type 'file': the attributes `spec.files` can't contain more than one element for conditions")
-	}
 	if len(f.spec.ReplacePattern) > 0 {
 		validationErrors = append(validationErrors, "Validation error in condition of type 'file': the attribute `spec.replacepattern` is only supported for targets.")
 	}

--- a/pkg/plugins/resources/file/condition_test.go
+++ b/pkg/plugins/resources/file/condition_test.go
@@ -56,7 +56,7 @@ func TestFile_Condition(t *testing.T) {
 			wantedResult: true,
 		},
 		{
-			name: "Validation failure with more than one element in 'Files'",
+			name: "Validation failure with non-existing element in 'Files'",
 			spec: Spec{
 				Files: []string{
 					"foo.txt",
@@ -206,7 +206,30 @@ func TestFile_Condition(t *testing.T) {
 				"foo.txt": "Title\r\nGood Bye\r\nThe End",
 				"bar.txt": "Title\r\nNot In All Files\r\nThe End",
 			},
-			wantedErr: true,
+			wantedErr:    false,
+			wantedResult: false,
+		},
+		{
+			name: "Passing case with more than one 'Files'",
+			spec: Spec{
+				Files: []string{
+					"foo.txt",
+					"bar.txt",
+				},
+				Line:    2,
+				Content: "In All Files",
+			},
+			files: map[string]string{
+				"foo.txt": "",
+				"bar.txt": "",
+			},
+			inputSourceValue: "",
+			mockedContents: map[string]string{
+				"foo.txt": "Title\r\nIn All Files\r\nEnd",
+				"bar.txt": "Title\r\nIn All Files\r\nThe End",
+			},
+			wantedErr:    false,
+			wantedResult: true,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
This PR removes the limitation for multiple files in conditions, fix related tests that are failure validation to allow more than one element in 'Files' and add a passing test for such scenario.

Fix https://github.com/updatecli/updatecli/issues/1026

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
cd pkg/plugins/resources/file
go test
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->

Signed-off-by: Guilherme Macedo <guilherme.macedo@suse.com>
