### PR TITLE
Correctly handle pagination for gitea api request

### DIFF
--- a/pkg/plugins/resources/gitea/branch/main.go
+++ b/pkg/plugins/resources/gitea/branch/main.go
@@ -120,8 +120,6 @@ func (g *Gitea) SearchBranches() (tags []string, err error) {
 			return nil, err
 		}
 
-		page = resp.Page.Next
-
 		if resp.Status > 400 {
 			logrus.Debugf("RC: %q\nBody:\n%s", resp.Status, resp.Body)
 		}
@@ -130,9 +128,10 @@ func (g *Gitea) SearchBranches() (tags []string, err error) {
 			results = append(results, branch.Name)
 		}
 
-		if page == 0 {
+		if page >= resp.Page.Last {
 			break
 		}
+		page++
 	}
 
 	return results, nil

--- a/pkg/plugins/resources/gitea/branch/main.go
+++ b/pkg/plugins/resources/gitea/branch/main.go
@@ -103,27 +103,36 @@ func (g *Gitea) SearchBranches() (tags []string, err error) {
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	branches, resp, err := g.client.Git.ListBranches(
-		ctx,
-		strings.Join([]string{g.spec.Owner, g.spec.Repository}, "/"),
-		scm.ListOptions{
-			URL:  g.spec.URL,
-			Page: 1,
-			Size: 30,
-		},
-	)
-
-	if err != nil {
-		return nil, err
-	}
-
-	if resp.Status > 400 {
-		logrus.Debugf("RC: %q\nBody:\n%s", resp.Status, resp.Body)
-	}
-
 	results := []string{}
-	for _, branch := range branches {
-		results = append(results, branch.Name)
+	page := 0
+	for {
+		branches, resp, err := g.client.Git.ListBranches(
+			ctx,
+			strings.Join([]string{g.spec.Owner, g.spec.Repository}, "/"),
+			scm.ListOptions{
+				URL:  g.spec.URL,
+				Page: page,
+				Size: 30,
+			},
+		)
+
+		if err != nil {
+			return nil, err
+		}
+
+		page = resp.Page.Next
+
+		if resp.Status > 400 {
+			logrus.Debugf("RC: %q\nBody:\n%s", resp.Status, resp.Body)
+		}
+
+		for _, branch := range branches {
+			results = append(results, branch.Name)
+		}
+
+		if page == 0 {
+			break
+		}
 	}
 
 	return results, nil

--- a/pkg/plugins/resources/gitea/pullrequest/utils.go
+++ b/pkg/plugins/resources/gitea/pullrequest/utils.go
@@ -17,43 +17,53 @@ func (g *Gitea) isPullRequestExist() (bool, error) {
 	ctx, cancelList := context.WithTimeout(ctx, 30*time.Second)
 	defer cancelList()
 
-	optsSearch := scm.PullRequestListOptions{
-		Page:   1,
-		Size:   30,
-		Open:   true,
-		Closed: false,
-	}
+	page := 0
+	for {
 
-	pullrequests, resp, err := g.client.PullRequests.List(
-		ctx,
-		strings.Join([]string{
-			g.Owner,
-			g.Repository}, "/"),
-		optsSearch,
-	)
+		optsSearch := scm.PullRequestListOptions{
+			Page:   page,
+			Size:   30,
+			Open:   true,
+			Closed: false,
+		}
+		pullrequests, resp, err := g.client.PullRequests.List(
+			ctx,
+			strings.Join([]string{
+				g.Owner,
+				g.Repository}, "/"),
+			optsSearch,
+		)
 
-	if err != nil {
-		logrus.Debugf("RC: %d\nBody:\n%s", resp.Status, resp.Body)
-		return false, err
-	}
+		if err != nil {
+			logrus.Debugf("RC: %d\nBody:\n%s", resp.Status, resp.Body)
+			return false, err
+		}
 
-	if resp.Status > 400 {
-		logrus.Debugf("RC: %d\nBody:\n%s", resp.Status, resp.Body)
-	}
+		page = resp.Page.Next
 
-	for _, p := range pullrequests {
-		if p.Source == g.SourceBranch &&
-			p.Target == g.TargetBranch &&
-			!p.Closed &&
-			!p.Merged {
+		if resp.Status > 400 {
+			logrus.Debugf("RC: %d\nBody:\n%s", resp.Status, resp.Body)
+		}
 
-			logrus.Infof("%s Nothing else to do, our pullrequest already exist on:\n\t%s",
-				result.SUCCESS,
-				p.Link)
+		for _, p := range pullrequests {
+			if p.Source == g.SourceBranch &&
+				p.Target == g.TargetBranch &&
+				!p.Closed &&
+				!p.Merged {
 
-			return true, nil
+				logrus.Infof("%s Nothing else to do, our pullrequest already exist on:\n\t%s",
+					result.SUCCESS,
+					p.Link)
+
+				return true, nil
+			}
+		}
+
+		if page == 0 {
+			break
 		}
 	}
+
 	return false, nil
 }
 

--- a/pkg/plugins/resources/gitea/pullrequest/utils.go
+++ b/pkg/plugins/resources/gitea/pullrequest/utils.go
@@ -13,12 +13,12 @@ import (
 // isPullRequestExist queries a remote Gitea instance to know if a pullrequest already exists.
 func (g *Gitea) isPullRequestExist() (bool, error) {
 	ctx := context.Background()
-	// Timeout api query after 30sec
-	ctx, cancelList := context.WithTimeout(ctx, 30*time.Second)
-	defer cancelList()
 
 	page := 0
 	for {
+		// Timeout api query after 30sec
+		ctx, cancelList := context.WithTimeout(ctx, 30*time.Second)
+		defer cancelList()
 
 		optsSearch := scm.PullRequestListOptions{
 			Page:   page,
@@ -39,8 +39,6 @@ func (g *Gitea) isPullRequestExist() (bool, error) {
 			return false, err
 		}
 
-		page = resp.Page.Next
-
 		if resp.Status > 400 {
 			logrus.Debugf("RC: %d\nBody:\n%s", resp.Status, resp.Body)
 		}
@@ -59,9 +57,10 @@ func (g *Gitea) isPullRequestExist() (bool, error) {
 			}
 		}
 
-		if page == 0 {
+		if page >= resp.Page.Last {
 			break
 		}
+		page++
 	}
 
 	return false, nil

--- a/pkg/plugins/resources/gitea/release/main.go
+++ b/pkg/plugins/resources/gitea/release/main.go
@@ -117,30 +117,40 @@ func (g *Gitea) SearchReleases() ([]string, error) {
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	releases, resp, err := g.client.Releases.List(
-		ctx,
-		strings.Join([]string{g.spec.Owner, g.spec.Repository}, "/"),
-		scm.ReleaseListOptions{
-			Page:   1,
-			Size:   30,
-			Open:   true,
-			Closed: true,
-		},
-	)
-
-	if err != nil {
-		return nil, err
-	}
-
-	if resp.Status > 400 {
-		logrus.Debugf("Gitea Api Response:\n%+v", resp)
-	}
-
 	results := []string{}
-	for i := len(releases) - 1; i >= 0; i-- {
-		if !releases[i].Draft {
-			results = append(results, releases[i].Tag)
+	page := 0
+	for {
+		releases, resp, err := g.client.Releases.List(
+			ctx,
+			strings.Join([]string{g.spec.Owner, g.spec.Repository}, "/"),
+			scm.ReleaseListOptions{
+				Page:   page,
+				Size:   30,
+				Open:   true,
+				Closed: true,
+			},
+		)
+
+		if err != nil {
+			return nil, err
 		}
+
+		page = resp.Page.Next
+
+		if resp.Status > 400 {
+			logrus.Debugf("Gitea Api Response:\n%+v", resp)
+		}
+
+		for i := len(releases) - 1; i >= 0; i-- {
+			if !releases[i].Draft {
+				results = append(results, releases[i].Tag)
+			}
+		}
+
+		if page == 0 {
+			break
+		}
+
 	}
 
 	return results, nil

--- a/pkg/plugins/resources/gitea/release/main.go
+++ b/pkg/plugins/resources/gitea/release/main.go
@@ -113,13 +113,13 @@ func New(spec interface{}) (*Gitea, error) {
 func (g *Gitea) SearchReleases() ([]string, error) {
 
 	ctx := context.Background()
-	// Timeout api query after 30sec
-	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	defer cancel()
 
 	results := []string{}
 	page := 0
 	for {
+		// Timeout api query after 30sec
+		ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		defer cancel()
 		releases, resp, err := g.client.Releases.List(
 			ctx,
 			strings.Join([]string{g.spec.Owner, g.spec.Repository}, "/"),
@@ -135,8 +135,6 @@ func (g *Gitea) SearchReleases() ([]string, error) {
 			return nil, err
 		}
 
-		page = resp.Page.Next
-
 		if resp.Status > 400 {
 			logrus.Debugf("Gitea Api Response:\n%+v", resp)
 		}
@@ -147,9 +145,10 @@ func (g *Gitea) SearchReleases() ([]string, error) {
 			}
 		}
 
-		if page == 0 {
+		if page >= resp.Page.Last {
 			break
 		}
+		page++
 
 	}
 


### PR DESCRIPTION
While working on the gitlab integration, I realize that I wasn't correctly handling pagination on gitea.
The reason is that during my tests, I have a lot less data on my gitea instance.
The consequence is that Updatecli wouldn't detect older information

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
cp <to_package_directory>
go test
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
