### PR TITLE
Upgrade updatecli manifest

### DIFF
--- a/pkg/core/transformer/findSubMatch.go
+++ b/pkg/core/transformer/findSubMatch.go
@@ -10,8 +10,8 @@ import (
 // FindSubMatch is a struct used to feed regexp.findSubMatch
 type FindSubMatch struct {
 	// Pattern defines regular expression to use for retrieving a submatch
-	Pattern                string
-	DeprecatedCaptureIndex int `yaml:"captureIndex"`
+	Pattern                string `yaml:",omitempty" jsonschema:"required"`
+	DeprecatedCaptureIndex int    `yaml:"captureIndex,omitempty" jsonschema:"-"`
 	// CaptureIndex defines which substring occurrence to retrieve. Note also that a value of `0` for `captureIndex` returns all submatches, and individual submatch indexes start at `1`.
 	CaptureIndex int
 }

--- a/pkg/core/transformer/replacer.go
+++ b/pkg/core/transformer/replacer.go
@@ -3,9 +3,9 @@ package transformer
 // Replacer is struct used to feed strings.Replacer
 type Replacer struct {
 	// From defines the source value which need to be replaced
-	From string `yaml:",omitempty"`
+	From string `yaml:",omitempty" jsonschema:"required"`
 	// To defines the "to what" a "from" value needs to be replaced
-	To string `yaml:",omitempty"`
+	To string `yaml:",omitempty" jsonschema:"required"`
 }
 
 // Replacers is an array of Replacer

--- a/pkg/core/version/main.go
+++ b/pkg/core/version/main.go
@@ -18,6 +18,9 @@ var (
 
 	// GoVersion contains the golang version uses to build this binary
 	GoVersion string
+
+	// DisableDevWarning is used to identify if we already notify that we use a dev version
+	isDevWarningDisabled bool
 )
 
 // Show displays various version information
@@ -38,7 +41,12 @@ func IsGreaterThan(binaryVersion, manifestVersion string) (bool, error) {
 	}
 
 	if len(binaryVersion) == 0 {
-		binaryVersion = "0.0.0"
+		if !isDevWarningDisabled {
+			logrus.Warningf("Updatecli binary version is unset. This means you are using a development version that ignores manifest version constraint.\n")
+			isDevWarningDisabled = true
+		}
+
+		return true, nil
 	}
 
 	mv, err := sv.NewVersion(manifestVersion)

--- a/pkg/core/version/main_test.go
+++ b/pkg/core/version/main_test.go
@@ -22,7 +22,7 @@ func TestIsGreaterThan(t *testing.T) {
 		{
 			updatecliBinaryVersion:           "",
 			updatecliManifestRequiredVersion: "1.2.0",
-			expectedResult:                   false,
+			expectedResult:                   true,
 		},
 		{
 			updatecliBinaryVersion:           "1.0.0",

--- a/updatecli/updatecli.d/golang.yaml
+++ b/updatecli/updatecli.d/golang.yaml
@@ -1,9 +1,9 @@
 name: Bump Golang Version
 pipelineid: 5ba938aaacf1b88e3db4076b2a7a7db6ee1e00eb19dbe2469abf35c96f008e8d
-pullrequests:
+actions:
     default:
         title: '[updatecli] Bump Golang version to {{ source "latestGoVersion" }}'
-        kind: github
+        kind: github/pullrequest
         spec:
             labels:
                 - chore
@@ -51,7 +51,6 @@ conditions:
         spec:
             image: golang
             tag: '{{ source "latestGoVersion" }}'
-        scmid: default
         sourceid: latestGoVersion
     workflowgo:
         name: Ensure GA step is defined in Github Action named go

--- a/updatecli/updatecli.d/golangci-lint.yaml
+++ b/updatecli/updatecli.d/golangci-lint.yaml
@@ -1,9 +1,9 @@
 name: Bump golangci-lint version
 pipelineid: e6d141666bd851d4bac9467b898b5e908012a53932de7a805c0767c9e7aeb532
-pullrequests:
+actions:
     default:
         title: '[updatecli] Bump golangci-lint version to {{ source "default" }}'
-        kind: github
+        kind: github/pullrequest
         spec:
             automerge: true
             labels:
@@ -49,7 +49,6 @@ targets:
         transformers:
             - findsubmatch:
                 pattern: v(\d*)\.(\d*)
-                captureIndex: 0
                 captureindex: 0
         spec:
             file: .github/workflows/go.yaml

--- a/updatecli/updatecli.d/updatecli.yaml
+++ b/updatecli/updatecli.d/updatecli.yaml
@@ -1,9 +1,9 @@
 name: Bump udpatecli version
 pipelineid: cac467f9bdc931266038f8cf363edc865370121deb3954b93e70d0588827a04f
-pullrequests:
+actions:
     default:
         title: '[updatecli] Bump updatecli version to {{ source "latestVersion" }}'
-        kind: github
+        kind: github/pullrequest
         spec:
             automerge: true
             labels:

--- a/updatecli/updatecli.d/venom.yaml
+++ b/updatecli/updatecli.d/venom.yaml
@@ -1,9 +1,9 @@
 name: Bump venom version
 pipelineid: 6a1c726e25648f93a45aa3b540ba8fd6307a62f92830404f55259bfbbc1b3c6f
-pullrequests:
+actions:
     default:
         title: '[updatecli] Bump Venom version to {{ source "latestVersion" }}'
-        kind: github
+        kind: github/pullrequest
         spec:
             automerge: true
             labels:


### PR DESCRIPTION
**Opening for visibility but I'll merge once the test pass**

While updating the updatecli manifest to remove the deprecation warning.
I spotted a few minor issues

* A dev version of Updatecli shouldn't fail if binary version is unset . Instead we should a warning message
* I add a jsonschema tag
* Add a yaml omitempty to a deprecated parameter in transformer

<!-- Describe the changes introduced by this pull request -->

## Test

/

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
