### PR TITLE
fix(actions) print the deprecation action's kind warning only once

### DIFF
--- a/pkg/core/pipeline/action/main.go
+++ b/pkg/core/pipeline/action/main.go
@@ -72,9 +72,11 @@ func (c *Config) Validate() (err error) {
 	/** Deprecated items **/
 	if c.Kind == githubIdentifier {
 		logrus.Warnf("The kind %q for actions is deprecated in favor of '%s/pullrequest'", githubIdentifier, githubIdentifier)
+		c.Kind = "github/pullrequest"
 	}
 	if c.Kind == giteaIdentifier {
 		logrus.Warnf("The kind %q for actions is deprecated in favor of '%s/pullrequest'", giteaIdentifier, giteaIdentifier)
+		c.Kind = "gitea/pullrequest"
 	}
 	if c.DeprecatedScmID != "" {
 		switch len(c.ScmID) {

--- a/pkg/core/pipeline/action/main_test.go
+++ b/pkg/core/pipeline/action/main_test.go
@@ -1,0 +1,81 @@
+package action
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_Validate(t *testing.T) {
+	tests := []struct {
+		name           string
+		config         Config
+		wantErrMessage string
+		wantConfig     Config
+	}{
+		{
+			name:           "Failing case with missing 'Kind' and 'scmid'",
+			config:         Config{},
+			wantErrMessage: `missing value for parameter(s) ["kind,scmid"]`,
+		},
+		{
+			name: "Passing case with 'Kind' set to lowercase",
+			config: Config{
+				Kind:  "GitHub/PullRequest",
+				ScmID: "default",
+			},
+			wantConfig: Config{
+				Kind:  "github/pullrequest",
+				ScmID: "default",
+			},
+		},
+		{
+			name: "Passing case with 'DeprecatedScmID' set to 'ScmID' instead",
+			config: Config{
+				Kind:            "github/pullrequest",
+				DeprecatedScmID: "default",
+			},
+			wantConfig: Config{
+				Kind:  "github/pullrequest",
+				ScmID: "default",
+			},
+		},
+		{
+			name: "Passing case with 'Kind: github' set to 'github/pullrequest'",
+			config: Config{
+				Kind:  "github",
+				ScmID: "default",
+			},
+			wantConfig: Config{
+				Kind:  "github/pullrequest",
+				ScmID: "default",
+			},
+		},
+		{
+			name: "Passing case with 'Kind: gitea' set to 'gitea/pullrequest'",
+			config: Config{
+				Kind:  "gitea",
+				ScmID: "default",
+			},
+			wantConfig: Config{
+				Kind:  "gitea/pullrequest",
+				ScmID: "default",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sut := tt.config
+			gotErr := sut.Validate()
+			if tt.wantErrMessage != "" {
+				require.Error(t, gotErr)
+				assert.Equal(t, tt.wantErrMessage, gotErr.Error())
+				return
+			}
+			require.NoError(t, gotErr)
+			// sut can be mutated so we check the new state
+			assert.Equal(t, tt.wantConfig, sut)
+		})
+	}
+}


### PR DESCRIPTION
Fix #1035

When writing #990 , I introduced a minor bug where the warning message telling the user about using a kind of action that is deprecated.

I forgot to update the internal config state, so the processing of template triggered the message at least a 2nd time (or more...).

This PR adds the required unit test that fails with the `0.40.0` behavior.

## Test

To test this pull request, you can run the following commands:

```shell
# Build a local updatecli binary
go build -o ./dist/updatecli

# Remove the `version:` top level directive to avoid a failure, as local binary builds does not have a version
sed '/version:/d' ./updatecli/updatecli.d/golang.yaml | wc -l

# Execute the golang manifest, with only 1 warning this time
./dist/updatecli diff --config ./updatecli/updatecli.d/golang.yaml
```

result:

```text
./dist/updatecli diff --config ./updatecli/updatecli.d/golang.yaml


+++++++++++
+ PREPARE +
+++++++++++

Loading Pipeline "./updatecli/updatecli.d/golang.yaml"
WARNING: The `pullrequests` keyword is deprecated in favor of `actions`, please update this manifest. Updatecli will continue the execution while trying to translate `pullrequests` to `actions`.
WARNING: The kind "github" for actions is deprecated in favor of 'github/pullrequest'

SCM repository retrieved: 1

# ...
```

## Additional Information

- Using the `version` top-level directive is blocking local builds and debug. We should set a default "dev" or "debug" version by default, that would be accepted. It can be cumbersome when debugging.
  - Should we remove it from the manifests? I can't remember the use case of specifying it?

- The unit test does not cover the whole package code: room for improvement :)
  - There is a (minor) bug caught by unit tests (I did not added the failing unit tests here as it's another scope) that I'll try to fix tomorrow.