### PR TITLE
Fix autodiscovery jsonschema

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -141,7 +141,7 @@ require (
 	github.com/hashicorp/yamux v0.0.0-20211028200310-0bc27b27de87 // indirect
 	github.com/howeyc/gopass v0.0.0-20210920133722-c8aef6fb66ef // indirect
 	github.com/huandu/xstrings v1.3.2 // indirect
-	github.com/iancoleman/orderedmap v0.0.0-20190318233801-ac98e3ecb4b0 // indirect
+	github.com/iancoleman/orderedmap v0.0.0-20190318233801-ac98e3ecb4b0
 	github.com/imdario/mergo v0.3.13 // indirect
 	github.com/inconshreveable/mousetrap v1.0.1 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
@@ -211,7 +211,7 @@ require (
 	golang.org/x/sync v0.1.0 // indirect
 	golang.org/x/sys v0.4.0 // indirect
 	golang.org/x/term v0.4.0 // indirect
-	golang.org/x/time v0.0.0-20220224211638-0e9765cccd65 // indirect
+	golang.org/x/time v0.0.0-20220224211638-0e9765cccd65
 	golang.org/x/tools v0.1.12 // indirect
 	google.golang.org/api v0.96.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect

--- a/pkg/core/jsonschema/main.go
+++ b/pkg/core/jsonschema/main.go
@@ -3,13 +3,13 @@ package jsonschema
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
 	"strings"
 
 	"github.com/go-git/go-git/v5"
+	"github.com/iancoleman/orderedmap"
 	jschema "github.com/invopop/jsonschema"
 	"github.com/sirupsen/logrus"
 )
@@ -99,50 +99,9 @@ func (s *Schema) GenerateSchema(object interface{}) error {
 	return nil
 }
 
-func GenerateJsonSchema(resourceConfigSchema interface{}, anyOf map[string]interface{}) *jschema.Schema {
-
-	var err error
-	var commentMap map[string]string
-
-	// Retrieve Updatecli code comments
-	commentMap, err = GetPackageComments(commentDir)
-
-	if err != nil {
-		logrus.Errorf(err.Error())
-		return nil
-	}
-
-	resourceSchema := jschema.Schema{}
-
-	for id, spec := range anyOf {
-		r := new(jschema.Reflector)
-
-		r.Anonymous = true
-		r.DoNotReference = true
-		r.RequiredFromJSONSchemaTags = true
-		r.CommentMap = commentMap
-		r.KeyNamer = strings.ToLower
-
-		// schema we need a way to remove schema
-
-		resourceConfig := r.Reflect(resourceConfigSchema)
-
-		spec := r.Reflect(spec)
-
-		resourceConfig.Properties.Set("spec", spec)
-		resourceConfig.Properties.Set("kind", jschema.Schema{
-			Enum: []interface{}{id}})
-
-		resourceSchema.OneOf = append(resourceSchema.OneOf, resourceConfig)
-
-	}
-	return &resourceSchema
-
-}
-
 // Save export a jsonschema to a local file
 func (s *Schema) Save() error {
-	err := ioutil.WriteFile(filepath.Join(s.SchemaDir, "config.json"), []byte(s.String()), 0600)
+	err := os.WriteFile(filepath.Join(s.SchemaDir, "config.json"), []byte(s.String()), 0600)
 	if err != nil {
 		return err
 	}
@@ -232,4 +191,86 @@ func CleanCommentDirectory() error {
 	}
 
 	return nil
+}
+
+// AppendOneOfToJsonschema generates a jsonschema based on a baseConfig and then append a oneOf based on the mapConfig.
+func AppendOneOfToJsonSchema(baseConfig interface{}, anyOf map[string]interface{}) *jschema.Schema {
+
+	var err error
+	var commentMap map[string]string
+
+	// Retrieve Updatecli code comments
+	commentMap, err = GetPackageComments(commentDir)
+
+	if err != nil {
+		logrus.Errorf(err.Error())
+		return nil
+	}
+
+	resourceSchema := jschema.Schema{}
+
+	for id, spec := range anyOf {
+		r := new(jschema.Reflector)
+
+		r.Anonymous = true
+		r.DoNotReference = true
+		r.RequiredFromJSONSchemaTags = true
+		r.CommentMap = commentMap
+		r.KeyNamer = strings.ToLower
+
+		// schema we need a way to remove schema
+
+		resourceConfig := r.Reflect(baseConfig)
+
+		spec := r.Reflect(spec)
+
+		resourceConfig.Properties.Set("spec", spec)
+		resourceConfig.Properties.Set("kind", jschema.Schema{
+			Enum: []interface{}{id}})
+
+		resourceSchema.OneOf = append(resourceSchema.OneOf, resourceConfig)
+
+	}
+	return &resourceSchema
+
+}
+
+// AppendMapToJsonSchema generates a jsonschema based on a baseConfig and then append a map of properties using the mapConfig.
+func AppendMapToJsonSchema(baseConfig interface{}, mapConfig map[string]interface{}) *jschema.Schema {
+
+	var err error
+	var commentMap map[string]string
+
+	// Retrieve Updatecli code comments
+	commentMap, err = GetPackageComments(commentDir)
+
+	if err != nil {
+		logrus.Errorf(err.Error())
+		return nil
+	}
+
+	if baseConfig == nil {
+		return nil
+	}
+
+	r := new(jschema.Reflector)
+
+	r.Anonymous = true
+	r.DoNotReference = true
+	r.RequiredFromJSONSchemaTags = true
+	r.CommentMap = commentMap
+	r.KeyNamer = strings.ToLower
+
+	resourceConfig := r.Reflect(baseConfig)
+
+	if resourceConfig.Properties == nil {
+		resourceConfig.Properties = orderedmap.New()
+	}
+
+	for key := range mapConfig {
+		spec := r.Reflect(mapConfig[key])
+		resourceConfig.Properties.Set(key, spec)
+	}
+
+	return resourceConfig
 }

--- a/pkg/core/pipeline/action/main.go
+++ b/pkg/core/pipeline/action/main.go
@@ -207,5 +207,5 @@ func (Config) JSONSchema() *jschema.Schema {
 		"gitea/pullrequest":  &gitea.Spec{},
 	}
 
-	return jsonschema.GenerateJsonSchema(configAlias{}, anyOfSpec)
+	return jsonschema.AppendOneOfToJsonSchema(configAlias{}, anyOfSpec)
 }

--- a/pkg/core/pipeline/autodiscovery/config.go
+++ b/pkg/core/pipeline/autodiscovery/config.go
@@ -2,8 +2,8 @@ package autodiscovery
 
 // Config defines autodiscovery parameters
 type Config struct {
-	// Crawlers specifies crawler configuration
-	Crawlers map[string]interface{} `yaml:",omitempty"`
+	// Crawlers defines a map of crawler configuration where the key represent the crawler type
+	Crawlers CrawlersConfig `yaml:",omitempty"`
 	// ScmID specifies a scmid configuration to use to generate the manifest
 	ScmId string `yaml:",omitempty"`
 	// ActionId specifies an action configuration to use to generate the manifest
@@ -13,3 +13,6 @@ type Config struct {
 	// !Deprecated in favor of `actionid`
 	PullrequestId string `yaml:",omitempty"`
 }
+
+// CrawlersConfig is a custom type used to generated the jsonschema.
+type CrawlersConfig map[string]interface{}

--- a/pkg/core/pipeline/autodiscovery/jsonschema.go
+++ b/pkg/core/pipeline/autodiscovery/jsonschema.go
@@ -6,7 +6,10 @@ import (
 )
 
 // JSONSchema implements the json schema interface to generate the "condition" jsonschema.
-func (Config) JSONSchema() *jschema.Schema {
-	type configAlias Config
-	return jsonschema.GenerateJsonSchema(configAlias{}, AutodiscoverySpecsMapping)
+func (CrawlersConfig) JSONSchema() *jschema.Schema {
+	type CrawlersConfigAlias CrawlersConfig
+
+	return jsonschema.AppendMapToJsonSchema(
+		CrawlersConfigAlias{},
+		AutodiscoverySpecsMapping)
 }

--- a/pkg/core/pipeline/autodiscovery/main.go
+++ b/pkg/core/pipeline/autodiscovery/main.go
@@ -16,7 +16,7 @@ import (
 var (
 	// DefaultGenericsSpecs defines the default builder that we want to run
 	DefaultCrawlerSpecs = Config{
-		Crawlers: map[string]interface{}{
+		Crawlers: CrawlersConfig{
 			"dockercompose": dockercompose.Spec{},
 			"dockerfile":    dockerfile.Spec{},
 			"helm":          helm.Spec{},

--- a/pkg/core/pipeline/condition/main.go
+++ b/pkg/core/pipeline/condition/main.go
@@ -96,7 +96,7 @@ func (c Config) JSONSchema() *jschema.Schema {
 	type configAlias Config
 	anyOfSpec := resource.GetResourceMapping()
 
-	return jsonschema.GenerateJsonSchema(configAlias{}, anyOfSpec)
+	return jsonschema.AppendOneOfToJsonSchema(configAlias{}, anyOfSpec)
 }
 
 func (c *Config) Validate() error {

--- a/pkg/core/pipeline/scm/config.go
+++ b/pkg/core/pipeline/scm/config.go
@@ -157,5 +157,5 @@ func (Config) JSONSchema() *jschema.Schema {
 		"gitea":  &gitea.Spec{},
 	}
 
-	return jsonschema.GenerateJsonSchema(configAlias{}, anyOfSpec)
+	return jsonschema.AppendOneOfToJsonSchema(configAlias{}, anyOfSpec)
 }

--- a/pkg/core/pipeline/source/main.go
+++ b/pkg/core/pipeline/source/main.go
@@ -111,7 +111,7 @@ func (Config) JSONSchema() *jschema.Schema {
 
 	anyOfSpec := resource.GetResourceMapping()
 
-	return jsonschema.GenerateJsonSchema(configAlias{}, anyOfSpec)
+	return jsonschema.AppendOneOfToJsonSchema(configAlias{}, anyOfSpec)
 }
 
 func (c *Config) Validate() error {

--- a/pkg/core/pipeline/target/main.go
+++ b/pkg/core/pipeline/target/main.go
@@ -172,7 +172,7 @@ func (Config) JSONSchema() *jschema.Schema {
 
 	anyOfSpec := resource.GetResourceMapping()
 
-	return jsonschema.GenerateJsonSchema(configAlias{}, anyOfSpec)
+	return jsonschema.AppendOneOfToJsonSchema(configAlias{}, anyOfSpec)
 }
 
 func (c *Config) Validate() error {


### PR DESCRIPTION
This pullrequest fix the jsonschema generated for the autodiscovery.

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
cd pkg/core/jsonschema/
go test
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

As of today, Updatecli codebase, relies on the function `New` to initiate object. it uses a map of plugin to define the behavior and due to that, the invopop/jsonschema requires  to implement the interface `func (ConfigType) JSONSchema() *jschema.Schema` to generate the jsonschema corresponding to the map of plugin. Hence the current pullrequest

Another approach would be to implement a json (un)marshaller for each config that works with plugins. If we get rid of the New function in favor of the unmarshaller approach, then we would also need to implement of yaml.
Based on my initial experimentation, it makes the codebase more difficult to write and maintain  
