### PR TITLE
Execute action in DRY_RUN mode if apply parameter --push=false is set

### DIFF
--- a/pkg/core/pipeline/actions.go
+++ b/pkg/core/pipeline/actions.go
@@ -127,7 +127,7 @@ func (p *Pipeline) RunActions() error {
 		}
 		action.Changelog = changelog
 
-		if p.Options.Target.DryRun {
+		if p.Options.Target.DryRun || !p.Options.Target.Push {
 			if len(attentionTargetIDs) > 0 {
 				logrus.Infof("[Dry Run] An action of kind %q is expected.", action.Config.Kind)
 


### PR DESCRIPTION
<!-- Describe the changes introduced by this pull request -->
When we run `updatecli apply --push=false`, at the moment Updatecli still tries to apply action such as opening github pullrequest. Obviously if local changes haven't been published then that operation fails as the branch do not exist on the remote location. This is especially confusing for newcomers as they think that the pipeline failed due to the pullrequest even though the root cause is usually at the git operation level.

```updatecli apply --config updatecli/updatecli.d/golangci-lint.yaml --push=false --clean=false --debug```

I often use --push=false to test the local behavior before changing the remote repository

<details><summary>Before fix Output</summary>

```
TARGETS
========

default
-------
DEBUG: stage: git-checkout

DEBUG: checkout branch "updatecli_e6d141666bd851d4bac9467b898b5e908012a53932de7a805c0767c9e7aeb532", based on "main" to directory "/tmp/updatecli/github/updatecli/updatecli"
DEBUG: 
DEBUG: No remote name "updatecli_e6d141666bd851d4bac9467b898b5e908012a53932de7a805c0767c9e7aeb532"
DEBUG: Relative path detected: changing from ".github/workflows/go.yaml" to absolute path from SCM: "/tmp/updatecli/github/updatecli/updatecli/.github/workflows/go.yaml"
⚠ Key 'jobs.build.steps[2].with.version', from file '/tmp/updatecli/github/updatecli/updatecli/.github/workflows/go.yaml', was updated from 'v1.51' to 'v1.50'
DEBUG: stage: git-add

DEBUG: adding file: "/tmp/updatecli/github/updatecli/updatecli/.github/workflows/go.yaml"
DEBUG: absolute file path detected: "/tmp/updatecli/github/updatecli/updatecli/.github/workflows/go.yaml" converted to relative path ".github/workflows/go.yaml"
DEBUG: stage: git-commit

DEBUG: status: "M  .github/workflows/go.yaml\n"
DEBUG: git commit object:
commit 38bf830fe4936ee77a1776f87937a8d4e7d83caf
Author: updatecli <me@olblak.com>
Date:   Thu Feb 23 08:34:25 2023 +0100

    chore: Update key "jobs.build.steps[2].with.version" from file "/tmp/...

    ... updatecli/github/updatecli/updatecli/.github/workflows/go.yaml"

    Made with ❤️️ by updatecli



ACTIONS
========

Pipeline "Bump golangci-lint version" failed
Skipping due to:
	action stage:	"Head sha can't be blank, Base sha can't be blank, No commits between main and updatecli_e6d141666bd851d4bac9467b898b5e908012a53932de7a805c0767c9e7aeb532, Head ref must be a branch"

```
</details>

<details><summary>After fix Output</summary>

```
TARGETS
========

default
-------
DEBUG: stage: git-checkout

DEBUG: checkout branch "updatecli_e6d141666bd851d4bac9467b898b5e908012a53932de7a805c0767c9e7aeb532", based on "main" to directory "/tmp/updatecli/github/updatecli/updatecli"
DEBUG: 
DEBUG: No remote name "updatecli_e6d141666bd851d4bac9467b898b5e908012a53932de7a805c0767c9e7aeb532"
DEBUG: Relative path detected: changing from ".github/workflows/go.yaml" to absolute path from SCM: "/tmp/updatecli/github/updatecli/updatecli/.github/workflows/go.yaml"
✔ Key 'jobs.build.steps[2].with.version', from file '/tmp/updatecli/github/updatecli/updatecli/.github/workflows/go.yaml', already set to v1.50, nothing else need to be done


ACTIONS
========

DEBUG: The expected action would have the following information:
	|	
	|	##Title:
	|	[updatecli] Bump golangci-lint version to v1.50.0
	|	
	|	##Changelog:
	|	
	|	
	|	Release published on the 2022-10-04 10:46:42 +0000 UTC at the url https://github.com/golangci/golangci-lint/releases/tag/v1.50.0
	|	
	|	## Changelog
	|	* 890a8265 Normalize exclude-rules paths for Windows (#2387)
	|	* db4955a3 build(deps): bump github.com/OpenPeeDeeP/depguard from 1.1.0 to 1.1.1 (#3186)
	|	* 937e3d40 build(deps): bump github.com/curioswitch/go-reassign v0.1.2 to v0.2.0 (#3234)
	|	* 40082da3 build(deps): bump github.com/daixiang0/gci from 0.6.3 to 0.7.0 (#3190)
	|	* c78bc230 build(deps): bump github.com/daixiang0/gci from 0.7.0 to 0.8.0 (#3241)
	|	* 28d70954 build(deps): bump github.com/go-critic/go-critic from 0.6.4 to 0.6.5 (#3150)
	|	* ff61ea9f build(deps): bump github.com/kkHAIKE/contextcheck from 1.1.0 to 1.1.1 (#3208)
	|	* 0a581b3c build(deps): bump github.com/kkHAIKE/contextcheck from 1.1.1 to 1.1.2 (#3243)
	|	* 0a94c369 build(deps): bump github.com/mgechev/revive from 1.2.3 to 1.2.4 (#3257)
	|	* 33a78c92 build(deps): bump github.com/nishanths/exhaustive from 0.8.1 to 0.8.3 (#3207)
	|	* d5dc2a19 build(deps): bump github.com/polyfloyd/go-errorlint from 1.0.2 to 1.0.3 (#3209)
	|	* ac95c85f build(deps): bump github.com/polyfloyd/go-errorlint from 1.0.3 to 1.0.4 (#3226)
	|	* b5203c38 build(deps): bump github.com/polyfloyd/go-errorlint from 1.0.4 to 1.0.5 (#3254)
	|	* 4189d1cc build(deps): bump github.com/sashamelentyev/usestdlibvars from 1.13.0 to 1.14.0 (#3147)
	|	* 70d595e9 build(deps): bump github.com/sashamelentyev/usestdlibvars from 1.14.0 to 1.17.1 (#3188)
	|	* 1f155b7e build(deps): bump github.com/sashamelentyev/usestdlibvars from 1.17.1 to 1.19.0 (#3206)
	|	* d1dc9ae4 build(deps): bump github.com/sashamelentyev/usestdlibvars from 1.19.0 to 1.19.1 (#3242)
	|	* e3aa30f3 build(deps): bump github.com/sashamelentyev/usestdlibvars from 1.19.1 to 1.20.0 (#3255)
	|	* 24f86dfd build(deps): bump github.com/shirou/gopsutil/v3 from 3.22.7 to 3.22.8 (#3187)
	|	* 704109c6 build(deps): bump github.com/shirou/gopsutil/v3 from 3.22.8 to 3.22.9 (#3267)
	|	* 794f00c0 build(deps): bump github.com/spf13/viper from 1.12.0 to 1.13.0 (#3205)
	|	* 942e7e51 build(deps): bump github.com/sylvia7788/contextcheck from 1.0.6 to 1.0.8 (#3148)
	|	* ed47d7bf build(deps): bump github.com/sylvia7788/contextcheck from 1.0.8 to 1.0.9 (#3189)
	|	* 2019f766 build(deps): bump mvdan.cc/gofumpt from 0.3.1 to 0.4.0 (#3256)
	|	* 0d33a5ba cli: remove reference to old service (#3173)
	|	* 213fb565 contextcheck: change owner (#3198)
	|	* 8a3b754c exhaustive: add missing config (#3212)
	|	* febe5fdb feat: add linter dupword (#3192)
	|	* 281e1847 feat: add testableexamples linter (#3170)
	|	* 3a2ad908 feat: rename logrlint to loggercheck (#3144)
	|	* aba80c7f feat: update gofmt and goimports and add option "rewrite-rules" (#3174)
	|	* 091d2f43 interfacebloat: fix configuration loading (#3194)
	|	* 05c3af1a paralleltest: add tests of the ignore-missing option (#3233)
	|	* b1cec475 wsl: support all configs and update docs (#3202)
	|	
	|	
	|	
	|	
	|	##Report:
	|	
	|		Source:
	|			✔ [default] Get latest golangci-lint version(githubrelease)
	|	
	|	
	|		Condition:
	|			✔ [default] Test golangci-lint is used in workflow go.yaml(yaml)
	|	
	|		Target:
	|			✔ [default] Update Golangci-lint version to v1.50.0(yaml)
	|	
	|	
	|	
	|	
	|	=====
	|	

=============================

```
</details>


```shell
cp <to_package_directory>
go test
```

## Additional Information

### Tradeoff

While the initial intend of `--push=false` was to disable `git push` operation, I am evolving the concept to all actions which may have side effect in mid-long term as we add more "action" kind.

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
