### PR TITLE
Add Gitlab support

### DIFF
--- a/e2e/updatecli.d/success.d/gitlab/branch.yaml
+++ b/e2e/updatecli.d/success.d/gitlab/branch.yaml
@@ -1,0 +1,25 @@
+name: "Test Gitlab branch"
+
+sources:
+  default:
+    kind: "gitlab/branch"
+    spec:
+      owner: "olblak"
+      repository: "updatecli"
+      branch: main
+
+conditions:
+  default:
+    kind: "gitlab/branch"
+    disablesourceinput: true
+    spec:
+      owner: "olblak"
+      repository: "updatecli"
+      branch: "main"
+
+  sourcedefault:
+    kind: "gitlab/branch"
+    sourceid: "default"
+    spec:
+      owner: "olblak"
+      repository: "updatecli"

--- a/e2e/updatecli.d/success.d/gitlab/release.yaml
+++ b/e2e/updatecli.d/success.d/gitlab/release.yaml
@@ -1,27 +1,27 @@
-name: Test Gitea release
+name: Test Gitlab release
 
 sources:
   default:
-    kind: gitlab/release  
+    kind: gitlab/release
     spec:
       owner: "olblak"
       repository: "updatecli"
       versionfilter:
         kind: semver
         pattern: "~0"
-        
+
 conditions:
   default:
-    kind: gitlab/release  
+    kind: gitlab/release
     spec:
-      owner: "updatecli"
-      repository: "updatecli-action"
-      tag: "v2.15.0"
+      owner: "olblak"
+      repository: "updatecli"
+      tag: "v0.46.2"
   sourcedefault:
-    kind: gitea/release  
+    kind: gitlab/release
     sourceid: default
     spec:
-      url: "codeberg.org"
-      owner: "updatecli"
-      repository: "updatecli-action"
+      url: "gitlab.com"
+      owner: "olblak"
+      repository: "updatecli"
 

--- a/e2e/updatecli.d/success.d/gitlab/release.yaml
+++ b/e2e/updatecli.d/success.d/gitlab/release.yaml
@@ -1,0 +1,27 @@
+name: Test Gitea release
+
+sources:
+  default:
+    kind: gitlab/release  
+    spec:
+      owner: "olblak"
+      repository: "updatecli"
+      versionfilter:
+        kind: semver
+        pattern: "~0"
+        
+conditions:
+  default:
+    kind: gitlab/release  
+    spec:
+      owner: "updatecli"
+      repository: "updatecli-action"
+      tag: "v2.15.0"
+  sourcedefault:
+    kind: gitea/release  
+    sourceid: default
+    spec:
+      url: "codeberg.org"
+      owner: "updatecli"
+      repository: "updatecli-action"
+

--- a/e2e/updatecli.d/success.d/gitlab/scm.yaml
+++ b/e2e/updatecli.d/success.d/gitlab/scm.yaml
@@ -52,3 +52,10 @@ targets:
     scmid: gitlab
     spec:
       file: README.adoc
+
+actions:
+  default:
+    title: Bump xxx
+    kind: gitlab/mergerequest
+    scmid: gitlab
+    spec:

--- a/e2e/updatecli.d/success.d/gitlab/scm.yaml
+++ b/e2e/updatecli.d/success.d/gitlab/scm.yaml
@@ -1,0 +1,54 @@
+name: Test Gitea scm
+
+scms:
+  gitlab:
+    kind: gitlab
+    spec:
+      owner: "olblak"
+      repository: "updatecli"
+      branch: main
+
+sources:
+  license:
+    name: Retrieve license file content
+    kind: file
+    scmid: gitlab
+    spec:
+      file: LICENSE
+  readme:
+    name: Retrieve readme file content
+    kind: file
+    scmid: gitlab
+    spec:
+      file: README.adoc
+
+conditions:
+  license:
+    name: Retrieve license file content
+    kind: file
+    scmid: gitlab
+    sourceid: license
+    spec:
+      file: LICENSE
+  readme:
+    name: Retrieve license file content
+    kind: file
+    sourceid: readme
+    scmid: gitlab
+    spec:
+      file: README.adoc
+targets:
+  license:
+    name: Update license file content
+    kind: file
+    scmid: gitlab
+    sourceid: license
+    spec:
+      file: LICENSE
+  readme:
+    name: Update README license file content
+    kind: file
+    sourceid: readme
+    scmid: gitlab
+    spec:
+      file: README.adoc

--- a/e2e/updatecli.d/success.d/gitlab/tag.yaml
+++ b/e2e/updatecli.d/success.d/gitlab/tag.yaml
@@ -1,0 +1,50 @@
+name: "Test Gitea tag"
+
+sources:
+  default:
+    kind: "gitea/tag"
+    spec:
+      url: "codeberg.org"
+      owner: "updatecli"
+      repository: "updatecli-action"
+      versionfilter:
+        kind: "semver"
+        pattern: "~2"
+  latest:
+    kind: "gitea/tag"
+    spec:
+      url: "codeberg.org"
+      owner: "updatecli"
+      repository: "updatecli-action"
+
+  mirror:
+    kind: "gitea/tag"
+    spec:
+      url: "codeberg.org"
+      owner: "updatecli"
+      repository: "updatecli-action"
+        
+conditions:
+  default:
+    kind: "gitea/tag"
+    disablesourceinput: true
+    spec:
+      url: "codeberg.org"
+      owner: "updatecli"
+      repository: "updatecli-action"
+      tag: "v2.15.0"
+    failwhen: true
+  sourcedefault:
+    kind: "gitea/tag"
+    sourceid: "default"
+    spec:
+      url: "codeberg.org"
+      owner: "updatecli"
+      repository: "updatecli-action"
+  latest:
+    kind: "gitea/tag"
+    sourceid: "latest"
+    spec:
+      url: "codeberg.org"
+      owner: "updatecli"
+      repository: "updatecli-action"

--- a/e2e/updatecli.d/success.d/gitlab/tag.yaml
+++ b/e2e/updatecli.d/success.d/gitlab/tag.yaml
@@ -2,49 +2,42 @@ name: "Test Gitea tag"
 
 sources:
   default:
-    kind: "gitea/tag"
+    kind: "gitlab/tag"
     spec:
-      url: "codeberg.org"
-      owner: "updatecli"
-      repository: "updatecli-action"
+      owner: "olblak"
+      repository: "updatecli"
       versionfilter:
         kind: "semver"
-        pattern: "~2"
+        pattern: "~0.46"
   latest:
-    kind: "gitea/tag"
+    kind: "gitlab/tag"
     spec:
-      url: "codeberg.org"
-      owner: "updatecli"
-      repository: "updatecli-action"
+      url: "gitlab.com"
+      owner: "olblak"
+      repository: "updatecli"
 
-  mirror:
-    kind: "gitea/tag"
-    spec:
-      url: "codeberg.org"
-      owner: "updatecli"
-      repository: "updatecli-action"
-        
 conditions:
   default:
-    kind: "gitea/tag"
+    name: Test that tag v0.1.11 do not exist
+    kind: "gitlab/tag"
     disablesourceinput: true
     spec:
-      url: "codeberg.org"
-      owner: "updatecli"
-      repository: "updatecli-action"
-      tag: "v2.15.0"
+      owner: "olblak"
+      repository: "updatecli"
+      tag: "v0.1.11"
     failwhen: true
   sourcedefault:
-    kind: "gitea/tag"
+    name: Test that tag retrieved from sourceid default exist
+    kind: "gitlab/tag"
     sourceid: "default"
     spec:
-      url: "codeberg.org"
-      owner: "updatecli"
-      repository: "updatecli-action"
+      owner: "olblak"
+      repository: "updatecli"
   latest:
-    kind: "gitea/tag"
+    name: Test that tag retrieved from sourceid latest exist
+    kind: "gitlab/tag"
     sourceid: "latest"
     spec:
-      url: "codeberg.org"
-      owner: "updatecli"
-      repository: "updatecli-action"
+      owner: "olblak"
+      repository: "updatecli"
+

--- a/pkg/core/pipeline/resource/main.go
+++ b/pkg/core/pipeline/resource/main.go
@@ -19,6 +19,9 @@ import (
 	giteaRelease "github.com/updatecli/updatecli/pkg/plugins/resources/gitea/release"
 	giteaTag "github.com/updatecli/updatecli/pkg/plugins/resources/gitea/tag"
 	"github.com/updatecli/updatecli/pkg/plugins/resources/githubrelease"
+	gitlabBranch "github.com/updatecli/updatecli/pkg/plugins/resources/gitlab/branch"
+	gitlabRelease "github.com/updatecli/updatecli/pkg/plugins/resources/gitlab/release"
+	gitlabTag "github.com/updatecli/updatecli/pkg/plugins/resources/gitlab/tag"
 	"github.com/updatecli/updatecli/pkg/plugins/resources/gittag"
 	"github.com/updatecli/updatecli/pkg/plugins/resources/helm"
 	"github.com/updatecli/updatecli/pkg/plugins/resources/jenkins"
@@ -84,6 +87,12 @@ func New(rs ResourceConfig) (resource Resource, err error) {
 		return giteaTag.New(rs.Spec)
 	case "gitea/release":
 		return giteaRelease.New(rs.Spec)
+	case "gitlab/branch":
+		return gitlabBranch.New(rs.Spec)
+	case "gitlab/tag":
+		return gitlabTag.New(rs.Spec)
+	case "gitlab/release":
+		return gitlabRelease.New(rs.Spec)
 	case "file":
 		return file.New(rs.Spec)
 	case "helmchart":
@@ -123,27 +132,30 @@ type Resource interface {
 func GetResourceMapping() map[string]interface{} {
 
 	return map[string]interface{}{
-		"aws/ami":       &awsami.Spec{},
-		"cargopackage":  &cargopackage.Spec{},
-		"csv":           &csv.Spec{},
-		"dockerdigest":  &dockerdigest.Spec{},
-		"dockerfile":    &dockerfile.Spec{},
-		"dockerimage":   &dockerimage.Spec{},
-		"file":          &file.Spec{},
-		"gittag":        &gittag.Spec{},
-		"gitbranch":     &gitbranch.Spec{},
-		"gitea/branch":  &giteaBranch.Spec{},
-		"gitea/release": &giteaRelease.Spec{},
-		"gitea/tag":     &giteaTag.Spec{},
-		"githubrelease": &githubrelease.Spec{},
-		"helmchart":     &helm.Spec{},
-		"jenkins":       &jenkins.Spec{},
-		"json":          &json.Spec{},
-		"maven":         &maven.Spec{},
-		"shell":         &shell.Spec{},
-		"toml":          &toml.Spec{},
-		"xml":           &xml.Spec{},
-		"yaml":          &yaml.Spec{},
-		"npm":           &npm.Spec{},
+		"aws/ami":        &awsami.Spec{},
+		"cargopackage":   &cargopackage.Spec{},
+		"csv":            &csv.Spec{},
+		"dockerdigest":   &dockerdigest.Spec{},
+		"dockerfile":     &dockerfile.Spec{},
+		"dockerimage":    &dockerimage.Spec{},
+		"file":           &file.Spec{},
+		"gittag":         &gittag.Spec{},
+		"gitbranch":      &gitbranch.Spec{},
+		"gitea/branch":   &giteaBranch.Spec{},
+		"gitea/release":  &giteaRelease.Spec{},
+		"gitea/tag":      &giteaTag.Spec{},
+		"gitlab/branch":  &gitlabBranch.Spec{},
+		"gitlab/release": &gitlabRelease.Spec{},
+		"gitlab/tag":     &gitlabTag.Spec{},
+		"githubrelease":  &githubrelease.Spec{},
+		"helmchart":      &helm.Spec{},
+		"jenkins":        &jenkins.Spec{},
+		"json":           &json.Spec{},
+		"maven":          &maven.Spec{},
+		"shell":          &shell.Spec{},
+		"toml":           &toml.Spec{},
+		"xml":            &xml.Spec{},
+		"yaml":           &yaml.Spec{},
+		"npm":            &npm.Spec{},
 	}
 }

--- a/pkg/core/pipeline/scm/config.go
+++ b/pkg/core/pipeline/scm/config.go
@@ -155,7 +155,7 @@ func (Config) JSONSchema() *jschema.Schema {
 		"git":    &git.Spec{},
 		"gitea":  &gitea.Spec{},
 		"github": &github.Spec{},
-		"gitlab":  &gitlab.Spec{},
+		"gitlab": &gitlab.Spec{},
 	}
 
 	return jsonschema.AppendOneOfToJsonSchema(configAlias{}, anyOfSpec)

--- a/pkg/core/pipeline/scm/config.go
+++ b/pkg/core/pipeline/scm/config.go
@@ -12,6 +12,7 @@ import (
 	"github.com/updatecli/updatecli/pkg/plugins/scms/git"
 	"github.com/updatecli/updatecli/pkg/plugins/scms/gitea"
 	"github.com/updatecli/updatecli/pkg/plugins/scms/github"
+	"github.com/updatecli/updatecli/pkg/plugins/scms/gitlab"
 	"github.com/updatecli/updatecli/pkg/plugins/utils/gitgeneric"
 )
 
@@ -152,8 +153,9 @@ func (Config) JSONSchema() *jschema.Schema {
 
 	anyOfSpec := map[string]interface{}{
 		"git":    &git.Spec{},
-		"github": &github.Spec{},
 		"gitea":  &gitea.Spec{},
+		"github": &github.Spec{},
+		"gitlab":  &gitlab.Spec{},
 	}
 
 	return jsonschema.AppendOneOfToJsonSchema(configAlias{}, anyOfSpec)

--- a/pkg/core/pipeline/scm/main.go
+++ b/pkg/core/pipeline/scm/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/updatecli/updatecli/pkg/plugins/scms/git"
 	"github.com/updatecli/updatecli/pkg/plugins/scms/gitea"
 	"github.com/updatecli/updatecli/pkg/plugins/scms/github"
+	"github.com/updatecli/updatecli/pkg/plugins/scms/gitlab"
 )
 
 type Scm struct {
@@ -61,6 +62,15 @@ func (s *Scm) GenerateSCM() error {
 	switch s.Config.Kind {
 	case "gitea":
 		g, err := gitea.New(s.Config.Spec, s.PipelineID)
+
+		if err != nil {
+			return err
+		}
+
+		s.Handler = g
+
+	case "gitlab":
+		g, err := gitlab.New(s.Config.Spec, s.PipelineID)
 
 		if err != nil {
 			return err

--- a/pkg/plugins/resources/gitlab/branch/changelog.go
+++ b/pkg/plugins/resources/gitlab/branch/changelog.go
@@ -1,0 +1,6 @@
+package branch
+
+// Changelog returns the changelog for this resource, or an empty string if not supported
+func (g *Gitlab) Changelog() string {
+	return ""
+}

--- a/pkg/plugins/resources/gitlab/branch/condition.go
+++ b/pkg/plugins/resources/gitlab/branch/condition.go
@@ -1,0 +1,45 @@
+package branch
+
+import (
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
+	"github.com/updatecli/updatecli/pkg/core/result"
+)
+
+func (g *Gitlab) Condition(source string) (bool, error) {
+	if len(g.spec.Branch) == 0 {
+		g.spec.Branch = source
+	}
+
+	branches, err := g.SearchBranches()
+
+	if len(g.spec.Branch) == 0 {
+		g.spec.Branch = source
+	}
+
+	if err != nil {
+		logrus.Error(err)
+		return false, err
+	}
+
+	if len(branches) == 0 {
+		logrus.Infof("%s No Gitlab branch found.", result.ATTENTION)
+		return false, nil
+	}
+
+	for _, branch := range branches {
+		if branch == g.spec.Branch {
+			logrus.Infof("%s Gitlab branch %q found", result.SUCCESS, branch)
+			return true, nil
+		}
+	}
+
+	logrus.Infof("%s No Gitlab branch found matching pattern %q", result.FAILURE, g.versionFilter.Pattern)
+	return false, nil
+}
+
+func (g *Gitlab) ConditionFromSCM(source string, scm scm.ScmHandler) (bool, error) {
+	return false, fmt.Errorf("Condition not supported for the plugin GitHub Release")
+}

--- a/pkg/plugins/resources/gitlab/branch/condition_test.go
+++ b/pkg/plugins/resources/gitlab/branch/condition_test.go
@@ -22,7 +22,7 @@ func TestCondition(t *testing.T) {
 		wantErr    bool
 	}{
 		{
-			name: "repository olblak/updatecli should not exist",
+			name: "repository olblak/updatecli-donotexist should not exist",
 			manifest: struct {
 				URL        string
 				Token      string
@@ -30,9 +30,9 @@ func TestCondition(t *testing.T) {
 				Repository string
 				Branch     string
 			}{
-				URL:        "codeberg.org",
+				URL:        "gitlab.com",
 				Token:      "",
-				Owner:      "updatecli",
+				Owner:      "olblak",
 				Repository: "updatecli-donotexist",
 				Branch:     "v2",
 			},
@@ -48,11 +48,29 @@ func TestCondition(t *testing.T) {
 				Repository string
 				Branch     string
 			}{
-				URL:        "codeberg.org",
+				URL:        "gitlab.com",
 				Token:      "",
-				Owner:      "updatecli",
-				Repository: "updatecli-action",
-				Branch:     "v1",
+				Owner:      "olblak",
+				Repository: "updatecli",
+				Branch:     "main",
+			},
+			wantResult: true,
+			wantErr:    false,
+		},
+		{
+			name: "repository olblak/updatecli should not have branch donotexist",
+			manifest: struct {
+				URL        string
+				Token      string
+				Owner      string
+				Repository string
+				Branch     string
+			}{
+				URL:        "gitlab.com",
+				Token:      "",
+				Owner:      "olblak",
+				Repository: "updatecli",
+				Branch:     "donotexist",
 			},
 			wantResult: true,
 			wantErr:    false,

--- a/pkg/plugins/resources/gitlab/branch/condition_test.go
+++ b/pkg/plugins/resources/gitlab/branch/condition_test.go
@@ -72,7 +72,7 @@ func TestCondition(t *testing.T) {
 				Repository: "updatecli",
 				Branch:     "donotexist",
 			},
-			wantResult: true,
+			wantResult: false,
 			wantErr:    false,
 		},
 	}

--- a/pkg/plugins/resources/gitlab/branch/condition_test.go
+++ b/pkg/plugins/resources/gitlab/branch/condition_test.go
@@ -1,0 +1,82 @@
+package branch
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCondition(t *testing.T) {
+
+	tests := []struct {
+		name     string
+		manifest struct {
+			URL        string
+			Token      string
+			Owner      string
+			Repository string
+			Branch     string
+		}
+		wantResult bool
+		wantErr    bool
+	}{
+		{
+			name: "repository olblak/updatecli should not exist",
+			manifest: struct {
+				URL        string
+				Token      string
+				Owner      string
+				Repository string
+				Branch     string
+			}{
+				URL:        "codeberg.org",
+				Token:      "",
+				Owner:      "updatecli",
+				Repository: "updatecli-donotexist",
+				Branch:     "v2",
+			},
+			wantResult: false,
+			wantErr:    true,
+		},
+		{
+			name: "repository olblak/updatecli-mirror should exist with branches",
+			manifest: struct {
+				URL        string
+				Token      string
+				Owner      string
+				Repository string
+				Branch     string
+			}{
+				URL:        "codeberg.org",
+				Token:      "",
+				Owner:      "updatecli",
+				Repository: "updatecli-action",
+				Branch:     "v1",
+			},
+			wantResult: true,
+			wantErr:    false,
+		},
+	}
+
+	for _, tt := range tests {
+
+		t.Run(tt.name, func(t *testing.T) {
+
+			g, gotErr := New(tt.manifest)
+			require.NoError(t, gotErr)
+
+			gotResult, gotErr := g.Condition("")
+
+			if tt.wantErr {
+				require.Error(t, gotErr)
+			} else {
+				require.NoError(t, gotErr)
+			}
+
+			assert.Equal(t, tt.wantResult, gotResult)
+
+		})
+
+	}
+}

--- a/pkg/plugins/resources/gitlab/branch/main.go
+++ b/pkg/plugins/resources/gitlab/branch/main.go
@@ -1,0 +1,161 @@
+package branch
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/drone/go-scm/scm"
+	"github.com/mitchellh/mapstructure"
+	"github.com/sirupsen/logrus"
+	"github.com/updatecli/updatecli/pkg/plugins/resources/gitlab/client"
+	"github.com/updatecli/updatecli/pkg/plugins/utils/version"
+)
+
+// Spec defines settings used to interact with Gitlab release
+type Spec struct {
+	client.Spec `yaml:",inline,omitempty"`
+	// [S][C] Owner specifies repository owner
+	Owner string `yaml:",omitempty" jsonschema:"required"`
+	// [S][C] Repository specifies the name of a repository for a specific owner
+	Repository string `yaml:",omitempty" jsonschema:"required"`
+	// [S] VersionFilter provides parameters to specify version pattern and its type like regex, semver, or just latest.
+	VersionFilter version.Filter `yaml:",omitempty"`
+	// [C] Branch specifies the branch name
+	Branch string `yaml:",omitempty"`
+}
+
+// Gitlab contains information to interact with Gitlab api
+type Gitlab struct {
+	// spec contains inputs coming from updatecli configuration
+	spec Spec
+	// client handle the api authentication
+	client        client.Client
+	HeadBranch    string
+	foundVersion  version.Version
+	versionFilter version.Filter
+}
+
+// New returns a new valid Gitlab object.
+func New(spec interface{}) (*Gitlab, error) {
+
+	var s Spec
+	var clientSpec client.Spec
+
+	// mapstructure.Decode cannot handle embedded fields
+	// hence we decode it in two steps
+	err := mapstructure.Decode(spec, &clientSpec)
+	if err != nil {
+		return &Gitlab{}, err
+	}
+
+	err = mapstructure.Decode(spec, &s)
+	if err != nil {
+		return &Gitlab{}, nil
+	}
+
+	err = clientSpec.Validate()
+	if err != nil {
+		return &Gitlab{}, err
+	}
+
+	err = clientSpec.Sanitize()
+	if err != nil {
+		return &Gitlab{}, err
+	}
+
+	s.Spec = clientSpec
+
+	err = s.Validate()
+
+	if err != nil {
+		return &Gitlab{}, err
+	}
+
+	c, err := client.New(clientSpec)
+
+	if err != nil {
+		return &Gitlab{}, err
+	}
+
+	newFilter, err := s.VersionFilter.Init()
+	if err != nil {
+		return &Gitlab{}, err
+	}
+	s.VersionFilter = newFilter
+
+	g := Gitlab{
+		spec:          s,
+		client:        c,
+		versionFilter: newFilter,
+	}
+
+	return &g, nil
+
+}
+
+// Retrieve Gitlab branches from a remote Gitlab repository
+func (g *Gitlab) SearchBranches() (tags []string, err error) {
+
+	// Timeout api query after 30sec
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	branches, resp, err := g.client.Git.ListBranches(
+		ctx,
+		strings.Join([]string{g.spec.Owner, g.spec.Repository}, "/"),
+		scm.ListOptions{
+			URL:  g.spec.URL,
+			Page: 1,
+			Size: 30,
+		},
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.Status > 400 {
+		logrus.Debugf("RC: %q\nBody:\n%s", resp.Status, resp.Body)
+	}
+
+	results := []string{}
+	for _, branch := range branches {
+		results = append(results, branch.Name)
+	}
+
+	return results, nil
+}
+
+func (s Spec) Validate() error {
+	gotError := false
+	missingParameters := []string{}
+
+	err := s.Spec.Validate()
+
+	if err != nil {
+		gotError = true
+	}
+
+	if len(s.Owner) == 0 {
+		gotError = true
+		missingParameters = append(missingParameters, "owner")
+	}
+
+	if len(s.Repository) == 0 {
+		gotError = true
+		missingParameters = append(missingParameters, "repository")
+	}
+
+	if len(missingParameters) > 0 {
+		logrus.Errorf("missing parameter(s) [%s]", strings.Join(missingParameters, ","))
+	}
+
+	if gotError {
+		return fmt.Errorf("wrong Gitlab configuration")
+	}
+
+	return nil
+}

--- a/pkg/plugins/resources/gitlab/branch/main.go
+++ b/pkg/plugins/resources/gitlab/branch/main.go
@@ -123,7 +123,6 @@ func (g *Gitlab) SearchBranches() (tags []string, err error) {
 		if page == 0 {
 			break
 		}
-
 	}
 
 	return results, nil

--- a/pkg/plugins/resources/gitlab/branch/main.go
+++ b/pkg/plugins/resources/gitlab/branch/main.go
@@ -55,16 +55,6 @@ func New(spec interface{}) (*Gitlab, error) {
 		return &Gitlab{}, nil
 	}
 
-	err = clientSpec.Validate()
-	if err != nil {
-		return &Gitlab{}, err
-	}
-
-	err = clientSpec.Sanitize()
-	if err != nil {
-		return &Gitlab{}, err
-	}
-
 	s.Spec = clientSpec
 
 	err = s.Validate()
@@ -132,12 +122,6 @@ func (g *Gitlab) SearchBranches() (tags []string, err error) {
 func (s Spec) Validate() error {
 	gotError := false
 	missingParameters := []string{}
-
-	err := s.Spec.Validate()
-
-	if err != nil {
-		gotError = true
-	}
 
 	if len(s.Owner) == 0 {
 		gotError = true

--- a/pkg/plugins/resources/gitlab/branch/main.go
+++ b/pkg/plugins/resources/gitlab/branch/main.go
@@ -93,27 +93,37 @@ func (g *Gitlab) SearchBranches() (tags []string, err error) {
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	branches, resp, err := g.client.Git.ListBranches(
-		ctx,
-		strings.Join([]string{g.spec.Owner, g.spec.Repository}, "/"),
-		scm.ListOptions{
-			URL:  g.spec.URL,
-			Page: 1,
-			Size: 30,
-		},
-	)
-
-	if err != nil {
-		return nil, err
-	}
-
-	if resp.Status > 400 {
-		logrus.Debugf("RC: %q\nBody:\n%s", resp.Status, resp.Body)
-	}
-
 	results := []string{}
-	for _, branch := range branches {
-		results = append(results, branch.Name)
+	page := 0
+	for {
+		branches, resp, err := g.client.Git.ListBranches(
+			ctx,
+			strings.Join([]string{g.spec.Owner, g.spec.Repository}, "/"),
+			scm.ListOptions{
+				URL:  g.client.BaseURL.Host,
+				Page: page,
+				Size: 30,
+			},
+		)
+
+		if err != nil {
+			return nil, err
+		}
+
+		page = resp.Page.Next
+
+		if resp.Status > 400 {
+			logrus.Debugf("RC: %q\nBody:\n%s", resp.Status, resp.Body)
+		}
+
+		for _, branch := range branches {
+			results = append(results, branch.Name)
+		}
+		// if the next page is 0 then it means we visited all pages
+		if page == 0 {
+			break
+		}
+
 	}
 
 	return results, nil

--- a/pkg/plugins/resources/gitlab/branch/source.go
+++ b/pkg/plugins/resources/gitlab/branch/source.go
@@ -1,0 +1,48 @@
+package branch
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+	"github.com/updatecli/updatecli/pkg/core/result"
+	"github.com/updatecli/updatecli/pkg/plugins/utils/version"
+)
+
+func (g *Gitlab) Source(workingDir string) (string, error) {
+	versions, err := g.SearchBranches()
+
+	if err != nil {
+		return "", err
+	}
+
+	if len(versions) == 0 {
+		logrus.Infof("%s No Gitlab branches found", result.FAILURE)
+		return "", errors.New("no result found")
+	}
+
+	g.foundVersion, err = g.spec.VersionFilter.Search(versions)
+
+	if err != nil {
+		switch err {
+		case version.ErrNoVersionFound:
+			logrus.Infof("%s No Gitlab branches found matching pattern %q", result.FAILURE, g.versionFilter.Pattern)
+			return "", errors.New("no result found")
+		default:
+			return "", err
+		}
+	}
+
+	value := g.foundVersion.GetVersion()
+
+	if len(value) == 0 {
+		logrus.Infof("%s No Gitlab branches found matching pattern %q", result.FAILURE, g.versionFilter.Pattern)
+		return "", errors.New("no result found")
+	} else if len(value) > 0 {
+		logrus.Infof("%s Gitlab branches %q found matching pattern %q", result.SUCCESS, value, g.versionFilter.Pattern)
+		return value, nil
+	}
+
+	return "", fmt.Errorf("something unexpected happened in Gitlab source")
+
+}

--- a/pkg/plugins/resources/gitlab/branch/source_test.go
+++ b/pkg/plugins/resources/gitlab/branch/source_test.go
@@ -48,7 +48,6 @@ func TestSource(t *testing.T) {
 				Repository    string
 				VersionFilter version.Filter
 			}{
-				URL:        "gitlab.com",
 				Token:      "",
 				Owner:      "olblak",
 				Repository: "updatecli",

--- a/pkg/plugins/resources/gitlab/branch/source_test.go
+++ b/pkg/plugins/resources/gitlab/branch/source_test.go
@@ -22,25 +22,8 @@ func TestSource(t *testing.T) {
 		wantResult string
 		wantErr    bool
 	}{
-		//{
-		//	name: "repository olblak/updatecli should not exist",
-		//	manifest: struct {
-		//		URL           string
-		//		Token         string
-		//		Owner         string
-		//		Repository    string
-		//		VersionFilter version.Filter
-		//	}{
-		//		URL:        "codeberg.org",
-		//		Token:      "",
-		//		Owner:      "updatecli",
-		//		Repository: "updatecli-donotexist",
-		//	},
-		//	wantResult: "",
-		//	wantErr:    true,
-		//},
 		{
-			name: "repository should exist with latest branch v3",
+			name: "repository olblak/updatecli-donotexist should not exist",
 			manifest: struct {
 				URL           string
 				Token         string
@@ -48,18 +31,55 @@ func TestSource(t *testing.T) {
 				Repository    string
 				VersionFilter version.Filter
 			}{
-				//URL:        "codeberg.org",
 				URL:        "gitlab.com",
 				Token:      "",
-				Owner:      "cicd-devroom",
-				Repository: "FOSDEM22",
-				//VersionFilter: version.Filter{
-				//	Kind:    "regex",
-				//	Pattern: "v1",
-				//},
+				Owner:      "updatecli",
+				Repository: "updatecli-donotexist",
+			},
+			wantResult: "",
+			wantErr:    true,
+		},
+		{
+			name: "repository should exist with a branch main",
+			manifest: struct {
+				URL           string
+				Token         string
+				Owner         string
+				Repository    string
+				VersionFilter version.Filter
+			}{
+				URL:        "gitlab.com",
+				Token:      "",
+				Owner:      "olblak",
+				Repository: "updatecli",
+				VersionFilter: version.Filter{
+					Kind:    "regex",
+					Pattern: "main",
+				},
 			},
 			wantResult: "main",
 			wantErr:    false,
+		},
+		{
+			name: "repository should not have branch donotexist",
+			manifest: struct {
+				URL           string
+				Token         string
+				Owner         string
+				Repository    string
+				VersionFilter version.Filter
+			}{
+				URL:        "gitlab.com",
+				Token:      "",
+				Owner:      "olblak",
+				Repository: "updatecli",
+				VersionFilter: version.Filter{
+					Kind:    "regex",
+					Pattern: "donotexist",
+				},
+			},
+			wantResult: "",
+			wantErr:    true,
 		},
 	}
 

--- a/pkg/plugins/resources/gitlab/branch/source_test.go
+++ b/pkg/plugins/resources/gitlab/branch/source_test.go
@@ -1,0 +1,87 @@
+package branch
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/updatecli/updatecli/pkg/plugins/utils/version"
+)
+
+func TestSource(t *testing.T) {
+
+	tests := []struct {
+		name     string
+		manifest struct {
+			URL           string
+			Token         string
+			Owner         string
+			Repository    string
+			VersionFilter version.Filter
+		}
+		wantResult string
+		wantErr    bool
+	}{
+		//{
+		//	name: "repository olblak/updatecli should not exist",
+		//	manifest: struct {
+		//		URL           string
+		//		Token         string
+		//		Owner         string
+		//		Repository    string
+		//		VersionFilter version.Filter
+		//	}{
+		//		URL:        "codeberg.org",
+		//		Token:      "",
+		//		Owner:      "updatecli",
+		//		Repository: "updatecli-donotexist",
+		//	},
+		//	wantResult: "",
+		//	wantErr:    true,
+		//},
+		{
+			name: "repository should exist with latest branch v3",
+			manifest: struct {
+				URL           string
+				Token         string
+				Owner         string
+				Repository    string
+				VersionFilter version.Filter
+			}{
+				//URL:        "codeberg.org",
+				URL:        "gitlab.com",
+				Token:      "",
+				Owner:      "cicd-devroom",
+				Repository: "FOSDEM22",
+				//VersionFilter: version.Filter{
+				//	Kind:    "regex",
+				//	Pattern: "v1",
+				//},
+			},
+			wantResult: "main",
+			wantErr:    false,
+		},
+	}
+
+	for _, tt := range tests {
+
+		t.Run(tt.name, func(t *testing.T) {
+
+			// Init gitea object
+			g, gotErr := New(tt.manifest)
+			require.NoError(t, gotErr)
+
+			gotResult, gotErr := g.Source("")
+
+			if tt.wantErr {
+				require.Error(t, gotErr)
+			} else {
+				require.NoError(t, gotErr)
+			}
+
+			assert.Equal(t, tt.wantResult, gotResult)
+
+		})
+
+	}
+}

--- a/pkg/plugins/resources/gitlab/branch/target.go
+++ b/pkg/plugins/resources/gitlab/branch/target.go
@@ -1,0 +1,17 @@
+package branch
+
+import (
+	"fmt"
+
+	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
+)
+
+// Target ensure that a specific release exist on Gitlab, otherwise creates it
+func (g *Gitlab) Target(source string, dryRun bool) (bool, error) {
+	return false, fmt.Errorf("target not supported for the plugin Gitlab branch")
+
+}
+
+func (g Gitlab) TargetFromSCM(source string, scm scm.ScmHandler, dryRun bool) (bool, []string, string, error) {
+	return false, []string{}, "", fmt.Errorf("target not supported for the plugin Gitlab branch")
+}

--- a/pkg/plugins/resources/gitlab/client/main.go
+++ b/pkg/plugins/resources/gitlab/client/main.go
@@ -1,0 +1,77 @@
+package client
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/drone/go-scm/scm"
+	"github.com/drone/go-scm/scm/driver/gitlab"
+	"github.com/drone/go-scm/scm/transport/oauth2"
+	"github.com/sirupsen/logrus"
+)
+
+// Spec defines a specification for a "Gitlab" resource
+// parsed from an updatecli manifest file
+type Spec struct {
+	// [S][C][T] URL specifies the default github url in case of Gitlab enterprise
+	URL string `yaml:",omitempty" jsonschema:"required"`
+	// [S][C][T] Username specifies the username used to authenticate with Gitlab API
+	Username string `yaml:",omitempty"`
+	// [S][C][T] Token specifies the credential used to authenticate with
+	Token string `yaml:",omitempty"`
+}
+
+type Client *scm.Client
+
+func New(s Spec) (Client, error) {
+
+	client, err := gitlab.New(s.URL)
+
+	if err != nil {
+		return nil, err
+	}
+
+	client.Client = &http.Client{}
+
+	if len(s.Token) >= 0 {
+		client.Client = &http.Client{
+			Transport: &oauth2.Transport{
+				Source: oauth2.StaticTokenSource(
+					&scm.Token{
+						Token: s.Token,
+					},
+				),
+			},
+		}
+	}
+
+	return client, nil
+
+}
+
+// Validate validates that a spec contains good content
+func (s Spec) Validate() error {
+
+	if len(s.URL) == 0 {
+		logrus.Errorf("missing %q parameter", "url")
+		return fmt.Errorf("wrong configuration")
+	}
+
+	return nil
+}
+
+// Sanitize parse and update if needed a spec content
+func (s *Spec) Sanitize() error {
+
+	err := s.Validate()
+	if err != nil {
+		return err
+	}
+
+	if !strings.HasPrefix(s.URL, "https://") && !strings.HasPrefix(s.URL, "http://") {
+		s.URL = "https://" + s.URL
+	}
+
+	return nil
+}

--- a/pkg/plugins/resources/gitlab/client/main.go
+++ b/pkg/plugins/resources/gitlab/client/main.go
@@ -26,7 +26,13 @@ type Client *scm.Client
 
 func New(s Spec) (Client, error) {
 
-	client, err := gitlab.New(s.URL)
+	url := s.URL
+
+	if url == "" {
+		url = "gitlab.com"
+	}
+
+	client, err := gitlab.New(url)
 
 	if err != nil {
 		return nil, err

--- a/pkg/plugins/resources/gitlab/client/main.go
+++ b/pkg/plugins/resources/gitlab/client/main.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -20,6 +21,12 @@ type Spec struct {
 	Token string `yaml:",omitempty"`
 }
 
+const (
+
+	// GITLABDOMAIN defines the default gitlab url
+	GITLABDOMAIN string = "gitlab.com"
+)
+
 type Client *scm.Client
 
 func New(s Spec) (Client, error) {
@@ -27,7 +34,7 @@ func New(s Spec) (Client, error) {
 	url := s.URL
 
 	if url == "" {
-		url = "https://gitlab.com"
+		url = fmt.Sprintf("https://%s", GITLABDOMAIN)
 	}
 
 	if !strings.HasPrefix(url, "https://") && !strings.HasPrefix(url, "http://") {

--- a/pkg/plugins/resources/gitlab/client/main.go
+++ b/pkg/plugins/resources/gitlab/client/main.go
@@ -1,14 +1,12 @@
 package client
 
 import (
-	"fmt"
 	"net/http"
 	"strings"
 
 	"github.com/drone/go-scm/scm"
 	"github.com/drone/go-scm/scm/driver/gitlab"
 	"github.com/drone/go-scm/scm/transport/oauth2"
-	"github.com/sirupsen/logrus"
 )
 
 // Spec defines a specification for a "Gitlab" resource
@@ -29,7 +27,11 @@ func New(s Spec) (Client, error) {
 	url := s.URL
 
 	if url == "" {
-		url = "gitlab.com"
+		url = "https://gitlab.com"
+	}
+
+	if !strings.HasPrefix(url, "https://") && !strings.HasPrefix(url, "http://") {
+		url = "https://" + url
 	}
 
 	client, err := gitlab.New(url)
@@ -54,30 +56,4 @@ func New(s Spec) (Client, error) {
 
 	return client, nil
 
-}
-
-// Validate validates that a spec contains good content
-func (s Spec) Validate() error {
-
-	if len(s.URL) == 0 {
-		logrus.Errorf("missing %q parameter", "url")
-		return fmt.Errorf("wrong configuration")
-	}
-
-	return nil
-}
-
-// Sanitize parse and update if needed a spec content
-func (s *Spec) Sanitize() error {
-
-	err := s.Validate()
-	if err != nil {
-		return err
-	}
-
-	if !strings.HasPrefix(s.URL, "https://") && !strings.HasPrefix(s.URL, "http://") {
-		s.URL = "https://" + s.URL
-	}
-
-	return nil
 }

--- a/pkg/plugins/resources/gitlab/mergerequest/create.go
+++ b/pkg/plugins/resources/gitlab/mergerequest/create.go
@@ -1,0 +1,97 @@
+package mergerequest
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/drone/go-scm/scm"
+	"github.com/sirupsen/logrus"
+)
+
+// CreateAction opens a Pull Request on the Gitlab server
+func (g *Gitlab) CreateAction(title, changelog, pipelineReport string) error {
+
+	body := changelog + "\n" + pipelineReport
+
+	if len(g.spec.Body) > 0 {
+		body = g.spec.Body
+	}
+
+	if len(g.spec.Title) > 0 {
+		title = g.spec.Title
+	}
+
+	// Check if a pull-request is already opened then exit early if it does.
+	exist, err := g.isPullRequestExist()
+	if err != nil {
+		return err
+	}
+
+	if exist {
+		return nil
+	}
+
+	// Test that both sourceBranch and targetBranch exists on remote before creating a new one
+	ok, err := g.isRemoteBranchesExist()
+
+	if err != nil {
+		return err
+	}
+
+	/*
+		Due to the following scenario, Updatecli always tries to open a Pullrequest
+			* A pullrequest has been "manually" closed via UI
+			* A previous Updatecli run failed during a Pullrequest creation for example due to network issues
+
+
+		Therefore we always try to open a pull request, we don't consider being an error if all conditions are not met
+		such as missing remote branches.
+	*/
+	if !ok {
+		logrus.Debugln("skipping pullrequest creation")
+		return nil
+	}
+
+	opts := scm.PullRequestInput{
+		Title:  title,
+		Body:   body,
+		Source: g.SourceBranch,
+		Target: g.TargetBranch,
+	}
+
+	logrus.Debugf("Title:\t%q\nBody:\t%q\nSource:\n%q\ntarget:\t%q\n",
+		title,
+		body,
+		g.SourceBranch,
+		g.TargetBranch)
+
+	// Timeout api query after 30sec
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	pr, resp, err := g.client.PullRequests.Create(
+		ctx,
+		strings.Join([]string{
+			g.Owner,
+			g.Repository}, "/"),
+		&opts,
+	)
+
+	if resp.Status > 400 {
+		logrus.Debugf("RC: %d\nBody:\n%s", resp.Status, resp.Body)
+	}
+
+	if err != nil {
+		if err.Error() == scm.ErrNotFound.Error() {
+			logrus.Infof("Gitlab pullrequest not created, skipping")
+			return nil
+		}
+		return err
+	}
+
+	logrus.Infof("Gitlab pullrequest successfully opened on %q", pr.Link)
+
+	return nil
+}

--- a/pkg/plugins/resources/gitlab/mergerequest/main.go
+++ b/pkg/plugins/resources/gitlab/mergerequest/main.go
@@ -1,0 +1,105 @@
+package mergerequest
+
+import (
+	"github.com/mitchellh/mapstructure"
+	"github.com/updatecli/updatecli/pkg/plugins/resources/gitlab/client"
+
+	gitlabscm "github.com/updatecli/updatecli/pkg/plugins/scms/gitlab"
+)
+
+// Spec defines settings used to interact with Gitlab pullrequest
+// It's a mapping of user input from a Updatecli manifest and it shouldn't modified
+type Spec struct {
+	client.Spec
+	// SourceBranch specifies the pullrequest source branch
+	SourceBranch string `yaml:",inline,omitempty"`
+	// TargetBranch specifies the pullrequest target branch
+	TargetBranch string `yaml:",inline,omitempty"`
+	// Owner specifies repository owner
+	Owner string `yaml:",omitempty" jsonschema:"required"`
+	// Repository specifies the name of a repository for a specific owner
+	Repository string `yaml:",omitempty" jsonschema:"required"`
+	// Title defines the Gitlab pullrequest title.
+	Title string `yaml:",inline,omitempty"`
+	// Body defines the Gitlab pullrequest body
+	Body string `yaml:",inline,omitempty"`
+}
+
+// Gitlab contains information to interact with Gitlab api
+type Gitlab struct {
+	// spec contains inputs coming from updatecli configuration
+	spec Spec
+	// client handle the api authentication
+	client client.Client
+	// scm allows to interact with a scm object
+	scm *gitlabscm.Gitlab
+	// SourceBranch specifies the pullrequest source branch.
+	SourceBranch string `yaml:",inline,omitempty"`
+	// TargetBranch specifies the pullrequest target branch
+	TargetBranch string `yaml:",inline,omitempty"`
+	// Owner specifies repository owner
+	Owner string `yaml:",omitempty" jsonschema:"required"`
+	// Repository specifies the name of a repository for a specific owner
+	Repository string `yaml:",omitempty" jsonschema:"required"`
+}
+
+// New returns a new valid Gitlab object.
+func New(spec interface{}, scm *gitlabscm.Gitlab) (Gitlab, error) {
+
+	var clientSpec client.Spec
+	var s Spec
+
+	// mapstructure.Decode cannot handle embedded fields
+	// hence we decode it in two steps
+	err := mapstructure.Decode(spec, &clientSpec)
+	if err != nil {
+		return Gitlab{}, err
+	}
+
+	err = mapstructure.Decode(spec, &s)
+	if err != nil {
+		return Gitlab{}, nil
+	}
+
+	if scm != nil {
+
+		if len(clientSpec.Token) == 0 && len(scm.Spec.Token) > 0 {
+			clientSpec.Token = scm.Spec.Token
+		}
+
+		if len(clientSpec.URL) == 0 && len(scm.Spec.URL) > 0 {
+			clientSpec.URL = scm.Spec.URL
+		}
+
+		if len(clientSpec.Username) == 0 && len(scm.Spec.Username) > 0 {
+			clientSpec.Username = scm.Spec.Username
+		}
+	}
+
+	// Sanitize modifies the clientSpec so it must be done once initialization is completed
+	err = clientSpec.Sanitize()
+	if err != nil {
+		return Gitlab{}, err
+	}
+
+	c, err := client.New(clientSpec)
+
+	if err != nil {
+		return Gitlab{}, err
+	}
+
+	g := Gitlab{
+		spec:   s,
+		client: c,
+		scm:    scm,
+	}
+
+	g.inheritFromScm()
+
+	if err != nil {
+		return Gitlab{}, nil
+	}
+
+	return g, nil
+
+}

--- a/pkg/plugins/resources/gitlab/mergerequest/main.go
+++ b/pkg/plugins/resources/gitlab/mergerequest/main.go
@@ -76,12 +76,6 @@ func New(spec interface{}, scm *gitlabscm.Gitlab) (Gitlab, error) {
 		}
 	}
 
-	// Sanitize modifies the clientSpec so it must be done once initialization is completed
-	err = clientSpec.Sanitize()
-	if err != nil {
-		return Gitlab{}, err
-	}
-
 	c, err := client.New(clientSpec)
 
 	if err != nil {

--- a/pkg/plugins/resources/gitlab/mergerequest/main_test.go
+++ b/pkg/plugins/resources/gitlab/mergerequest/main_test.go
@@ -32,7 +32,7 @@ func TestNew(t *testing.T) {
 			scm: &gitlabscm.Gitlab{
 				Spec: gitlabscm.Spec{
 					Spec: gitlabclient.Spec{
-						URL:      "gitea.updatecli.io",
+						URL:      "gitlab.com",
 						Token:    "xxx",
 						Username: "tes",
 					},
@@ -54,7 +54,7 @@ func TestNew(t *testing.T) {
 			scm: &gitlabscm.Gitlab{
 				Spec: gitlabscm.Spec{
 					Spec: gitlabclient.Spec{
-						URL: "gitea.updatecli.io",
+						URL: "gitlab.com",
 					},
 					Repository: "updatecli-test",
 					Branch:     "v2",
@@ -73,7 +73,7 @@ func TestNew(t *testing.T) {
 			scm: &gitlabscm.Gitlab{
 				Spec: gitlabscm.Spec{
 					Spec: gitlabclient.Spec{
-						URL: "gitea.updatecli.io",
+						URL: "gitlab.com",
 					},
 					Repository: "updatecli-test",
 					Branch:     "v2",

--- a/pkg/plugins/resources/gitlab/mergerequest/main_test.go
+++ b/pkg/plugins/resources/gitlab/mergerequest/main_test.go
@@ -86,14 +86,6 @@ func TestNew(t *testing.T) {
 			expectedGitlabSourceBranch: "workingBranchv2",
 			expectedGitlabTargetBranch: "v2",
 		},
-		{
-			name: "Test required parameter URL not specified",
-			spec: Spec{
-				Owner: "updatecli",
-			},
-			scm:     nil,
-			wantErr: true,
-		},
 	}
 
 	for _, tt := range testData {

--- a/pkg/plugins/resources/gitlab/mergerequest/main_test.go
+++ b/pkg/plugins/resources/gitlab/mergerequest/main_test.go
@@ -1,0 +1,119 @@
+package mergerequest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	gitlabclient "github.com/updatecli/updatecli/pkg/plugins/resources/gitlab/client"
+	gitlabscm "github.com/updatecli/updatecli/pkg/plugins/scms/gitlab"
+)
+
+func TestNew(t *testing.T) {
+	testData := []struct {
+		name                       string
+		spec                       Spec
+		scm                        *gitlabscm.Gitlab
+		expectedGitlabOwner        string
+		expectedGitlabRepository   string
+		expectedGitlabSourceBranch string
+		expectedGitlabTargetBranch string
+		wantErr                    bool
+		wantErrMessage             string
+	}{
+		{
+			name: "Test basic scenario",
+			spec: Spec{
+				Owner:        "updatecli",
+				Repository:   "updatecli",
+				SourceBranch: "workingBranch",
+				TargetBranch: "main",
+			},
+			scm: &gitlabscm.Gitlab{
+				Spec: gitlabscm.Spec{
+					Spec: gitlabclient.Spec{
+						URL:      "gitea.updatecli.io",
+						Token:    "xxx",
+						Username: "tes",
+					},
+				},
+			},
+			expectedGitlabOwner:        "updatecli",
+			expectedGitlabRepository:   "updatecli",
+			expectedGitlabSourceBranch: "workingBranch",
+			expectedGitlabTargetBranch: "main",
+		},
+		{
+			name: "Test parameter inheritance 1",
+			spec: Spec{
+				Owner:        "updatecli",
+				Repository:   "updatecli",
+				SourceBranch: "workingBranch",
+				TargetBranch: "main",
+			},
+			scm: &gitlabscm.Gitlab{
+				Spec: gitlabscm.Spec{
+					Spec: gitlabclient.Spec{
+						URL: "gitea.updatecli.io",
+					},
+					Repository: "updatecli-test",
+					Branch:     "v2",
+					Owner:      "tartempion",
+				},
+				HeadBranch: "workingBranch",
+			},
+			expectedGitlabOwner:        "updatecli",
+			expectedGitlabRepository:   "updatecli",
+			expectedGitlabSourceBranch: "workingBranch",
+			expectedGitlabTargetBranch: "main",
+		},
+		{
+			name: "Test parameter inheritance 2",
+			spec: Spec{},
+			scm: &gitlabscm.Gitlab{
+				Spec: gitlabscm.Spec{
+					Spec: gitlabclient.Spec{
+						URL: "gitea.updatecli.io",
+					},
+					Repository: "updatecli-test",
+					Branch:     "v2",
+					Owner:      "tartempion",
+				},
+				HeadBranch: "workingBranchv2",
+			},
+			expectedGitlabOwner:        "tartempion",
+			expectedGitlabRepository:   "updatecli-test",
+			expectedGitlabSourceBranch: "workingBranchv2",
+			expectedGitlabTargetBranch: "v2",
+		},
+		{
+			name: "Test required parameter URL not specified",
+			spec: Spec{
+				Owner: "updatecli",
+			},
+			scm:     nil,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range testData {
+
+		t.Run(tt.name, func(t *testing.T) {
+
+			g, gotErr := New(tt.spec, tt.scm)
+
+			if tt.wantErr {
+				require.Error(t, gotErr)
+			} else {
+				require.NoError(t, gotErr)
+			}
+
+			assert.Equal(t, g.Owner, tt.expectedGitlabOwner)
+			assert.Equal(t, g.Repository, tt.expectedGitlabRepository)
+			assert.Equal(t, g.SourceBranch, tt.expectedGitlabSourceBranch)
+			assert.Equal(t, g.TargetBranch, tt.expectedGitlabTargetBranch)
+		})
+
+	}
+
+}

--- a/pkg/plugins/resources/gitlab/mergerequest/utils.go
+++ b/pkg/plugins/resources/gitlab/mergerequest/utils.go
@@ -1,0 +1,173 @@
+package mergerequest
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/drone/go-scm/scm"
+	"github.com/sirupsen/logrus"
+	"github.com/updatecli/updatecli/pkg/core/result"
+)
+
+// isPullRequestExist queries a remote Gitlab instance to know if a pullrequest already exists.
+func (g *Gitlab) isPullRequestExist() (bool, error) {
+	ctx := context.Background()
+	// Timeout api query after 30sec
+	ctx, cancelList := context.WithTimeout(ctx, 30*time.Second)
+	defer cancelList()
+
+	optsSearch := scm.PullRequestListOptions{
+		Page:   1,
+		Size:   30,
+		Open:   true,
+		Closed: false,
+	}
+
+	pullrequests, resp, err := g.client.PullRequests.List(
+		ctx,
+		strings.Join([]string{
+			g.Owner,
+			g.Repository}, "/"),
+		optsSearch,
+	)
+
+	if err != nil {
+		logrus.Debugf("RC: %d\nBody:\n%s", resp.Status, resp.Body)
+		return false, err
+	}
+
+	if resp.Status > 400 {
+		logrus.Debugf("RC: %d\nBody:\n%s", resp.Status, resp.Body)
+	}
+
+	for _, p := range pullrequests {
+		if p.Source == g.SourceBranch &&
+			p.Target == g.TargetBranch &&
+			!p.Closed &&
+			!p.Merged {
+
+			logrus.Infof("%s Nothing else to do, our pullrequest already exist on:\n\t%s",
+				result.SUCCESS,
+				p.Link)
+
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// isRemoteBranchesExist queries a remote Gitlab instance to know if both the pull-request source branch and the target branch exist.
+func (g *Gitlab) isRemoteBranchesExist() (bool, error) {
+
+	var sourceBranch string
+	var targetBranch string
+	var owner string
+	var repository string
+
+	if g.scm != nil {
+		sourceBranch = g.scm.HeadBranch
+		targetBranch = g.scm.Spec.Branch
+		owner = g.scm.Spec.Owner
+		repository = g.scm.Spec.Repository
+	}
+
+	if len(g.spec.SourceBranch) > 0 {
+		sourceBranch = g.spec.SourceBranch
+	}
+
+	if len(g.spec.TargetBranch) > 0 {
+		targetBranch = g.spec.TargetBranch
+	}
+
+	if len(g.spec.Owner) > 0 {
+		owner = g.spec.Owner
+	}
+
+	if len(g.spec.Repository) > 0 {
+		repository = g.spec.Repository
+	}
+
+	// Timeout api query after 30sec
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	remoteBranches, resp, err := g.client.Git.ListBranches(
+		ctx,
+		strings.Join([]string{owner, repository}, "/"),
+		scm.ListOptions{
+			URL:  g.spec.URL,
+			Page: 1,
+			Size: 30,
+		},
+	)
+
+	if err != nil {
+		logrus.Debugf("RC: %d\nBody:\n%s", resp.Status, resp.Body)
+		return false, err
+	}
+
+	if resp.Status > 400 {
+		logrus.Debugf("RC: %d\nBody:\n%s", resp.Status, resp.Body)
+	}
+
+	foundRemoteSourceBranch := false
+	foundRemoteTargetBranch := false
+
+	for _, remoteBranch := range remoteBranches {
+		if remoteBranch.Name == sourceBranch {
+			foundRemoteSourceBranch = true
+		}
+		if remoteBranch.Name == targetBranch {
+			foundRemoteTargetBranch = true
+		}
+
+		if foundRemoteSourceBranch && foundRemoteTargetBranch {
+			return true, nil
+		}
+	}
+
+	if !foundRemoteSourceBranch {
+		logrus.Debugf("Branch %q not found on remote repository %s/%s",
+			sourceBranch,
+			owner,
+			repository)
+	}
+
+	if !foundRemoteTargetBranch {
+		logrus.Debugf("Branch %q not found on remote repository %s/%s",
+			targetBranch,
+			owner,
+			repository)
+	}
+
+	return false, nil
+}
+
+// inheritFromScm retrieve missing Gitlab settings from the Gitlab scm object.
+func (g *Gitlab) inheritFromScm() {
+
+	if g.scm != nil {
+		g.SourceBranch = g.scm.HeadBranch
+		g.TargetBranch = g.scm.Spec.Branch
+		g.Owner = g.scm.Spec.Owner
+		g.Repository = g.scm.Spec.Repository
+	}
+
+	if len(g.spec.SourceBranch) > 0 {
+		g.SourceBranch = g.spec.SourceBranch
+	}
+
+	if len(g.spec.TargetBranch) > 0 {
+		g.TargetBranch = g.spec.TargetBranch
+	}
+
+	if len(g.spec.Owner) > 0 {
+		g.Owner = g.spec.Owner
+	}
+
+	if len(g.spec.Repository) > 0 {
+		g.Repository = g.spec.Repository
+	}
+}

--- a/pkg/plugins/resources/gitlab/mergerequest/utils.go
+++ b/pkg/plugins/resources/gitlab/mergerequest/utils.go
@@ -17,43 +17,52 @@ func (g *Gitlab) isPullRequestExist() (bool, error) {
 	ctx, cancelList := context.WithTimeout(ctx, 30*time.Second)
 	defer cancelList()
 
-	optsSearch := scm.PullRequestListOptions{
-		Page:   1,
-		Size:   30,
-		Open:   true,
-		Closed: false,
-	}
+	page := 0
+	for {
+		optsSearch := scm.PullRequestListOptions{
+			Page:   page,
+			Size:   30,
+			Open:   true,
+			Closed: false,
+		}
 
-	pullrequests, resp, err := g.client.PullRequests.List(
-		ctx,
-		strings.Join([]string{
-			g.Owner,
-			g.Repository}, "/"),
-		optsSearch,
-	)
+		pullrequests, resp, err := g.client.PullRequests.List(
+			ctx,
+			strings.Join([]string{
+				g.Owner,
+				g.Repository}, "/"),
+			optsSearch,
+		)
 
-	if err != nil {
-		logrus.Debugf("RC: %d\nBody:\n%s", resp.Status, resp.Body)
-		return false, err
-	}
+		if err != nil {
+			logrus.Debugf("RC: %d\nBody:\n%s", resp.Status, resp.Body)
+			return false, err
+		}
 
-	if resp.Status > 400 {
-		logrus.Debugf("RC: %d\nBody:\n%s", resp.Status, resp.Body)
-	}
+		page = resp.Page.Next
 
-	for _, p := range pullrequests {
-		if p.Source == g.SourceBranch &&
-			p.Target == g.TargetBranch &&
-			!p.Closed &&
-			!p.Merged {
+		if resp.Status > 400 {
+			logrus.Debugf("RC: %d\nBody:\n%s", resp.Status, resp.Body)
+		}
 
-			logrus.Infof("%s Nothing else to do, our pullrequest already exist on:\n\t%s",
-				result.SUCCESS,
-				p.Link)
+		for _, p := range pullrequests {
+			if p.Source == g.SourceBranch &&
+				p.Target == g.TargetBranch &&
+				!p.Closed &&
+				!p.Merged {
 
-			return true, nil
+				logrus.Infof("%s Nothing else to do, our pullrequest already exist on:\n\t%s",
+					result.SUCCESS,
+					p.Link)
+
+				return true, nil
+			}
+		}
+		if page == 0 {
+			break
 		}
 	}
+
 	return false, nil
 }
 

--- a/pkg/plugins/resources/gitlab/release/changelog.go
+++ b/pkg/plugins/resources/gitlab/release/changelog.go
@@ -1,0 +1,6 @@
+package release
+
+// Changelog returns the changelog for this resource, or an empty string if not supported
+func (g *Gitlab) Changelog() string {
+	return ""
+}

--- a/pkg/plugins/resources/gitlab/release/condition.go
+++ b/pkg/plugins/resources/gitlab/release/condition.go
@@ -1,0 +1,42 @@
+package release
+
+import (
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
+	"github.com/updatecli/updatecli/pkg/core/result"
+)
+
+func (g *Gitlab) Condition(source string) (bool, error) {
+	releases, err := g.SearchReleases()
+
+	if len(g.spec.Tag) == 0 {
+		g.spec.Tag = source
+	}
+
+	if err != nil {
+		logrus.Error(err)
+		return false, err
+	}
+
+	if len(releases) == 0 {
+		logrus.Infof("%s No Gitlab release found. As a fallback you may be looking for git tags", result.ATTENTION)
+		return false, nil
+	}
+
+	for _, release := range releases {
+		if release == g.spec.Tag {
+			logrus.Infof("%s Gitlab Release tag %q found", result.SUCCESS, release)
+			return true, nil
+		}
+	}
+
+	logrus.Infof("%s No Gitlab Release tag found matching pattern %q", result.FAILURE, g.versionFilter.Pattern)
+	return false, nil
+
+}
+
+func (g *Gitlab) ConditionFromSCM(source string, scm scm.ScmHandler) (bool, error) {
+	return false, fmt.Errorf("Condition not supported for the plugin Gitlab Release")
+}

--- a/pkg/plugins/resources/gitlab/release/condition_test.go
+++ b/pkg/plugins/resources/gitlab/release/condition_test.go
@@ -22,7 +22,7 @@ func TestCondition(t *testing.T) {
 		wantErr    bool
 	}{
 		{
-			name: "repository olblak/updatecli should not exist",
+			name: "repository olblak/updatecli-donotexiset should not exist",
 			manifest: struct {
 				URL        string
 				Token      string
@@ -30,16 +30,16 @@ func TestCondition(t *testing.T) {
 				Repository string
 				Tag        string
 			}{
-				URL:        "codeberg.org",
+				URL:        "gitlab.com",
 				Token:      "",
-				Owner:      "updatecli",
+				Owner:      "olblak",
 				Repository: "updatecli-donotexist",
 			},
 			wantResult: false,
 			wantErr:    true,
 		},
 		{
-			name: "repository olblak/updatecli-mirror should exist but no release",
+			name: "repository cicd-devroom/FOSDEM22 should exist but no release",
 			manifest: struct {
 				URL        string
 				Token      string
@@ -47,10 +47,10 @@ func TestCondition(t *testing.T) {
 				Repository string
 				Tag        string
 			}{
-				URL:        "codeberg.org",
+				URL:        "gitlab.com",
 				Token:      "",
-				Owner:      "updatecli",
-				Repository: "demo-terminal",
+				Owner:      "cicd-devroom",
+				Repository: "FOSDEM22",
 			},
 			wantResult: false,
 			wantErr:    false,
@@ -64,17 +64,17 @@ func TestCondition(t *testing.T) {
 				Repository string
 				Tag        string
 			}{
-				URL:        "codeberg.org",
+				URL:        "gitlab.com",
 				Token:      "",
-				Owner:      "updatecli",
-				Repository: "demo-terminal",
+				Owner:      "cicd-devroom",
+				Repository: "FOSDEM22",
 				Tag:        "2.0.0",
 			},
 			wantResult: false,
 			wantErr:    false,
 		},
 		{
-			name: "repository should exist with release v2.15.0",
+			name: "repository should exist with release v0.46.2",
 			manifest: struct {
 				URL        string
 				Token      string
@@ -82,11 +82,11 @@ func TestCondition(t *testing.T) {
 				Repository string
 				Tag        string
 			}{
-				URL:        "codeberg.org",
+				URL:        "gitlab.com",
 				Token:      "",
-				Owner:      "updatecli",
-				Repository: "updatecli-action",
-				Tag:        "v2.15.0",
+				Owner:      "olblak",
+				Repository: "updatecli",
+				Tag:        "v0.46.2",
 			},
 			wantResult: true,
 			wantErr:    false,

--- a/pkg/plugins/resources/gitlab/release/condition_test.go
+++ b/pkg/plugins/resources/gitlab/release/condition_test.go
@@ -1,0 +1,116 @@
+package release
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCondition(t *testing.T) {
+
+	tests := []struct {
+		name     string
+		manifest struct {
+			URL        string
+			Token      string
+			Owner      string
+			Repository string
+			Tag        string
+		}
+		wantResult bool
+		wantErr    bool
+	}{
+		{
+			name: "repository olblak/updatecli should not exist",
+			manifest: struct {
+				URL        string
+				Token      string
+				Owner      string
+				Repository string
+				Tag        string
+			}{
+				URL:        "codeberg.org",
+				Token:      "",
+				Owner:      "updatecli",
+				Repository: "updatecli-donotexist",
+			},
+			wantResult: false,
+			wantErr:    true,
+		},
+		{
+			name: "repository olblak/updatecli-mirror should exist but no release",
+			manifest: struct {
+				URL        string
+				Token      string
+				Owner      string
+				Repository string
+				Tag        string
+			}{
+				URL:        "codeberg.org",
+				Token:      "",
+				Owner:      "updatecli",
+				Repository: "demo-terminal",
+			},
+			wantResult: false,
+			wantErr:    false,
+		},
+		{
+			name: "repository should exist with no release 2.0.0",
+			manifest: struct {
+				URL        string
+				Token      string
+				Owner      string
+				Repository string
+				Tag        string
+			}{
+				URL:        "codeberg.org",
+				Token:      "",
+				Owner:      "updatecli",
+				Repository: "demo-terminal",
+				Tag:        "2.0.0",
+			},
+			wantResult: false,
+			wantErr:    false,
+		},
+		{
+			name: "repository should exist with release v2.15.0",
+			manifest: struct {
+				URL        string
+				Token      string
+				Owner      string
+				Repository string
+				Tag        string
+			}{
+				URL:        "codeberg.org",
+				Token:      "",
+				Owner:      "updatecli",
+				Repository: "updatecli-action",
+				Tag:        "v2.15.0",
+			},
+			wantResult: true,
+			wantErr:    false,
+		},
+	}
+
+	for _, tt := range tests {
+
+		t.Run(tt.name, func(t *testing.T) {
+
+			g, gotErr := New(tt.manifest)
+			require.NoError(t, gotErr)
+
+			gotResult, gotErr := g.Condition("")
+
+			if tt.wantErr {
+				require.Error(t, gotErr)
+			} else {
+				require.NoError(t, gotErr)
+			}
+
+			assert.Equal(t, tt.wantResult, gotResult)
+
+		})
+
+	}
+}

--- a/pkg/plugins/resources/gitlab/release/main.go
+++ b/pkg/plugins/resources/gitlab/release/main.go
@@ -70,16 +70,6 @@ func New(spec interface{}) (*Gitlab, error) {
 		return &Gitlab{}, nil
 	}
 
-	err = clientSpec.Validate()
-	if err != nil {
-		return &Gitlab{}, err
-	}
-
-	err = clientSpec.Sanitize()
-	if err != nil {
-		return &Gitlab{}, err
-	}
-
 	s.Spec = clientSpec
 
 	err = s.Validate()
@@ -149,13 +139,6 @@ func (g *Gitlab) SearchReleases() ([]string, error) {
 func (s Spec) Validate() error {
 	gotError := false
 	missingParameters := []string{}
-
-	err := s.Spec.Validate()
-
-	if err != nil {
-		logrus.Errorln(err)
-		gotError = true
-	}
 
 	if len(s.Owner) == 0 {
 		gotError = true

--- a/pkg/plugins/resources/gitlab/release/main.go
+++ b/pkg/plugins/resources/gitlab/release/main.go
@@ -110,6 +110,7 @@ func (g *Gitlab) SearchReleases() ([]string, error) {
 	results := []string{}
 	page := 0
 	for {
+
 		releases, resp, err := g.client.Releases.List(
 			ctx,
 			strings.Join([]string{g.spec.Owner, g.spec.Repository}, "/"),
@@ -125,8 +126,6 @@ func (g *Gitlab) SearchReleases() ([]string, error) {
 			return nil, err
 		}
 
-		page = resp.Page.Next
-
 		if resp.Status > 400 {
 			logrus.Debugf("Gitlab Api Response:\n%+v", resp)
 		}
@@ -137,10 +136,11 @@ func (g *Gitlab) SearchReleases() ([]string, error) {
 			}
 		}
 
-		if page == 0 {
+		// Means that we parsed all pages
+		if page >= resp.Page.Last {
 			break
 		}
-
+		page++
 	}
 
 	return results, nil

--- a/pkg/plugins/resources/gitlab/release/main.go
+++ b/pkg/plugins/resources/gitlab/release/main.go
@@ -1,0 +1,179 @@
+package release
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/drone/go-scm/scm"
+	"github.com/mitchellh/mapstructure"
+	"github.com/sirupsen/logrus"
+	"github.com/updatecli/updatecli/pkg/plugins/resources/gitlab/client"
+	"github.com/updatecli/updatecli/pkg/plugins/utils/version"
+)
+
+// Spec defines settings used to interact with Gitlab release
+type Spec struct {
+	client.Spec `yaml:",inline,omitempty"`
+	// [S][C][T] Owner specifies repository owner
+	Owner string `yaml:",omitempty" jsonschema:"required"`
+	// [S][C][T]Repository specifies the name of a repository for a specific owner
+	Repository string `yaml:",omitempty" jsonschema:"required"`
+	// [S] VersionFilter provides parameters to specify version pattern and its type like regex, semver, or just latest.
+	VersionFilter version.Filter `yaml:",omitempty"`
+	// [T] Title defines the Gitlab release title.
+	Title string `yaml:",omitempty"`
+	// [C][T] Tag defines the Gitlab release tag.
+	Tag string `yaml:",omitempty"`
+	// [T] Commitish defines the commit-ish such as `main`
+	Commitish string `yaml:",omitempty"`
+	// [T] Drescription defines if the new release description
+	Drescription string `yaml:",omitempty"`
+	// [T] Draft defines if the release is a draft release
+	Draft bool `yaml:",omitempty"`
+	// [T] Prerelease defines if the release is a pre-release release
+	Prerelease bool `yaml:",omitempty"`
+}
+
+const (
+	// #nosec g101
+	// updatecliCredits contains the message displayed at the end of a newly credit release
+	updatecliCredits string = "Made with ❤️️ by updatecli"
+)
+
+// Gitlab contains information to interact with Gitlab api
+type Gitlab struct {
+	// spec contains inputs coming from updatecli configuration
+	spec Spec
+	// client handle the api authentication
+	client       client.Client
+	foundVersion version.Version
+	// Holds the "valid" version.filter, that might be different than the user-specified filter (Spec.VersionFilter)
+	versionFilter version.Filter
+}
+
+// New returns a new valid Github object.
+func New(spec interface{}) (*Gitlab, error) {
+	var s Spec
+	var clientSpec client.Spec
+
+	// mapstructure.Decode cannot handle embedded fields
+	// hence we decode it in two steps
+	err := mapstructure.Decode(spec, &clientSpec)
+	if err != nil {
+		return &Gitlab{}, err
+	}
+
+	err = mapstructure.Decode(spec, &s)
+	if err != nil {
+		return &Gitlab{}, nil
+	}
+
+	err = clientSpec.Validate()
+	if err != nil {
+		return &Gitlab{}, err
+	}
+
+	err = clientSpec.Sanitize()
+	if err != nil {
+		return &Gitlab{}, err
+	}
+
+	s.Spec = clientSpec
+
+	err = s.Validate()
+
+	if err != nil {
+		return &Gitlab{}, err
+	}
+
+	c, err := client.New(clientSpec)
+
+	if err != nil {
+		return &Gitlab{}, err
+	}
+
+	newFilter, err := s.VersionFilter.Init()
+	if err != nil {
+		return &Gitlab{}, err
+	}
+	s.VersionFilter = newFilter
+
+	g := Gitlab{
+		spec:          s,
+		client:        c,
+		versionFilter: newFilter,
+	}
+
+	return &g, nil
+}
+
+// Retrieve git tags from a remote Gitlab repository
+func (g *Gitlab) SearchReleases() ([]string, error) {
+
+	ctx := context.Background()
+	// Timeout api query after 30sec
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	releases, resp, err := g.client.Releases.List(
+		ctx,
+		strings.Join([]string{g.spec.Owner, g.spec.Repository}, "/"),
+		scm.ReleaseListOptions{
+			Page:   1,
+			Size:   30,
+			Open:   true,
+			Closed: true,
+		},
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.Status > 400 {
+		logrus.Debugf("Gitlab Api Response:\n%+v", resp)
+	}
+
+	results := []string{}
+	for i := len(releases) - 1; i >= 0; i-- {
+		if !releases[i].Draft {
+			results = append(results, releases[i].Tag)
+		}
+	}
+
+	return results, nil
+}
+
+func (s Spec) Validate() error {
+	gotError := false
+	missingParameters := []string{}
+
+	err := s.Spec.Validate()
+
+	if err != nil {
+		logrus.Errorln(err)
+		gotError = true
+	}
+
+	if len(s.Owner) == 0 {
+		gotError = true
+		missingParameters = append(missingParameters, "owner")
+	}
+
+	if len(s.Repository) == 0 {
+		gotError = true
+		missingParameters = append(missingParameters, "repository")
+	}
+
+	if len(missingParameters) > 0 {
+		logrus.Errorf("missing parameter(s) [%s]", strings.Join(missingParameters, ","))
+	}
+
+	if gotError {
+		return fmt.Errorf("wrong Gitlab configuration")
+	}
+
+	return nil
+}

--- a/pkg/plugins/resources/gitlab/release/main.go
+++ b/pkg/plugins/resources/gitlab/release/main.go
@@ -107,30 +107,40 @@ func (g *Gitlab) SearchReleases() ([]string, error) {
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	releases, resp, err := g.client.Releases.List(
-		ctx,
-		strings.Join([]string{g.spec.Owner, g.spec.Repository}, "/"),
-		scm.ReleaseListOptions{
-			Page:   1,
-			Size:   30,
-			Open:   true,
-			Closed: true,
-		},
-	)
-
-	if err != nil {
-		return nil, err
-	}
-
-	if resp.Status > 400 {
-		logrus.Debugf("Gitlab Api Response:\n%+v", resp)
-	}
-
 	results := []string{}
-	for i := len(releases) - 1; i >= 0; i-- {
-		if !releases[i].Draft {
-			results = append(results, releases[i].Tag)
+	page := 0
+	for {
+		releases, resp, err := g.client.Releases.List(
+			ctx,
+			strings.Join([]string{g.spec.Owner, g.spec.Repository}, "/"),
+			scm.ReleaseListOptions{
+				Page:   page,
+				Size:   30,
+				Open:   true,
+				Closed: true,
+			},
+		)
+
+		if err != nil {
+			return nil, err
 		}
+
+		page = resp.Page.Next
+
+		if resp.Status > 400 {
+			logrus.Debugf("Gitlab Api Response:\n%+v", resp)
+		}
+
+		for i := len(releases) - 1; i >= 0; i-- {
+			if !releases[i].Draft {
+				results = append(results, releases[i].Tag)
+			}
+		}
+
+		if page == 0 {
+			break
+		}
+
 	}
 
 	return results, nil

--- a/pkg/plugins/resources/gitlab/release/source.go
+++ b/pkg/plugins/resources/gitlab/release/source.go
@@ -1,0 +1,51 @@
+package release
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+	"github.com/updatecli/updatecli/pkg/core/result"
+	"github.com/updatecli/updatecli/pkg/plugins/utils/version"
+)
+
+func (g *Gitlab) Source(workingDir string) (string, error) {
+	versions, err := g.SearchReleases()
+
+	if err != nil {
+		logrus.Error(err)
+		return "", err
+	}
+
+	if len(versions) == 0 {
+		logrus.Infof("%s No Gitlab Release found. As a fallback you may be looking for git tags", result.ATTENTION)
+		return "", errors.New("no result found")
+	}
+
+	g.foundVersion, err = g.spec.VersionFilter.Search(versions)
+
+	if err != nil {
+		switch err {
+		case version.ErrNoVersionFound:
+			logrus.Infof("%s No Gitlab Release tag found matching pattern %q", result.FAILURE, g.versionFilter.Pattern)
+			return "", errors.New("no result found")
+		default:
+			return "", err
+		}
+	}
+
+	value := g.foundVersion.GetVersion()
+
+	logrus.Infof("Latest Release found: %v", g.foundVersion.GetVersion())
+
+	if len(value) == 0 {
+		logrus.Infof("%s No Gitlab Release tag found matching pattern %q", result.FAILURE, g.versionFilter.Pattern)
+		return "", errors.New("no result found")
+	} else if len(value) > 0 {
+		logrus.Infof("%s Gitlab Release tag %q found matching pattern %q", result.SUCCESS, value, g.versionFilter.Pattern)
+		return value, nil
+	}
+
+	return "", fmt.Errorf("something unexpected happened in Gitlab source")
+
+}

--- a/pkg/plugins/resources/gitlab/release/source_test.go
+++ b/pkg/plugins/resources/gitlab/release/source_test.go
@@ -48,7 +48,6 @@ func TestSource(t *testing.T) {
 				Repository    string
 				VersionFilter version.Filter
 			}{
-				URL:        "gitlab.com",
 				Token:      "",
 				Owner:      "cicd-devroom",
 				Repository: "FOSDEM22",

--- a/pkg/plugins/resources/gitlab/release/source_test.go
+++ b/pkg/plugins/resources/gitlab/release/source_test.go
@@ -1,0 +1,102 @@
+package release
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/updatecli/updatecli/pkg/plugins/utils/version"
+)
+
+func TestSource(t *testing.T) {
+
+	tests := []struct {
+		name     string
+		manifest struct {
+			URL           string
+			Token         string
+			Owner         string
+			Repository    string
+			VersionFilter version.Filter
+		}
+		wantResult string
+		wantErr    bool
+	}{
+		{
+			name: "repository updatecli/updatecli-donotexist should not exist",
+			manifest: struct {
+				URL           string
+				Token         string
+				Owner         string
+				Repository    string
+				VersionFilter version.Filter
+			}{
+				URL:        "codeberg.org",
+				Token:      "",
+				Owner:      "updatecli",
+				Repository: "updatecli-donotexist",
+			},
+			wantResult: "",
+			wantErr:    true,
+		},
+		{
+			name: "repository updatecli/demo-terminal should exist but no release",
+			manifest: struct {
+				URL           string
+				Token         string
+				Owner         string
+				Repository    string
+				VersionFilter version.Filter
+			}{
+				URL:        "codeberg.org",
+				Token:      "",
+				Owner:      "updatecli",
+				Repository: "demo-terminal",
+			},
+			wantResult: "",
+			wantErr:    true,
+		},
+		{
+			name: "repository should exist with release 0.0.3",
+			manifest: struct {
+				URL           string
+				Token         string
+				Owner         string
+				Repository    string
+				VersionFilter version.Filter
+			}{
+				URL:        "codeberg.org",
+				Token:      "",
+				Owner:      "updatecli",
+				Repository: "updatecli-action",
+				VersionFilter: version.Filter{
+					Kind:    "semver",
+					Pattern: "~2.15",
+				},
+			},
+			wantResult: "v2.15.0",
+			wantErr:    false,
+		},
+	}
+
+	for _, tt := range tests {
+
+		t.Run(tt.name, func(t *testing.T) {
+
+			g, gotErr := New(tt.manifest)
+			require.NoError(t, gotErr)
+
+			gotResult, gotErr := g.Source("")
+
+			if tt.wantErr {
+				require.Error(t, gotErr)
+			} else {
+				require.NoError(t, gotErr)
+			}
+
+			assert.Equal(t, tt.wantResult, gotResult)
+
+		})
+
+	}
+}

--- a/pkg/plugins/resources/gitlab/release/source_test.go
+++ b/pkg/plugins/resources/gitlab/release/source_test.go
@@ -31,16 +31,16 @@ func TestSource(t *testing.T) {
 				Repository    string
 				VersionFilter version.Filter
 			}{
-				URL:        "codeberg.org",
+				URL:        "gitlab.com",
 				Token:      "",
-				Owner:      "updatecli",
+				Owner:      "olblak",
 				Repository: "updatecli-donotexist",
 			},
 			wantResult: "",
 			wantErr:    true,
 		},
 		{
-			name: "repository updatecli/demo-terminal should exist but no release",
+			name: "repository cicd-devroom/FOSDEM22 should exist but no release",
 			manifest: struct {
 				URL           string
 				Token         string
@@ -48,16 +48,16 @@ func TestSource(t *testing.T) {
 				Repository    string
 				VersionFilter version.Filter
 			}{
-				URL:        "codeberg.org",
+				URL:        "gitlab.com",
 				Token:      "",
-				Owner:      "updatecli",
-				Repository: "demo-terminal",
+				Owner:      "cicd-devroom",
+				Repository: "FOSDEM22",
 			},
 			wantResult: "",
 			wantErr:    true,
 		},
 		{
-			name: "repository should exist with release 0.0.3",
+			name: "repository should exist with release 0.46.2",
 			manifest: struct {
 				URL           string
 				Token         string
@@ -65,16 +65,16 @@ func TestSource(t *testing.T) {
 				Repository    string
 				VersionFilter version.Filter
 			}{
-				URL:        "codeberg.org",
+				URL:        "gitlab.com",
 				Token:      "",
-				Owner:      "updatecli",
-				Repository: "updatecli-action",
+				Owner:      "olblak",
+				Repository: "updatecli",
 				VersionFilter: version.Filter{
 					Kind:    "semver",
-					Pattern: "~2.15",
+					Pattern: "~0.46.0",
 				},
 			},
-			wantResult: "v2.15.0",
+			wantResult: "v0.46.2",
 			wantErr:    false,
 		},
 	}

--- a/pkg/plugins/resources/gitlab/release/target.go
+++ b/pkg/plugins/resources/gitlab/release/target.go
@@ -1,0 +1,106 @@
+package release
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	goscm "github.com/drone/go-scm/scm"
+	"github.com/sirupsen/logrus"
+	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
+	"github.com/updatecli/updatecli/pkg/core/result"
+)
+
+// Target ensure that a specific release exist on Gitlab, otherwise creates it
+func (g *Gitlab) Target(source string, dryRun bool) (bool, error) {
+
+	if len(g.spec.Tag) == 0 {
+		g.spec.Tag = source
+	}
+
+	if len(g.spec.Title) == 0 {
+		g.spec.Title = g.spec.Tag
+	}
+
+	if len(g.spec.Commitish) == 0 {
+		logrus.Warningf("No commitish provided, fallback to branch %q\n", "main")
+		g.spec.Commitish = "main"
+	}
+
+	// Ensure that a release doesn't exist yet
+
+	ctx := context.Background()
+	// Timeout api query after 30 second
+	ctx, cancelListQuery := context.WithTimeout(ctx, 30*time.Second)
+	defer cancelListQuery()
+
+	releases, resp, err := g.client.Releases.List(
+		ctx,
+		strings.Join([]string{g.spec.Owner, g.spec.Repository}, "/"),
+		goscm.ReleaseListOptions{
+			Page:   1,
+			Size:   30,
+			Open:   true,
+			Closed: true,
+		},
+	)
+
+	if err != nil {
+		logrus.Debugf("Gitlab Api Response:\nReturn Code: %q\nBody:\n%s", resp.Status, resp.Body)
+		return false, err
+	}
+
+	for _, r := range releases {
+		if r.Tag == g.spec.Tag {
+			logrus.Infof("%s Release Tag %q already exist, nothing else to do", result.SUCCESS, g.spec.Tag)
+			return false, nil
+		}
+	}
+
+	if dryRun {
+		logrus.Infof("%s Release Tag %q doesn't exist, we need to create it", result.SUCCESS, g.spec.Tag)
+		return true, nil
+	}
+
+	if len(g.spec.Token) == 0 {
+		return true, fmt.Errorf("wrong configuration, missing parameter %q", "token")
+	}
+
+	// Create a new release as it doesn't exist yet
+
+	ctx = context.Background()
+	// Timeout api query after 30 second
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	release, resp, err := g.client.Releases.Create(
+		ctx,
+		strings.Join([]string{g.spec.Owner, g.spec.Repository}, "/"),
+		&goscm.ReleaseInput{
+			Title:       g.spec.Title,
+			Description: g.spec.Drescription + "\n" + updatecliCredits,
+			Tag:         g.spec.Tag,
+			Commitish:   g.spec.Commitish,
+			Draft:       g.spec.Draft,
+			Prerelease:  g.spec.Prerelease,
+		},
+	)
+
+	if err != nil {
+		return false, err
+	}
+
+	if resp.Status >= 400 {
+		logrus.Debugf("RC: %q\nBody:\n%s", resp.Status, resp.Body)
+		return false, fmt.Errorf("error from Gitlab api: %v", resp.Status)
+	}
+
+	logrus.Infof("Gitlab Release %q successfully open on %q", release.Title, release.Link)
+
+	return true, nil
+}
+
+func (g Gitlab) TargetFromSCM(source string, scm scm.ScmHandler, dryRun bool) (bool, []string, string, error) {
+	return false, []string{}, "", fmt.Errorf("target not supported for the plugin Gitlab Release")
+}

--- a/pkg/plugins/resources/gitlab/tag/changelog.go
+++ b/pkg/plugins/resources/gitlab/tag/changelog.go
@@ -1,0 +1,6 @@
+package tag
+
+// Changelog returns the changelog for this resource, or an empty string if not supported
+func (g *Gitlab) Changelog() string {
+	return ""
+}

--- a/pkg/plugins/resources/gitlab/tag/condition.go
+++ b/pkg/plugins/resources/gitlab/tag/condition.go
@@ -1,0 +1,43 @@
+package tag
+
+import (
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
+	"github.com/updatecli/updatecli/pkg/core/result"
+)
+
+func (g *Gitlab) Condition(source string) (bool, error) {
+
+	if len(g.spec.Tag) == 0 {
+		g.spec.Tag = source
+	}
+
+	tags, err := g.SearchTags()
+
+	if err != nil {
+		logrus.Error(err)
+		return false, err
+	}
+
+	if len(tags) == 0 {
+		logrus.Infof("%s No Gitlab Tags found.", result.ATTENTION)
+		return false, nil
+	}
+
+	for _, tag := range tags {
+		if tag == g.spec.Tag {
+			logrus.Infof("%s Gitlab tag %q found", result.SUCCESS, tag)
+			return true, nil
+		}
+	}
+
+	logrus.Infof("%s No Gitlab Tags found matching  %q", result.FAILURE, g.spec.Tag)
+	return false, nil
+
+}
+
+func (g *Gitlab) ConditionFromSCM(source string, scm scm.ScmHandler) (bool, error) {
+	return false, fmt.Errorf("Condition not supported for the plugin GitHub Release")
+}

--- a/pkg/plugins/resources/gitlab/tag/condition_test.go
+++ b/pkg/plugins/resources/gitlab/tag/condition_test.go
@@ -1,0 +1,116 @@
+package tag
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCondition(t *testing.T) {
+
+	tests := []struct {
+		name     string
+		manifest struct {
+			URL        string
+			Token      string
+			Owner      string
+			Repository string
+			Tag        string
+		}
+		wantResult bool
+		wantErr    bool
+	}{
+		{
+			name: "repository olblak/updatecli should not exist",
+			manifest: struct {
+				URL        string
+				Token      string
+				Owner      string
+				Repository string
+				Tag        string
+			}{
+				URL:        "codeberg.org",
+				Token:      "",
+				Owner:      "updatecli",
+				Repository: "updatecli-donotexist",
+			},
+			wantResult: false,
+			wantErr:    true,
+		},
+		{
+			name: "repository olblak/updatecli-mirror should exist with tags",
+			manifest: struct {
+				URL        string
+				Token      string
+				Owner      string
+				Repository string
+				Tag        string
+			}{
+				URL:        "codeberg.org",
+				Token:      "",
+				Owner:      "updatecli",
+				Repository: "updatecli-action",
+			},
+			wantResult: false,
+			wantErr:    false,
+		},
+		{
+			name: "repository should exist with no tag v2.15.0",
+			manifest: struct {
+				URL        string
+				Token      string
+				Owner      string
+				Repository string
+				Tag        string
+			}{
+				URL:        "codeberg.org",
+				Token:      "",
+				Owner:      "updatecli",
+				Repository: "updatecli-action",
+				Tag:        "v2.15.0",
+			},
+			wantResult: true,
+			wantErr:    false,
+		},
+		{
+			name: "repository should exist with no release 0.0.35",
+			manifest: struct {
+				URL        string
+				Token      string
+				Owner      string
+				Repository string
+				Tag        string
+			}{
+				URL:        "codeberg.org",
+				Token:      "",
+				Owner:      "updatecli",
+				Repository: "updatecli-action",
+				Tag:        "0.0.35",
+			},
+			wantResult: false,
+			wantErr:    false,
+		},
+	}
+
+	for _, tt := range tests {
+
+		t.Run(tt.name, func(t *testing.T) {
+
+			g, gotErr := New(tt.manifest)
+			require.NoError(t, gotErr)
+
+			gotResult, gotErr := g.Condition("")
+
+			if tt.wantErr {
+				require.Error(t, gotErr)
+			} else {
+				require.NoError(t, gotErr)
+			}
+
+			assert.Equal(t, tt.wantResult, gotResult)
+
+		})
+
+	}
+}

--- a/pkg/plugins/resources/gitlab/tag/condition_test.go
+++ b/pkg/plugins/resources/gitlab/tag/condition_test.go
@@ -22,7 +22,7 @@ func TestCondition(t *testing.T) {
 		wantErr    bool
 	}{
 		{
-			name: "repository olblak/updatecli should not exist",
+			name: "repository olblak/updatecli-donotexist should not exist",
 			manifest: struct {
 				URL        string
 				Token      string
@@ -30,16 +30,16 @@ func TestCondition(t *testing.T) {
 				Repository string
 				Tag        string
 			}{
-				URL:        "codeberg.org",
+				URL:        "gitlab.com",
 				Token:      "",
-				Owner:      "updatecli",
+				Owner:      "olblak",
 				Repository: "updatecli-donotexist",
 			},
 			wantResult: false,
 			wantErr:    true,
 		},
 		{
-			name: "repository olblak/updatecli-mirror should exist with tags",
+			name: "repository olblak/updatecli should exist with tags",
 			manifest: struct {
 				URL        string
 				Token      string
@@ -47,16 +47,16 @@ func TestCondition(t *testing.T) {
 				Repository string
 				Tag        string
 			}{
-				URL:        "codeberg.org",
+				URL:        "gitlab.com",
 				Token:      "",
-				Owner:      "updatecli",
-				Repository: "updatecli-action",
+				Owner:      "olblak",
+				Repository: "updatecli",
 			},
 			wantResult: false,
 			wantErr:    false,
 		},
 		{
-			name: "repository should exist with no tag v2.15.0",
+			name: "repository should exist with no tag v0.1.11",
 			manifest: struct {
 				URL        string
 				Token      string
@@ -64,31 +64,31 @@ func TestCondition(t *testing.T) {
 				Repository string
 				Tag        string
 			}{
-				URL:        "codeberg.org",
+				URL:        "gitlab.com",
 				Token:      "",
-				Owner:      "updatecli",
-				Repository: "updatecli-action",
-				Tag:        "v2.15.0",
+				Owner:      "olblak",
+				Repository: "updatecli",
+				Tag:        "v0.1.11",
+			},
+			wantResult: false,
+			wantErr:    false,
+		},
+		{
+			name: "repository should exist with tag v0.3.0",
+			manifest: struct {
+				URL        string
+				Token      string
+				Owner      string
+				Repository string
+				Tag        string
+			}{
+				URL:        "gitlab.com",
+				Token:      "",
+				Owner:      "olblak",
+				Repository: "updatecli",
+				Tag:        "v0.3.0",
 			},
 			wantResult: true,
-			wantErr:    false,
-		},
-		{
-			name: "repository should exist with no release 0.0.35",
-			manifest: struct {
-				URL        string
-				Token      string
-				Owner      string
-				Repository string
-				Tag        string
-			}{
-				URL:        "codeberg.org",
-				Token:      "",
-				Owner:      "updatecli",
-				Repository: "updatecli-action",
-				Tag:        "0.0.35",
-			},
-			wantResult: false,
 			wantErr:    false,
 		},
 	}

--- a/pkg/plugins/resources/gitlab/tag/main.go
+++ b/pkg/plugins/resources/gitlab/tag/main.go
@@ -1,0 +1,159 @@
+package tag
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/drone/go-scm/scm"
+	"github.com/mitchellh/mapstructure"
+	"github.com/sirupsen/logrus"
+	"github.com/updatecli/updatecli/pkg/plugins/resources/gitlab/client"
+	"github.com/updatecli/updatecli/pkg/plugins/utils/version"
+)
+
+// Spec defines settings used to interact with Gitlab release
+type Spec struct {
+	client.Spec `yaml:",inline,omitempty"`
+	// [S][C] Owner specifies repository owner
+	Owner string `yaml:",omitempty" jsonschema:"required"`
+	// [S][C] Repository specifies the name of a repository for a specific owner
+	Repository string `yaml:",omitempty" jsonschema:"required"`
+	// [S][C] VersionFilter provides parameters to specify version pattern and its type like regex, semver, or just latest.
+	VersionFilter version.Filter `yaml:",omitempty"`
+	// [S] Tag defines the Gitlab tag .
+	Tag string `yaml:",omitempty"`
+}
+
+// Gitlab contains information to interact with Gitlab api
+type Gitlab struct {
+	// spec contains inputs coming from updatecli configuration
+	spec Spec
+	// client handle the api authentication
+	client        client.Client
+	foundVersion  version.Version
+	versionFilter version.Filter
+}
+
+// New returns a new valid Gitlab object.
+func New(spec interface{}) (*Gitlab, error) {
+	var s Spec
+	var clientSpec client.Spec
+
+	// mapstructure.Decode cannot handle embedded fields
+	// hence we decode it in two steps
+	err := mapstructure.Decode(spec, &clientSpec)
+	if err != nil {
+		return &Gitlab{}, err
+	}
+
+	err = mapstructure.Decode(spec, &s)
+	if err != nil {
+		return &Gitlab{}, nil
+	}
+
+	err = clientSpec.Validate()
+
+	if err != nil {
+		return &Gitlab{}, err
+	}
+
+	err = clientSpec.Sanitize()
+	if err != nil {
+		return &Gitlab{}, err
+	}
+
+	s.Spec = clientSpec
+	err = s.Validate()
+
+	if err != nil {
+		return &Gitlab{}, err
+	}
+
+	c, err := client.New(clientSpec)
+
+	if err != nil {
+		return &Gitlab{}, err
+	}
+
+	newFilter, err := s.VersionFilter.Init()
+	if err != nil {
+		return &Gitlab{}, err
+	}
+	s.VersionFilter = newFilter
+
+	g := Gitlab{
+		spec:          s,
+		client:        c,
+		versionFilter: newFilter,
+	}
+
+	return &g, nil
+
+}
+
+// Retrieve git tags from a remote Gitlab repository
+func (g *Gitlab) SearchTags() (tags []string, err error) {
+
+	// Timeout api query after 30sec
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	references, resp, err := g.client.Git.ListTags(
+		ctx,
+		strings.Join([]string{g.spec.Owner, g.spec.Repository}, "/"),
+		scm.ListOptions{
+			URL:  g.spec.URL,
+			Page: 1,
+			Size: 30,
+		},
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.Status > 400 {
+		logrus.Debugf("RC: %q\nBody:\n%s", resp.Status, resp.Body)
+	}
+
+	for _, ref := range references {
+		tags = append(tags, ref.Name)
+	}
+
+	return tags, nil
+}
+
+func (s Spec) Validate() error {
+	gotError := false
+	missingParameters := []string{}
+
+	err := s.Spec.Validate()
+
+	if err != nil {
+		logrus.Errorln(err)
+		gotError = true
+	}
+
+	if len(s.Owner) == 0 {
+		gotError = true
+		missingParameters = append(missingParameters, "owner")
+	}
+
+	if len(s.Repository) == 0 {
+		gotError = true
+		missingParameters = append(missingParameters, "repository")
+	}
+
+	if len(missingParameters) > 0 {
+		logrus.Errorf("missing parameter(s) [%s]", strings.Join(missingParameters, ","))
+	}
+
+	if gotError {
+		return fmt.Errorf("wrong Gitlab configuration")
+	}
+
+	return nil
+}

--- a/pkg/plugins/resources/gitlab/tag/main.go
+++ b/pkg/plugins/resources/gitlab/tag/main.go
@@ -100,17 +100,13 @@ func (g *Gitlab) SearchTags() (tags []string, err error) {
 			scm.ListOptions{
 				URL:  g.client.BaseURL.Host,
 				Page: page,
-				Size: 30,
+				Size: 100,
 			},
 		)
 
 		if err != nil {
 			return nil, err
 		}
-
-		page = resp.Page.Next
-
-		fmt.Println(resp.Page.Next)
 
 		if resp.Status > 400 {
 			logrus.Debugf("RC: %q\nBody:\n%s", resp.Status, resp.Body)
@@ -120,9 +116,10 @@ func (g *Gitlab) SearchTags() (tags []string, err error) {
 			tags = append(tags, ref.Name)
 		}
 
-		if page == 0 {
+		if page >= resp.Page.Last {
 			break
 		}
+		page++
 	}
 
 	return tags, nil

--- a/pkg/plugins/resources/gitlab/tag/main.go
+++ b/pkg/plugins/resources/gitlab/tag/main.go
@@ -53,17 +53,6 @@ func New(spec interface{}) (*Gitlab, error) {
 		return &Gitlab{}, nil
 	}
 
-	err = clientSpec.Validate()
-
-	if err != nil {
-		return &Gitlab{}, err
-	}
-
-	err = clientSpec.Sanitize()
-	if err != nil {
-		return &Gitlab{}, err
-	}
-
 	s.Spec = clientSpec
 	err = s.Validate()
 
@@ -129,13 +118,6 @@ func (g *Gitlab) SearchTags() (tags []string, err error) {
 func (s Spec) Validate() error {
 	gotError := false
 	missingParameters := []string{}
-
-	err := s.Spec.Validate()
-
-	if err != nil {
-		logrus.Errorln(err)
-		gotError = true
-	}
 
 	if len(s.Owner) == 0 {
 		gotError = true

--- a/pkg/plugins/resources/gitlab/tag/source.go
+++ b/pkg/plugins/resources/gitlab/tag/source.go
@@ -1,0 +1,49 @@
+package tag
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+	"github.com/updatecli/updatecli/pkg/core/result"
+	"github.com/updatecli/updatecli/pkg/plugins/utils/version"
+)
+
+func (g *Gitlab) Source(workingDir string) (string, error) {
+	versions, err := g.SearchTags()
+
+	if err != nil {
+		logrus.Error(err)
+		return "", err
+	}
+
+	if len(versions) == 0 {
+		logrus.Infof("%s No Gitlab Tags found", result.ATTENTION)
+		return "", errors.New("no result found")
+	}
+
+	g.foundVersion, err = g.spec.VersionFilter.Search(versions)
+
+	if err != nil {
+		switch err {
+		case version.ErrNoVersionFound:
+			logrus.Infof("%s No Gitlab tags found matching pattern %q", result.FAILURE, g.versionFilter.Pattern)
+			return "", errors.New("no result found")
+		default:
+			return "", err
+		}
+	}
+
+	value := g.foundVersion.GetVersion()
+
+	if len(value) == 0 {
+		logrus.Infof("%s No Gitlab tags found matching pattern %q", result.FAILURE, g.versionFilter.Pattern)
+		return "", errors.New("no result found")
+	} else if len(value) > 0 {
+		logrus.Infof("%s Gitlab tags %q found matching pattern %q", result.SUCCESS, value, g.versionFilter.Pattern)
+		return value, nil
+	}
+
+	return "", fmt.Errorf("something unexpected happened in Gitlab source")
+
+}

--- a/pkg/plugins/resources/gitlab/tag/source_test.go
+++ b/pkg/plugins/resources/gitlab/tag/source_test.go
@@ -1,0 +1,106 @@
+package tag
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/updatecli/updatecli/pkg/plugins/utils/version"
+)
+
+func TestSource(t *testing.T) {
+
+	tests := []struct {
+		name     string
+		manifest struct {
+			URL           string
+			Token         string
+			Owner         string
+			Repository    string
+			VersionFilter version.Filter
+		}
+		wantResult string
+		wantErr    bool
+	}{
+		{
+			name: "repository olblak/updatecli should not exist",
+			manifest: struct {
+				URL           string
+				Token         string
+				Owner         string
+				Repository    string
+				VersionFilter version.Filter
+			}{
+				URL:        "codeberg.org",
+				Token:      "",
+				Owner:      "updatecli",
+				Repository: "updatecli-dotnotexist",
+			},
+			wantResult: "",
+			wantErr:    true,
+		},
+		{
+			name: "repository should exist with release 0.0.3",
+			manifest: struct {
+				URL           string
+				Token         string
+				Owner         string
+				Repository    string
+				VersionFilter version.Filter
+			}{
+				URL:        "codeberg.org",
+				Token:      "",
+				Owner:      "updatecli",
+				Repository: "updatecli-action",
+				VersionFilter: version.Filter{
+					Kind:    "semver",
+					Pattern: "~1",
+				},
+			},
+			wantResult: "v1.33.0",
+			wantErr:    false,
+		},
+		{
+			name: "repository should exist with no release 1.0.0",
+			manifest: struct {
+				URL           string
+				Token         string
+				Owner         string
+				Repository    string
+				VersionFilter version.Filter
+			}{
+				URL:        "codeberg.org",
+				Token:      "",
+				Owner:      "updatecli",
+				Repository: "updatecli-action",
+				VersionFilter: version.Filter{
+					Kind:    "semver",
+					Pattern: "~0",
+				},
+			},
+			wantResult: "",
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+
+		t.Run(tt.name, func(t *testing.T) {
+
+			g, gotErr := New(tt.manifest)
+			require.NoError(t, gotErr)
+
+			gotResult, gotErr := g.Source("")
+
+			if tt.wantErr {
+				require.Error(t, gotErr)
+			} else {
+				require.NoError(t, gotErr)
+			}
+
+			assert.Equal(t, tt.wantResult, gotResult)
+
+		})
+
+	}
+}

--- a/pkg/plugins/resources/gitlab/tag/source_test.go
+++ b/pkg/plugins/resources/gitlab/tag/source_test.go
@@ -23,7 +23,7 @@ func TestSource(t *testing.T) {
 		wantErr    bool
 	}{
 		{
-			name: "repository olblak/updatecli should not exist",
+			name: "repository olblak/updatecli-donotexist should not exist",
 			manifest: struct {
 				URL           string
 				Token         string
@@ -31,16 +31,16 @@ func TestSource(t *testing.T) {
 				Repository    string
 				VersionFilter version.Filter
 			}{
-				URL:        "codeberg.org",
+				URL:        "gitlab.com",
 				Token:      "",
-				Owner:      "updatecli",
+				Owner:      "olblak",
 				Repository: "updatecli-dotnotexist",
 			},
 			wantResult: "",
 			wantErr:    true,
 		},
 		{
-			name: "repository should exist with release 0.0.3",
+			name: "repository should exist with tag 0.3.0",
 			manifest: struct {
 				URL           string
 				Token         string
@@ -48,20 +48,20 @@ func TestSource(t *testing.T) {
 				Repository    string
 				VersionFilter version.Filter
 			}{
-				URL:        "codeberg.org",
+				URL:        "gitlab.com",
 				Token:      "",
-				Owner:      "updatecli",
-				Repository: "updatecli-action",
+				Owner:      "olblak",
+				Repository: "updatecli",
 				VersionFilter: version.Filter{
 					Kind:    "semver",
-					Pattern: "~1",
+					Pattern: "0.3.0",
 				},
 			},
-			wantResult: "v1.33.0",
+			wantResult: "v0.3.0",
 			wantErr:    false,
 		},
 		{
-			name: "repository should exist with no release 1.0.0",
+			name: "repository should exist with no tag 0.3.11",
 			manifest: struct {
 				URL           string
 				Token         string
@@ -69,13 +69,13 @@ func TestSource(t *testing.T) {
 				Repository    string
 				VersionFilter version.Filter
 			}{
-				URL:        "codeberg.org",
+				URL:        "gitlab.com",
 				Token:      "",
-				Owner:      "updatecli",
-				Repository: "updatecli-action",
+				Owner:      "olblak",
+				Repository: "updatecli",
 				VersionFilter: version.Filter{
 					Kind:    "semver",
-					Pattern: "~0",
+					Pattern: "v0.3.11",
 				},
 			},
 			wantResult: "",

--- a/pkg/plugins/resources/gitlab/tag/source_test.go
+++ b/pkg/plugins/resources/gitlab/tag/source_test.go
@@ -40,6 +40,26 @@ func TestSource(t *testing.T) {
 			wantErr:    true,
 		},
 		{
+			name: "repository should exist with tag 0.3.0 withou specifying gitlab.com",
+			manifest: struct {
+				URL           string
+				Token         string
+				Owner         string
+				Repository    string
+				VersionFilter version.Filter
+			}{
+				Token:      "",
+				Owner:      "olblak",
+				Repository: "updatecli",
+				VersionFilter: version.Filter{
+					Kind:    "semver",
+					Pattern: "0.3.0",
+				},
+			},
+			wantResult: "v0.3.0",
+			wantErr:    false,
+		},
+		{
 			name: "repository should exist with tag 0.3.0",
 			manifest: struct {
 				URL           string

--- a/pkg/plugins/resources/gitlab/tag/target.go
+++ b/pkg/plugins/resources/gitlab/tag/target.go
@@ -1,0 +1,16 @@
+package tag
+
+import (
+	"fmt"
+
+	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
+)
+
+// Target ensure that a specific release exist on Gitlab, otherwise creates it
+func (g *Gitlab) Target(source string, dryRun bool) (bool, error) {
+	return false, fmt.Errorf("target not supported for the plugin Gitlab Tags")
+}
+
+func (g Gitlab) TargetFromSCM(source string, scm scm.ScmHandler, dryRun bool) (bool, []string, string, error) {
+	return false, []string{}, "", fmt.Errorf("target not supported for the plugin Gitlab Tags")
+}

--- a/pkg/plugins/scms/gitlab/main.go
+++ b/pkg/plugins/scms/gitlab/main.go
@@ -63,17 +63,6 @@ func New(spec interface{}, pipelineID string) (*Gitlab, error) {
 		return &Gitlab{}, err
 	}
 
-	err = clientSpec.Sanitize()
-	if err != nil {
-		return &Gitlab{}, err
-	}
-
-	err = clientSpec.Validate()
-
-	if err != nil {
-		return &Gitlab{}, err
-	}
-
 	err = mapstructure.Decode(spec, &s)
 	if err != nil {
 		return &Gitlab{}, nil

--- a/pkg/plugins/scms/gitlab/main.go
+++ b/pkg/plugins/scms/gitlab/main.go
@@ -1,0 +1,175 @@
+package gitlab
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/drone/go-scm/scm"
+	"github.com/mitchellh/mapstructure"
+	"github.com/sirupsen/logrus"
+	"github.com/updatecli/updatecli/pkg/core/tmp"
+	"github.com/updatecli/updatecli/pkg/plugins/resources/gitlab/client"
+	"github.com/updatecli/updatecli/pkg/plugins/scms/git/commit"
+	"github.com/updatecli/updatecli/pkg/plugins/scms/git/sign"
+
+	"github.com/updatecli/updatecli/pkg/plugins/utils/gitgeneric"
+)
+
+// Spec defines settings used to interact with Gitlab release
+type Spec struct {
+	client.Spec `yaml:",inline,omitempty"`
+	// CommitMessage represents conventional commit metadata as type or scope, used to generate the final commit message.
+	CommitMessage commit.Commit `yaml:",omitempty"`
+	// Directory specifies where the github repository is cloned on the local disk
+	Directory string `yaml:",omitempty"`
+	// Email specifies which emails to use when creating commits
+	Email string `yaml:",omitempty"`
+	// Force is used during the git push phase to run `git push --force`.
+	Force bool `yaml:",omitempty"`
+	// GPG key and passphrased used for commit signing
+	GPG sign.GPGSpec `yaml:",omitempty"`
+	// Owner specifies repository owner
+	Owner string `yaml:",omitempty" jsonschema:"required"`
+	// Repository specifies the name of a repository for a specific owner
+	Repository string `yaml:",omitempty" jsonschema:"required"`
+	// User specifies the user of the git commit messages
+	User string `yaml:",omitempty"`
+	// Branch specifies which Gitlab repository branch to work on
+	Branch string `yaml:",omitempty"`
+}
+
+// Gitlab contains information to interact with Gitlab api
+type Gitlab struct {
+	// Spec contains inputs coming from updatecli configuration
+	Spec Spec
+	// client handle the api authentication
+	client           client.Client
+	HeadBranch       string
+	nativeGitHandler gitgeneric.GitHandler
+}
+
+// New returns a new valid Gitlab object.
+func New(spec interface{}, pipelineID string) (*Gitlab, error) {
+	var s Spec
+	var clientSpec client.Spec
+
+	// mapstructure.Decode cannot handle embedded fields
+	// hence we decode it in two steps
+	err := mapstructure.Decode(spec, &clientSpec)
+	if err != nil {
+		return &Gitlab{}, err
+	}
+
+	err = clientSpec.Sanitize()
+	if err != nil {
+		return &Gitlab{}, err
+	}
+
+	err = clientSpec.Validate()
+
+	if err != nil {
+		return &Gitlab{}, err
+	}
+
+	err = mapstructure.Decode(spec, &s)
+	if err != nil {
+		return &Gitlab{}, nil
+	}
+
+	s.Spec = clientSpec
+
+	err = s.Validate()
+
+	if err != nil {
+		return &Gitlab{}, err
+	}
+
+	if s.Directory == "" {
+		s.Directory = path.Join(tmp.Directory, "gitlab", s.Owner, s.Repository)
+	}
+
+	if len(s.Branch) == 0 {
+		logrus.Warningf("no git branch specified, fallback to %q", "main")
+		s.Branch = "main"
+	}
+
+	c, err := client.New(clientSpec)
+
+	if err != nil {
+		return &Gitlab{}, err
+	}
+
+	nativeGitHandler := gitgeneric.GoGit{}
+	g := Gitlab{
+		Spec:             s,
+		client:           c,
+		HeadBranch:       nativeGitHandler.SanitizeBranchName(fmt.Sprintf("updatecli_%v", pipelineID)),
+		nativeGitHandler: nativeGitHandler,
+	}
+
+	g.setDirectory()
+
+	return &g, nil
+
+}
+
+// Retrieve git tags from a remote gitlab repository
+func (g *Gitlab) SearchTags() (tags []string, err error) {
+
+	// Timeout api query after 30sec
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	references, resp, err := g.client.Git.ListTags(
+		ctx,
+		strings.Join([]string{g.Spec.Owner, g.Spec.Repository}, "/"),
+		scm.ListOptions{
+			URL:  g.Spec.URL,
+			Page: 1,
+			Size: 30,
+		},
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.Status > 400 {
+		logrus.Debugf("RC: %q\nBody:\n%s", resp.Status, resp.Body)
+	}
+
+	for _, ref := range references {
+		tags = append(tags, ref.Name)
+	}
+
+	return tags, nil
+}
+
+func (s *Spec) Validate() error {
+	gotError := false
+	missingParameters := []string{}
+
+	if len(s.Owner) == 0 {
+		gotError = true
+		missingParameters = append(missingParameters, "owner")
+	}
+
+	if len(s.Repository) == 0 {
+		gotError = true
+		missingParameters = append(missingParameters, "repository")
+	}
+
+	if len(missingParameters) > 0 {
+		logrus.Errorf("missing parameter(s) [%s]", strings.Join(missingParameters, ","))
+	}
+
+	if gotError {
+		return fmt.Errorf("wrong gitlab configuration")
+	}
+
+	return nil
+}

--- a/pkg/plugins/scms/gitlab/scm.go
+++ b/pkg/plugins/scms/gitlab/scm.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/sirupsen/logrus"
+	"github.com/updatecli/updatecli/pkg/plugins/resources/gitlab/client"
 )
 
 // GetDirectory returns the local git repository path.
@@ -24,8 +25,14 @@ func (g *Gitlab) Clean() error {
 // Clone run `git clone`.
 func (g *Gitlab) Clone() (string, error) {
 
-	URL := fmt.Sprintf("%v/%v/%v.git",
-		g.Spec.URL,
+	url := g.Spec.URL
+
+	if url == "" {
+		url = client.GITLABDOMAIN
+	}
+
+	URL := fmt.Sprintf("https://%s/%s/%s.git",
+		url,
 		g.Spec.Owner,
 		g.Spec.Repository)
 

--- a/pkg/plugins/scms/gitlab/scm.go
+++ b/pkg/plugins/scms/gitlab/scm.go
@@ -1,0 +1,151 @@
+package gitlab
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/sirupsen/logrus"
+)
+
+// GetDirectory returns the local git repository path.
+func (g *Gitlab) GetDirectory() (directory string) {
+	return g.Spec.Directory
+}
+
+// Clean deletes github working directory.
+func (g *Gitlab) Clean() error {
+	err := os.RemoveAll(g.Spec.Directory)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Clone run `git clone`.
+func (g *Gitlab) Clone() (string, error) {
+
+	URL := fmt.Sprintf("%v/%v/%v.git",
+		g.Spec.URL,
+		g.Spec.Owner,
+		g.Spec.Repository)
+
+	g.setDirectory()
+
+	err := g.nativeGitHandler.Clone(g.Spec.User, g.Spec.Token, URL, g.GetDirectory())
+
+	if err != nil {
+		logrus.Errorf("failed cloning Gitlab repository %q", URL)
+		return "", err
+	}
+
+	if len(g.HeadBranch) > 0 && len(g.GetDirectory()) > 0 {
+		err = g.nativeGitHandler.Checkout(
+			g.Spec.Username,
+			g.Spec.Token,
+			g.Spec.Branch,
+			g.HeadBranch,
+			g.GetDirectory(),
+			true)
+	}
+
+	if err != nil {
+		logrus.Errorf("initial Gitlab checkout failed for repository %q", URL)
+		return "", err
+	}
+
+	return g.Spec.Directory, nil
+}
+
+// Commit run `git commit`.
+func (g *Gitlab) Commit(message string) error {
+
+	// Generate the conventional commit message
+	commitMessage, err := g.Spec.CommitMessage.Generate(message)
+	if err != nil {
+		return err
+	}
+
+	err = g.nativeGitHandler.Commit(g.Spec.User, g.Spec.Email, commitMessage, g.GetDirectory(), g.Spec.GPG.SigningKey, g.Spec.GPG.Passphrase)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Checkout create and then uses a temporary git branch.
+func (g *Gitlab) Checkout() error {
+	err := g.nativeGitHandler.Checkout(
+		g.Spec.Username,
+		g.Spec.Token,
+		g.Spec.Branch,
+		g.HeadBranch,
+		g.Spec.Directory,
+		false)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Add run `git add`.
+func (g *Gitlab) Add(files []string) error {
+
+	err := g.nativeGitHandler.Add(files, g.Spec.Directory)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// IsRemoteBranchUpToDate checks if the branche reference name is published on
+// on the default remote
+func (g *Gitlab) IsRemoteBranchUpToDate() (bool, error) {
+	return g.nativeGitHandler.IsLocalBranchPublished(
+		g.Spec.Branch,
+		g.HeadBranch,
+		g.Spec.Username,
+		g.Spec.Token,
+		g.GetDirectory())
+}
+
+// Push run `git push` to the corresponding Gitlab remote branch if not already created.
+func (g *Gitlab) Push() error {
+
+	err := g.nativeGitHandler.Push(g.Spec.Username, g.Spec.Token, g.GetDirectory(), g.Spec.Force)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// PushTag push tags
+func (g *Gitlab) PushTag(tag string) error {
+
+	err := g.nativeGitHandler.PushTag(tag, g.Spec.Username, g.Spec.Token, g.GetDirectory(), g.Spec.Force)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// PushBranch push branch
+func (g *Gitlab) PushBranch(branch string) error {
+
+	err := g.nativeGitHandler.PushTag(
+		branch,
+		g.Spec.Username,
+		g.Spec.Token,
+		g.GetDirectory(),
+		g.Spec.Force)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (g *Gitlab) GetChangedFiles(workingDir string) ([]string, error) {
+	return g.nativeGitHandler.GetChangedFiles(workingDir)
+}

--- a/pkg/plugins/scms/gitlab/util.go
+++ b/pkg/plugins/scms/gitlab/util.go
@@ -1,0 +1,18 @@
+package gitlab
+
+import (
+	"os"
+
+	"github.com/sirupsen/logrus"
+)
+
+func (g *Gitlab) setDirectory() {
+
+	if _, err := os.Stat(g.Spec.Directory); os.IsNotExist(err) {
+
+		err := os.MkdirAll(g.Spec.Directory, 0755)
+		if err != nil {
+			logrus.Errorf("err - %s", err)
+		}
+	}
+}


### PR DESCRIPTION
Fix #738 

This pullrequest add the following items
* Gitlab scm support 
* gitlab/mergerequest action
* Add gitlab resource to manipulate 
  * branch
  * tag
  * release

Some effort is still need to fix the tests and to add e2e tests.
I'll probably need to mirror github.com/updatecli-test to gitlab

## Test

To test this pull request, you can run the following commands:

```shell
cp <to_package_directory>
go test
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
