### PR TITLE
[gittag] Use `spec.path` instead of working dir

### DIFF
--- a/pkg/plugins/resources/gittag/source.go
+++ b/pkg/plugins/resources/gittag/source.go
@@ -19,7 +19,7 @@ func (gt *GitTag) Source(workingDir string) (string, error) {
 		return "", err
 	}
 
-	tags, err := gt.nativeGitHandler.Tags(workingDir)
+	tags, err := gt.nativeGitHandler.Tags(gt.spec.Path)
 
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Fix #1101 

The `spec.path` value was updated with the `workingDir` if not specified, but still the working directory was used.
