### PR TITLE
Add Golang module support

### DIFF
--- a/pkg/plugins/resources/go/module/changelog.go
+++ b/pkg/plugins/resources/go/module/changelog.go
@@ -1,0 +1,73 @@
+package gomodule
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httputil"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+)
+
+// Changelog returns the changelog for a specific golang module, or an empty string if it couldn't find one
+func (g *GoModule) Changelog() string {
+	if strings.HasPrefix(g.spec.Path, "github.com") {
+		return getChangelogFromGitHub(g.spec.Path, g.foundVersion.OriginalVersion)
+	}
+	return ""
+}
+
+func getChangelogFromGitHub(module, version string) string {
+	parsedModule := strings.Split(module, "/")
+
+	if len(parsedModule) != 3 {
+		return ""
+	}
+
+	URL := fmt.Sprintf("https://api.%s/repos/%s/%s/releases/tags/%s",
+		parsedModule[0], parsedModule[1], parsedModule[2], version)
+
+	req, err := http.NewRequest("GET", URL, nil)
+	if err != nil {
+		logrus.Debugf("failed to retrieve changelog from GitHub %q\n", err)
+		return ""
+	}
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		logrus.Debugf("failed to retrieve changelog from GitHub %q\n", err)
+		return ""
+	}
+
+	defer res.Body.Close()
+	if res.StatusCode >= 400 {
+		body, err := httputil.DumpResponse(res, false)
+		logrus.Debugf("failed to retrieve changelog from GitHub %q\n", err)
+		logrus.Debugf("\n%v\n", string(body))
+		return ""
+	}
+
+	data, err := io.ReadAll(res.Body)
+	if err != nil {
+		logrus.Errorf("something went wrong while getting npm api data%q\n", err)
+		return ""
+	}
+
+	type ReleaseInfo struct {
+		HtmlURL string `json:"html_url,"`
+		Body    string `json:"body,"`
+	}
+
+	release := ReleaseInfo{}
+
+	err = json.Unmarshal(data, &release)
+	if err != nil {
+		logrus.Errorf("error unmarshalling json: %q", err)
+		return ""
+	}
+
+	return fmt.Sprintf("Changelog retrieved from:\n\t%s\n%s",
+		release.HtmlURL, release.Body)
+}

--- a/pkg/plugins/resources/go/module/changelog_test.go
+++ b/pkg/plugins/resources/go/module/changelog_test.go
@@ -1,0 +1,35 @@
+package gomodule
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/updatecli/updatecli/pkg/plugins/utils/version"
+)
+
+func TestChangelog(t *testing.T) {
+	tests := []struct {
+		name           string
+		version        GoModule
+		expectedResult string
+	}{
+		{
+			name: "Test getting changelog from github",
+			version: GoModule{
+				spec: Spec{
+					Path: "github.com/updatecli/updatecli",
+				},
+				foundVersion: version.Version{
+					OriginalVersion: "v0.42.0",
+				},
+			},
+			expectedResult: "Changelog retrieved from:\n\thttps://github.com/updatecli/updatecli/releases/tag/v0.42.0\n## Changes\r\n\r\n## 🚀 Features\r\n\r\n- [source][condition] Add Cargo Package support @loispostula (#1081)\r\n\r\n## 🐛 Bug Fixes\r\n\r\n- chore sourceID deprecated for sourceid @pilere (#1070)\r\n- Only set git http auth if both username && password are specified @olblak (#1079)\r\n\r\n## 🧰 Maintenance\r\n\r\n- chore(deps): Bump github.com/aws/aws-sdk-go from 1.44.156 to 1.44.179 @dependabot (#1085)\r\n- chore(deps): Bump github.com/containerd/containerd from 1.6.6 to 1.6.12 @dependabot (#1082)\r\n- chore(deps): Bump updatecli/updatecli-action from 2.16.2 to 2.17.0 @dependabot (#1080)\r\n- chore(deps): Bump golang.org/x/oauth2 from 0.3.0 to 0.4.0 @dependabot (#1072)\r\n- chore(deps): Bump golang.org/x/text from 0.5.0 to 0.6.0 @dependabot (#1074)\r\n- chore(deps): Bump github.com/go-git/go-git/v5 from 5.5.1 to 5.5.2 @dependabot (#1075)\r\n\r\n## Contributors\r\n\r\n@dependabot, @dependabot[bot], @loispostula, @olblak, @pilere, @updateclibot and @updateclibot[bot]\r\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expectedResult, tt.version.Changelog())
+		})
+	}
+}

--- a/pkg/plugins/resources/go/module/condition.go
+++ b/pkg/plugins/resources/go/module/condition.go
@@ -1,0 +1,46 @@
+package gomodule
+
+import (
+	"errors"
+
+	"github.com/sirupsen/logrus"
+	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
+	"github.com/updatecli/updatecli/pkg/core/result"
+)
+
+// Condition checks that a version exists for a specific golang module
+func (g *GoModule) Condition(source string) (bool, error) {
+	return g.condition(source)
+}
+
+// ConditionFromSCM is not support supported
+func (g *GoModule) ConditionFromSCM(source string, scm scm.ScmHandler) (bool, error) {
+	return g.condition(source)
+}
+
+// Condition checks if a go module with a specific version is published
+func (g *GoModule) condition(source string) (bool, error) {
+	versionToCheck := g.spec.Version
+	if versionToCheck == "" {
+		versionToCheck = source
+	}
+	if len(versionToCheck) == 0 {
+		return false, errors.New("no version defined")
+	}
+
+	_, versions, err := g.versions()
+	if err != nil {
+		return false, err
+	}
+
+	for _, v := range versions {
+		if v == versionToCheck {
+			logrus.Infof("%s version %q available\n", result.SUCCESS, versionToCheck)
+			return true, nil
+		}
+	}
+
+	logrus.Infof("%s version %q doesn't exist\n", result.FAILURE, versionToCheck)
+
+	return false, nil
+}

--- a/pkg/plugins/resources/go/module/condition_test.go
+++ b/pkg/plugins/resources/go/module/condition_test.go
@@ -1,0 +1,48 @@
+package gomodule
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCondition(t *testing.T) {
+	tests := []struct {
+		name           string
+		spec           Spec
+		expectedResult bool
+		expectedError  bool
+	}{
+		{
+			name: "canonical test",
+			spec: Spec{
+				Path:    "github.com/updatecli/updatecli",
+				Version: "v0.47.2",
+			},
+			expectedResult: true,
+		},
+		{
+			name: "Test go module with upper case character",
+			spec: Spec{
+				Path:    "github.com/MakeNowJust/heredoc",
+				Version: "v1.0.0",
+			},
+			expectedResult: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := New(tt.spec, false)
+			require.NoError(t, err)
+			gotVersion, err := got.Condition("")
+			if tt.expectedError {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedResult, gotVersion)
+		})
+	}
+
+}

--- a/pkg/plugins/resources/go/module/main.go
+++ b/pkg/plugins/resources/go/module/main.go
@@ -1,0 +1,48 @@
+package gomodule
+
+import (
+	"net/http"
+
+	"github.com/mitchellh/mapstructure"
+	"github.com/updatecli/updatecli/pkg/core/httpclient"
+	"github.com/updatecli/updatecli/pkg/plugins/utils/version"
+)
+
+/*
+	https://go.dev/ref/mod#goproxy-protocol
+*/
+
+const (
+	goModuleDefaultProxy string = "https://proxy.golang.org"
+)
+
+// GoModule defines a resource of type "gomodule"
+type GoModule struct {
+	spec Spec
+	// versionFilter holds the "valid" version.filter, that might be different from the user-specified filter (Spec.VersionFilter)
+	versionFilter version.Filter
+	foundVersion  version.Version
+	webClient     httpclient.HTTPClient
+}
+
+// New returns a reference to a newly initialized Go Module object from a godmodule.Spec
+// or an error if the provided Spec triggers a validation error.
+func New(spec interface{}, isSCM bool) (*GoModule, error) {
+	newSpec := Spec{}
+
+	err := mapstructure.Decode(spec, &newSpec)
+	if err != nil {
+		return nil, err
+	}
+
+	newFilter, err := newSpec.VersionFilter.Init()
+	if err != nil {
+		return nil, err
+	}
+
+	return &GoModule{
+		spec:          newSpec,
+		versionFilter: newFilter,
+		webClient:     http.DefaultClient,
+	}, nil
+}

--- a/pkg/plugins/resources/go/module/source.go
+++ b/pkg/plugins/resources/go/module/source.go
@@ -1,0 +1,25 @@
+package gomodule
+
+import (
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+	"github.com/updatecli/updatecli/pkg/core/result"
+)
+
+// Source returns the latest go module version
+func (g GoModule) Source(workingDir string) (string, error) {
+	version, _, err := g.versions()
+	if err != nil {
+		return "", err
+	}
+
+	if version != "" {
+		logrus.Infof("%s Version %s found for the GO module %q", result.SUCCESS, version, g.spec.Path)
+		return version, nil
+	}
+
+	logrus.Infof("%s Unknown version %s found for GO module %q ", result.FAILURE, version, g.spec.Path)
+
+	return "", fmt.Errorf("%s Unknown version %s found for GO module %q ", result.FAILURE, version, g.spec.Path)
+}

--- a/pkg/plugins/resources/go/module/source_test.go
+++ b/pkg/plugins/resources/go/module/source_test.go
@@ -1,0 +1,75 @@
+package gomodule
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/updatecli/updatecli/pkg/plugins/utils/version"
+)
+
+func TestSource(t *testing.T) {
+	tests := []struct {
+		name           string
+		spec           Spec
+		expectedResult string
+		expectedError  bool
+	}{
+		{
+			spec: Spec{
+				Path: "github.com/updatecli/updatecli",
+				VersionFilter: version.Filter{
+					Kind:    "semver",
+					Pattern: "0.47",
+				},
+			},
+			expectedResult: "v0.47.2",
+		},
+		{
+			spec: Spec{
+				Proxy: "proxy.golang.org",
+				Path:  "github.com/updatecli/updatecli",
+				VersionFilter: version.Filter{
+					Kind:    "semver",
+					Pattern: "0.47",
+				},
+			},
+			expectedResult: "v0.47.2",
+		},
+		{
+			spec: Spec{
+				Proxy: "direct,proxy.golang.org",
+				Path:  "github.com/updatecli/updatecli",
+				VersionFilter: version.Filter{
+					Kind:    "semver",
+					Pattern: "0.47",
+				},
+			},
+			expectedResult: "v0.47.2",
+		},
+		{
+			spec: Spec{
+				Path: "github.com/MakeNowJust/heredoc",
+				VersionFilter: version.Filter{
+					Kind:    "semver",
+					Pattern: "1.0.0",
+				},
+			},
+			expectedResult: "v1.0.0",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := New(tt.spec, false)
+			require.NoError(t, err)
+			gotVersion, err := got.Source("")
+			if tt.expectedError {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedResult, gotVersion)
+		})
+	}
+
+}

--- a/pkg/plugins/resources/go/module/spec.go
+++ b/pkg/plugins/resources/go/module/spec.go
@@ -1,0 +1,19 @@
+package gomodule
+
+import (
+	"github.com/updatecli/updatecli/pkg/plugins/utils/version"
+)
+
+// Spec defines a specification for a "gomodule" resource
+// parsed from an updatecli manifest file
+type Spec struct {
+	// Proxy may have the schemes https, http. file is not supported at this time. If a URL has no scheme, https is assumed
+	// [S][C] Proxy allows to override GO proxy similarly to GOPROXY environment variable.
+	Proxy string `yaml:",omitempty"`
+	// [S][C] Path specifies the name of the module
+	Path string `yaml:",omitempty" jsonschema:"required"`
+	// [C] Defines a specific package version
+	Version string `yaml:",omitempty"`
+	// [S] VersionFilter provides parameters to specify version pattern and its type like regex, semver, or just latest.
+	VersionFilter version.Filter `yaml:",omitempty"`
+}

--- a/pkg/plugins/resources/go/module/target.go
+++ b/pkg/plugins/resources/go/module/target.go
@@ -1,0 +1,17 @@
+package gomodule
+
+import (
+	"fmt"
+
+	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
+)
+
+// Target is not support for gomodule
+func (g *GoModule) Target(source string, dryRun bool) (bool, error) {
+	return false, fmt.Errorf("Target not supported for the plugin Go module")
+}
+
+// TargetFromSCM is not support for gomodule
+func (g *GoModule) TargetFromSCM(source string, scm scm.ScmHandler, dryRun bool) (bool, []string, string, error) {
+	return false, []string{}, "", fmt.Errorf("Target not supported for the plugin GO module")
+}

--- a/pkg/plugins/resources/go/module/utils.go
+++ b/pkg/plugins/resources/go/module/utils.go
@@ -1,0 +1,42 @@
+package gomodule
+
+import (
+	"strings"
+	"unicode"
+
+	"github.com/sirupsen/logrus"
+)
+
+// sanitizeGoModuleNameForProxy is used to lowercase any uppercase character with a ! prefix as explained on https://go.dev/ref/mod#goproxy-protocol
+func sanitizeGoModuleNameForProxy(module string) string {
+	var result string
+	for _, r := range module {
+		switch !unicode.IsLower(r) && unicode.IsLetter(r) {
+		case true:
+			result += "!" + strings.ToLower(string(r))
+		case false:
+			result += string(r)
+		}
+	}
+	return result
+}
+
+func isSupportedGoProxy(proxy string) bool {
+	if proxy == "direct" || proxy == "off" {
+		logrus.Debugf("proxy %q has no meaning from an Updatecli stand point", proxy)
+		return false
+	}
+	if strings.HasPrefix(proxy, "file://") {
+		logrus.Debugln("updatecli do not support proxy using file protocol at this time. Feel free to open a pullrequest")
+		return false
+	}
+
+	return true
+}
+
+func sanitizeGoProxy(proxy string) string {
+	if strings.HasPrefix(proxy, "https://") || strings.HasPrefix(proxy, "http://") {
+		return proxy
+	}
+	return "https://" + proxy
+}

--- a/pkg/plugins/resources/go/module/utils_test.go
+++ b/pkg/plugins/resources/go/module/utils_test.go
@@ -1,0 +1,34 @@
+package gomodule
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSanitizeGoModuleName(t *testing.T) {
+
+	tests := []struct {
+		name           string
+		module         string
+		expectedResult string
+	}{
+		{
+			name:           "check that uppercase character are correctly lowercase with !",
+			module:         "github.com/UpdateCli/updateclI",
+			expectedResult: "github.com/!update!cli/updatecl!i",
+		},
+		{
+			name:           "check that uppercase character are correctly lowercase with !",
+			module:         "github.com/updatecli/updatecli",
+			expectedResult: "github.com/updatecli/updatecli",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotResult := sanitizeGoModuleNameForProxy(tt.module)
+			assert.Equal(t, tt.expectedResult, gotResult)
+		})
+	}
+}

--- a/pkg/plugins/resources/go/module/version.go
+++ b/pkg/plugins/resources/go/module/version.go
@@ -1,0 +1,86 @@
+package gomodule
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+)
+
+// GetVersions fetch all versions of a Golang module
+func (g *GoModule) versions() (v string, versions []string, err error) {
+
+	var GOPROXY string
+	if g.spec.Proxy != "" {
+		GOPROXY = g.spec.Proxy
+	} else if os.Getenv("GOPROXY") != "" {
+		GOPROXY = os.Getenv("GOPROXY")
+	} else {
+		GOPROXY = goModuleDefaultProxy
+	}
+
+	for _, proxy := range strings.Split(GOPROXY, ",") {
+		if !isSupportedGoProxy(proxy) {
+			continue
+		}
+
+		URL, err := url.JoinPath(
+			sanitizeGoProxy(proxy),
+			sanitizeGoModuleNameForProxy(g.spec.Path),
+			"@v", "list")
+		if err != nil {
+			logrus.Errorf("something went wrong while getting go module api data %q\n", err)
+			return "", []string{}, err
+		}
+
+		req, err := http.NewRequest("GET", URL, nil)
+		if err != nil {
+			logrus.Errorf("something went wrong while getting go module api data %q\n", err)
+			return "", []string{}, err
+		}
+
+		res, err := g.webClient.Do(req)
+		if err != nil {
+			logrus.Errorf("something went wrong while getting go module api data %q\n", err)
+			return "", []string{}, err
+		}
+
+		defer res.Body.Close()
+		if res.StatusCode >= 400 {
+			body, err := httputil.DumpResponse(res, false)
+			logrus.Errorf("something went wrong while getting golang module data %q\n", err)
+			logrus.Debugf("skipping proxy %q due to %q\n", proxy, err)
+			logrus.Debugf("\n%v\n", string(body))
+			continue
+		}
+
+		data, err := io.ReadAll(res.Body)
+		if err != nil {
+			logrus.Errorf("something went wrong while getting npm api data%q\n", err)
+			return "", []string{}, err
+		}
+
+		/*
+			The response should be a list of version separated by \n
+			as explained on https://go.dev/ref/mod#goproxy-protocol
+		*/
+		versions = append(versions, strings.Split(string(data), "\n")...)
+
+		sort.Strings(versions)
+		g.foundVersion, err = g.versionFilter.Search(versions)
+		if err != nil {
+			return "", nil, err
+		}
+
+		return g.foundVersion.GetVersion(), versions, nil
+
+	}
+
+	return "", nil, fmt.Errorf("GO module %q not found on proxy %q", g.spec.Path, GOPROXY)
+}


### PR DESCRIPTION
Related to https://github.com/updatecli/updatecli/issues/1088

This improvement allows to manipulate version from Golang registries.
It support GOPROXY

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
cd pkg/plugins/resources/go/module
go test
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

I don't know yet, this pullrequest is part of some experimentation.
