### PR TITLE
remove scms mention from some of the yaml e2e tests

### DIFF
--- a/e2e/updatecli.d/success.d/yaml/duplicate.yaml
+++ b/e2e/updatecli.d/success.d/yaml/duplicate.yaml
@@ -79,4 +79,6 @@ targets:
       files:
       - e2e/updatecli.d/success.d/yaml/noscm.yaml
       - e2e/updatecli.d/success.d/yaml/duplicate.yaml
-      key: scms.default.kind
+      key: sources.scenario1.kind
+    transformers:
+      - addsuffix: -beta

--- a/e2e/updatecli.d/success.d/yaml/noscm.yaml
+++ b/e2e/updatecli.d/success.d/yaml/noscm.yaml
@@ -75,8 +75,11 @@ targets:
     name: Update files content
     kind: yaml
     sourceid: scenario1
+    transformers:
+      - addsuffix: -beta
     spec:
       files:
       - e2e/updatecli.d/success.d/yaml/noscm.yaml
       - e2e/updatecli.d/success.d/yaml/duplicate.yaml
-      key: scms.default.kind
+      key: sources.scenario1.kind
+


### PR DESCRIPTION
Fix end to end tests

In https://github.com/updatecli/updatecli/pull/1187, I refactored a bit the end to end tests to focus either on scm and none scms situation. But because the tests depended on the main branch, I merged the change without waiting for green CI and I let mistake going through

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
go build -o bin/updatecli .
./bin/updatecli diff --config e2e/updatecli.d/success.d/yaml/
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
