### PR TITLE
Use semver for default Golang version filtering

### DIFF
--- a/pkg/plugins/resources/go/language/main.go
+++ b/pkg/plugins/resources/go/language/main.go
@@ -28,9 +28,11 @@ func New(spec interface{}) (*Language, error) {
 		return nil, err
 	}
 
-	newFilter, err := newSpec.VersionFilter.Init()
-	if err != nil {
-		return nil, err
+	newFilter := newSpec.VersionFilter
+	if newFilter.IsZero() {
+		// By default, golang versioning uses semantic versioning
+		newFilter.Kind = "semver"
+		newFilter.Pattern = "*"
 	}
 
 	return &Language{


### PR DESCRIPTION
By default the golang source plugin returns the wrong version because it uses the wrong version filtering rule

## Test

To test this pull request, you can run the following commands:
Following manifest should return 1.20.3 instead of 1.9.4

```shell
sources:
    golang:
        name: Get latest Golang version
        kind: golang
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
