### PR TITLE
doc(e2e tests) add a minimalistic documentation

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -193,8 +193,54 @@ targets:
       - addPrefix: "olblak/polls@256:"
 ```
 
+=== TEST
 
-=== Documentation
+==== Unit Tests
+
+Unit tests are golang test which are executed by default, even with the `-short` flag set up (e.g. executed when `testing.Short() == "true"`).
+
+They usually uses mocks as they should:
+
+- Have no external dependencies such as database or external API
+- Avoid as much as possible network requests
+- Run in less than 2s (compilation excluded)
+
+[source,bash]
+----
+make test-short
+----
+
+==== Integration Tests
+
+Integration tests are golang test which are executed by default but not with the `-short` flag set up (e.g. not executed when `testing.Short() == "true"`).
+
+[source,bash]
+----
+make test
+----
+
+==== End to End (e2e) Tests
+
+* https://github.com/ovh/venom[OVH's Venom CLI] is required
+* A https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token[GitHub Personal Access Token (PAT)] is required with read access to public repositories
+* Define the following environment variables (otherwise the `make` command will fail with a message telling you which variable is missing):`
+** `$GITHUB_TOKEN` set to the GitHub PAT mentioned above
+** `$GITHUB_ACTOR` set to the GitHub username associated to the aforementioned GitHub PAT
+
+
+[source,bash]
+----
+export GITHUB_TOKEN=$(<command to get token from password manager>) # Treat this as a SENSITIVE value!
+export GITHUB_ACTOR=xxxxx
+
+venom version # expect v1.2.0
+
+make test-e2e
+----
+
+The execution log is written by Venom into `./e2e/venom.log`.
+
+=== DOCUMENTATION
 
 If you spot phrasing issues or just a lack of documentation, feel free to open link:https://github.com/updatecli/updatecli/issues[an issue] and/or link:https://github.com/updatecli/updatecli/pulls[a pull request].
 https://github.com/updatecli/website[website]

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ DOCKER_BUILDKIT=1
 export DOCKER_BUILDKIT
 
 # Used by the test-e2e system
-VENOM_VAR_binpath ?= $(CURDIR)/dist/updatecli_$(shell go env GOOS)_$(shell go env GOARCH)
+VENOM_VAR_binpath ?= $(CURDIR)/dist/updatecli_$(shell go env GOOS)_$(shell go env GOARCH)_v1
 export VENOM_VAR_binpath
 VENOM_VAR_rootpath ?= $(CURDIR)
 export VENOM_VAR_rootpath
@@ -58,15 +58,11 @@ test-short: ## Execute the Golang's tests for updatecli
 	go test ./... -short
 
 .PHONY: test-e2e
-test-e2e: $(VENOM_VAR_binpath)/updatecli ## Execute updatecli end to end tests
+test-e2e: ## Execute updatecli end to end tests
 	@echo "==\nUsing the following updatecli binary (from variable 'VENOM_VAR_binpath'): $(VENOM_VAR_binpath)/updatecli\n=="
 	@test -n "$$GITHUB_TOKEN" || { echo "Undefined required variable 'GITHUB_TOKEN'"; exit 1; }
 	@test -n "$$GITHUB_ACTOR" || { echo "Undefined required variable 'GITHUB_ACTOR'"; exit 1; }
 	time venom run e2e/venom.d/* --output-dir ./e2e --format yaml
-
-# Not PHONY
-$(VENOM_VAR_binpath)/updatecli:
-	go build -o $(VENOM_VAR_binpath)/updatecli
 
 .PHONY: lint
 lint: ## Execute the Golang's linters on updatecli's source code

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ DOCKER_BUILDKIT=1
 export DOCKER_BUILDKIT
 
 # Used by the test-e2e system
-VENOM_VAR_binpath ?= $(CURDIR)/dist/updatecli_$(shell go env GOOS)_$(shell go env GOARCH)_v1
+VENOM_VAR_binpath ?= $(CURDIR)/dist/updatecli_$(shell go env GOOS)_$(shell go env GOARCH)
 export VENOM_VAR_binpath
 VENOM_VAR_rootpath ?= $(CURDIR)
 export VENOM_VAR_rootpath
@@ -58,11 +58,15 @@ test-short: ## Execute the Golang's tests for updatecli
 	go test ./... -short
 
 .PHONY: test-e2e
-test-e2e: ## Execute updatecli end to end tests
+test-e2e: $(VENOM_VAR_binpath)/updatecli ## Execute updatecli end to end tests
 	@echo "==\nUsing the following updatecli binary (from variable 'VENOM_VAR_binpath'): $(VENOM_VAR_binpath)/updatecli\n=="
 	@test -n "$$GITHUB_TOKEN" || { echo "Undefined required variable 'GITHUB_TOKEN'"; exit 1; }
 	@test -n "$$GITHUB_ACTOR" || { echo "Undefined required variable 'GITHUB_ACTOR'"; exit 1; }
 	time venom run e2e/venom.d/* --output-dir ./e2e --format yaml
+
+# Not PHONY
+$(VENOM_VAR_binpath)/updatecli:
+	go build -o $(VENOM_VAR_binpath)/updatecli
 
 .PHONY: lint
 lint: ## Execute the Golang's linters on updatecli's source code

--- a/updatecli/updatecli.d/venom.yaml
+++ b/updatecli/updatecli.d/venom.yaml
@@ -1,45 +1,54 @@
 name: "ci: bump Venom version"
 pipelineid: "venom"
 actions:
-    default:
-        title: 'ci: bump Venom version to {{ source "latestVersion" }}'
-        kind: github/pullrequest
-        spec:
-            automerge: true
-            labels:
-                - chore
-                - skip-changelog
-        scmid: default
+  default:
+    title: 'ci: bump Venom version to {{ source "latestVersion" }}'
+    kind: github/pullrequest
+    spec:
+      automerge: true
+      labels:
+        - chore
+        - skip-changelog
+    scmid: default
 scms:
-    default:
-        kind: github
-        spec:
-            branch: '{{ .scm.branch }}'
-            email: '{{ .scm.email }}'
-            owner: '{{ .scm.owner }}'
-            repository: '{{ .scm.repository }}'
-            token: '{{ requiredEnv "GITHUB_TOKEN" }}'
-            user: '{{ .scm.user }}'
-            username: '{{ requiredEnv "GITHUB_ACTOR" }}'
-        disabled: false
+  default:
+    kind: github
+    spec:
+      branch: "{{ .scm.branch }}"
+      email: "{{ .scm.email }}"
+      owner: "{{ .scm.owner }}"
+      repository: "{{ .scm.repository }}"
+      token: '{{ requiredEnv "GITHUB_TOKEN" }}'
+      user: "{{ .scm.user }}"
+      username: '{{ requiredEnv "GITHUB_ACTOR" }}'
+    disabled: false
 sources:
-    latestVersion:
-        name: Get latest Venom release
-        kind: githubrelease
-        spec:
-            owner: ovh
-            repository: venom
-            token: '{{ requiredEnv "GITHUB_TOKEN" }}'
-            username: '{{ requiredEnv "GITHUB_ACTOR" }}'
-            versionfilter:
-                kind: semver
+  latestVersion:
+    name: Get latest Venom release
+    kind: githubrelease
+    spec:
+      owner: ovh
+      repository: venom
+      token: '{{ requiredEnv "GITHUB_TOKEN" }}'
+      username: '{{ requiredEnv "GITHUB_ACTOR" }}'
+      versionfilter:
+        kind: semver
 targets:
-    goWorkflow:
-        name: 'ci: update Venom version to {{ source "latestVersion" }}'
-        kind: file
-        spec:
-            content: 'VENOM_VERSION: {{ source `latestVersion` }}'
-            file: .github/workflows/go.yaml
-            matchpattern: 'VENOM_VERSION: .*'
-        scmid: default
-        sourceid: latestVersion
+  goWorkflow:
+    name: 'ci: update Venom version to {{ source "latestVersion" }}'
+    kind: file
+    spec:
+      content: 'VENOM_VERSION: {{ source "latestVersion" }}'
+      file: .github/workflows/go.yaml
+      matchpattern: "VENOM_VERSION: .*"
+    scmid: default
+    sourceid: latestVersion
+  contributing-doc:
+    name: 'CONTRIBUTING documentation: update Venom version to {{ source "latestVersion" }}'
+    kind: file
+    spec:
+      file: CONTRIBUTING.adoc
+      matchpattern: 'venom version # expect .*'
+      replacepattern: 'venom version # expect {{ source "latestVersion" }}'
+    scmid: default
+    sourceid: latestVersion


### PR DESCRIPTION
In https://github.com/updatecli/updatecli/pull/650, @hervelemeur had been slowed down (and blocked) by the end to end testing.

This PR is a first step to help contributor: which add a minimalist doc of the constraints required to run the e2e locally

## Test

To test this pull request, you can run the following commands:

```shell
cp <to_package_directory>
go test
```

## Additional Information

The updatecli check will fail as the file `CONTRIBUTING.adoc` introduces a tracked line (in the new target for `venom.yaml` manifest).

Tested locally without the `scmid` looks good:

```
✔ ci: bump Venom version:
        Source:
                ✔ [latestVersion] Get latest Venom release
        Target:
                ✔ [contributing-doc] CONTRIBUTING documentation: update Venom version to v1.2.0
                ✔ [goWorkflow] ci: update Venom version to v1.2.0
```