### PR TITLE
Support scm actions with a suffix head branch for gitea and github

### DIFF
--- a/e2e/updatecli.d/success.d/githubPullrequest.yaml
+++ b/e2e/updatecli.d/success.d/githubPullrequest.yaml
@@ -8,6 +8,7 @@ scms:
       repository: updatecli
       token: '{{ requiredEnv "GITHUB_TOKEN" }}'
       branch: main
+      headBranchSuffix: '-my-super-suffix'
 
 sources:
   jenkins:

--- a/pkg/plugins/scms/gitea/main.go
+++ b/pkg/plugins/scms/gitea/main.go
@@ -39,6 +39,8 @@ type Spec struct {
 	User string `yaml:",omitempty"`
 	// Branch specifies which Gitea repository branch to work on
 	Branch string `yaml:",omitempty"`
+	// Suffix for the Head Branch where the github repository is checked out to.
+	HeadBranchSuffix string `yaml:",omitempty"`
 }
 
 // Gitea contains information to interact with Gitea api
@@ -106,7 +108,7 @@ func New(spec interface{}, pipelineID string) (*Gitea, error) {
 	g := Gitea{
 		Spec:             s,
 		client:           c,
-		HeadBranch:       nativeGitHandler.SanitizeBranchName(fmt.Sprintf("updatecli_%v", pipelineID)),
+		HeadBranch:       nativeGitHandler.SanitizeBranchName(fmt.Sprintf("updatecli_%v%v", pipelineID, s.HeadBranchSuffix)),
 		nativeGitHandler: nativeGitHandler,
 	}
 

--- a/pkg/plugins/scms/github/main.go
+++ b/pkg/plugins/scms/github/main.go
@@ -45,6 +45,8 @@ type Spec struct {
 	Force bool `yaml:",omitempty"`
 	// CommitMessage represents conventional commit metadata as type or scope, used to generate the final commit message.
 	CommitMessage commit.Commit `yaml:",omitempty"`
+	// Suffix for the Head Branch where the github repository is checked out to.
+	HeadBranchSuffix string `yaml:",omitempty"`
 }
 
 // Github contains settings to interact with Github
@@ -90,7 +92,7 @@ func New(s Spec, pipelineID string) (*Github, error) {
 
 	g := Github{
 		Spec:             s,
-		HeadBranch:       nativeGitHandler.SanitizeBranchName(fmt.Sprintf("updatecli_%v", pipelineID)),
+		HeadBranch:       nativeGitHandler.SanitizeBranchName(fmt.Sprintf("updatecli_%v%v", pipelineID, s.HeadBranchSuffix)),
 		nativeGitHandler: nativeGitHandler,
 	}
 
@@ -159,6 +161,9 @@ func (gs *Spec) Merge(child interface{}) error {
 	}
 	if childGHSpec.GPG != (sign.GPGSpec{}) {
 		gs.GPG = childGHSpec.GPG
+	}
+	if childGHSpec.HeadBranchSuffix != "" {
+		gs.HeadBranchSuffix = childGHSpec.HeadBranchSuffix
 	}
 	if childGHSpec.Owner != "" {
 		gs.Owner = childGHSpec.Owner

--- a/pkg/plugins/scms/github/main_test.go
+++ b/pkg/plugins/scms/github/main_test.go
@@ -193,6 +193,33 @@ func TestNew(t *testing.T) {
 			},
 		},
 		{
+			name:       "Custom Head branch",
+			pipelineID: "12345",
+			spec: Spec{
+				Branch:           "main",
+				Repository:       "updatecli",
+				Owner:            "updatecli",
+				Directory:        "/home/updatecli",
+				Username:         "joe",
+				Token:            "superSecretTOkenOfJoe",
+				URL:              "github.com",
+				HeadBranchSuffix: "my_branch",
+			},
+			want: Github{
+				HeadBranch: "updatecli_12345my_branch",
+				Spec: Spec{
+					Branch:           "main",
+					Repository:       "updatecli",
+					Owner:            "updatecli",
+					Directory:        "/home/updatecli",
+					Username:         "joe",
+					Token:            "superSecretTOkenOfJoe",
+					URL:              "https://github.com",
+					HeadBranchSuffix: "my_branch",
+				},
+			},
+		},
+		{
 			name:       "Validation Error (missing token)",
 			pipelineID: "12345",
 			spec: Spec{


### PR DESCRIPTION
Fix #1159

## Test

To test this pull request, you can run the following commands:

```shell
make test
```

## Additional Information

This is trying to solve the issue of running the same pipeline in different branches as they reuse the same `HeadBranch`

### Tradeoff

Name of the suffix to be added without a `_` to separate the name of the branch from the pipelineID

### Potential improvement

