### PR TITLE
Github Release condition shouldn't rely on versionfilter

### DIFF
--- a/e2e/updatecli.d/success.d/githubrelease/condition.yaml
+++ b/e2e/updatecli.d/success.d/githubrelease/condition.yaml
@@ -29,9 +29,6 @@ conditions:
       owner: updatecli
       repository: updatecli
       token: '{{ requiredEnv "GITHUB_TOKEN" }}'
-      versionfilter:
-        kind: regex
-        pattern: "v0.40.1"
 targets:
   version:
     name: Only run if conditions succeeded

--- a/e2e/updatecli.d/success.d/githubrelease/condition.yaml
+++ b/e2e/updatecli.d/success.d/githubrelease/condition.yaml
@@ -1,0 +1,41 @@
+name: Test checking that both github release and gittag exist
+
+scms:
+  default:
+    kind: github
+    spec:
+      owner: updatecli
+      repository: updatecli
+      branch: main
+      token: '{{ requiredEnv "GITHUB_TOKEN" }}'
+
+sources:
+  shell:
+    name: Get version from shell command output
+    kind: shell
+    spec:
+      command: echo v0.40.0
+conditions:
+  gittag:
+    name: Test that gittag exist based on source output
+    sourceid: shell
+    kind: gittag
+    scmid: default
+  githubrelease:
+    name: Test that github release tag exist based on source output
+    kind: githubrelease
+    sourceid: shell
+    spec:
+      owner: updatecli
+      repository: updatecli
+      token: '{{ requiredEnv "GITHUB_TOKEN" }}'
+      versionfilter:
+        kind: regex
+        pattern: "v0.40.1"
+targets:
+  version:
+    name: Only run if conditions succeeded
+    kind: shell
+    spec:
+      command: echo release 
+

--- a/pkg/plugins/resources/githubrelease/condition.go
+++ b/pkg/plugins/resources/githubrelease/condition.go
@@ -40,21 +40,11 @@ func (gr GitHubRelease) Condition(source string) (bool, error) {
 		}
 	}
 
-	gr.foundVersion, err = gr.versionFilter.Search(versions)
-	if err != nil {
-		return false, err
-	}
-
-	value := gr.foundVersion.GetVersion()
-
-	if len(value) == 0 {
-		logrus.Infof("%s No Github Release version found matching pattern %q", result.FAILURE, expectedValue)
-		return false, fmt.Errorf("%s Github Release %q not found", result.FAILURE, expectedValue)
-	}
-
-	if value == expectedValue {
-		logrus.Infof("%s Github Release version %q found", result.SUCCESS, value)
-		return true, nil
+	for _, version := range versions {
+		if version == expectedValue {
+			logrus.Infof("%s Github Release version %q found", result.SUCCESS, expectedValue)
+			return true, nil
+		}
 	}
 
 	return false, fmt.Errorf("%s Github Release %q not found", result.FAILURE, expectedValue)

--- a/pkg/plugins/resources/githubrelease/main.go
+++ b/pkg/plugins/resources/githubrelease/main.go
@@ -18,7 +18,7 @@ type Spec struct {
 	// [s][c] URL specifies the default github url in case of GitHub enterprise
 	URL string `yaml:",omitempty"`
 	// [s][c] Username specifies the username used to authenticate with Github API
-	Username string `yaml:",omitempty" jsonschema:"required"`
+	Username string `yaml:",omitempty"`
 	// [s] VersionFilter provides parameters to specify version pattern and its type like regex, semver, or just latest.
 	VersionFilter version.Filter `yaml:",omitempty"`
 	// [s][c] TypeFilter specifies the Github Release type to retrieve before applying the versionfilter rule

--- a/pkg/plugins/resources/githubrelease/main.go
+++ b/pkg/plugins/resources/githubrelease/main.go
@@ -19,7 +19,7 @@ type Spec struct {
 	URL string `yaml:",omitempty"`
 	// [s][c] Username specifies the username used to authenticate with Github API
 	Username string `yaml:",omitempty" jsonschema:"required"`
-	// [s][c] VersionFilter provides parameters to specify version pattern and its type like regex, semver, or just latest.
+	// [s] VersionFilter provides parameters to specify version pattern and its type like regex, semver, or just latest.
 	VersionFilter version.Filter `yaml:",omitempty"`
 	// [s][c] TypeFilter specifies the Github Release type to retrieve before applying the versionfilter rule
 	TypeFilter github.ReleaseType `yaml:",omitempty"`


### PR DESCRIPTION
Fix the GitHub release condition. The current code wasn't convenient to use as we needed to provide the appropriate versionfilter parameter. 
This pullrequest simplifies the githubrelease condition by removing the useless versionfilter.

While I am removing the versionfilter from the condition, existing manifest will still works

Fix #1084 

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
cp <to_package_directory>
go test
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
