### PR TITLE
feat: Add the ability to use source in commit message

### DIFF
--- a/pkg/core/pipeline/scm/main.go
+++ b/pkg/core/pipeline/scm/main.go
@@ -33,6 +33,7 @@ type ScmHandler interface {
 	PushTag(tag string) error
 	PushBranch(branch string) error
 	GetChangedFiles(workingDir string) ([]string, error)
+	UpdateSpec(spec interface{}) error
 }
 
 func New(config *Config, pipelineID string) (Scm, error) {

--- a/pkg/core/pipeline/targets.go
+++ b/pkg/core/pipeline/targets.go
@@ -44,6 +44,14 @@ func (p *Pipeline) RunTargets() error {
 		target := p.Targets[id]
 		target.Config = p.Config.Spec.Targets[id]
 
+		if target.Scm != nil {
+			scm := *target.Scm
+			err = scm.UpdateSpec(p.Config.Spec.SCMs[target.Config.SCMID].Spec)
+			if err != nil {
+				return err
+			}
+		}
+
 		report := p.Report.Targets[id]
 		// Update report name as the target configuration might has been updated (templated values)
 		report.Name = target.Config.Name

--- a/pkg/plugins/scms/git/main.go
+++ b/pkg/plugins/scms/git/main.go
@@ -6,6 +6,7 @@ import (
 	"path"
 	"strings"
 
+	"github.com/mitchellh/mapstructure"
 	"github.com/sirupsen/logrus"
 
 	"github.com/updatecli/updatecli/pkg/core/tmp"
@@ -176,4 +177,17 @@ func sanitizeDirectoryName(URL string) string {
 		}
 	}
 	return URL
+}
+
+func (g *Git) UpdateSpec(spec interface{}) error {
+	gitSpec := Spec{}
+
+	err := mapstructure.Decode(spec, &gitSpec)
+	if err != nil {
+		return err
+	}
+
+	g.spec.CommitMessage = gitSpec.CommitMessage
+
+	return nil
 }

--- a/pkg/plugins/scms/gitea/main.go
+++ b/pkg/plugins/scms/gitea/main.go
@@ -173,3 +173,16 @@ func (s *Spec) Validate() error {
 
 	return nil
 }
+
+func (g *Gitea) UpdateSpec(spec interface{}) error {
+	giteaSpec := Spec{}
+
+	err := mapstructure.Decode(spec, &giteaSpec)
+	if err != nil {
+		return err
+	}
+
+	g.Spec.CommitMessage = giteaSpec.CommitMessage
+
+	return nil
+}

--- a/pkg/plugins/scms/github/main.go
+++ b/pkg/plugins/scms/github/main.go
@@ -8,6 +8,7 @@ import (
 	"path"
 	"strings"
 
+	"github.com/mitchellh/mapstructure"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/oauth2"
 
@@ -255,4 +256,17 @@ func (g *Github) queryRepositoryID() (string, error) {
 
 	return query.Repository.ID, nil
 
+}
+
+func (g *Github) UpdateSpec(spec interface{}) error {
+	githubSpec := Spec{}
+
+	err := mapstructure.Decode(spec, &githubSpec)
+	if err != nil {
+		return err
+	}
+
+	g.Spec.CommitMessage = githubSpec.CommitMessage
+
+	return nil
 }


### PR DESCRIPTION
Fix #1129 

## Test

To test this pull request, you can run the following commands:

```shell
cp <to_package_directory>
go test
```

Testing commit to repo:

```yaml
scms:
  default:
    kind: github
    spec:
      branch: main
      email: '{{ requiredEnv "UPDATECLI_GITHUB_EMAIL" }}'
      owner: updatecli
      repository: updatecli
      token: '{{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}'
      user: updatecli
      username: '{{ requiredEnv "UPDATECLI_GITHUB_ACTOR" }}'
      commitmessage:
        title: 'Update version to "{{ source `latestVersion` }}"'
    disabled: false

sources:
  latestVersion:
    name: Get latest updatecli release
    kind: githubrelease
    spec:
      owner: updatecli
      repository: updatecli
      token: '{{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}'
      username: '{{ requiredEnv "UPDATECLI_GITHUB_ACTOR" }}'

targets:
  target:
    name: 'Update updatecli version to {{ source "latestVersion" }}'
    kind: file
    spec:
      file: version.md
      forcecreate: true
    scmid: default
    sourceid: latestVersion

```

Check commit message:

```text
cd <tmp_directory>
git log --pretty=format:%s -n1
```

Expected output:

```text
chore: Update version to "v0.43.0"
```

## Additional Information

### Tradeoff

I'm not 100% sure if adding `UpdateSpec(spec interface{}) error` is the correct way to attack this problem.

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
