### PR TITLE
Correctly handle XML file path

### DIFF
--- a/pkg/plugins/resources/xml/main.go
+++ b/pkg/plugins/resources/xml/main.go
@@ -46,8 +46,8 @@ func New(spec interface{}) (*XML, error) {
 	return &x, err
 }
 
-func (x *XML) Read() error {
-	textContent, err := x.contentRetriever.ReadAll(x.spec.File)
+func (x *XML) Read(filename string) error {
+	textContent, err := x.contentRetriever.ReadAll(filename)
 	if err != nil {
 		return err
 	}

--- a/pkg/plugins/resources/xml/target_test.go
+++ b/pkg/plugins/resources/xml/target_test.go
@@ -52,7 +52,7 @@ func TestTarget(t *testing.T) {
 				Value: "Alice",
 			},
 			expectedResult:   false,
-			expectedErrorMsg: errors.New("the XML file \"testdata/doNotExist.xml\" does not exist"),
+			expectedErrorMsg: errors.New("file \"testdata/doNotExist.xml\" does not exist"),
 			wantErr:          true,
 		},
 		{


### PR DESCRIPTION
This pullrequest correctly handle XML file path according the different scenarios, relative path, path from scm, etc.

Fix #1210 

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
go build -o bin/updatecli . 
./bin/updatecli apply --config e2e/updatecli.d/success.d/xml.yaml --clean=true --push=false
cd pkg/plugins/resources/xml
go test .
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

* The source function received a workdir set to the current directory by default. This means we need additional code for each plugin to check the value of that workdir param. This behavior is confusing and should be handled in the "core" codebase 