### PR TITLE
fix golang autodiscovery matching rule

### DIFF
--- a/pkg/plugins/autodiscovery/golang/matchingRule_test.go
+++ b/pkg/plugins/autodiscovery/golang/matchingRule_test.go
@@ -33,6 +33,15 @@ func TestIsMatchingRule(t *testing.T) {
 					Path: "go.mod",
 				},
 			},
+			filePath:       "go.mod",
+			expectedResult: true,
+		},
+		{
+			rules: MatchingRules{
+				MatchingRule{
+					Path: "go.mod",
+				},
+			},
 			filePath:       "./pkg/go.mod",
 			expectedResult: false,
 		},
@@ -45,6 +54,20 @@ func TestIsMatchingRule(t *testing.T) {
 			},
 			filePath:       "go.mod",
 			goVersion:      "1.20",
+			expectedResult: true,
+		},
+		{
+			rules: MatchingRules{
+				MatchingRule{
+					Path: "go.mod",
+				},
+				MatchingRule{
+					Modules: map[string]string{
+						"github.com/updatecli/updatecli": "",
+					},
+				},
+			},
+			filePath:       "go.mod",
 			expectedResult: true,
 		},
 		{


### PR DESCRIPTION
Correctly handle golang autodiscovery matching rule

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
cp <to_package_directory>
go test
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
