### PR TITLE
Only git reset operation after a git clone

### DIFF
--- a/pkg/plugins/scms/git/main.go
+++ b/pkg/plugins/scms/git/main.go
@@ -72,7 +72,7 @@ func New(s Spec) (*Git, error) {
 func (gs *Spec) Merge(child interface{}) error {
 	childGHSpec, ok := child.(Spec)
 	if !ok {
-		return fmt.Errorf("unable to merge GitHub spec with unknown object type.")
+		return fmt.Errorf("unable to merge GitHub spec with unknown object type")
 	}
 
 	if childGHSpec.Branch != "" {

--- a/pkg/plugins/scms/git/scm.go
+++ b/pkg/plugins/scms/git/scm.go
@@ -22,7 +22,9 @@ func (g *Git) Checkout() error {
 		g.spec.Password,
 		g.spec.Branch,
 		g.remoteBranch,
-		g.GetDirectory())
+		g.GetDirectory(),
+		false)
+
 	if err != nil {
 		return err
 	}
@@ -58,7 +60,14 @@ func (g *Git) Clone() (string, error) {
 	}
 
 	if len(g.remoteBranch) > 0 && len(g.GetDirectory()) > 0 {
-		err = g.Checkout()
+		err := g.nativeGitHandler.Checkout(
+			g.spec.Username,
+			g.spec.Password,
+			g.spec.Branch,
+			g.remoteBranch,
+			g.GetDirectory(),
+			true)
+
 		if err != nil {
 			logrus.Errorf("err - %s", err)
 			return "", err

--- a/pkg/plugins/scms/gitea/scm.go
+++ b/pkg/plugins/scms/gitea/scm.go
@@ -36,7 +36,13 @@ func (g *Gitea) Clone() (string, error) {
 	}
 
 	if len(g.HeadBranch) > 0 && len(g.GetDirectory()) > 0 {
-		err = g.nativeGitHandler.Checkout(g.Spec.Username, g.Spec.Token, g.Spec.Branch, g.HeadBranch, g.GetDirectory())
+		err = g.nativeGitHandler.Checkout(
+			g.Spec.Username,
+			g.Spec.Token,
+			g.Spec.Branch,
+			g.HeadBranch,
+			g.GetDirectory(),
+			true)
 	}
 
 	if err != nil {
@@ -64,7 +70,13 @@ func (g *Gitea) Commit(message string) error {
 
 // Checkout create and then uses a temporary git branch.
 func (g *Gitea) Checkout() error {
-	err := g.nativeGitHandler.Checkout(g.Spec.Username, g.Spec.Token, g.Spec.Branch, g.HeadBranch, g.Spec.Directory)
+	err := g.nativeGitHandler.Checkout(
+		g.Spec.Username,
+		g.Spec.Token,
+		g.Spec.Branch,
+		g.HeadBranch,
+		g.Spec.Directory,
+		false)
 	if err != nil {
 		return err
 	}

--- a/pkg/plugins/scms/github/scm.go
+++ b/pkg/plugins/scms/github/scm.go
@@ -37,7 +37,13 @@ func (g *Github) Clone() (string, error) {
 	}
 
 	if len(g.HeadBranch) > 0 && len(g.GetDirectory()) > 0 {
-		err = g.nativeGitHandler.Checkout(g.Spec.Username, g.Spec.Token, g.Spec.Branch, g.HeadBranch, g.GetDirectory())
+		err = g.nativeGitHandler.Checkout(
+			g.Spec.Username,
+			g.Spec.Token,
+			g.Spec.Branch,
+			g.HeadBranch,
+			g.GetDirectory(),
+			true)
 	}
 
 	if err != nil {
@@ -65,7 +71,13 @@ func (g *Github) Commit(message string) error {
 
 // Checkout create and then uses a temporary git branch.
 func (g *Github) Checkout() error {
-	err := g.nativeGitHandler.Checkout(g.Spec.Username, g.Spec.Token, g.Spec.Branch, g.HeadBranch, g.Spec.Directory)
+	err := g.nativeGitHandler.Checkout(
+		g.Spec.Username,
+		g.Spec.Token,
+		g.Spec.Branch,
+		g.HeadBranch,
+		g.Spec.Directory,
+		false)
 	if err != nil {
 		return err
 	}

--- a/pkg/plugins/utils/gitgeneric/main.go
+++ b/pkg/plugins/utils/gitgeneric/main.go
@@ -154,6 +154,18 @@ func (g GoGit) Checkout(username, password, branch, remoteBranch, workingDir str
 		return err
 	}
 
+	// Retrieve local branch
+	head, err := r.Head()
+	if err != nil {
+		return err
+	}
+
+	if head.Name().IsBranch() {
+		if head.Name().Short() == branch {
+			return nil
+		}
+	}
+
 	b := bytes.Buffer{}
 
 	auth := transportHttp.BasicAuth{

--- a/pkg/plugins/utils/gitgeneric/main.go
+++ b/pkg/plugins/utils/gitgeneric/main.go
@@ -21,7 +21,7 @@ import (
 
 type GitHandler interface {
 	Add(files []string, workingDir string) error
-	Checkout(username, password, branch, remoteBranch, workingDir string) error
+	Checkout(username, password, branch, remoteBranch, workingDir string, forceReset bool) error
 	Clone(username, password, URL, workingDir string) error
 	Commit(user, email, message, workingDir string, signingKey string, passprase string) error
 	GetChangedFiles(workingDir string) ([]string, error)
@@ -134,7 +134,7 @@ func (g GoGit) Add(files []string, workingDir string) error {
 }
 
 // Checkout create and then uses a temporary git branch.
-func (g GoGit) Checkout(username, password, branch, remoteBranch, workingDir string) error {
+func (g GoGit) Checkout(username, password, branch, remoteBranch, workingDir string, forceReset bool) error {
 
 	logrus.Debugf("stage: git-checkout\n\n")
 
@@ -263,14 +263,16 @@ func (g GoGit) Checkout(username, password, branch, remoteBranch, workingDir str
 			return err
 		}
 
-		err = w.Reset(&git.ResetOptions{
-			Commit: remoteRef.Hash(),
-			Mode:   git.HardReset,
-		})
+		if forceReset {
+			err = w.Reset(&git.ResetOptions{
+				Commit: remoteRef.Hash(),
+				Mode:   git.HardReset,
+			})
 
-		if err != nil {
-			logrus.Debugln(err)
-			return err
+			if err != nil {
+				logrus.Debugln(err)
+				return err
+			}
 		}
 
 		err = w.Checkout(&git.CheckoutOptions{


### PR DESCRIPTION
Fix #1133 

<!-- Describe the changes introduced by this pull request -->
Only execute git reset operation after a git clone and not anymore after each git checkout operation

## Test

To test this pull request, you can run the following commands:

```shell
cp <to_package_directory>
go test
```

## Additional Information

### Tradeoff

I hesitated to totally remove the git reset operation but decided to keep at the beginning of a pipeline run as an intermediary step.
This reduce the risk of working from a "none" clean directory and we can still disable this behavior in the future once we have the local scm fully implemented  

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
