### PR TITLE
Support for npm private registry

### DIFF
--- a/pkg/plugins/resources/npm/condition_test.go
+++ b/pkg/plugins/resources/npm/condition_test.go
@@ -1,7 +1,6 @@
 package npm
 
 import (
-	"log"
 	"os"
 	"path/filepath"
 	"testing"
@@ -13,7 +12,7 @@ import (
 func TestCondition(t *testing.T) {
 	dir, err := CreateDummyRc()
 	if err != nil {
-		log.Fatal(err)
+		require.NoError(t, err)
 	}
 	defer os.RemoveAll(dir)
 	tests := []struct {

--- a/pkg/plugins/resources/npm/condition_test.go
+++ b/pkg/plugins/resources/npm/condition_test.go
@@ -112,10 +112,6 @@ func TestCondition(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := New(tt.spec)
-			if tt.expectedError {
-				assert.Error(t, err)
-				return
-			}
 			require.NoError(t, err)
 			if tt.mockedResponse {
 				got.webClient = GetMockClient(tt.mockedUrl, tt.mockedToken, tt.mockedBody, tt.mockedHTTPStatusCode)

--- a/pkg/plugins/resources/npm/condition_test.go
+++ b/pkg/plugins/resources/npm/condition_test.go
@@ -1,6 +1,9 @@
 package npm
 
 import (
+	"log"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -8,12 +11,22 @@ import (
 )
 
 func TestCondition(t *testing.T) {
+	dir, err := CreateDummyRc()
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
 	tests := []struct {
-		name           string
-		url            string
-		spec           Spec
-		expectedResult bool
-		expectedError  bool
+		name                 string
+		url                  string
+		spec                 Spec
+		expectedResult       bool
+		expectedError        bool
+		mockedResponse       bool
+		mockedBody           string
+		mockedUrl            string
+		mockedToken          string
+		mockedHTTPStatusCode int
 	}{
 		{
 			name: "Passing case of retrieving axios versions ",
@@ -33,10 +46,80 @@ func TestCondition(t *testing.T) {
 			expectedResult: false,
 			expectedError:  false,
 		},
+		{
+			name: "Passing case of retrieving axios versions using custom default registry",
+			spec: Spec{
+				Name:          "axios",
+				Version:       "0.2.0",
+				URL:           "https://mycustomregistry.updatecli.io",
+				RegistryToken: "mytoken",
+			},
+			expectedResult:       true,
+			expectedError:        false,
+			mockedResponse:       true,
+			mockedBody:           existingPackageData,
+			mockedHTTPStatusCode: 200,
+			mockedToken:          "mytoken",
+			mockedUrl:            "https://mycustomregistry.updatecli.io",
+		},
+		{
+			name: "Passing case of retrieving latest axios version using latest rule using custom default registry ",
+			spec: Spec{
+				Name:          "axios",
+				Version:       "99.99.99",
+				URL:           "https://mycustomregistry.updatecli.io",
+				RegistryToken: "mytoken",
+			},
+			expectedResult:       false,
+			expectedError:        false,
+			mockedResponse:       true,
+			mockedBody:           existingPackageData,
+			mockedHTTPStatusCode: 200,
+			mockedToken:          "mytoken",
+			mockedUrl:            "https://mycustomregistry.updatecli.io",
+		},
+		{
+			name: "Passing case of retrieving axios versions using private registry in npmrc",
+			spec: Spec{
+				Name:      "@TestScope/test",
+				Version:   "0.2.0",
+				NpmrcPath: filepath.Join(dir, ".npmrc"),
+			},
+			expectedResult:       true,
+			expectedError:        false,
+			mockedResponse:       true,
+			mockedBody:           existingScopedPackageData,
+			mockedHTTPStatusCode: 200,
+			mockedToken:          "mytoken",
+			mockedUrl:            "https://mycustomregistry.updatecli.io",
+		},
+		{
+			name: "Passing case of retrieving latest axios version using latest rule using private registry in npmrc ",
+			spec: Spec{
+				Name:      "@TestScope/test",
+				Version:   "99.99.99",
+				NpmrcPath: filepath.Join(dir, ".npmrc"),
+			},
+			expectedResult:       false,
+			expectedError:        false,
+			mockedResponse:       true,
+			mockedBody:           existingScopedPackageData,
+			mockedHTTPStatusCode: 200,
+			mockedToken:          "mytoken",
+			mockedUrl:            "https://mycustomregistry.updatecli.io",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := New(tt.spec)
+			if tt.expectedError {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			if tt.mockedResponse {
+				got.webClient = GetMockClient(tt.mockedUrl, tt.mockedToken, tt.mockedBody, tt.mockedHTTPStatusCode)
+			}
 			if tt.expectedError {
 				assert.Error(t, err)
 				return

--- a/pkg/plugins/resources/npm/main.go
+++ b/pkg/plugins/resources/npm/main.go
@@ -120,28 +120,37 @@ type RcConfig struct {
 	Scopes     map[string]string
 }
 
-func defaultNpmConfig(default_url string, default_token string) RcConfig {
+func defaultNpmConfig(defaultUrl string, defaultToken string) RcConfig {
 	var config RcConfig
 	config.Registries = make(map[string]Registry)
 	var url string
-	if default_url == "" {
+	if defaultUrl == "" {
 		url = npmDefaultApiURL
 	} else {
-		url = default_url
+		url = defaultUrl
 	}
 	config.Registries["default"] = Registry{
 		Url:       url,
-		AuthToken: default_token,
+		AuthToken: defaultToken,
 	}
 	config.Scopes = make(map[string]string)
 	return config
 }
 
-func getNpmrcConfig(path string, default_url string, default_token string) (RcConfig, error) {
-	config := defaultNpmConfig(default_url, default_token)
-	if path == "" {
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return !os.IsNotExist(err)
+}
+
+func getNpmrcConfig(path string, defaultUrl string, defaultToken string) (RcConfig, error) {
+	config := defaultNpmConfig(defaultUrl, defaultToken)
+	if path == "" || !fileExists(path) {
 		path = fmt.Sprintf("%s/.npmrc", os.Getenv("HOME"))
 	}
+	if !fileExists(path) {
+		return config, nil
+	}
+
 	cfg, err := ini.Load(path)
 	if err != nil {
 		return config, err

--- a/pkg/plugins/resources/npm/main.go
+++ b/pkg/plugins/resources/npm/main.go
@@ -34,7 +34,7 @@ type Spec struct {
 	// VersionFilter provides parameters to specify version pattern and its type like regex, semver, or just latest.
 	VersionFilter version.Filter `yaml:",omitempty"`
 	// NpmrcPath defines the path to the .npmrc file
-	NpmrcPath string `yaml:"npmrcPath,omitempty"`
+	NpmrcPath string `yaml:"npmrcpath,omitempty"`
 }
 
 type distTags struct {

--- a/pkg/plugins/resources/npm/main.go
+++ b/pkg/plugins/resources/npm/main.go
@@ -11,6 +11,8 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/updatecli/updatecli/pkg/core/httpclient"
+
 	"gopkg.in/ini.v1"
 
 	"github.com/mitchellh/mapstructure"
@@ -57,6 +59,7 @@ type Npm struct {
 	versionFilter version.Filter // Holds the "valid" version.filter, that might be different than the user-specified filter (Spec.VersionFilter)
 	foundVersion  version.Version
 	data          Data
+	webClient     httpclient.HTTPClient
 	rcConfig      RcConfig
 }
 
@@ -94,6 +97,7 @@ func New(spec interface{}) (*Npm, error) {
 		spec:          newSpec,
 		versionFilter: newFilter,
 		rcConfig:      rcConfig,
+		webClient:     http.DefaultClient,
 	}, nil
 }
 
@@ -220,7 +224,7 @@ func (n *Npm) getPackageData(packageName string) (Data, error) {
 		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", registry.AuthToken))
 	}
 
-	res, err := http.DefaultClient.Do(req)
+	res, err := n.webClient.Do(req)
 	if err != nil {
 		logrus.Errorf("something went wrong while getting npm api data %q\n", err)
 		return Data{}, err

--- a/pkg/plugins/resources/npm/main_test.go
+++ b/pkg/plugins/resources/npm/main_test.go
@@ -1,7 +1,6 @@
 package npm
 
 import (
-	"log"
 	"os"
 	"path/filepath"
 	"testing"
@@ -13,7 +12,7 @@ import (
 func TestParseNpmRc(t *testing.T) {
 	dir, err := CreateDummyRc()
 	if err != nil {
-		log.Fatal(err)
+		require.NoError(t, err)
 	}
 	defer os.RemoveAll(dir)
 	t.Run("Test parsing custom npmrc", func(t *testing.T) {

--- a/pkg/plugins/resources/npm/main_test.go
+++ b/pkg/plugins/resources/npm/main_test.go
@@ -1,0 +1,60 @@
+package npm
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func CreateDummyRc() (string, error) {
+	dir, err := os.MkdirTemp("", "")
+	if err != nil {
+		return "", err
+	}
+	config, err := os.Create(filepath.Join(dir, ".npmrc"))
+	if err != nil {
+		return "", err
+	}
+	defer config.Close()
+	_, err = fmt.Fprintf(config, "//npm.pkg.github.com/:_authToken=1234567890\n")
+	if err != nil {
+		return "", err
+	}
+	_, err = fmt.Fprintf(config, "@TestScope:registry=https://npm.pkg.github.com/\n")
+	if err != nil {
+		return "", err
+	}
+	return dir, nil
+}
+
+func TestParseNpmRc(t *testing.T) {
+	dir, err := CreateDummyRc()
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+	t.Run("Test parsing custom npmrc", func(t *testing.T) {
+		cfg, err := getNpmrcConfig(filepath.Join(dir, ".npmrc"), "", "")
+		require.NoError(t, err)
+		assert.Contains(t, cfg.Registries, "default")
+		assert.Equal(t, cfg.Registries["default"].AuthToken, "")
+		assert.Equal(t, cfg.Registries["default"].Url, "https://registry.npmjs.org/")
+		assert.Contains(t, cfg.Registries, "npm.pkg.github.com/")
+		assert.Equal(t, cfg.Registries["npm.pkg.github.com/"].AuthToken, "1234567890")
+		assert.Equal(t, cfg.Registries["npm.pkg.github.com/"].Url, "https://npm.pkg.github.com/")
+		assert.Contains(t, cfg.Scopes, "@TestScope")
+		assert.Equal(t, cfg.Scopes["@TestScope"], "npm.pkg.github.com/")
+	})
+	t.Run("Test parsing custom npmrc with auth token", func(t *testing.T) {
+		cfg, err := getNpmrcConfig("", "https://npm.pkg.github.com/", "1234567890")
+		require.NoError(t, err)
+		assert.Contains(t, cfg.Registries, "default")
+		assert.Equal(t, cfg.Registries["default"].AuthToken, "1234567890")
+		assert.Equal(t, cfg.Registries["default"].Url, "https://npm.pkg.github.com/")
+	})
+}

--- a/pkg/plugins/resources/npm/main_test.go
+++ b/pkg/plugins/resources/npm/main_test.go
@@ -1,7 +1,6 @@
 package npm
 
 import (
-	"fmt"
 	"log"
 	"os"
 	"path/filepath"
@@ -10,27 +9,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-func CreateDummyRc() (string, error) {
-	dir, err := os.MkdirTemp("", "")
-	if err != nil {
-		return "", err
-	}
-	config, err := os.Create(filepath.Join(dir, ".npmrc"))
-	if err != nil {
-		return "", err
-	}
-	defer config.Close()
-	_, err = fmt.Fprintf(config, "//npm.pkg.github.com/:_authToken=1234567890\n")
-	if err != nil {
-		return "", err
-	}
-	_, err = fmt.Fprintf(config, "@TestScope:registry=https://npm.pkg.github.com/\n")
-	if err != nil {
-		return "", err
-	}
-	return dir, nil
-}
 
 func TestParseNpmRc(t *testing.T) {
 	dir, err := CreateDummyRc()
@@ -44,17 +22,17 @@ func TestParseNpmRc(t *testing.T) {
 		assert.Contains(t, cfg.Registries, "default")
 		assert.Equal(t, cfg.Registries["default"].AuthToken, "")
 		assert.Equal(t, cfg.Registries["default"].Url, "https://registry.npmjs.org/")
-		assert.Contains(t, cfg.Registries, "npm.pkg.github.com/")
-		assert.Equal(t, cfg.Registries["npm.pkg.github.com/"].AuthToken, "1234567890")
-		assert.Equal(t, cfg.Registries["npm.pkg.github.com/"].Url, "https://npm.pkg.github.com/")
+		assert.Contains(t, cfg.Registries, "mycustomregistry.updatecli.io/")
+		assert.Equal(t, cfg.Registries["mycustomregistry.updatecli.io/"].AuthToken, "mytoken")
+		assert.Equal(t, cfg.Registries["mycustomregistry.updatecli.io/"].Url, "https://mycustomregistry.updatecli.io/")
 		assert.Contains(t, cfg.Scopes, "@TestScope")
-		assert.Equal(t, cfg.Scopes["@TestScope"], "npm.pkg.github.com/")
+		assert.Equal(t, cfg.Scopes["@TestScope"], "mycustomregistry.updatecli.io/")
 	})
 	t.Run("Test parsing custom npmrc with auth token", func(t *testing.T) {
-		cfg, err := getNpmrcConfig("", "https://npm.pkg.github.com/", "1234567890")
+		cfg, err := getNpmrcConfig("", "https://mycustomregistry.updatecli.io/", "mytoken")
 		require.NoError(t, err)
 		assert.Contains(t, cfg.Registries, "default")
-		assert.Equal(t, cfg.Registries["default"].AuthToken, "1234567890")
-		assert.Equal(t, cfg.Registries["default"].Url, "https://npm.pkg.github.com/")
+		assert.Equal(t, cfg.Registries["default"].AuthToken, "mytoken")
+		assert.Equal(t, cfg.Registries["default"].Url, "https://mycustomregistry.updatecli.io/")
 	})
 }

--- a/pkg/plugins/resources/npm/source_test.go
+++ b/pkg/plugins/resources/npm/source_test.go
@@ -116,10 +116,6 @@ func TestSource(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := New(tt.spec)
-			if tt.expectedError {
-				assert.Error(t, err)
-				return
-			}
 			require.NoError(t, err)
 			if tt.mockedResponse {
 				got.webClient = GetMockClient(tt.mockedUrl, tt.mockedToken, tt.mockedBody, tt.mockedHTTPStatusCode)

--- a/pkg/plugins/resources/npm/source_test.go
+++ b/pkg/plugins/resources/npm/source_test.go
@@ -1,7 +1,6 @@
 package npm
 
 import (
-	"log"
 	"os"
 	"path/filepath"
 	"testing"
@@ -14,7 +13,7 @@ import (
 func TestSource(t *testing.T) {
 	dir, err := CreateDummyRc()
 	if err != nil {
-		log.Fatal(err)
+		require.NoError(t, err)
 	}
 	defer os.RemoveAll(dir)
 	tests := []struct {

--- a/pkg/plugins/resources/npm/source_test.go
+++ b/pkg/plugins/resources/npm/source_test.go
@@ -1,6 +1,9 @@
 package npm
 
 import (
+	"log"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -9,12 +12,22 @@ import (
 )
 
 func TestSource(t *testing.T) {
+	dir, err := CreateDummyRc()
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
 	tests := []struct {
-		name           string
-		url            string
-		spec           Spec
-		expectedResult string
-		expectedError  bool
+		name                 string
+		url                  string
+		spec                 Spec
+		expectedResult       string
+		expectedError        bool
+		mockedResponse       bool
+		mockedBody           string
+		mockedUrl            string
+		mockedToken          string
+		mockedHTTPStatusCode int
 	}{
 		{
 			name: "Passing case of retrieving axios versions ",
@@ -28,6 +41,77 @@ func TestSource(t *testing.T) {
 			expectedResult: "0.27.2",
 			expectedError:  false,
 		},
+		{
+			name: "Passing case of retrieving latest axios version using private registry",
+			spec: Spec{
+				Name: "axios",
+				VersionFilter: version.Filter{
+					Kind:    "semver",
+					Pattern: "~0",
+				},
+				URL:           "https://mycustomregistry.updatecli.io",
+				RegistryToken: "mytoken",
+			},
+			mockedResponse:       true,
+			mockedBody:           existingPackageData,
+			mockedHTTPStatusCode: 200,
+			mockedToken:          "mytoken",
+			mockedUrl:            "https://mycustomregistry.updatecli.io",
+			expectedResult:       "0.2.0",
+		},
+		{
+			name: "Failing case of retrieving latest axios version using private registry but bad token",
+			spec: Spec{
+				Name: "axios",
+				VersionFilter: version.Filter{
+					Kind:    "semver",
+					Pattern: "~0",
+				},
+				URL:           "https://mycustomregistry.updatecli.io",
+				RegistryToken: "badtoken",
+			},
+			mockedResponse:       true,
+			mockedBody:           existingPackageData,
+			mockedHTTPStatusCode: 200,
+			mockedToken:          "mytoken",
+			mockedUrl:            "https://mycustomregistry.updatecli.io",
+			expectedError:        true,
+		},
+		{
+			name: "Failing case of retrieving latest non existing package using private registry",
+			spec: Spec{
+				Name: "axiosnotexisting",
+				VersionFilter: version.Filter{
+					Kind:    "semver",
+					Pattern: "~0",
+				},
+				URL:           "https://mycustomregistry.updatecli.io",
+				RegistryToken: "mytoken",
+			},
+			mockedResponse:       true,
+			mockedBody:           nonExistingPackageData,
+			mockedHTTPStatusCode: 404,
+			mockedToken:          "mytoken",
+			mockedUrl:            "https://mycustomregistry.updatecli.io",
+			expectedError:        true,
+		},
+		{
+			name: "Passing case of retrieving latest @TestScope:registry version using private registry in npmrc",
+			spec: Spec{
+				Name: "@TestScope/test",
+				VersionFilter: version.Filter{
+					Kind:    "semver",
+					Pattern: "~0",
+				},
+				NpmrcPath: filepath.Join(dir, ".npmrc"),
+			},
+			mockedResponse:       true,
+			mockedBody:           existingScopedPackageData,
+			mockedHTTPStatusCode: 200,
+			mockedToken:          "mytoken",
+			mockedUrl:            "https://mycustomregistry.updatecli.io",
+			expectedResult:       "0.2.0",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -36,7 +120,15 @@ func TestSource(t *testing.T) {
 				assert.Error(t, err)
 				return
 			}
+			require.NoError(t, err)
+			if tt.mockedResponse {
+				got.webClient = GetMockClient(tt.mockedUrl, tt.mockedToken, tt.mockedBody, tt.mockedHTTPStatusCode)
+			}
 			gotVersion, err := got.Source("")
+			if tt.expectedError {
+				assert.Error(t, err)
+				return
+			}
 			require.NoError(t, err)
 			assert.Equal(t, tt.expectedResult, gotVersion)
 		})

--- a/pkg/plugins/resources/npm/test_utils.go
+++ b/pkg/plugins/resources/npm/test_utils.go
@@ -1,0 +1,62 @@
+package npm
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/updatecli/updatecli/pkg/core/httpclient"
+)
+
+const existingPackageData = "{\"_id\":\"axios\",\"_rev\":\"779-b37ceeb27a03858a89a0226f7c554aaf\",\"name\":\"axios\",\"description\":\"Promise based HTTP client for the browser and node.js\",\"dist-tags\":{\"latest\":\"0.1.0\",\"next\":\"0.2.0\"},\"versions\":{\"0.1.0\":{\"name\":\"axios\",\"version\":\"0.1.0\",\"description\":\"Promise based XHR library\",\"main\":\"index.js\",\"scripts\":{\"test\":\"grunt test\",\"start\":\"node ./sandbox/index.js\"},\"repository\":{\"type\":\"git\",\"url\":\"https://github.com/mzabriskie/axios.git\"},\"keywords\":[\"xhr\",\"http\",\"ajax\",\"promise\"],\"author\":{\"name\":\"Matt Zabriskie\"},\"license\":\"MIT\",\"bugs\":{\"url\":\"https://github.com/mzabriskie/axios/issues\"},\"homepage\":\"https://github.com/mzabriskie/axios\",\"dependencies\":{\"es6-promise\":\"^1.0.0\"},\"devDependencies\":{\"grunt\":\"^0.4.5\",\"grunt-contrib-clean\":\"^0.6.0\",\"grunt-contrib-watch\":\"^0.6.1\",\"webpack\":\"^1.3.3-beta2\",\"webpack-dev-server\":\"^1.4.10\",\"grunt-webpack\":\"^1.0.8\",\"load-grunt-tasks\":\"^0.6.0\",\"karma\":\"^0.12.21\",\"karma-jasmine\":\"^0.1.5\",\"grunt-karma\":\"^0.8.3\",\"karma-phantomjs-launcher\":\"^0.1.4\",\"karma-jasmine-ajax\":\"^0.1.4\",\"grunt-update-json\":\"^0.1.3\",\"grunt-contrib-nodeunit\":\"^0.4.1\",\"grunt-banner\":\"^0.2.3\"},\"_id\":\"axios@0.1.0\",\"dist\":{\"shasum\":\"854e14f2999c2ef7fab058654fd995dd183688f2\",\"tarball\":\"https://registry.npmjs.org/axios/-/axios-0.1.0.tgz\",\"integrity\":\"sha512-hRPotWTy88LEsJ31RWEs2fmU7mV2YJs3Cw7Tk5XkKGtnT5NKOyIvPU+6qTWfwQFusxzChe8ozjay8r56wfpX8w==\",\"signatures\":[{\"keyid\":\"SHA256:jl3bwswu80PjjokCgh0o2w5c2U4LhQAE57gj9cz1kzA\",\"sig\":\"MEYCIQC/cOvHsV7UqLAet6WE89O4Ga3AUHgkqqoP0riLs6sgTAIhAIrePavu3Uw0T3vLyYMlfEI9bqENYjPzH5jGK8vYQVJK\"}]},\"_from\":\"./\",\"_npmVersion\":\"1.4.3\",\"_npmUser\":{\"name\":\"mzabriskie\",\"email\":\"mzabriskie@gmail.com\"},\"maintainers\":[{\"name\":\"mzabriskie\",\"email\":\"mzabriskie@gmail.com\"}],\"directories\":{},\"deprecated\":\"Critical security vulnerability fixed in v0.21.1. For more information, see https://github.com/axios/axios/pull/3410\"},\"0.2.0\":{\"name\":\"axios\",\"version\":\"0.2.0\",\"description\":\"Promise based HTTP client for the browser and node.js\",\"main\":\"index.js\",\"scripts\":{\"test\":\"grunt test\",\"start\":\"node ./sandbox/server.js\"},\"repository\":{\"type\":\"git\",\"url\":\"https://github.com/mzabriskie/axios.git\"},\"keywords\":[\"xhr\",\"http\",\"ajax\",\"promise\",\"node\"],\"author\":{\"name\":\"Matt Zabriskie\"},\"license\":\"MIT\",\"bugs\":{\"url\":\"https://github.com/mzabriskie/axios/issues\"},\"homepage\":\"https://github.com/mzabriskie/axios\",\"dependencies\":{\"es6-promise\":\"^1.0.0\"},\"devDependencies\":{\"grunt\":\"^0.4.5\",\"grunt-contrib-clean\":\"^0.6.0\",\"grunt-contrib-watch\":\"^0.6.1\",\"webpack\":\"^1.3.3-beta2\",\"webpack-dev-server\":\"^1.4.10\",\"grunt-webpack\":\"^1.0.8\",\"load-grunt-tasks\":\"^0.6.0\",\"karma\":\"^0.12.21\",\"karma-jasmine\":\"^0.1.5\",\"grunt-karma\":\"^0.8.3\",\"karma-phantomjs-launcher\":\"^0.1.4\",\"karma-jasmine-ajax\":\"^0.1.4\",\"grunt-update-json\":\"^0.1.3\",\"grunt-contrib-nodeunit\":\"^0.4.1\",\"grunt-banner\":\"^0.2.3\"},\"_id\":\"axios@0.2.0\",\"dist\":{\"shasum\":\"315cd618142078fd22f2cea35380caad19e32069\",\"tarball\":\"https://registry.npmjs.org/axios/-/axios-0.2.0.tgz\",\"integrity\":\"sha512-ZQb2IDQfop5Asx8PlKvccsSVPD8yFCwYZpXrJCyU+MqL4XgJVjMHkCTNQV/pmB0Wv7l74LUJizSM/SiPz6r9uw==\",\"signatures\":[{\"keyid\":\"SHA256:jl3bwswu80PjjokCgh0o2w5c2U4LhQAE57gj9cz1kzA\",\"sig\":\"MEQCIAkrijLTtL7uiw0fQf5GL/y7bJ+3J8Z0zrrzNLC5fTXlAiBd4Nr/EJ2nWfBGWv/9OkrAONoboG5C8t8plIt5LVeGQA==\"}]},\"_from\":\"./\",\"_npmVersion\":\"1.4.3\",\"_npmUser\":{\"name\":\"mzabriskie\",\"email\":\"mzabriskie@gmail.com\"},\"maintainers\":[{\"name\":\"mzabriskie\",\"email\":\"mzabriskie@gmail.com\"}],\"directories\":{},\"deprecated\":\"Critical security vulnerability fixed in v0.21.1. For more information, see https://github.com/axios/axios/pull/3410\"}},\"readme\":\"axios\",\"maintainers\":[],\"time\":{\"modified\":\"2022-12-29T06:38:42.456Z\",\"created\":\"2014-08-29T23:08:36.810Z\",\"0.1.0\":\"2014-08-29T23:08:36.810Z\",\"0.2.0\":\"2014-09-12T20:06:33.167Z\"},\"homepage\":\"https://axios-http.com\",\"keywords\":[],\"repository\":{\"type\":\"git\",\"url\":\"git+https://github.com/axios/axios.git\"},\"author\":{\"name\":\"Matt Zabriskie\"},\"bugs\":{\"url\":\"https://github.com/axios/axios/issues\"},\"license\":\"MIT\",\"readmeFilename\":\"README.md\",\"users\":{},\"contributors\":[]}\n"
+const existingScopedPackageData = "{\"_id\":\"@TestScope/test\",\"_rev\":\"779-b37ceeb27a03858a89a0226f7c554aaf\",\"name\":\"@TestScope/test\",\"description\":\"Promise based HTTP client for the browser and node.js\",\"dist-tags\":{\"latest\":\"0.1.0\",\"next\":\"0.2.0\"},\"versions\":{\"0.1.0\":{\"name\":\"@TestScope/test\",\"version\":\"0.1.0\",\"description\":\"Promise based XHR library\",\"main\":\"index.js\",\"scripts\":{\"test\":\"grunt test\",\"start\":\"node ./sandbox/index.js\"},\"repository\":{\"type\":\"git\",\"url\":\"https://github.com/mzabriskie/@TestScope/test.git\"},\"keywords\":[\"xhr\",\"http\",\"ajax\",\"promise\"],\"author\":{\"name\":\"Matt Zabriskie\"},\"license\":\"MIT\",\"bugs\":{\"url\":\"https://github.com/mzabriskie/@TestScope/test/issues\"},\"homepage\":\"https://github.com/mzabriskie/@TestScope/test\",\"dependencies\":{\"es6-promise\":\"^1.0.0\"},\"devDependencies\":{\"grunt\":\"^0.4.5\",\"grunt-contrib-clean\":\"^0.6.0\",\"grunt-contrib-watch\":\"^0.6.1\",\"webpack\":\"^1.3.3-beta2\",\"webpack-dev-server\":\"^1.4.10\",\"grunt-webpack\":\"^1.0.8\",\"load-grunt-tasks\":\"^0.6.0\",\"karma\":\"^0.12.21\",\"karma-jasmine\":\"^0.1.5\",\"grunt-karma\":\"^0.8.3\",\"karma-phantomjs-launcher\":\"^0.1.4\",\"karma-jasmine-ajax\":\"^0.1.4\",\"grunt-update-json\":\"^0.1.3\",\"grunt-contrib-nodeunit\":\"^0.4.1\",\"grunt-banner\":\"^0.2.3\"},\"_id\":\"@TestScope/test@0.1.0\",\"dist\":{\"shasum\":\"854e14f2999c2ef7fab058654fd995dd183688f2\",\"tarball\":\"https://registry.npmjs.org/@TestScope/test/-/@TestScope/test-0.1.0.tgz\",\"integrity\":\"sha512-hRPotWTy88LEsJ31RWEs2fmU7mV2YJs3Cw7Tk5XkKGtnT5NKOyIvPU+6qTWfwQFusxzChe8ozjay8r56wfpX8w==\",\"signatures\":[{\"keyid\":\"SHA256:jl3bwswu80PjjokCgh0o2w5c2U4LhQAE57gj9cz1kzA\",\"sig\":\"MEYCIQC/cOvHsV7UqLAet6WE89O4Ga3AUHgkqqoP0riLs6sgTAIhAIrePavu3Uw0T3vLyYMlfEI9bqENYjPzH5jGK8vYQVJK\"}]},\"_from\":\"./\",\"_npmVersion\":\"1.4.3\",\"_npmUser\":{\"name\":\"mzabriskie\",\"email\":\"mzabriskie@gmail.com\"},\"maintainers\":[{\"name\":\"mzabriskie\",\"email\":\"mzabriskie@gmail.com\"}],\"directories\":{},\"deprecated\":\"Critical security vulnerability fixed in v0.21.1. For more information, see https://github.com/@TestScope/test/@TestScope/test/pull/3410\"},\"0.2.0\":{\"name\":\"@TestScope/test\",\"version\":\"0.2.0\",\"description\":\"Promise based HTTP client for the browser and node.js\",\"main\":\"index.js\",\"scripts\":{\"test\":\"grunt test\",\"start\":\"node ./sandbox/server.js\"},\"repository\":{\"type\":\"git\",\"url\":\"https://github.com/mzabriskie/@TestScope/test.git\"},\"keywords\":[\"xhr\",\"http\",\"ajax\",\"promise\",\"node\"],\"author\":{\"name\":\"Matt Zabriskie\"},\"license\":\"MIT\",\"bugs\":{\"url\":\"https://github.com/mzabriskie/@TestScope/test/issues\"},\"homepage\":\"https://github.com/mzabriskie/@TestScope/test\",\"dependencies\":{\"es6-promise\":\"^1.0.0\"},\"devDependencies\":{\"grunt\":\"^0.4.5\",\"grunt-contrib-clean\":\"^0.6.0\",\"grunt-contrib-watch\":\"^0.6.1\",\"webpack\":\"^1.3.3-beta2\",\"webpack-dev-server\":\"^1.4.10\",\"grunt-webpack\":\"^1.0.8\",\"load-grunt-tasks\":\"^0.6.0\",\"karma\":\"^0.12.21\",\"karma-jasmine\":\"^0.1.5\",\"grunt-karma\":\"^0.8.3\",\"karma-phantomjs-launcher\":\"^0.1.4\",\"karma-jasmine-ajax\":\"^0.1.4\",\"grunt-update-json\":\"^0.1.3\",\"grunt-contrib-nodeunit\":\"^0.4.1\",\"grunt-banner\":\"^0.2.3\"},\"_id\":\"@TestScope/test@0.2.0\",\"dist\":{\"shasum\":\"315cd618142078fd22f2cea35380caad19e32069\",\"tarball\":\"https://registry.npmjs.org/@TestScope/test/-/@TestScope/test-0.2.0.tgz\",\"integrity\":\"sha512-ZQb2IDQfop5Asx8PlKvccsSVPD8yFCwYZpXrJCyU+MqL4XgJVjMHkCTNQV/pmB0Wv7l74LUJizSM/SiPz6r9uw==\",\"signatures\":[{\"keyid\":\"SHA256:jl3bwswu80PjjokCgh0o2w5c2U4LhQAE57gj9cz1kzA\",\"sig\":\"MEQCIAkrijLTtL7uiw0fQf5GL/y7bJ+3J8Z0zrrzNLC5fTXlAiBd4Nr/EJ2nWfBGWv/9OkrAONoboG5C8t8plIt5LVeGQA==\"}]},\"_from\":\"./\",\"_npmVersion\":\"1.4.3\",\"_npmUser\":{\"name\":\"mzabriskie\",\"email\":\"mzabriskie@gmail.com\"},\"maintainers\":[{\"name\":\"mzabriskie\",\"email\":\"mzabriskie@gmail.com\"}],\"directories\":{},\"deprecated\":\"Critical security vulnerability fixed in v0.21.1. For more information, see https://github.com/@TestScope/test/@TestScope/test/pull/3410\"}},\"readme\":\"@TestScope/test\",\"maintainers\":[],\"time\":{\"modified\":\"2022-12-29T06:38:42.456Z\",\"created\":\"2014-08-29T23:08:36.810Z\",\"0.1.0\":\"2014-08-29T23:08:36.810Z\",\"0.2.0\":\"2014-09-12T20:06:33.167Z\"},\"homepage\":\"https://@TestScope/test-http.com\",\"keywords\":[],\"repository\":{\"type\":\"git\",\"url\":\"git+https://github.com/@TestScope/test/@TestScope/test.git\"},\"author\":{\"name\":\"Matt Zabriskie\"},\"bugs\":{\"url\":\"https://github.com/@TestScope/test/@TestScope/test/issues\"},\"license\":\"MIT\",\"readmeFilename\":\"README.md\",\"users\":{},\"contributors\":[]}\n"
+const nonExistingPackageData = "{\"error\":\"Not found\"}"
+
+func GetMockClient(baseUrl string, mockedToken string, mockedBody string, mockedHTTPStatusCode int) *httpclient.MockClient {
+	return &httpclient.MockClient{
+		DoFunc: func(req *http.Request) (*http.Response, error) {
+			var statusCode int
+			var httpError error
+			var body string
+			if !strings.HasPrefix(req.URL.String(), baseUrl) {
+				statusCode = 404
+				httpError = errors.New("not found")
+			} else if req.Header.Get("Authorization") != fmt.Sprintf("Bearer %s", mockedToken) {
+				statusCode = 401
+				httpError = errors.New("unauthorized")
+			} else {
+				body = mockedBody
+				statusCode = mockedHTTPStatusCode
+			}
+			return &http.Response{
+				StatusCode: statusCode,
+				Body:       ioutil.NopCloser(strings.NewReader(body)),
+			}, httpError
+		},
+	}
+}
+
+func CreateDummyRc() (string, error) {
+	dir, err := os.MkdirTemp("", "")
+	if err != nil {
+		return "", err
+	}
+	config, err := os.Create(filepath.Join(dir, ".npmrc"))
+	if err != nil {
+		return "", err
+	}
+	defer config.Close()
+	_, err = fmt.Fprintf(config, "//mycustomregistry.updatecli.io/:_authToken=mytoken\n")
+	if err != nil {
+		return "", err
+	}
+	_, err = fmt.Fprintf(config, "@TestScope:registry=https://mycustomregistry.updatecli.io/\n")
+	if err != nil {
+		return "", err
+	}
+	return dir, nil
+}


### PR DESCRIPTION
Fix [1012](https://github.com/updatecli/updatecli/issues/1012)

Implement support of private npm registry

## Test

To test this pull request, you can run the following commands:

```shell
cp pkg/plugins/resources/npm
go test
```

## Additional Information

When working with a private registry, it is necessary to specify the registry URL and an authorization token. These details can be provided in the resource specification and will be used as the default registry for connecting.

The resource code also checks for the presence of an `npmrc` file. This file contains information about scoped packages and can be specified in the `spec.NpmrcPath` field or defaults to `$HOME/.npmrc`.

The code will first establish the default registry by using the provided URL and token or defaulting to the npm registry. It then parses the `npmrc` file to identify additional registries and determine which scoped packages should use them.

When searching for a package, the resource code checks if it is a scoped package and if the scope has a custom registry configured. If so, it uses that registry, otherwise, it uses the default registry.

I've also fleshed out the test to introduced a mocked registry client
### Tradeoff


### Potential improvement

