### PR TITLE
add more information for disableinputsource

### DIFF
--- a/pkg/core/pipeline/target/main.go
+++ b/pkg/core/pipeline/target/main.go
@@ -39,7 +39,6 @@ type Config struct {
 	ReportBody string `yaml:",omitempty"`
 	// ! Deprecated - please use all lowercase `sourceid`
 	DeprecatedSourceID string `yaml:"sourceID,omitempty" jsonschema:"-"`
-	// disablesourceinput disables the mechanism to retrieve a default value from a source. For example, if true, 
 	// disablesourceinput disables the mechanism to retrieve a default value from a source. For example, if true, source information like changelog will not be accessible for a github/pullrequest action.
 	DisableSourceInput bool `yaml:",omitempty"`
 	// sourceid specifies where retrieving the default value

--- a/pkg/core/pipeline/target/main.go
+++ b/pkg/core/pipeline/target/main.go
@@ -39,11 +39,11 @@ type Config struct {
 	ReportBody string `yaml:",omitempty"`
 	// ! Deprecated - please use all lowercase `sourceid`
 	DeprecatedSourceID string `yaml:"sourceID,omitempty" jsonschema:"-"`
-	// disablesourceinput disables the mechanism to retrieve a default value from a source.
+	// disablesourceinput disables the mechanism to retrieve a default value from a source. For example, if true, 
+	// source information like changelog will not be accessible for a github/pullrequest action.
 	DisableSourceInput bool `yaml:",omitempty"`
 	// sourceid specifies where retrieving the default value
 	SourceID string `yaml:",omitempty"`
-	// disablesourceinput
 }
 
 // Check verifies if mandatory Targets parameters are provided and return false if not.

--- a/pkg/core/pipeline/target/main.go
+++ b/pkg/core/pipeline/target/main.go
@@ -40,7 +40,7 @@ type Config struct {
 	// ! Deprecated - please use all lowercase `sourceid`
 	DeprecatedSourceID string `yaml:"sourceID,omitempty" jsonschema:"-"`
 	// disablesourceinput disables the mechanism to retrieve a default value from a source. For example, if true, 
-	// source information like changelog will not be accessible for a github/pullrequest action.
+	// disablesourceinput disables the mechanism to retrieve a default value from a source. For example, if true, source information like changelog will not be accessible for a github/pullrequest action.
 	DisableSourceInput bool `yaml:",omitempty"`
 	// sourceid specifies where retrieving the default value
 	SourceID string `yaml:",omitempty"`


### PR DESCRIPTION
Adding a little more information so users understand the impact of not being able to retrieve a source value in the target. 

relates to #1190 
