### PR TITLE
Git Tag target shouldn't fail

### DIFF
--- a/pkg/plugins/resources/gittag/target.go
+++ b/pkg/plugins/resources/gittag/target.go
@@ -46,7 +46,9 @@ func (gt *GitTag) target(source string, dryRun bool) (bool, []string, string, er
 		logrus.Warningf("No specified message for gittag target. Using default value %q", gt.spec.Message)
 	}
 
-	files := []string{}
+	// cfr https://github.com/updatecli/updatecli/issues/1126
+	// to know why the following line is needed at the moment
+	files := []string{""}
 	message := gt.spec.Message
 
 	// Fail if a pattern is specified


### PR DESCRIPTION
Signed-off-by: Olblak <me@olblak.com>

Related to https://github.com/updatecli/updatecli/issues/1126

Git tag target shouldn't fail

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
cp <to_package_directory>
go test
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
