### PR TITLE
Add K3s as an adopter

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -10,4 +10,4 @@ We are adding public references of Updatecli but feel free to add your organizat
 * [Epinio](https://github.com/epinio/helm-charts/tree/main/updatecli)
 * [Asciidoctor](https://github.com/asciidoctor/docker-asciidoctor/tree/main/updatecli)
 * [SUSE Rancher](https://github.com/rancherlabs/updatecli-automation)
-
+* [K3s](https://github.com/k3s-io/k3s/tree/master/updatecli)


### PR DESCRIPTION
Add [K3s](https://github.com/k3s-io) project as an adopter. Updatecli is being implemented in multiple repositories, some examples are:

- [k3s-io/k3s](https://github.com/k3s-io/k3s/tree/master/updatecli)
- [k3s-io/kine](https://github.com/k3s-io/kine/tree/master/updatecli)
- [k3s-io/klipper-helm](https://github.com/k3s-io/klipper-helm/tree/master/updatecli)
- [k3s-io/klipper-lb](https://github.com/k3s-io/klipper-lb/tree/master/updatecli)