### PR TITLE
fix yaml resource source filepath

### DIFF
--- a/e2e/updatecli.d/success.d/yaml/duplicate.yaml
+++ b/e2e/updatecli.d/success.d/yaml/duplicate.yaml
@@ -1,31 +1,25 @@
-name: Test YAML resource
-
-scms:
-  default:
-    kind: git
-    spec:
-      url: https://github.com/updatecli/updatecli.git
+name: Test duplicated YAML resource
 
 sources:
   scenario1:
     name: Basic yaml source
     kind: yaml
     spec:
-      file: e2e/updatecli.d/success.d/yaml.yaml
+      file: e2e/updatecli.d/success.d/yaml/noscm.yaml
       key: sources.scenario1.kind
 
   scenario2:
     name: Basic yaml source
     kind: yaml
     spec:
-      file: file://e2e/updatecli.d/success.d/yaml.yaml
+      file: file://e2e/updatecli.d/success.d/yaml/noscm.yaml
       key: sources.scenario1.kind
 
   scenario21:
     name: Basic yaml source
     kind: yaml
     spec:
-      file: file://e2e/updatecli.d/success.d/yaml.yaml
+      file: file://e2e/updatecli.d/success.d/yaml/noscm.yaml
       key: sources.scenario1.kind
 
   scenario3:
@@ -38,7 +32,6 @@ sources:
   scenario31:
     name: Test URL scheme
     kind: yaml
-    scmid: default
     spec:
       file: https://raw.githubusercontent.com/updatecli/updatecli/main/e2e/venom.d/test_diff.yaml
       key: name
@@ -50,8 +43,8 @@ conditions:
     disablesourceinput: true
     spec:
       files:
-      - e2e/updatecli.d/success.d/yaml.yaml
-      - e2e/updatecli.d/success.d/yaml-duplicate.yaml
+      - e2e/updatecli.d/success.d/yaml/noscm.yaml
+      - e2e/updatecli.d/success.d/yaml/duplicate.yaml
       key: sources.scenario1.kind
       value: yaml
 
@@ -61,8 +54,8 @@ conditions:
     disablesourceinput: true
     spec:
       files:
-      - file://e2e/updatecli.d/success.d/yaml.yaml
-      - file://e2e/updatecli.d/success.d/yaml-duplicate.yaml
+      - file://e2e/updatecli.d/success.d/yaml/noscm.yaml
+      - file://e2e/updatecli.d/success.d/yaml/duplicate.yaml
       key: sources.scenario1.kind
       value: yaml
 
@@ -72,8 +65,8 @@ conditions:
     disablesourceinput: true
     spec:
       files:
-      - https://raw.githubusercontent.com/updatecli/updatecli/main/e2e/updatecli.d/success.d/yaml.yaml
-      - https://raw.githubusercontent.com/updatecli/updatecli/main/e2e/updatecli.d/success.d/yaml-duplicate.yaml
+      - https://raw.githubusercontent.com/updatecli/updatecli/main/e2e/updatecli.d/success.d/yaml/noscm.yaml
+      - https://raw.githubusercontent.com/updatecli/updatecli/main/e2e/updatecli.d/success.d/yaml/duplicate.yaml
       key: sources.scenario1.kind
       value: yaml
 
@@ -81,10 +74,9 @@ targets:
   multiples:
     name: Update files content
     kind: yaml
-    scmid: default
     sourceid: scenario1
     spec:
       files:
-      - e2e/updatecli.d/success.d/yaml.yaml
-      - e2e/updatecli.d/success.d/yaml-duplicate.yaml
+      - e2e/updatecli.d/success.d/yaml/noscm.yaml
+      - e2e/updatecli.d/success.d/yaml/duplicate.yaml
       key: scms.default.kind

--- a/e2e/updatecli.d/success.d/yaml/noscm.yaml
+++ b/e2e/updatecli.d/success.d/yaml/noscm.yaml
@@ -1,31 +1,25 @@
-name: Test YAML resource
-
-scms:
-  default:
-    kind: git
-    spec:
-      url: https://github.com/updatecli/updatecli.git
+name: Test YAML resource without scm
 
 sources:
   scenario1:
     name: Basic yaml source
     kind: yaml
     spec:
-      file: e2e/updatecli.d/success.d/yaml.yaml
+      file: e2e/updatecli.d/success.d/yaml/noscm.yaml
       key: sources.scenario1.kind
 
   scenario2:
     name: Basic yaml source
     kind: yaml
     spec:
-      file: file://e2e/updatecli.d/success.d/yaml.yaml
+      file: file://e2e/updatecli.d/success.d/yaml/noscm.yaml
       key: sources.scenario1.kind
 
   scenario21:
     name: Basic yaml source
     kind: yaml
     spec:
-      file: file://e2e/updatecli.d/success.d/yaml.yaml
+      file: file://e2e/updatecli.d/success.d/yaml/noscm.yaml
       key: sources.scenario1.kind
 
   scenario3:
@@ -38,7 +32,6 @@ sources:
   scenario31:
     name: Test URL scheme
     kind: yaml
-    scmid: default
     spec:
       file: https://raw.githubusercontent.com/updatecli/updatecli/main/e2e/venom.d/test_diff.yaml
       key: name
@@ -50,8 +43,8 @@ conditions:
     disablesourceinput: true
     spec:
       files:
-      - e2e/updatecli.d/success.d/yaml.yaml
-      - e2e/updatecli.d/success.d/yaml-duplicate.yaml
+      - e2e/updatecli.d/success.d/yaml/noscm.yaml
+      - e2e/updatecli.d/success.d/yaml/duplicate.yaml
       key: sources.scenario1.kind
       value: yaml
 
@@ -61,8 +54,8 @@ conditions:
     disablesourceinput: true
     spec:
       files:
-      - file://e2e/updatecli.d/success.d/yaml.yaml
-      - file://e2e/updatecli.d/success.d/yaml-duplicate.yaml
+      - file://e2e/updatecli.d/success.d/yaml/noscm.yaml
+      - file://e2e/updatecli.d/success.d/yaml/duplicate.yaml
       key: sources.scenario1.kind
       value: yaml
 
@@ -72,8 +65,8 @@ conditions:
     disablesourceinput: true
     spec:
       files:
-      - https://raw.githubusercontent.com/updatecli/updatecli/main/e2e/updatecli.d/success.d/yaml.yaml
-      - https://raw.githubusercontent.com/updatecli/updatecli/main/e2e/updatecli.d/success.d/yaml-duplicate.yaml
+      - https://raw.githubusercontent.com/updatecli/updatecli/main/e2e/updatecli.d/success.d/yaml/noscm.yaml
+      - https://raw.githubusercontent.com/updatecli/updatecli/main/e2e/updatecli.d/success.d/yaml/duplicate.yaml
       key: sources.scenario1.kind
       value: yaml
 
@@ -81,10 +74,9 @@ targets:
   multiples:
     name: Update files content
     kind: yaml
-    scmid: default
     sourceid: scenario1
     spec:
       files:
-      - e2e/updatecli.d/success.d/yaml.yaml
-      - e2e/updatecli.d/success.d/yaml-duplicate.yaml
+      - e2e/updatecli.d/success.d/yaml/noscm.yaml
+      - e2e/updatecli.d/success.d/yaml/duplicate.yaml
       key: scms.default.kind

--- a/e2e/updatecli.d/success.d/yaml/scm.yaml
+++ b/e2e/updatecli.d/success.d/yaml/scm.yaml
@@ -1,0 +1,65 @@
+name: Test YAML resource with scm
+
+scms:
+  default:
+    kind: git
+    spec:
+      url: https://github.com/updatecli-test/kwctl.git
+
+sources:
+  scenario1:
+    name: Basic yaml source
+    scmid: default
+    kind: yaml
+    spec:
+      file: .clomonitor.yml
+      key: exemptions[0].reason
+
+  scenario2:
+    name: Basic yaml source
+    scmid: default
+    kind: yaml
+    spec:
+      files:
+        - .clomonitor.yml
+      key: exemptions[0].reason
+
+conditions:
+  scenario1:
+    name: using file
+    kind: yaml
+    scmid: default
+    sourceid: scenario1
+    spec:
+      file: .clomonitor.yml
+      key: exemptions[0].reason
+
+  scenario2:
+    name: using files
+    kind: yaml
+    scmid: default
+    sourceid: scenario1
+    spec:
+      files:
+      - .clomonitor.yml
+      key: exemptions[0].reason
+
+targets:
+  scenario1:
+    name: using file
+    kind: yaml
+    scmid: default
+    sourceid: scenario1
+    spec:
+      file: .clomonitor.yml
+      key: exemptions[0].reason
+
+  scenario2:
+    name: using files
+    kind: yaml
+    scmid: default
+    sourceid: scenario1
+    spec:
+      files:
+      - .clomonitor.yml
+      key: exemptions[0].reason

--- a/pkg/plugins/resources/yaml/main.go
+++ b/pkg/plugins/resources/yaml/main.go
@@ -115,7 +115,7 @@ func (y *Yaml) Read() error {
 				return err
 			}
 		} else {
-			return fmt.Errorf("%s The specified file %q does not exist.\n", result.FAILURE, filePath)
+			return fmt.Errorf("%s The specified file %q does not exist", result.FAILURE, filePath)
 		}
 	}
 	return nil

--- a/pkg/plugins/resources/yaml/source.go
+++ b/pkg/plugins/resources/yaml/source.go
@@ -1,7 +1,9 @@
 package yaml
 
 import (
+	"errors"
 	"fmt"
+	"os"
 
 	"github.com/sirupsen/logrus"
 	"github.com/updatecli/updatecli/pkg/core/result"
@@ -15,8 +17,16 @@ func (y *Yaml) Source(workingDir string) (string, error) {
 	var fileContent string
 	var filePath string
 
+	// By the default workingdir is set to the current working directory
+	// it would be better to have it empty by default but it must be changed in the
+	// souce core codebase.
+	currentWorkingDirectory, err := os.Getwd()
+	if err != nil {
+		return "", errors.New("fail getting current working directory")
+	}
+
 	if len(y.files) > 1 {
-		validationError := fmt.Errorf("Validation error in sources of type 'yaml': the attributes `spec.files` can't contain more than one element for conditions")
+		validationError := fmt.Errorf("validation error in sources of type 'yaml': the attributes `spec.files` can't contain more than one element for conditions")
 		logrus.Errorf(validationError.Error())
 		return "", validationError
 	}
@@ -25,29 +35,41 @@ func (y *Yaml) Source(workingDir string) (string, error) {
 		logrus.Warnf("Key 'Value' is not used by source YAML")
 	}
 
-	if err := y.Read(); err != nil {
-		return "", err
-	}
-
+	var errs []error
 	// loop over the only file
 	for theFilePath := range y.files {
 		fileContent = y.files[theFilePath]
 		filePath = theFilePath
 
-		// Merge File path with current workingDir, unless File is an HTTP URL
-		if workingDir != filePath {
+		// Ideally currentWorkingDirectory should be empty
+		if workingDir != currentWorkingDirectory {
+			logrus.Debugf("current working directory set to %q", workingDir)
 			filePath = joinPathWithWorkingDirectoryPath(filePath, workingDir)
 		}
 
 		// Test at runtime if a file exist
 		if !y.contentRetriever.FileExists(filePath) {
-			return "", fmt.Errorf("the yaml file %q does not exist", filePath)
+			errs = append(errs, fmt.Errorf("the yaml file %q does not exist", filePath))
+			continue
 		}
+
+		y.files[filePath], err = y.contentRetriever.ReadAll(filePath)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("fail reading file %q, skipping", filePath))
+			continue
+		}
+	}
+
+	if len(errs) > 0 {
+		for i := range errs {
+			logrus.Errorf("\t * %s\n", errs[i])
+		}
+		return "", fmt.Errorf("fail reading yaml files (%d/%d)", len(errs), len(y.files))
 	}
 
 	var out yaml.Node
 
-	err := yaml.Unmarshal([]byte(fileContent), &out)
+	err = yaml.Unmarshal([]byte(fileContent), &out)
 
 	if err != nil {
 		return "", fmt.Errorf("cannot unmarshal content of file %s: %v", filePath, err)


### PR DESCRIPTION
Fix #XXX

While automating a file update, I spot a regression where the yaml resource wouldn't use the correct filepath when used with scm.

## Test

I updated the e2e tests to catch this issue but it's worth mentioning they will only pass once the current pullrequest is merged on the main branch

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

* A source pipeline shouldn't set by default the current working directory. It's very confusing in resource plugins. https://github.com/updatecli/updatecli/blob/427cb7795834ddd3684d8061df81c6035de0906b/pkg/core/pipeline/source/main.go#L52 I would need to investigate the initial intend and then review all plugins as I first noticed this behavior in the cargo package plugin and now in the yaml