### PR TITLE
Bump golangci version to 1.51

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -29,7 +29,7 @@ jobs:
           # Required: the version of golangci-lint is required
           # and must be specified without patch version:
           # we always use the latest patch version.
-          version: v1.50
+          version: v1.51
       - name: Install GoReleaser
         uses: goreleaser/goreleaser-action@v4
         with:

--- a/pkg/core/pipeline/autodiscovery/main.go
+++ b/pkg/core/pipeline/autodiscovery/main.go
@@ -204,10 +204,7 @@ func (g *AutoDiscovery) Run() ([][]byte, error) {
 
 		logrus.Printf("Manifest detected: %d\n", len(discoveredManifests))
 		if len(discoveredManifests) > 0 {
-
-			for i := range discoveredManifests {
-				totalDiscoveredManifests = append(totalDiscoveredManifests, discoveredManifests[i])
-			}
+			totalDiscoveredManifests = append(totalDiscoveredManifests, discoveredManifests...)
 		}
 	}
 

--- a/pkg/plugins/resources/yaml/main.go
+++ b/pkg/plugins/resources/yaml/main.go
@@ -192,8 +192,6 @@ func replace(entry *yaml.Node, keys []string, version string, columnRef int) (fo
 
 				keys = keys[1:]
 
-				column = entry.Content[0].Content[positionIndex].Column
-
 				valueFound, oldVersion, column = replace(entry.Content[0].Content[positionIndex],
 					keys,
 					version,


### PR DESCRIPTION
Fix https://github.com/updatecli/updatecli/pull/1131

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
golangci-lint run
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
