### PR TITLE
yaml target should be able to parse key containing dots

### DIFF
--- a/pkg/plugins/resources/yaml/condition_test.go
+++ b/pkg/plugins/resources/yaml/condition_test.go
@@ -23,6 +23,32 @@ func Test_Condition(t *testing.T) {
 		isErrorWanted    bool
 	}{
 		{
+			name: "Passing Case with complex key",
+			spec: Spec{
+				File: "test.yaml",
+				Key:  "annotations.github\\.owner",
+			},
+			files: map[string]string{
+				"test.yaml": "",
+			},
+			inputSourceValue: "olblak",
+			mockedContents: map[string]string{
+				"test.yaml": `---
+annotations:
+  github.owner: olblak
+  repository: charts
+`,
+			},
+			wantedContents: map[string]string{
+				"test.yaml": `---
+annotations:
+  github.owner: olblak
+  repository: charts
+`,
+			},
+			isResultWanted: true,
+		},
+		{
 			name: "Passing Case",
 			spec: Spec{
 				File: "test.yaml",

--- a/pkg/plugins/resources/yaml/source_test.go
+++ b/pkg/plugins/resources/yaml/source_test.go
@@ -22,6 +22,28 @@ func Test_Source(t *testing.T) {
 		isErrorWanted    bool
 	}{
 		{
+			name: "Passing Case with 'File' and complex key",
+			spec: Spec{
+				File: "test.yaml",
+				Key:  "annotations.github\\.owner",
+			},
+			files: map[string]string{
+				"test.yaml": "",
+			},
+			inputSourceValue: "olblak",
+			mockedContents: map[string]string{
+				"test.yaml": `---
+annotations:
+  github.owner: olblak
+  repository: charts
+`,
+			},
+			wantedContents: map[string]string{
+				"test.yaml": "olblak",
+			},
+			isResultWanted: true,
+		},
+		{
 			name: "Passing Case with 'File'",
 			spec: Spec{
 				File: "test.yaml",

--- a/pkg/plugins/resources/yaml/target.go
+++ b/pkg/plugins/resources/yaml/target.go
@@ -78,14 +78,13 @@ func (y *Yaml) target(source string, dryRun bool) (bool, []string, string, error
 		originalContents[filePath] = y.files[filePath]
 
 		out := yaml.Node{}
-
 		err := yaml.Unmarshal([]byte(y.files[filePath]), &out)
 
 		if err != nil {
 			return false, files, message.String(), fmt.Errorf("cannot unmarshal content of file %s: %v", filePath, err)
 		}
 
-		keyFound, oldVersion, _ := replace(&out, strings.Split(y.spec.Key, "."), valueToWrite, 1)
+		keyFound, oldVersion, _ := replace(&out, parseKey(y.spec.Key), valueToWrite, 1)
 
 		if !keyFound {
 			return false, files, message.String(), fmt.Errorf("%s cannot find key '%s' from file '%s'",

--- a/pkg/plugins/resources/yaml/target_test.go
+++ b/pkg/plugins/resources/yaml/target_test.go
@@ -24,6 +24,33 @@ func Test_Target(t *testing.T) {
 		dryRun           bool
 	}{
 		{
+			name: "Passing case with both complex input source and specified value (specified value should be used)",
+			spec: Spec{
+				File:  "test.yaml",
+				Key:   "annotations.github\\.owner",
+				Value: "obiwankenobi",
+			},
+			files: map[string]string{
+				"test.yaml": "",
+			},
+			inputSourceValue: "olblak",
+			mockedContents: map[string]string{
+				"test.yaml": `---
+annotations:
+    github.owner: olblak
+    repository: charts
+`,
+			},
+			// Note: the re-encoded file doesn't contain any separator anymore
+			wantedContents: map[string]string{
+				"test.yaml": `annotations:
+    github.owner: obiwankenobi
+    repository: charts
+`,
+			},
+			wantedResult: true,
+		},
+		{
 			name: "Passing case with both input source and specified value (specified value should be used)",
 			spec: Spec{
 				File:  "test.yaml",


### PR DESCRIPTION
https://github.com/updatecli/updatecli/pull/650 introduce a regression where a yaml target wouldn't correctly parse yaml key using dots

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
cd pkg/plugins/resources/yaml/
go test
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
