### PR TITLE
Refactor target resource to return more metadata

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -14,7 +14,7 @@ docker run --rm -v "$PWD":/usr/src/updatecli -w /usr/src/updatecli -e GOOS=windo
 
 == CONTRIBUTE
 
-They are multiple ways to contribute which don't necessarily involve coding, like providing feedback, improving documentation and processes.
+They're multiple ways to contribute which don't necessarily involve coding, like providing feedback, improving documentation and processes.
 Here I'll just highlight some of them:
 
 === FEEDBACK
@@ -27,13 +27,13 @@ The code is divided into two categories, core and plugins. The core is designed 
 
 ==== CORE
 
-This section is still evolving as they are many areas that need attention.
+This section is still evolving as they're many areas that need attention.
 
 ==== PLUGINS
 
 Plugins can be easily added by following this workflow:
 
-===== 1. Define Package name
+===== 1. Define package name
 
 Creating a new directory using your "packageName" under the directory `pkg/plugins` that will contain your go package similar to:
 
@@ -105,11 +105,10 @@ type Spec interface {
 | Target
 | ```
 type Spec interface {
-    Target(source string, dryRun bool) (bool, error)
-    TargetFromSCM(source string, scm scm.Scm, dryRun bool) (changed bool, files []string, message string, err error)
+    Target(source string, scm scm.Scm, dryRun bool) (changed bool, files []string, message string, err error)
 
 ```
-| Define how a target file will be updated
+| Define how a target file is updated
 
 |===
 

--- a/pkg/core/pipeline/actions.go
+++ b/pkg/core/pipeline/actions.go
@@ -78,8 +78,9 @@ func (p *Pipeline) RunActions() error {
 
 			actionTarget := reports.ActionTarget{
 				// Better for ID to use hash string
-				ID:    fmt.Sprintf("%x", sha256.Sum256([]byte(t))),
-				Title: p.Targets[t].Config.Name,
+				ID:          fmt.Sprintf("%x", sha256.Sum256([]byte(t))),
+				Title:       p.Targets[t].Config.Name,
+				Description: p.Targets[t].Result.Description,
 			}
 
 			if p.Sources[p.Targets[t].Config.SourceID].Changelog != "" {

--- a/pkg/core/pipeline/actions.go
+++ b/pkg/core/pipeline/actions.go
@@ -72,7 +72,7 @@ func (p *Pipeline) RunActions() error {
 
 		for _, t := range relatedTargets {
 			// We only care about target that have changed something
-			if p.Targets[t].Result != result.ATTENTION {
+			if !p.Targets[t].Result.Changed {
 				continue
 			}
 

--- a/pkg/core/pipeline/main.go
+++ b/pkg/core/pipeline/main.go
@@ -60,7 +60,7 @@ func (p *Pipeline) Init(config *config.Config, options Options) error {
 	// Init context resource size
 	p.Report.Sources = make(map[string]reports.Stage, len(config.Spec.Sources))
 	p.Report.Conditions = make(map[string]reports.Stage, len(config.Spec.Conditions))
-	p.Report.Targets = make(map[string]reports.Stage, len(config.Spec.Targets))
+	p.Report.Targets = make(map[string]*result.Target, len(config.Spec.Targets))
 	p.Report.Name = config.Spec.Name
 	p.Report.Result = result.SKIPPED
 
@@ -176,15 +176,14 @@ func (p *Pipeline) Init(config *config.Config, options Options) error {
 
 		p.Targets[id] = target.Target{
 			Config: config.Spec.Targets[id],
-			Result: result.SKIPPED,
-			Scm:    scmPointer,
+			Result: result.Target{
+				Result: result.SKIPPED,
+			},
+			Scm: scmPointer,
 		}
 
-		p.Report.Targets[id] = reports.Stage{
-			Name:   config.Spec.Targets[id].Name,
-			Kind:   config.Spec.Targets[id].Kind,
-			Result: result.SKIPPED,
-		}
+		r := p.Targets[id].Result
+		p.Report.Targets[id] = &r
 	}
 	return nil
 
@@ -264,7 +263,7 @@ func (p *Pipeline) String() string {
 	result = result + fmt.Sprintf("%q:\n", "Targets")
 	for key, value := range p.Targets {
 		result = result + fmt.Sprintf("\t%q:\n", key)
-		result = result + fmt.Sprintf("\t\t%q: %q\n", "Result", value.Result)
+		result = result + fmt.Sprintf("\t\t%q: %q\n", "Result", value.Result.Result)
 	}
 
 	return result

--- a/pkg/core/pipeline/resource/main.go
+++ b/pkg/core/pipeline/resource/main.go
@@ -138,7 +138,7 @@ type Resource interface {
 	Source(workingDir string) (string, error)
 	Condition(version string) (bool, error)
 	ConditionFromSCM(version string, scm scm.ScmHandler) (bool, error)
-	Target(source string, scm scm.ScmHandler, dryRun bool) (changed bool, files []string, message string, err error)
+	Target(source string, scm scm.ScmHandler, dryRun bool, targetResult *result.Target) (err error)
 	Changelog() string
 }
 

--- a/pkg/core/pipeline/resource/main.go
+++ b/pkg/core/pipeline/resource/main.go
@@ -138,8 +138,7 @@ type Resource interface {
 	Source(workingDir string) (string, error)
 	Condition(version string) (bool, error)
 	ConditionFromSCM(version string, scm scm.ScmHandler) (bool, error)
-	Target(source string, dryRun bool) (bool, error)
-	TargetFromSCM(source string, scm scm.ScmHandler, dryRun bool) (changed bool, files []string, message string, err error)
+	Target(source string, scm scm.ScmHandler, dryRun bool) (changed bool, files []string, message string, err error)
 	Changelog() string
 }
 

--- a/pkg/core/pipeline/target/main.go
+++ b/pkg/core/pipeline/target/main.go
@@ -88,7 +88,7 @@ func (t *Target) Run(source string, o *Options) (err error) {
 	// If no scm configuration provided then stop early
 	if t.Scm == nil {
 
-		changed, err = target.Target(source, o.DryRun)
+		changed, _, _, err = target.Target(source, nil, o.DryRun)
 		if err != nil {
 			t.Result = result.FAILURE
 			return err
@@ -119,7 +119,7 @@ func (t *Target) Run(source string, o *Options) (err error) {
 		return err
 	}
 
-	changed, files, message, err = target.TargetFromSCM(source, s, o.DryRun)
+	changed, files, message, err = target.Target(source, s, o.DryRun)
 	if err != nil {
 		t.Result = result.FAILURE
 		return err

--- a/pkg/core/reports/main.go
+++ b/pkg/core/reports/main.go
@@ -36,7 +36,8 @@ REPORTS:
 {{- if .Targets -}}
 {{- "\t" -}}Target:
 {{ range $ID, $target := .Targets }}
-{{- "\t" }}{{"\t"}}{{- $target.Result }} [{{ $ID }}] {{ $target.Name }} (kind: {{ $target.Kind -}}){{"\n"}}
+{{- "\t" }}{{"\t"}}{{- $target.Result }} [{{ $ID }}] {{ $target.Name }}{{"\n"}}
+{{- "\t" }}{{"\t"}}{{"\t"}}=> {{ $target.Description -}}{{"\n"}}
 {{- end }}
 {{ end }}
 {{- end -}}

--- a/pkg/core/reports/main.go
+++ b/pkg/core/reports/main.go
@@ -37,7 +37,6 @@ REPORTS:
 {{- "\t" -}}Target:
 {{ range $ID, $target := .Targets }}
 {{- "\t" }}{{"\t"}}{{- $target.Result }} [{{ $ID }}] {{ $target.Name }}{{"\n"}}
-{{- "\t" }}{{"\t"}}{{"\t"}}=> {{ $target.Description -}}{{"\n"}}
 {{- end }}
 {{ end }}
 {{- end -}}

--- a/pkg/core/reports/report.go
+++ b/pkg/core/reports/report.go
@@ -70,7 +70,7 @@ type Report struct {
 	Result     string
 	Sources    map[string]Stage
 	Conditions map[string]Stage
-	Targets    map[string]Stage
+	Targets    map[string]*result.Target
 }
 
 // Init initializes a new report for a specific configuration
@@ -81,7 +81,7 @@ func (r *Report) Init(name string, sourceNbr, conditionNbr, targetNbr int) {
 
 	r.Sources = make(map[string]Stage, sourceNbr)
 	r.Conditions = make(map[string]Stage, conditionNbr)
-	r.Targets = make(map[string]Stage, targetNbr)
+	r.Targets = make(map[string]*result.Target, targetNbr)
 }
 
 // String returns a report as a string

--- a/pkg/core/result/target.go
+++ b/pkg/core/result/target.go
@@ -1,0 +1,32 @@
+package result
+
+import "fmt"
+
+// Target holds target execution result
+type Target struct {
+	// Name holds the target name
+	Name string
+	/*
+		Result holds the target result, accepted values must be one:
+			* "SUCCESS"
+			* "FAILURE"
+			* "ATTENTION"
+			* "SKIPPED"
+	*/
+	Result string
+	// OldInformation stores the old information detected by the target execution
+	OldInformation string
+	// NewInformation stores the new information updated by during the target execution
+	NewInformation string
+	// Description stores the target execution description
+	Description string
+	// Files holds the list of files modified by a target execution
+	Files   []string
+	Changed bool
+}
+
+func (t *Target) String() string {
+	str := fmt.Sprintf("%q => %q", t.OldInformation, t.NewInformation)
+	str = str + fmt.Sprintf("\n%s - %s", t.Result, t.Description)
+	return str
+}

--- a/pkg/plugins/resources/awsami/target.go
+++ b/pkg/plugins/resources/awsami/target.go
@@ -6,10 +6,6 @@ import (
 	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
 )
 
-func (a *AMI) Target(source string, dryRun bool) (bool, error) {
-	return false, fmt.Errorf("Target not supported for the plugin AWS/AMI")
-}
-
-func (a *AMI) TargetFromSCM(source string, scm scm.ScmHandler, dryRun bool) (bool, []string, string, error) {
+func (a *AMI) Target(source string, scm scm.ScmHandler, dryRun bool) (bool, []string, string, error) {
 	return false, []string{}, "", fmt.Errorf("Target not supported for the plugin AWS/AMI")
 }

--- a/pkg/plugins/resources/awsami/target.go
+++ b/pkg/plugins/resources/awsami/target.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 
 	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
+	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
-func (a *AMI) Target(source string, scm scm.ScmHandler, dryRun bool) (bool, []string, string, error) {
-	return false, []string{}, "", fmt.Errorf("Target not supported for the plugin AWS/AMI")
+func (a *AMI) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
+	return fmt.Errorf("Target not supported for the plugin AWS/AMI")
 }

--- a/pkg/plugins/resources/cargopackage/target.go
+++ b/pkg/plugins/resources/cargopackage/target.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 
 	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
+	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
-func (cp *CargoPackage) Target(source string, scm scm.ScmHandler, dryRun bool) (bool, []string, string, error) {
-	return false, []string{}, "", fmt.Errorf("Target not supported for the plugin Cargo Package")
+func (cp *CargoPackage) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
+	return fmt.Errorf("Target not supported for the plugin Cargo Package")
 }

--- a/pkg/plugins/resources/cargopackage/target.go
+++ b/pkg/plugins/resources/cargopackage/target.go
@@ -6,10 +6,6 @@ import (
 	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
 )
 
-func (cp *CargoPackage) Target(source string, dryRun bool) (bool, error) {
-	return false, fmt.Errorf("Target not supported for the plugin Cargo Package")
-}
-
-func (cp *CargoPackage) TargetFromSCM(source string, scm scm.ScmHandler, dryRun bool) (bool, []string, string, error) {
+func (cp *CargoPackage) Target(source string, scm scm.ScmHandler, dryRun bool) (bool, []string, string, error) {
 	return false, []string{}, "", fmt.Errorf("Target not supported for the plugin Cargo Package")
 }

--- a/pkg/plugins/resources/csv/target.go
+++ b/pkg/plugins/resources/csv/target.go
@@ -40,8 +40,10 @@ func (c *CSV) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarge
 		var queryResults []string
 		var err error
 
+		query := ""
 		switch len(c.spec.Query) > 0 {
 		case true:
+			query = c.spec.Query
 			queryResults, err = c.contents[i].MultipleQuery(c.spec.Query)
 
 			if err != nil {
@@ -49,6 +51,7 @@ func (c *CSV) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarge
 			}
 
 		case false:
+			query = c.spec.Key
 			queryResult, err := c.contents[i].Query(c.spec.Key)
 
 			if err != nil {
@@ -66,23 +69,23 @@ func (c *CSV) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarge
 
 			switch resultTarget.NewInformation == resultTarget.OldInformation {
 			case true:
-				resultTarget.Description = fmt.Sprintf("%s \n * Key %q, from file %q, is correctly set to %q",
+				resultTarget.Description = fmt.Sprintf("%s \n * Query %q correctly return %q from file %q",
 					resultTarget.Description,
-					c.spec.Key,
-					c.contents[i].FilePath,
-					resultTarget.NewInformation)
+					query,
+					resultTarget.NewInformation,
+					c.contents[i].FilePath)
 
 			case false:
 				fileChanged = true
 				resultTarget.Changed = true
 				resultTarget.Files = append(resultTarget.Files, resourceFile)
 				resultTarget.Result = result.ATTENTION
-				resultTarget.Description = fmt.Sprintf("%s\n * Key %q, from file %q, should be updated from %q to %q",
+				resultTarget.Description = fmt.Sprintf("%s\n * Query %q, return update from %q to %q in file %q",
 					resultTarget.Description,
-					c.spec.Key,
-					c.contents[i].FilePath,
+					query,
 					resultTarget.OldInformation,
 					resultTarget.NewInformation,
+					c.contents[i].FilePath,
 				)
 
 			}
@@ -115,7 +118,7 @@ func (c *CSV) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarge
 		}
 	}
 
-	resultTarget.Description = strings.TrimPrefix(resultTarget.Description, "\n ")
+	resultTarget.Description = strings.TrimPrefix(resultTarget.Description, "\n")
 
 	if !dryRun {
 		resultTarget.Description = strings.ReplaceAll(resultTarget.Description, "should be", "")

--- a/pkg/plugins/resources/csv/target.go
+++ b/pkg/plugins/resources/csv/target.go
@@ -10,18 +10,8 @@ import (
 	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
-func (c *CSV) Target(source string, dryRun bool) (changed bool, err error) {
-
-	changed, _, _, err = c.TargetFromSCM(source, nil, dryRun)
-	if err != nil {
-		return changed, err
-	}
-
-	return changed, err
-}
-
-// TargetFromSCM updates a scm repository based on the modified yaml file.
-func (c *CSV) TargetFromSCM(source string, scm scm.ScmHandler, dryRun bool) (changed bool, files []string, message string, err error) {
+// Target updates a scm repository based on the modified yaml file.
+func (c *CSV) Target(source string, scm scm.ScmHandler, dryRun bool) (changed bool, files []string, message string, err error) {
 
 	rootDir := ""
 	if scm != nil {

--- a/pkg/plugins/resources/csv/target_test.go
+++ b/pkg/plugins/resources/csv/target_test.go
@@ -67,7 +67,7 @@ func TestTarget(t *testing.T) {
 
 			require.NoError(t, err)
 
-			gotResult, err := c.Target(tt.sourceInput, true)
+			gotResult, _, _, err := c.Target(tt.sourceInput, nil, true)
 
 			if tt.wantErr {
 				assert.Equal(t, tt.expectedErrorMsg.Error(), err.Error())

--- a/pkg/plugins/resources/csv/target_test.go
+++ b/pkg/plugins/resources/csv/target_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/updatecli/updatecli/pkg/core/result"
 	"gotest.tools/assert"
 )
 
@@ -67,7 +68,8 @@ func TestTarget(t *testing.T) {
 
 			require.NoError(t, err)
 
-			gotResult, _, _, err := c.Target(tt.sourceInput, nil, true)
+			gotResult := result.Target{}
+			err = c.Target(tt.sourceInput, nil, true, &gotResult)
 
 			if tt.wantErr {
 				assert.Equal(t, tt.expectedErrorMsg.Error(), err.Error())
@@ -75,7 +77,7 @@ func TestTarget(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			assert.Equal(t, tt.expectedResult, gotResult)
+			assert.Equal(t, tt.expectedResult, gotResult.Changed)
 		})
 	}
 }

--- a/pkg/plugins/resources/dockerdigest/target.go
+++ b/pkg/plugins/resources/dockerdigest/target.go
@@ -6,10 +6,6 @@ import (
 	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
 )
 
-func (ds *DockerDigest) Target(source string, dryRun bool) (bool, error) {
-	return false, fmt.Errorf("Target not supported for the plugin Docker Digest")
-}
-
-func (ds *DockerDigest) TargetFromSCM(source string, scm scm.ScmHandler, dryRun bool) (bool, []string, string, error) {
+func (ds *DockerDigest) Target(source string, scm scm.ScmHandler, dryRun bool) (bool, []string, string, error) {
 	return false, []string{}, "", fmt.Errorf("Target not supported for the plugin Docker Digest")
 }

--- a/pkg/plugins/resources/dockerdigest/target.go
+++ b/pkg/plugins/resources/dockerdigest/target.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 
 	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
+	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
-func (ds *DockerDigest) Target(source string, scm scm.ScmHandler, dryRun bool) (bool, []string, string, error) {
-	return false, []string{}, "", fmt.Errorf("Target not supported for the plugin Docker Digest")
+func (ds *DockerDigest) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
+	return fmt.Errorf("Target not supported for the plugin Docker Digest")
 }

--- a/pkg/plugins/resources/dockerfile/target.go
+++ b/pkg/plugins/resources/dockerfile/target.go
@@ -7,32 +7,39 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
+	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
 // Target updates a targeted Dockerfile from source control management system
-func (d *Dockerfile) Target(source string, scm scm.ScmHandler, dryRun bool) (changed bool, files []string, message string, err error) {
+func (d *Dockerfile) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) (err error) {
 	if !filepath.IsAbs(d.spec.File) && scm != nil {
 		d.spec.File = filepath.Join(scm.GetDirectory(), d.spec.File)
 		logrus.Debugf("Relative path detected: changing to absolute path from SCM: %q", d.spec.File)
 	}
-	return d.target(source, dryRun)
+	return d.target(source, dryRun, resultTarget)
 }
 
-func (d *Dockerfile) target(source string, dryRun bool) (changed bool, files []string, message string, err error) {
+func (d *Dockerfile) target(source string, dryRun bool, resultTarget *result.Target) (err error) {
 	dockerfileContent, err := d.contentRetriever.ReadAll(d.spec.File)
 	if err != nil {
-		return false, files, message, err
+		return err
 	}
 
-	logrus.Infof("\n🐋 On (Docker)file %q:\n\n", d.spec.File)
+	logrus.Debugf("\n🐋 On (Docker)file %q:\n\n", d.spec.File)
+
+	// At the moment, this plugin do not return the currently used value
+	// This could be a useful improvement for the source
+	resultTarget.OldInformation = "unknown"
+	resultTarget.NewInformation = source
 
 	newDockerfileContent, changedLines, err := d.parser.ReplaceInstructions([]byte(dockerfileContent), source)
 	if err != nil {
-		return false, files, message, err
+		return err
 	}
 
 	if len(changedLines) == 0 {
-		return false, files, message, err
+		logrus.Debugf("empty file detected %q, nothing to do", d.spec.File)
+		return nil
 	}
 
 	lines := []int{}
@@ -41,16 +48,18 @@ func (d *Dockerfile) target(source string, dryRun bool) (changed bool, files []s
 	}
 	sort.Ints(lines)
 
-	message = fmt.Sprintf("changed lines %v of file %q", lines, d.spec.File)
-	files = append(files, d.spec.File)
+	resultTarget.Description = fmt.Sprintf("changed lines %v of file %q", lines, d.spec.File)
+	resultTarget.Files = append(resultTarget.Files, d.spec.File)
+	resultTarget.Changed = true
+	resultTarget.Result = result.ATTENTION
 
 	if !dryRun {
 		// Write the new Dockerfile content from buffer to file
 		err := d.contentRetriever.WriteToFile(string(newDockerfileContent), d.spec.File)
 		if err != nil {
-			return false, files, message, err
+			return err
 		}
 	}
 
-	return true, files, message, err
+	return err
 }

--- a/pkg/plugins/resources/dockerfile/target.go
+++ b/pkg/plugins/resources/dockerfile/target.go
@@ -9,15 +9,9 @@ import (
 	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
 )
 
-// Target updates a targeted Dockerfile
-func (d *Dockerfile) Target(source string, dryRun bool) (bool, error) {
-	changed, _, _, err := d.target(source, dryRun)
-	return changed, err
-}
-
-// TargetFromSCM updates a targeted Dockerfile from source control management system
-func (d *Dockerfile) TargetFromSCM(source string, scm scm.ScmHandler, dryRun bool) (changed bool, files []string, message string, err error) {
-	if !filepath.IsAbs(d.spec.File) {
+// Target updates a targeted Dockerfile from source control management system
+func (d *Dockerfile) Target(source string, scm scm.ScmHandler, dryRun bool) (changed bool, files []string, message string, err error) {
+	if !filepath.IsAbs(d.spec.File) && scm != nil {
 		d.spec.File = filepath.Join(scm.GetDirectory(), d.spec.File)
 		logrus.Debugf("Relative path detected: changing to absolute path from SCM: %q", d.spec.File)
 	}

--- a/pkg/plugins/resources/dockerfile/target_test.go
+++ b/pkg/plugins/resources/dockerfile/target_test.go
@@ -143,7 +143,7 @@ CMD ["--help:golang"]
 				contentRetriever: mockFile,
 				parser:           newParser,
 			}
-			gotChanged, gotErr := d.Target(tt.inputSourceValue, tt.dryRun)
+			gotChanged, _, _, gotErr := d.Target(tt.inputSourceValue, nil, tt.dryRun)
 			if tt.wantErr != nil {
 				assert.Equal(t, tt.wantErr, gotErr)
 				return
@@ -215,7 +215,7 @@ func TestFile_TargetFromSCM(t *testing.T) {
 				contentRetriever: &mockFile,
 				parser:           newParser,
 			}
-			gotChanged, gotFiles, gotMessage, gotErr := d.TargetFromSCM(tt.inputSourceValue, tt.scm, tt.dryRun)
+			gotChanged, gotFiles, gotMessage, gotErr := d.Target(tt.inputSourceValue, tt.scm, tt.dryRun)
 			if tt.wantErr != nil {
 				assert.Equal(t, tt.wantErr, gotErr)
 				return

--- a/pkg/plugins/resources/dockerfile/target_test.go
+++ b/pkg/plugins/resources/dockerfile/target_test.go
@@ -138,19 +138,21 @@ CMD ["--help:golang"]
 
 			mockFile := &tt.mockFile
 
+			gotResult := result.Target{}
+
 			d := &Dockerfile{
 				spec:             tt.spec,
 				contentRetriever: mockFile,
 				parser:           newParser,
 			}
-			gotChanged, _, _, gotErr := d.Target(tt.inputSourceValue, nil, tt.dryRun)
+			gotErr := d.Target(tt.inputSourceValue, nil, tt.dryRun, &gotResult)
 			if tt.wantErr != nil {
 				assert.Equal(t, tt.wantErr, gotErr)
 				return
 			}
 
 			require.NoError(t, gotErr)
-			assert.Equal(t, tt.wantChanged, gotChanged)
+			assert.Equal(t, tt.wantChanged, gotResult.Changed)
 			assert.Equal(t, tt.wantMockState.Contents[tt.spec.File], mockFile.Contents[tt.spec.File])
 		})
 	}
@@ -215,16 +217,19 @@ func TestFile_TargetFromSCM(t *testing.T) {
 				contentRetriever: &mockFile,
 				parser:           newParser,
 			}
-			gotChanged, gotFiles, gotMessage, gotErr := d.Target(tt.inputSourceValue, tt.scm, tt.dryRun)
+
+			gotResult := result.Target{}
+
+			gotErr := d.Target(tt.inputSourceValue, tt.scm, tt.dryRun, &gotResult)
 			if tt.wantErr != nil {
 				assert.Equal(t, tt.wantErr, gotErr)
 				return
 			}
 
 			require.NoError(t, gotErr)
-			assert.Equal(t, tt.wantChanged, gotChanged)
-			assert.Equal(t, tt.wantFiles, gotFiles)
-			assert.Equal(t, tt.wantMessage, gotMessage)
+			assert.Equal(t, tt.wantChanged, gotResult.Changed)
+			assert.Equal(t, tt.wantFiles, gotResult.Files)
+			assert.Equal(t, tt.wantMessage, gotResult.Description)
 			assert.Equal(t, tt.wantMockState.Contents[filePath], mockFile.Contents[filePath])
 		})
 	}

--- a/pkg/plugins/resources/dockerimage/main.go
+++ b/pkg/plugins/resources/dockerimage/main.go
@@ -32,7 +32,7 @@ func New(spec interface{}) (*DockerImage, error) {
 
 	if len(newSpec.Architectures) > 0 {
 		if newSpec.Architecture != "" {
-			return nil, fmt.Errorf("Validation error in the resource of type 'dockerimage': the attributes `spec.architecture` and `spec.architecture` are mutually exclusive")
+			return nil, fmt.Errorf("validation error in the resource of type 'dockerimage': the attributes `spec.architecture` and `spec.architecture` are mutually exclusive")
 		}
 
 	} else {

--- a/pkg/plugins/resources/dockerimage/target.go
+++ b/pkg/plugins/resources/dockerimage/target.go
@@ -6,10 +6,6 @@ import (
 	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
 )
 
-func (di *DockerImage) Target(source string, dryRun bool) (bool, error) {
-	return false, fmt.Errorf("Target not supported for the plugin Docker Image")
-}
-
-func (di *DockerImage) TargetFromSCM(source string, scm scm.ScmHandler, dryRun bool) (bool, []string, string, error) {
+func (di *DockerImage) Target(source string, scm scm.ScmHandler, dryRun bool) (bool, []string, string, error) {
 	return false, []string{}, "", fmt.Errorf("Target not supported for the plugin Docker Image")
 }

--- a/pkg/plugins/resources/dockerimage/target.go
+++ b/pkg/plugins/resources/dockerimage/target.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 
 	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
+	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
-func (di *DockerImage) Target(source string, scm scm.ScmHandler, dryRun bool) (bool, []string, string, error) {
-	return false, []string{}, "", fmt.Errorf("Target not supported for the plugin Docker Image")
+func (di *DockerImage) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
+	return fmt.Errorf("target not supported for the plugin Docker Image")
 }

--- a/pkg/plugins/resources/file/condition.go
+++ b/pkg/plugins/resources/file/condition.go
@@ -2,7 +2,6 @@ package file
 
 import (
 	"fmt"
-	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -22,16 +21,10 @@ func (f *File) Condition(source string) (bool, error) {
 // ConditionFromSCM test if a file content from SCM match the content provided via configuration.
 // If the configuration doesn't specify a value then it fall back to the source output
 func (f *File) ConditionFromSCM(source string, scm scm.ScmHandler) (bool, error) {
-	absoluteFiles := make(map[string]string)
-	for filePath := range f.files {
-		absoluteFilePath := filePath
-		if !filepath.IsAbs(filePath) {
-			absoluteFilePath = filepath.Join(scm.GetDirectory(), filePath)
-			logrus.Debugf("Relative path detected: changing to absolute path from SCM: %q", absoluteFilePath)
-		}
-		absoluteFiles[absoluteFilePath] = f.files[filePath]
+	if scm != nil {
+		f.UpdateAbsoluteFilePath(scm.GetDirectory())
 	}
-	f.files = absoluteFiles
+
 	return f.checkCondition(source)
 }
 
@@ -71,10 +64,10 @@ func (f *File) condition(source string) (bool, error) {
 		return false, err
 	}
 
-	for filePath := range f.files {
-		logMessage := fmt.Sprintf("Content of the file %q", filePath)
+	for filePath, file := range f.files {
+		logMessage := fmt.Sprintf("Content of the file %q", file.originalPath)
 		if f.spec.Line > 0 {
-			logMessage = fmt.Sprintf("Content of the file %q (line %d)", filePath, f.spec.Line)
+			logMessage = fmt.Sprintf("Content of the file %q (line %d)", file.originalPath, f.spec.Line)
 		}
 
 		// If a matchPattern is specified, then return its result
@@ -86,7 +79,7 @@ func (f *File) condition(source string) (bool, error) {
 				return false, err
 			}
 
-			if !reg.MatchString(f.files[filePath]) {
+			if !reg.MatchString(file.content) {
 				logrus.Infof(
 					"%s %s did not match the pattern %q",
 					result.FAILURE,
@@ -108,12 +101,12 @@ func (f *File) condition(source string) (bool, error) {
 			}
 
 			// Compare the content of the file with the source's value
-			if f.files[filePath] != source {
+			if file.content != source {
 				logrus.Infof(
 					"%s %s is different than the input source value:\n%s",
 					result.FAILURE,
 					logMessage,
-					text.Diff(filePath, f.files[filePath], source),
+					text.Diff(filePath, file.content, source),
 				)
 
 				return false, nil
@@ -127,7 +120,7 @@ func (f *File) condition(source string) (bool, error) {
 			logrus.Debug("No attribute 'content' provided")
 			// No content + no source input values means the user only want to check if the line "exists" (e.g. is not empty) and that's all
 			if f.spec.Line > 0 {
-				if f.files[filePath] == "" {
+				if file.content == "" {
 					logrus.Infof("%s %s is empty or the file does not exist.", result.FAILURE, logMessage)
 					return false, nil
 				}
@@ -135,20 +128,22 @@ func (f *File) condition(source string) (bool, error) {
 			}
 
 			// No source, no content, no line: Only check for existence of the file
-			return f.contentRetriever.FileExists(filePath), nil
+			return f.contentRetriever.FileExists(file.path), nil
 		}
 
 		logrus.Debug("Attribute `content` detected")
 
-		if f.spec.Content != f.files[filePath] {
+		if f.spec.Content != file.content {
 			logrus.Infof("%s %s is different than the specified content: \n%s",
 				result.FAILURE,
 				logMessage,
-				text.Diff(filePath, f.files[filePath], f.spec.Content),
+				text.Diff(filePath, file.content, f.spec.Content),
 			)
 			return false, nil
 		}
 		logrus.Infof("%s %s is the same as the specified content.", result.SUCCESS, logMessage)
+
+		f.files[filePath] = file
 	}
 	return true, nil
 }

--- a/pkg/plugins/resources/file/condition.go
+++ b/pkg/plugins/resources/file/condition.go
@@ -29,14 +29,17 @@ func (f *File) ConditionFromSCM(source string, scm scm.ScmHandler) (bool, error)
 }
 
 func (f *File) checkCondition(source string) (bool, error) {
+	files := f.spec.Files
+	files = append(files, f.spec.File)
+
 	passing, err := f.condition(source)
 	if err != nil {
 		logrus.Infof("%s Condition on file errored: %s", result.FAILURE, err.Error())
 	} else {
 		if passing {
-			logrus.Infof("%s Condition on file %q passed", result.SUCCESS, f.spec.Files)
+			logrus.Infof("%s Condition on file %q passed", result.SUCCESS, files)
 		} else {
-			logrus.Infof("%s Condition on file %q did not pass", result.FAILURE, f.spec.Files)
+			logrus.Infof("%s Condition on file %q did not pass", result.FAILURE, files)
 		}
 	}
 

--- a/pkg/plugins/resources/file/condition.go
+++ b/pkg/plugins/resources/file/condition.go
@@ -61,7 +61,7 @@ func (f *File) condition(source string) (bool, error) {
 	}
 	// Return all the validation errors if found any
 	if len(validationErrors) > 0 {
-		return false, fmt.Errorf("Validation error: the provided manifest configuration had the following validation errors:\n%s", strings.Join(validationErrors, "\n\n"))
+		return false, fmt.Errorf("validation error: the provided manifest configuration had the following validation errors:\n%s", strings.Join(validationErrors, "\n\n"))
 	}
 
 	// Start by retrieving the specified file's content
@@ -102,7 +102,7 @@ func (f *File) condition(source string) (bool, error) {
 		if len(source) > 0 {
 			logrus.Debugf("Using source input value: %q", source)
 			if len(f.spec.Content) > 0 {
-				validationError := fmt.Errorf("Validation error in condition of type 'file': the attributes `sourceid` and `spec.content` are mutually exclusive")
+				validationError := fmt.Errorf("validation error in condition of type 'file': the attributes `sourceid` and `spec.content` are mutually exclusive")
 				logrus.Errorf(validationError.Error())
 				return false, validationError
 			}

--- a/pkg/plugins/resources/file/condition_test.go
+++ b/pkg/plugins/resources/file/condition_test.go
@@ -14,7 +14,7 @@ func TestFile_Condition(t *testing.T) {
 	tests := []struct {
 		name             string
 		spec             Spec
-		files            map[string]string
+		files            map[string]fileMetadata
 		inputSourceValue string
 		mockedContents   map[string]string
 		mockedError      error
@@ -29,8 +29,11 @@ func TestFile_Condition(t *testing.T) {
 				},
 				Line: 3,
 			},
-			files: map[string]string{
-				"foo.txt": "",
+			files: map[string]fileMetadata{
+				"foo.txt": {
+					originalPath: "foo.txt",
+					path:         "foo.txt",
+				},
 			},
 			inputSourceValue: "current_version=1.2.3",
 			mockedContents: map[string]string{
@@ -46,8 +49,11 @@ func TestFile_Condition(t *testing.T) {
 				},
 				Content: "Hello World",
 			},
-			files: map[string]string{
-				"foo.txt": "",
+			files: map[string]fileMetadata{
+				"foo.txt": {
+					originalPath: "foo.txt",
+					path:         "foo.txt",
+				},
 			},
 			mockedContents: map[string]string{
 				"foo.txt": "Hello World",
@@ -62,9 +68,15 @@ func TestFile_Condition(t *testing.T) {
 					"bar.txt",
 				},
 			},
-			files: map[string]string{
-				"foo.txt": "",
-				"bar.txt": "",
+			files: map[string]fileMetadata{
+				"foo.txt": {
+					originalPath: "foo.txt",
+					path:         "foo.txt",
+				},
+				"bar.txt": {
+					originalPath: "bar.txt",
+					path:         "bar.txt",
+				},
 			},
 			wantedErr: true,
 		},
@@ -76,8 +88,11 @@ func TestFile_Condition(t *testing.T) {
 				},
 				Content: "Hello World",
 			},
-			files: map[string]string{
-				"foo.txt": "",
+			files: map[string]fileMetadata{
+				"foo.txt": {
+					originalPath: "foo.txt",
+					path:         "foo.txt",
+				},
 			},
 			inputSourceValue: "1.2.3",
 			wantedErr:        true,
@@ -91,8 +106,11 @@ func TestFile_Condition(t *testing.T) {
 				MatchPattern:   "maven_(.*)",
 				ReplacePattern: "gradle_$1",
 			},
-			files: map[string]string{
-				"foo.txt": "",
+			files: map[string]fileMetadata{
+				"foo.txt": {
+					originalPath: "foo.txt",
+					path:         "foo.txt",
+				},
 			},
 			inputSourceValue: "1.2.3",
 			wantedErr:        true,
@@ -105,8 +123,11 @@ func TestFile_Condition(t *testing.T) {
 				},
 				Line: 11,
 			},
-			files: map[string]string{
-				"foo.txt": "",
+			files: map[string]fileMetadata{
+				"foo.txt": {
+					originalPath: "foo.txt",
+					path:         "foo.txt",
+				},
 			},
 			mockedContents: map[string]string{
 				"foo.txt": "",
@@ -121,8 +142,11 @@ func TestFile_Condition(t *testing.T) {
 				},
 				Line: 3,
 			},
-			files: map[string]string{
-				"foo.txt": "",
+			files: map[string]fileMetadata{
+				"foo.txt": {
+					originalPath: "foo.txt",
+					path:         "foo.txt",
+				},
 			},
 			mockedContents: map[string]string{
 				"foo.txt": "A first line\r\nAnother line\r\nSomething On The Specified Line",
@@ -137,8 +161,11 @@ func TestFile_Condition(t *testing.T) {
 				},
 				Line: 5,
 			},
-			files: map[string]string{
-				"foo.txt": "",
+			files: map[string]fileMetadata{
+				"foo.txt": {
+					originalPath: "foo.txt",
+					path:         "foo.txt",
+				},
 			},
 			wantedErr: true,
 		},
@@ -149,8 +176,11 @@ func TestFile_Condition(t *testing.T) {
 					"foo.txt",
 				},
 			},
-			files: map[string]string{
-				"foo.txt": "",
+			files: map[string]fileMetadata{
+				"foo.txt": {
+					originalPath: "foo.txt",
+					path:         "foo.txt",
+				},
 			},
 			wantedErr: true,
 		},
@@ -161,8 +191,11 @@ func TestFile_Condition(t *testing.T) {
 					"https://do.not.exists/foo",
 				},
 			},
-			files: map[string]string{
-				"https://do.not.exists/foo": "",
+			files: map[string]fileMetadata{
+				"https://do.not.exists/foo": {
+					originalPath: "https://do.not.exists/foo",
+					path:         "https://do.not.exists/foo",
+				},
 			},
 			mockedError: fmt.Errorf("URL %q not found or in error", "https://do.not.exists/foo"),
 			wantedErr:   true,
@@ -176,8 +209,11 @@ func TestFile_Condition(t *testing.T) {
 				Line:    2,
 				Content: "Not In All Files",
 			},
-			files: map[string]string{
-				"foo.txt": "",
+			files: map[string]fileMetadata{
+				"foo.txt": {
+					originalPath: "foo.txt",
+					path:         "foo.txt",
+				},
 			},
 			inputSourceValue: "",
 			mockedContents: map[string]string{
@@ -196,9 +232,15 @@ func TestFile_Condition(t *testing.T) {
 				Line:    2,
 				Content: "Not In All Files",
 			},
-			files: map[string]string{
-				"foo.txt": "",
-				"bar.txt": "",
+			files: map[string]fileMetadata{
+				"foo.txt": {
+					originalPath: "foo.txt",
+					path:         "foo.txt",
+				},
+				"bar.txt": {
+					originalPath: "bar.txt",
+					path:         "bar.txt",
+				},
 			},
 			inputSourceValue: "",
 			mockedContents: map[string]string{
@@ -218,9 +260,15 @@ func TestFile_Condition(t *testing.T) {
 				Line:    2,
 				Content: "In All Files",
 			},
-			files: map[string]string{
-				"foo.txt": "",
-				"bar.txt": "",
+			files: map[string]fileMetadata{
+				"foo.txt": {
+					originalPath: "foo.txt",
+					path:         "foo.txt",
+				},
+				"bar.txt": {
+					originalPath: "bar.txt",
+					path:         "bar.txt",
+				},
 			},
 			inputSourceValue: "",
 			mockedContents: map[string]string{
@@ -257,7 +305,7 @@ func TestFile_ConditionFromSCM(t *testing.T) {
 	tests := []struct {
 		name             string
 		spec             Spec
-		files            map[string]string
+		files            map[string]fileMetadata
 		scm              scm.ScmHandler
 		inputSourceValue string
 		mockedContents   map[string]string
@@ -275,8 +323,11 @@ func TestFile_ConditionFromSCM(t *testing.T) {
 				Content: "current_version=1.2.3",
 				Line:    3,
 			},
-			files: map[string]string{
-				"/tmp/foo.txt": "",
+			files: map[string]fileMetadata{
+				"/tmp/foo.txt": {
+					originalPath: "/tmp/foo.txt",
+					path:         "/tmp/foo.txt",
+				},
 			},
 			scm: &scm.MockScm{
 				WorkingDir: "/tmp",
@@ -297,8 +348,11 @@ func TestFile_ConditionFromSCM(t *testing.T) {
 				},
 				MatchPattern: "current_version.*",
 			},
-			files: map[string]string{
-				"/tmp/foo.txt": "",
+			files: map[string]fileMetadata{
+				"/tmp/foo.txt": {
+					originalPath: "/tmp/foo.txt",
+					path:         "/tmp/foo.txt",
+				},
 			},
 			scm: &scm.MockScm{
 				WorkingDir: "/tmp",
@@ -319,8 +373,11 @@ func TestFile_ConditionFromSCM(t *testing.T) {
 				},
 				ForceCreate: true,
 			},
-			files: map[string]string{
-				"/tmp/foo.txt": "",
+			files: map[string]fileMetadata{
+				"/tmp/foo.txt": {
+					originalPath: "foo.txt",
+					path:         "foo.txt",
+				},
 			},
 			scm: &scm.MockScm{
 				WorkingDir: "/tmp",
@@ -336,8 +393,11 @@ func TestFile_ConditionFromSCM(t *testing.T) {
 				},
 				MatchPattern: "^^[[[",
 			},
-			files: map[string]string{
-				"/tmp/foo.txt": "",
+			files: map[string]fileMetadata{
+				"/tmp/foo.txt": {
+					originalPath: "/tmp/foo.txt",
+					path:         "/tmp/foo.txt",
+				},
 			},
 			scm: &scm.MockScm{
 				WorkingDir: "/tmp",
@@ -353,8 +413,11 @@ func TestFile_ConditionFromSCM(t *testing.T) {
 				},
 				MatchPattern: "notMatching.*",
 			},
-			files: map[string]string{
-				"/tmp/foo.txt": "",
+			files: map[string]fileMetadata{
+				"/tmp/foo.txt": {
+					originalPath: "/tmp/foo.txt",
+					path:         "/tmp/foo.txt",
+				},
 			},
 			scm: &scm.MockScm{
 				WorkingDir: "/tmp",

--- a/pkg/plugins/resources/file/main.go
+++ b/pkg/plugins/resources/file/main.go
@@ -116,7 +116,7 @@ func (s *Spec) Validate() error {
 
 	// Return all the validation errors if any
 	if len(validationErrors) > 0 {
-		return fmt.Errorf("Validation error: the provided manifest configuration had the following validation errors:\n%s", strings.Join(validationErrors, "\n\n"))
+		return fmt.Errorf("validation error: the provided manifest configuration had the following validation errors:\n%s", strings.Join(validationErrors, "\n\n"))
 	}
 
 	return nil
@@ -151,9 +151,9 @@ func (f *File) Read() error {
 				logrus.Infof("Creating a new file at %q", filePath)
 			} else {
 				if f.spec.Line > 0 {
-					return fmt.Errorf("%s The specified line %d of the file %q does not exist.\n", result.FAILURE, f.spec.Line, filePath)
+					return fmt.Errorf("%s The specified line %d of the file %q does not exist", result.FAILURE, f.spec.Line, filePath)
 				}
-				return fmt.Errorf("%s The specified file %q does not exist. If you want to create it, you must set the attribute 'spec.forcecreate' to 'true'.\n", result.FAILURE, filePath)
+				return fmt.Errorf("%s The specified file %q does not exist. If you want to create it, you must set the attribute 'spec.forcecreate' to 'true'", result.FAILURE, filePath)
 			}
 		}
 	}

--- a/pkg/plugins/resources/file/main_test.go
+++ b/pkg/plugins/resources/file/main_test.go
@@ -151,7 +151,7 @@ func TestFile_Read(t *testing.T) {
 	tests := []struct {
 		name           string
 		spec           Spec
-		files          map[string]string
+		files          map[string]fileMetadata
 		mockedContents map[string]string
 		mockedError    error
 		wantedContents map[string]string
@@ -163,8 +163,11 @@ func TestFile_Read(t *testing.T) {
 			spec: Spec{
 				File: "/bar.txt",
 			},
-			files: map[string]string{
-				"/bar.txt": "",
+			files: map[string]fileMetadata{
+				"/bar.txt": {
+					originalPath: "/bar.txt",
+					path:         "/bar.txt",
+				},
 			},
 			mockedContents: map[string]string{
 				"/bar.txt": "Hello World",
@@ -180,8 +183,11 @@ func TestFile_Read(t *testing.T) {
 				Line: 3,
 				File: "/foo.txt",
 			},
-			files: map[string]string{
-				"/foo.txt": "",
+			files: map[string]fileMetadata{
+				"/foo.txt": {
+					originalPath: "/foo.txt",
+					path:         "/foo.txt",
+				},
 			},
 			mockedContents: map[string]string{
 				"/foo.txt": "Title\r\nGood Bye\r\nThe End",
@@ -197,8 +203,11 @@ func TestFile_Read(t *testing.T) {
 				Line: 5,
 				File: "/foo.txt",
 			},
-			files: map[string]string{
-				"/foo.txt": "",
+			files: map[string]fileMetadata{
+				"/foo.txt": {
+					originalPath: "/foo.txt",
+					path:         "/foo.txt",
+				},
 			},
 			mockedContents: map[string]string{
 				"/foo.txt": "Title\r\nGood Bye\r\nThe End",
@@ -213,8 +222,11 @@ func TestFile_Read(t *testing.T) {
 			spec: Spec{
 				File: "/not_existing.txt",
 			},
-			files: map[string]string{
-				"/not_existing.txt": "",
+			files: map[string]fileMetadata{
+				"/not_existing.txt": {
+					originalPath: "/not_existing.txt",
+					path:         "/not_existing.txt",
+				},
 			},
 			mockedError: fmt.Errorf("no such file or directory"),
 			wantedErr:   true,
@@ -225,8 +237,11 @@ func TestFile_Read(t *testing.T) {
 				File: "/not_existing.txt",
 				Line: 15,
 			},
-			files: map[string]string{
-				"/not_existing.txt": "",
+			files: map[string]fileMetadata{
+				"/not_existing.txt": {
+					originalPath: "/not_existing.txt",
+					path:         "/not_existing.txt",
+				},
 			},
 			mockedError: fmt.Errorf("no such file or directory"),
 			wantedErr:   true,

--- a/pkg/plugins/resources/file/source.go
+++ b/pkg/plugins/resources/file/source.go
@@ -47,7 +47,9 @@ func (f *File) Source(workingDir string) (string, error) {
 	// Replace old file path
 	if newFilePath != "" {
 		delete(f.files, oldFilePath)
-		f.files[newFilePath] = ""
+		file := f.files[newFilePath]
+		file.content = ""
+		f.files[newFilePath] = file
 	}
 
 	if err := f.Read(); err != nil {
@@ -56,7 +58,7 @@ func (f *File) Source(workingDir string) (string, error) {
 
 	// Looping on the only filePath in 'files'
 	for filePath := range f.files {
-		foundContent = f.files[filePath]
+		foundContent = f.files[filePath].content
 		// If a matchPattern is specified, then retrieve the string matched and returns the (eventually) multi-line string
 		if len(f.spec.MatchPattern) > 0 {
 			reg, err := regexp.Compile(f.spec.MatchPattern)
@@ -66,10 +68,10 @@ func (f *File) Source(workingDir string) (string, error) {
 			}
 
 			// Check if there is any match in the file
-			if !reg.MatchString(f.files[filePath]) {
+			if !reg.MatchString(f.files[filePath].content) {
 				return "", fmt.Errorf("no line matched in the file %q for the pattern %q", filePath, f.spec.MatchPattern)
 			}
-			matchedStrings := reg.FindAllString(f.files[filePath], -1)
+			matchedStrings := reg.FindAllString(f.files[filePath].content, -1)
 
 			foundContent = strings.Join(matchedStrings, "\n")
 		}

--- a/pkg/plugins/resources/file/source.go
+++ b/pkg/plugins/resources/file/source.go
@@ -19,20 +19,20 @@ func (f *File) Source(workingDir string) (string, error) {
 	var newFilePath string
 
 	if len(f.spec.Files) > 1 {
-		validationErrors = append(validationErrors, "Validation error in source of type 'file': the attributes `spec.files` can't contain more than one element for sources")
+		validationErrors = append(validationErrors, "validation error in source of type 'file': the attributes `spec.files` can't contain more than one element for sources")
 	}
 	if len(f.spec.ReplacePattern) > 0 {
-		validationErrors = append(validationErrors, "Validation error in source of type 'file': the attribute `spec.replacepattern` is only supported for targets.")
+		validationErrors = append(validationErrors, "validation error in source of type 'file': the attribute `spec.replacepattern` is only supported for targets")
 	}
 	if len(f.spec.Content) > 0 {
-		validationErrors = append(validationErrors, "Validation error in source of type 'file': the attribute `spec.content` is only supported for conditions and targets.")
+		validationErrors = append(validationErrors, "validation error in source of type 'file': the attribute `spec.content` is only supported for conditions and targets")
 	}
 	if f.spec.ForceCreate {
-		validationErrors = append(validationErrors, "Validation error in source of type 'file': the attribute `spec.forcecreate` is only supported for targets.")
+		validationErrors = append(validationErrors, "validation error in source of type 'file': the attribute `spec.forcecreate` is only supported for targets")
 	}
 	// Return all the validation errors if found any
 	if len(validationErrors) > 0 {
-		return "", fmt.Errorf("Validation error: the provided manifest configuration had the following validation errors:\n%s", strings.Join(validationErrors, "\n\n"))
+		return "", fmt.Errorf("validation error: the provided manifest configuration had the following validation errors:\n%s", strings.Join(validationErrors, "\n\n"))
 	}
 
 	// Looping on the only filePath in 'files'
@@ -41,7 +41,7 @@ func (f *File) Source(workingDir string) (string, error) {
 		if !text.IsURL(filePath) && !filepath.IsAbs(filePath) {
 			newFilePath = filepath.Join(workingDir, filePath)
 			oldFilePath = filePath
-			logrus.Debugf("Relative path detected: changing to absolute path from working directory: %q", filePath)
+			logrus.Debugf("relative path detected: changing to absolute path from working directory: %q", filePath)
 		}
 	}
 	// Replace old file path
@@ -61,13 +61,13 @@ func (f *File) Source(workingDir string) (string, error) {
 		if len(f.spec.MatchPattern) > 0 {
 			reg, err := regexp.Compile(f.spec.MatchPattern)
 			if err != nil {
-				logrus.Errorf("Validation error in source of type 'file': Unable to parse the regexp specified at f.spec.MatchPattern (%q)", f.spec.MatchPattern)
+				logrus.Errorf("validation error in source of type 'file': Unable to parse the regexp specified at f.spec.MatchPattern (%q)", f.spec.MatchPattern)
 				return "", err
 			}
 
 			// Check if there is any match in the file
 			if !reg.MatchString(f.files[filePath]) {
-				return "", fmt.Errorf("No line matched in the file %q for the pattern %q", filePath, f.spec.MatchPattern)
+				return "", fmt.Errorf("no line matched in the file %q for the pattern %q", filePath, f.spec.MatchPattern)
 			}
 			matchedStrings := reg.FindAllString(f.files[filePath], -1)
 

--- a/pkg/plugins/resources/file/source_test.go
+++ b/pkg/plugins/resources/file/source_test.go
@@ -13,7 +13,7 @@ func TestFile_Source(t *testing.T) {
 	tests := []struct {
 		name           string
 		spec           Spec
-		files          map[string]string
+		files          map[string]fileMetadata
 		mockedContents map[string]string
 		mockedError    error
 		wantedContents map[string]string
@@ -25,8 +25,11 @@ func TestFile_Source(t *testing.T) {
 			spec: Spec{
 				File: "/home/ucli/foo.txt",
 			},
-			files: map[string]string{
-				"/home/ucli/foo.txt": "",
+			files: map[string]fileMetadata{
+				"/home/ucli/foo.txt": {
+					originalPath: "/home/ucli/foo.txt",
+					path:         "/home/ucli/foo.txt",
+				},
 			},
 			mockedContents: map[string]string{
 				"/home/ucli/foo.txt": "Hello World",
@@ -43,8 +46,11 @@ func TestFile_Source(t *testing.T) {
 					"/home/ucli/foo.txt",
 				},
 			},
-			files: map[string]string{
-				"/home/ucli/foo.txt": "",
+			files: map[string]fileMetadata{
+				"/home/ucli/foo.txt": {
+					originalPath: "/home/ucli/foo.txt",
+					path:         "/home/ucli/foo.txt",
+				},
 			},
 			mockedContents: map[string]string{
 				"/home/ucli/foo.txt": "Hello World",
@@ -60,8 +66,11 @@ func TestFile_Source(t *testing.T) {
 				File: "/home/ucli/foo.txt",
 				Line: 3,
 			},
-			files: map[string]string{
-				"/home/ucli/foo.txt": "",
+			files: map[string]fileMetadata{
+				"/home/ucli/foo.txt": {
+					originalPath: "/home/ucli/foo.txt",
+					path:         "/home/ucli/foo.txt",
+				},
 			},
 			mockedContents: map[string]string{
 				"/home/ucli/foo.txt": "Title\r\nGood Bye\r\nThe End",
@@ -76,8 +85,11 @@ func TestFile_Source(t *testing.T) {
 				File:         "/home/ucli/foo.txt",
 				MatchPattern: ".*freebsd_386.*",
 			},
-			files: map[string]string{
-				"/home/ucli/foo.txt": "",
+			files: map[string]fileMetadata{
+				"/home/ucli/foo.txt": {
+					originalPath: "/home/ucli/foo.txt",
+					path:         "/home/ucli/foo.txt",
+				},
 			},
 			mockedContents: map[string]string{
 				"/home/ucli/foo.txt": `363d0e0c5c4cb4e69f5f2c7f64f9bf01ab73af0801665d577441521a24313a07  terraform_0.14.5_darwin_amd64.zip
@@ -105,8 +117,11 @@ func TestFile_Source(t *testing.T) {
 				File:         "/home/ucli/foo.txt",
 				MatchPattern: ".*terraform_.*_linux_.*",
 			},
-			files: map[string]string{
-				"/home/ucli/foo.txt": "",
+			files: map[string]fileMetadata{
+				"/home/ucli/foo.txt": {
+					originalPath: "/home/ucli/foo.txt",
+					path:         "/home/ucli/foo.txt",
+				},
 			},
 			mockedContents: map[string]string{
 				"/home/ucli/foo.txt": `363d0e0c5c4cb4e69f5f2c7f64f9bf01ab73af0801665d577441521a24313a07  terraform_0.14.5_darwin_amd64.zip
@@ -138,9 +153,15 @@ func TestFile_Source(t *testing.T) {
 					"/home/ucli/bar.txt",
 				},
 			},
-			files: map[string]string{
-				"/home/ucli/foo.txt": "",
-				"/home/ucli/bar.txt": "",
+			files: map[string]fileMetadata{
+				"/home/ucli/foo.txt": {
+					originalPath: "/home/ucli/foo.txt",
+					path:         "/home/ucli/foo.txt",
+				},
+				"/home/ucli/bar.txt": {
+					originalPath: "/home/ucli/bar.txt",
+					path:         "/home/ucli/bar.txt",
+				},
 			},
 			wantedErr: true,
 		},
@@ -151,8 +172,11 @@ func TestFile_Source(t *testing.T) {
 				ReplacePattern: "gradle_$1",
 				File:           "/home/ucli/foo.txt",
 			},
-			files: map[string]string{
-				"/home/ucli/foo.txt": "",
+			files: map[string]fileMetadata{
+				"/home/ucli/foo.txt": {
+					originalPath: "/home/ucli/foo.txt",
+					path:         "/home/ucli/foo.txt",
+				},
 			},
 			wantedErr: true,
 		},
@@ -162,8 +186,11 @@ func TestFile_Source(t *testing.T) {
 				Content: "Hello world",
 				File:    "/home/ucli/foo.txt",
 			},
-			files: map[string]string{
-				"/home/ucli/foo.txt": "",
+			files: map[string]fileMetadata{
+				"/home/ucli/foo.txt": {
+					originalPath: "/home/ucli/foo.txt",
+					path:         "/home/ucli/foo.txt",
+				},
 			},
 			wantedErr: true,
 		},
@@ -173,8 +200,11 @@ func TestFile_Source(t *testing.T) {
 				ForceCreate: true,
 				File:        "/home/ucli/foo.txt",
 			},
-			files: map[string]string{
-				"/home/ucli/foo.txt": "",
+			files: map[string]fileMetadata{
+				"/home/ucli/foo.txt": {
+					originalPath: "/home/ucli/foo.txt",
+					path:         "/home/ucli/foo.txt",
+				},
 			},
 			wantedErr: true,
 		},
@@ -184,14 +214,17 @@ func TestFile_Source(t *testing.T) {
 				MatchPattern: "(d+:1",
 				File:         "/home/ucli/foo.txt",
 			},
-			files: map[string]string{
-				"/home/ucli/foo.txt": "",
+			files: map[string]fileMetadata{
+				"/home/ucli/foo.txt": {
+					originalPath: "/home/ucli/foo.txt",
+					path:         "/home/ucli/foo.txt",
+				},
 			},
 			wantedErr: true,
 		},
 		{
 			name:        "Failing case with non existing 'File'",
-			files:       map[string]string{},
+			files:       map[string]fileMetadata{},
 			mockedError: fmt.Errorf("no such file or directory"),
 			wantedErr:   true,
 		},
@@ -201,8 +234,11 @@ func TestFile_Source(t *testing.T) {
 				File: "/home/ucli/foo.txt",
 				Line: 3,
 			},
-			files: map[string]string{
-				"/home/ucli/foo.txt": "",
+			files: map[string]fileMetadata{
+				"/home/ucli/foo.txt": {
+					originalPath: "/home/ucli/foo.txt",
+					path:         "/home/ucli/foo.txt",
+				},
 			},
 			mockedContents: map[string]string{
 				"/home/ucli/foo.txt": "Don't worry\r\nBe happy",

--- a/pkg/plugins/resources/file/target.go
+++ b/pkg/plugins/resources/file/target.go
@@ -157,7 +157,7 @@ func (f *File) target(source string, dryRun bool, resultTarget *result.Target) e
 			contentType,
 			filePath)
 
-		logrus.Debugf("%s updated %s of file %q\n\n%s\n",
+		logrus.Debugf("updated %s of file %q\n\n%s\n",
 			contentType,
 			filePath,
 			text.Diff(filePath, originalContents[filePath], f.files[filePath]),

--- a/pkg/plugins/resources/file/target.go
+++ b/pkg/plugins/resources/file/target.go
@@ -115,8 +115,6 @@ func (f *File) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarg
 		resultTarget.Changed = false
 		resultTarget.Result = result.SUCCESS
 
-		logrus.Infoln(resultTarget.Description)
-
 		return nil
 	}
 

--- a/pkg/plugins/resources/file/target.go
+++ b/pkg/plugins/resources/file/target.go
@@ -16,7 +16,7 @@ import (
 
 // Target creates or updates a file from a source control management system.
 // The default content is the value retrieved from source
-func (f *File) Target(source string, scm scm.ScmHandler, dryRun bool) (bool, []string, string, error) {
+func (f *File) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
 	absoluteFiles := make(map[string]string)
 	for filePath := range f.files {
 		absoluteFilePath := filePath
@@ -28,17 +28,16 @@ func (f *File) Target(source string, scm scm.ScmHandler, dryRun bool) (bool, []s
 	}
 	f.files = absoluteFiles
 
-	return f.target(source, dryRun)
+	return f.target(source, dryRun, resultTarget)
 }
 
-func (f *File) target(source string, dryRun bool) (bool, []string, string, error) {
+func (f *File) target(source string, dryRun bool, resultTarget *result.Target) error {
 	var files []string
-	var message strings.Builder
 
 	if f.spec.Line > 0 && f.spec.ForceCreate {
 		validationError := fmt.Errorf("validation error in target of type 'file': 'spec.line' and 'spec.forcecreate' are mutually exclusive")
 		logrus.Errorf(validationError.Error())
-		return false, files, message.String(), validationError
+		return validationError
 	}
 
 	// Test if target reference a file with a prefix like https:// or file://, as we don't know how to update those files.
@@ -47,13 +46,13 @@ func (f *File) target(source string, dryRun bool) (bool, []string, string, error
 		if text.IsURL(filePath) {
 			validationError := fmt.Errorf("validation error in target of type 'file': spec.files item value (%q) is an URL which is not supported for a target", filePath)
 			logrus.Errorf(validationError.Error())
-			return false, files, message.String(), validationError
+			return validationError
 		}
 	}
 
 	// Retrieving content of file(s) in memory (nothing in case of spec.forceCreate)
 	if err := f.Read(); err != nil {
-		return false, files, message.String(), err
+		return err
 	}
 
 	originalContents := make(map[string]string)
@@ -63,6 +62,19 @@ func (f *File) target(source string, dryRun bool) (bool, []string, string, error
 	if len(f.spec.Content) > 0 {
 		inputContent = f.spec.Content
 	}
+
+	resultTarget.NewInformation = inputContent
+	/*
+		At the moment, we don't have an easy to identify that precise information
+		that would be updated without considering the new file content.
+
+		It's doable but out of the current scope of the effort.
+
+		With a valid usecase we can improve the situation.
+
+		Especially considering that we may have multiple files to update
+	*/
+	resultTarget.OldInformation = "unknown"
 
 	// If we're using a regexp for the target
 	if len(f.spec.MatchPattern) > 0 {
@@ -74,14 +86,14 @@ func (f *File) target(source string, dryRun bool) (bool, []string, string, error
 		reg, err := regexp.Compile(f.spec.MatchPattern)
 		if err != nil {
 			logrus.Errorf("Validation error in target of type 'file': Unable to parse the regexp specified at f.spec.MatchPattern (%q)", f.spec.MatchPattern)
-			return false, files, message.String(), err
+			return err
 		}
 
 		for filePath := range f.files {
 			// Check if there is any match in the file
 			if !reg.MatchString(f.files[filePath]) {
 				// We allow the possibility to match only some files. In that case, just a warning here
-				return false, files, message.String(), fmt.Errorf("no line matched in the file %q for the pattern %q", filePath, f.spec.MatchPattern)
+				return fmt.Errorf("no line matched in file %q for pattern %q", filePath, f.spec.MatchPattern)
 			}
 			// Keep the original content for later comparison
 			originalContents[filePath] = f.files[filePath]
@@ -100,16 +112,24 @@ func (f *File) target(source string, dryRun bool) (bool, []string, string, error
 	for filePath := range f.files {
 		if f.files[filePath] == originalContents[filePath] {
 			notChanged++
-			logrus.Infof("%s Content from file %q already up to date", result.SUCCESS, filePath)
+			logrus.Debugf("content from file %q already up to date", filePath)
 		} else {
 			files = append(files, filePath)
 		}
 	}
 	if notChanged == len(f.files) {
-		logrus.Infof("%s All contents from 'file' and 'files' combined already up to date", result.SUCCESS)
-		return false, files, message.String(), nil
+		resultTarget.Description = "all contents from 'file' and 'files' combined already up to date"
+		resultTarget.Files = files
+		resultTarget.Changed = false
+		resultTarget.Result = result.SUCCESS
+
+		logrus.Infoln(resultTarget.Description)
+
+		return nil
 	}
+
 	sort.Strings(files)
+
 	// Otherwise write the new content to the file(s), or nothing but logs if dry run is enabled
 	for filePath := range f.files {
 		var contentType string
@@ -129,16 +149,26 @@ func (f *File) target(source string, dryRun bool) (bool, []string, string, error
 			contentType = fmt.Sprintf("line %d", f.spec.Line)
 		}
 		if err != nil {
-			return false, files, message.String(), err
+			return err
 		}
-		logrus.Infof("%s updated the %s of the file %q\n\n%s\n",
-			result.ATTENTION,
+
+		resultTarget.Description = fmt.Sprintf("%s\nUpdated %s of file %q\n",
+			resultTarget.Description,
+			contentType,
+			filePath)
+
+		logrus.Debugf("%s updated %s of file %q\n\n%s\n",
 			contentType,
 			filePath,
 			text.Diff(filePath, originalContents[filePath], f.files[filePath]),
 		)
-		message.WriteString(fmt.Sprintf("Updated the %s of the file %q\n", contentType, filePath))
 	}
 
-	return true, files, message.String(), nil
+	resultTarget.Description = strings.TrimPrefix(resultTarget.Description, "\n")
+
+	resultTarget.Result = result.ATTENTION
+	resultTarget.Changed = true
+	resultTarget.Files = files
+
+	return nil
 }

--- a/pkg/plugins/resources/file/target_test.go
+++ b/pkg/plugins/resources/file/target_test.go
@@ -371,7 +371,7 @@ func TestFile_TargetMultiples(t *testing.T) {
 				files:            tt.files,
 			}
 
-			gotResult, gotErr := f.Target(tt.inputSourceValue, tt.dryRun)
+			gotResult, _, _, gotErr := f.Target(tt.inputSourceValue, nil, tt.dryRun)
 
 			if tt.wantedErr {
 				assert.Error(t, gotErr)
@@ -520,7 +520,7 @@ func TestFile_TargetFromSCM(t *testing.T) {
 				files:            tt.files,
 			}
 
-			gotResult, gotFiles, _, gotErr := f.TargetFromSCM(tt.inputSourceValue, tt.scm, tt.dryRun)
+			gotResult, gotFiles, _, gotErr := f.Target(tt.inputSourceValue, tt.scm, tt.dryRun)
 
 			if tt.wantedErr {
 				assert.Error(t, gotErr)

--- a/pkg/plugins/resources/file/target_test.go
+++ b/pkg/plugins/resources/file/target_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
+	"github.com/updatecli/updatecli/pkg/core/result"
 	"github.com/updatecli/updatecli/pkg/core/text"
 )
 
@@ -371,7 +372,8 @@ func TestFile_TargetMultiples(t *testing.T) {
 				files:            tt.files,
 			}
 
-			gotResult, _, _, gotErr := f.Target(tt.inputSourceValue, nil, tt.dryRun)
+			gotResultTarget := result.Target{}
+			gotErr := f.Target(tt.inputSourceValue, nil, tt.dryRun, &gotResultTarget)
 
 			if tt.wantedErr {
 				assert.Error(t, gotErr)
@@ -379,7 +381,7 @@ func TestFile_TargetMultiples(t *testing.T) {
 			}
 			require.NoError(t, gotErr)
 
-			assert.Equal(t, tt.wantedResult, gotResult)
+			assert.Equal(t, tt.wantedResult, gotResultTarget.Changed)
 			for filePath := range tt.files {
 				assert.Equal(t, tt.wantedContents[filePath], mockedText.Contents[filePath])
 			}
@@ -520,7 +522,9 @@ func TestFile_TargetFromSCM(t *testing.T) {
 				files:            tt.files,
 			}
 
-			gotResult, gotFiles, _, gotErr := f.Target(tt.inputSourceValue, tt.scm, tt.dryRun)
+			gotResultTarget := result.Target{}
+
+			gotErr := f.Target(tt.inputSourceValue, tt.scm, tt.dryRun, &gotResultTarget)
 
 			if tt.wantedErr {
 				assert.Error(t, gotErr)
@@ -528,8 +532,8 @@ func TestFile_TargetFromSCM(t *testing.T) {
 			}
 			require.NoError(t, gotErr)
 
-			assert.Equal(t, tt.wantedResult, gotResult)
-			assert.Equal(t, tt.wantedFiles, gotFiles)
+			assert.Equal(t, tt.wantedResult, gotResultTarget.Changed)
+			assert.Equal(t, tt.wantedFiles, gotResultTarget.Files)
 
 			for filePath := range f.files {
 				assert.Equal(t, tt.wantedContents[filePath], mockedText.Contents[filePath])

--- a/pkg/plugins/resources/file/target_test.go
+++ b/pkg/plugins/resources/file/target_test.go
@@ -15,7 +15,7 @@ func TestFile_TargetMultiples(t *testing.T) {
 	tests := []struct {
 		name             string
 		spec             Spec
-		files            map[string]string
+		files            map[string]fileMetadata
 		inputSourceValue string
 		mockedContents   map[string]string
 		mockedError      error
@@ -32,8 +32,11 @@ func TestFile_TargetMultiples(t *testing.T) {
 				MatchPattern:   "maven_(.*)=.*",
 				ReplacePattern: "maven_$1= 3.9.0",
 			},
-			files: map[string]string{
-				"foo.txt": "",
+			files: map[string]fileMetadata{
+				"foo.txt": {
+					originalPath: "foo.txt",
+					path:         "foo.txt",
+				},
 			},
 			mockedContents: map[string]string{
 				"foo.txt": `maven_version = "3.8.2"
@@ -68,9 +71,15 @@ func TestFile_TargetMultiples(t *testing.T) {
 				MatchPattern:   "maven_(.*)=.*",
 				ReplacePattern: "maven_$1= 3.9.0",
 			},
-			files: map[string]string{
-				"foo.txt": "",
-				"bar.txt": "",
+			files: map[string]fileMetadata{
+				"foo.txt": {
+					originalPath: "foo.txt",
+					path:         "foo.txt",
+				},
+				"bar.txt": {
+					originalPath: "bar.txt",
+					path:         "bar.txt",
+				},
 			},
 			mockedContents: map[string]string{
 				"foo.txt": `maven_version = "3.8.2"
@@ -110,8 +119,11 @@ func TestFile_TargetMultiples(t *testing.T) {
 				File:    "foo.txt",
 				Content: "Be happy",
 			},
-			files: map[string]string{
-				"foo.txt": "",
+			files: map[string]fileMetadata{
+				"foo.txt": {
+					originalPath: "foo.txt",
+					path:         "foo.txt",
+				},
 			},
 			inputSourceValue: "current_version=1.2.3",
 			mockedContents: map[string]string{
@@ -131,9 +143,15 @@ func TestFile_TargetMultiples(t *testing.T) {
 				},
 				Content: "Be happy",
 			},
-			files: map[string]string{
-				"foo.txt": "",
-				"bar.txt": "",
+			files: map[string]fileMetadata{
+				"foo.txt": {
+					originalPath: "foo.txt",
+					path:         "foo.txt",
+				},
+				"bar.txt": {
+					originalPath: "bar.txt",
+					path:         "bar.txt",
+				},
 			},
 			inputSourceValue: "current_version=1.2.3",
 			mockedContents: map[string]string{
@@ -153,8 +171,11 @@ func TestFile_TargetMultiples(t *testing.T) {
 				Content: "Hello World",
 				Line:    2,
 			},
-			files: map[string]string{
-				"foo.txt": "",
+			files: map[string]fileMetadata{
+				"foo.txt": {
+					originalPath: "foo.txt",
+					path:         "foo.txt",
+				},
 			},
 			mockedContents: map[string]string{
 				"foo.txt": "Title\r\nGood Bye\r\nThe end",
@@ -175,9 +196,15 @@ func TestFile_TargetMultiples(t *testing.T) {
 				Content: "Hello World",
 				Line:    2,
 			},
-			files: map[string]string{
-				"foo.txt": "",
-				"bar.txt": "",
+			files: map[string]fileMetadata{
+				"foo.txt": {
+					originalPath: "foo.txt",
+					path:         "foo.txt",
+				},
+				"bar.txt": {
+					originalPath: "bar.txt",
+					path:         "bar.txt",
+				},
 			},
 			mockedContents: map[string]string{
 				"foo.txt": "Title\r\nGood Bye\r\nThe end",
@@ -195,8 +222,11 @@ func TestFile_TargetMultiples(t *testing.T) {
 			spec: Spec{
 				File: "https://github.com/foo.txt",
 			},
-			files: map[string]string{
-				"https://github.com/foo.txt": "",
+			files: map[string]fileMetadata{
+				"https://github.com/foo.txt": {
+					originalPath: "https://github.com/foo.txt",
+					path:         "https://github.com/foo.txt",
+				},
 			},
 			wantedResult: false,
 			wantedErr:    true,
@@ -209,9 +239,15 @@ func TestFile_TargetMultiples(t *testing.T) {
 					"https://github.com/bar.txt",
 				},
 			},
-			files: map[string]string{
-				"foo.txt":                    "",
-				"https://github.com/bar.txt": "",
+			files: map[string]fileMetadata{
+				"foo.txt": {
+					originalPath: "foo.txt",
+					path:         "foo.txt",
+				},
+				"https://github.com/bar.txt": {
+					originalPath: "https://github.com/bar.txt",
+					path:         "https://github.com/bar.txt",
+				},
 			},
 			wantedResult: false,
 			wantedErr:    true,
@@ -225,8 +261,11 @@ func TestFile_TargetMultiples(t *testing.T) {
 				ForceCreate: true,
 				Line:        2,
 			},
-			files: map[string]string{
-				"foo.txt": "",
+			files: map[string]fileMetadata{
+				"foo.txt": {
+					originalPath: "foo.txt",
+					path:         "foo.txt",
+				},
 			},
 			wantedResult: false,
 			wantedErr:    true,
@@ -239,8 +278,11 @@ func TestFile_TargetMultiples(t *testing.T) {
 				},
 				MatchPattern: "(d+:1",
 			},
-			files: map[string]string{
-				"foo.txt": "",
+			files: map[string]fileMetadata{
+				"foo.txt": {
+					originalPath: "foo.txt",
+					path:         "foo.txt",
+				},
 			},
 			wantedResult: false,
 			wantedErr:    true,
@@ -253,8 +295,11 @@ func TestFile_TargetMultiples(t *testing.T) {
 				},
 				Line: 3,
 			},
-			files: map[string]string{
-				"not_existing.txt": "",
+			files: map[string]fileMetadata{
+				"not_existing.txt": {
+					originalPath: "not_existing.txt",
+					path:         "not_existing.txt",
+				},
 			},
 			wantedResult: false,
 			wantedErr:    true,
@@ -267,8 +312,11 @@ func TestFile_TargetMultiples(t *testing.T) {
 				},
 				Content: "Hello World",
 			},
-			files: map[string]string{
-				"not_existing.txt": "",
+			files: map[string]fileMetadata{
+				"not_existing.txt": {
+					originalPath: "not_existing.txt",
+					path:         "not_existing.txt",
+				},
 			},
 			wantedResult: false,
 			wantedErr:    true,
@@ -281,8 +329,11 @@ func TestFile_TargetMultiples(t *testing.T) {
 				},
 				Line: 3,
 			},
-			files: map[string]string{
-				"foo.txt": "",
+			files: map[string]fileMetadata{
+				"foo.txt": {
+					originalPath: "foo.txt",
+					path:         "foo.txt",
+				},
 			},
 			mockedContents: map[string]string{
 				"foo.txt": "Be happy",
@@ -299,8 +350,11 @@ func TestFile_TargetMultiples(t *testing.T) {
 				},
 				Content: "Hello World",
 			},
-			files: map[string]string{
-				"foo.txt": "",
+			files: map[string]fileMetadata{
+				"foo.txt": {
+					originalPath: "foo.txt",
+					path:         "foo.txt",
+				},
 			},
 			mockedContents: map[string]string{
 				"foo.txt": "Be happy",
@@ -321,9 +375,15 @@ func TestFile_TargetMultiples(t *testing.T) {
 				},
 				Line: 3,
 			},
-			files: map[string]string{
-				"foo.txt": "",
-				"bar.txt": "",
+			files: map[string]fileMetadata{
+				"foo.txt": {
+					path:         "foo.txt",
+					originalPath: "foo.txt",
+				},
+				"bar.txt": {
+					path:         "bar.txt",
+					originalPath: "bar.txt",
+				},
 			},
 			inputSourceValue: "Be happy",
 			mockedContents: map[string]string{
@@ -344,9 +404,15 @@ func TestFile_TargetMultiples(t *testing.T) {
 					"bar.txt",
 				},
 			},
-			files: map[string]string{
-				"foo.txt": "",
-				"bar.txt": "",
+			files: map[string]fileMetadata{
+				"foo.txt": {
+					originalPath: "foo.txt",
+					path:         "foo.txt",
+				},
+				"bar.txt": {
+					originalPath: "bar.txt",
+					path:         "bar.txt",
+				},
 			},
 			inputSourceValue: "current_version=1.2.3",
 			mockedContents: map[string]string{
@@ -393,7 +459,7 @@ func TestFile_TargetFromSCM(t *testing.T) {
 	tests := []struct {
 		name             string
 		spec             Spec
-		files            map[string]string
+		files            map[string]fileMetadata
 		scm              scm.ScmHandler
 		inputSourceValue string
 		mockedContents   map[string]string
@@ -413,9 +479,15 @@ func TestFile_TargetFromSCM(t *testing.T) {
 				},
 				Line: 3,
 			},
-			files: map[string]string{
-				"/tmp/foo.txt": "",
-				"/tmp/bar.txt": "",
+			files: map[string]fileMetadata{
+				"/tmp/foo.txt": {
+					originalPath: "/tmp/foo.txt",
+					path:         "/tmp/foo.txt",
+				},
+				"/tmp/bar.txt": {
+					originalPath: "/tmp/bar.txt",
+					path:         "/tmp/bar.txt",
+				},
 			},
 			scm: &scm.MockScm{
 				WorkingDir: "/tmp",
@@ -445,9 +517,15 @@ func TestFile_TargetFromSCM(t *testing.T) {
 				},
 				ForceCreate: true,
 			},
-			files: map[string]string{
-				"/tmp/foo.txt": "",
-				"/tmp/bar.txt": "",
+			files: map[string]fileMetadata{
+				"/tmp/foo.txt": {
+					originalPath: "/tmp/foo.txt",
+					path:         "/tmp/foo.txt",
+				},
+				"/tmp/bar.txt": {
+					originalPath: "/tmp/bar.txt",
+					path:         "/tmp/bar.txt",
+				},
 			},
 			scm: &scm.MockScm{
 				WorkingDir: "/tmp",
@@ -478,9 +556,15 @@ func TestFile_TargetFromSCM(t *testing.T) {
 				MatchPattern:   "notmatching=*",
 				ReplacePattern: "maven_version= 3.9.0",
 			},
-			files: map[string]string{
-				"/tmp/bar.txt": "",
-				"/tmp/foo.txt": "",
+			files: map[string]fileMetadata{
+				"/tmp/bar.txt": {
+					originalPath: "/tmp/bar.txt",
+					path:         "/tmp/bar.txt",
+				},
+				"/tmp/foo.txt": {
+					originalPath: "/tmp/foo.txt",
+					path:         "/tmp/foo.txt",
+				},
 			},
 			scm: &scm.MockScm{
 				WorkingDir: "/tmp",

--- a/pkg/plugins/resources/file/utils.go
+++ b/pkg/plugins/resources/file/utils.go
@@ -1,0 +1,18 @@
+package file
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// joinPathwithworkingDirectoryPath To merge File path with current workingDir, unless file is an HTTP URL
+func joinPathWithWorkingDirectoryPath(filePath, workingDir string) string {
+	if workingDir == "" ||
+		filepath.IsAbs(filePath) ||
+		strings.HasPrefix(filePath, "https://") ||
+		strings.HasPrefix(filePath, "http://") {
+		return filePath
+	}
+
+	return filepath.Join(workingDir, filePath)
+}

--- a/pkg/plugins/resources/gitbranch/target.go
+++ b/pkg/plugins/resources/gitbranch/target.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Target creates and pushes a git tag based on the SCM configuration
-func (gt *GitBranch) Target(source string, scm scm.ScmHandler, dryRun bool) (changed bool, files []string, message string, err error) {
+func (gt *GitBranch) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) (err error) {
 
 	if scm != nil {
 		if len(gt.spec.Path) > 0 {
@@ -26,93 +26,100 @@ func (gt *GitBranch) Target(source string, scm scm.ScmHandler, dryRun bool) (cha
 		gt.branch = gt.spec.Branch
 	}
 
+	resultTarget.NewInformation = gt.branch
+
 	if gt.branch == "" {
-		return changed, files, message, fmt.Errorf("empty branch specified")
+		return fmt.Errorf("empty branch specified")
 	}
 
-	changed, files, message, err = gt.target(dryRun)
+	err = gt.target(dryRun, resultTarget)
 	if err != nil {
-		return changed, files, message, err
+		return err
 	}
 
 	if dryRun {
 		// Dry run: no changes to apply.
 		// Return early without creating branch but notify that a change should be made.
-		return changed, files, message, nil
+		return nil
 	}
 
-	if !changed {
-		logrus.Infof("%s The git branch %q already exist on the specified remote.", result.SUCCESS, gt.branch)
-		return changed, files, message, nil
+	if !resultTarget.Changed {
+		resultTarget.Description = fmt.Sprintf("the git branch %q already exist on the specified remote.", gt.branch)
+		return nil
 	}
 
 	logrus.Printf("git branch %q has been created.", gt.branch)
 
 	if scm == nil {
-		return changed, files, message, nil
+		resultTarget.Description = fmt.Sprintf("The git branch %q created but missing scm configuration to push it", gt.branch)
+		return nil
 	}
 
 	err = scm.PushBranch(gt.branch)
 	if err != nil {
 		logrus.Errorf("Git push tag error: %s", err)
-		return changed, files, message, err
+		return err
 	}
-	logrus.Infof("%s The git branch %q was pushed successfully to the specified remote.", result.ATTENTION, gt.branch)
-	return changed, files, message, err
+
+	resultTarget.Description = fmt.Sprintf("git branch %q created and pushed", gt.branch)
+	return nil
 }
 
-func (gt *GitBranch) target(dryRun bool) (bool, []string, string, error) {
+func (gt *GitBranch) target(dryRun bool, resultTarget *result.Target) error {
 
 	// cfr https://github.com/updatecli/updatecli/issues/1126
 	// to know why the following line is needed at the moment
-	files := []string{""}
-	message := ""
+	resultTarget.Files = []string{""}
 
 	// Fail if the git tag resource cannot be validated
 	err := gt.Validate()
 	if err != nil {
 		logrus.Errorln(err)
-		return false, files, message, err
+		return err
 	}
 
 	// Check if the provided branch (from source input value) already exists
 	branches, err := gt.nativeGitHandler.Branches(gt.spec.Path)
 	if err != nil {
-		return false, files, message, err
+		return err
 	}
 
 	found := false
 	for _, b := range branches {
 		if b == gt.branch {
 			found = true
+			break
 		}
 	}
 
+	resultTarget.NewInformation = gt.branch
+
 	if found {
-		// No error, but no change
-		logrus.Printf("%s The Git branch %q already exists, nothing else to do.",
-			result.SUCCESS,
-			gt.branch)
-		return false, files, message, nil
+		resultTarget.Result = result.SUCCESS
+		resultTarget.OldInformation = gt.branch
+		resultTarget.Description = fmt.Sprintf("git branch %q already exists", gt.branch)
+		return nil
 	}
 
-	// Otherwise proceed to create this new branch
-	logrus.Printf("%s The git branch %q does not exist: creating it.", result.ATTENTION, gt.branch)
+	resultTarget.Result = result.ATTENTION
+	resultTarget.Changed = true
+	resultTarget.OldInformation = ""
+
+	logrus.Debugf("git branch %q does not exist: creating it.", gt.branch)
 
 	if dryRun {
 		// Dry run: no changes to apply.
 		// Return early without creating branch but notify that a change should be made.
-		return true, files, message, nil
+		resultTarget.Description = fmt.Sprintf("git branch %q should be created", gt.branch)
+		return nil
 	}
 
-	changed, err := gt.nativeGitHandler.NewBranch(gt.branch, gt.spec.Path)
+	resultTarget.Changed, err = gt.nativeGitHandler.NewBranch(gt.branch, gt.spec.Path)
 	if err != nil {
-		return changed, files, message, err
+		return err
 	}
 
-	logrus.Printf("%s The git branch %q has been created.", result.ATTENTION, gt.branch)
+	resultTarget.Description = fmt.Sprintf("git branch %q created.", gt.branch)
 
-	message = fmt.Sprintf("Git branch %q has been created.", gt.branch)
-
-	return changed, files, message, nil
+	return nil
 }

--- a/pkg/plugins/resources/gitea/branch/target.go
+++ b/pkg/plugins/resources/gitea/branch/target.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 
 	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
+	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
-func (g Gitea) Target(source string, scm scm.ScmHandler, dryRun bool) (bool, []string, string, error) {
-	return false, []string{}, "", fmt.Errorf("target not supported for the plugin GitHub Release")
+func (g Gitea) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
+	return fmt.Errorf("target not supported for the plugin Gitea branch")
 }

--- a/pkg/plugins/resources/gitea/branch/target.go
+++ b/pkg/plugins/resources/gitea/branch/target.go
@@ -6,12 +6,6 @@ import (
 	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
 )
 
-// Target ensure that a specific release exist on gitea, otherwise creates it
-func (g *Gitea) Target(source string, dryRun bool) (bool, error) {
-	return false, fmt.Errorf("target not supported for the plugin Gitea branch")
-
-}
-
-func (g Gitea) TargetFromSCM(source string, scm scm.ScmHandler, dryRun bool) (bool, []string, string, error) {
+func (g Gitea) Target(source string, scm scm.ScmHandler, dryRun bool) (bool, []string, string, error) {
 	return false, []string{}, "", fmt.Errorf("target not supported for the plugin GitHub Release")
 }

--- a/pkg/plugins/resources/gitea/release/target.go
+++ b/pkg/plugins/resources/gitea/release/target.go
@@ -13,8 +13,7 @@ import (
 )
 
 // Target ensure that a specific release exist on gitea, otherwise creates it
-func (g *Gitea) Target(source string, dryRun bool) (bool, error) {
-
+func (g Gitea) Target(source string, scm scm.ScmHandler, dryRun bool) (bool, []string, string, error) {
 	if len(g.spec.Tag) == 0 {
 		g.spec.Tag = source
 	}
@@ -48,23 +47,23 @@ func (g *Gitea) Target(source string, dryRun bool) (bool, error) {
 
 	if err != nil {
 		logrus.Debugf("Gitea Api Response:\nReturn Code: %q\nBody:\n%s", resp.Status, resp.Body)
-		return false, err
+		return false, []string{}, "", err
 	}
 
 	for _, r := range releases {
 		if r.Tag == g.spec.Tag {
 			logrus.Infof("%s Release Tag %q already exist, nothing else to do", result.SUCCESS, g.spec.Tag)
-			return false, nil
+			return false, []string{}, "", nil
 		}
 	}
 
 	if dryRun {
 		logrus.Infof("%s Release Tag %q doesn't exist, we need to create it", result.SUCCESS, g.spec.Tag)
-		return true, nil
+		return true, []string{}, "", nil
 	}
 
 	if len(g.spec.Token) == 0 {
-		return true, fmt.Errorf("wrong configuration, missing parameter %q", "token")
+		return true, []string{}, "", fmt.Errorf("wrong configuration, missing parameter %q", "token")
 	}
 
 	// Create a new release as it doesn't exist yet
@@ -88,19 +87,15 @@ func (g *Gitea) Target(source string, dryRun bool) (bool, error) {
 	)
 
 	if err != nil {
-		return false, err
+		return false, []string{}, "", err
 	}
 
 	if resp.Status >= 400 {
 		logrus.Debugf("RC: %q\nBody:\n%s", resp.Status, resp.Body)
-		return false, fmt.Errorf("error from Gitea api: %v", resp.Status)
+		return false, []string{}, "", fmt.Errorf("error from Gitea api: %v", resp.Status)
 	}
 
 	logrus.Infof("Gitea Release %q successfully open on %q", release.Title, release.Link)
 
-	return true, nil
-}
-
-func (g Gitea) TargetFromSCM(source string, scm scm.ScmHandler, dryRun bool) (bool, []string, string, error) {
-	return false, []string{}, "", fmt.Errorf("target not supported for the plugin Gitea Release")
+	return true, []string{}, "", nil
 }

--- a/pkg/plugins/resources/gitea/tag/target.go
+++ b/pkg/plugins/resources/gitea/tag/target.go
@@ -7,10 +7,6 @@ import (
 )
 
 // Target ensure that a specific release exist on gitea, otherwise creates it
-func (g *Gitea) Target(source string, dryRun bool) (bool, error) {
-	return false, fmt.Errorf("target not supported for the plugin Gitea Tags")
-}
-
-func (g Gitea) TargetFromSCM(source string, scm scm.ScmHandler, dryRun bool) (bool, []string, string, error) {
+func (g Gitea) Target(source string, scm scm.ScmHandler, dryRun bool) (bool, []string, string, error) {
 	return false, []string{}, "", fmt.Errorf("target not supported for the plugin Gitea Tags")
 }

--- a/pkg/plugins/resources/gitea/tag/target.go
+++ b/pkg/plugins/resources/gitea/tag/target.go
@@ -4,9 +4,10 @@ import (
 	"fmt"
 
 	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
+	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
 // Target ensure that a specific release exist on gitea, otherwise creates it
-func (g Gitea) Target(source string, scm scm.ScmHandler, dryRun bool) (bool, []string, string, error) {
-	return false, []string{}, "", fmt.Errorf("target not supported for the plugin Gitea Tags")
+func (g Gitea) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
+	return fmt.Errorf("target not supported for the plugin Gitea Tags")
 }

--- a/pkg/plugins/resources/githubrelease/target.go
+++ b/pkg/plugins/resources/githubrelease/target.go
@@ -6,10 +6,6 @@ import (
 	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
 )
 
-func (ghr GitHubRelease) Target(source string, dryRun bool) (bool, error) {
-	return false, fmt.Errorf("Target not supported for the plugin GitHub Release")
-}
-
-func (ghr GitHubRelease) TargetFromSCM(source string, scm scm.ScmHandler, dryRun bool) (bool, []string, string, error) {
+func (ghr GitHubRelease) Target(source string, scm scm.ScmHandler, dryRun bool) (bool, []string, string, error) {
 	return false, []string{}, "", fmt.Errorf("Target not supported for the plugin GitHub Release")
 }

--- a/pkg/plugins/resources/githubrelease/target.go
+++ b/pkg/plugins/resources/githubrelease/target.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 
 	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
+	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
-func (ghr GitHubRelease) Target(source string, scm scm.ScmHandler, dryRun bool) (bool, []string, string, error) {
-	return false, []string{}, "", fmt.Errorf("Target not supported for the plugin GitHub Release")
+func (ghr GitHubRelease) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
+	return fmt.Errorf("target not supported for the plugin GitHub Release")
 }

--- a/pkg/plugins/resources/gitlab/branch/target.go
+++ b/pkg/plugins/resources/gitlab/branch/target.go
@@ -7,11 +7,6 @@ import (
 )
 
 // Target ensure that a specific release exist on Gitlab, otherwise creates it
-func (g *Gitlab) Target(source string, dryRun bool) (bool, error) {
-	return false, fmt.Errorf("target not supported for the plugin Gitlab branch")
-
-}
-
-func (g Gitlab) TargetFromSCM(source string, scm scm.ScmHandler, dryRun bool) (bool, []string, string, error) {
+func (g Gitlab) Target(source string, scm scm.ScmHandler, dryRun bool) (bool, []string, string, error) {
 	return false, []string{}, "", fmt.Errorf("target not supported for the plugin Gitlab branch")
 }

--- a/pkg/plugins/resources/gitlab/branch/target.go
+++ b/pkg/plugins/resources/gitlab/branch/target.go
@@ -4,9 +4,10 @@ import (
 	"fmt"
 
 	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
+	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
 // Target ensure that a specific release exist on Gitlab, otherwise creates it
-func (g Gitlab) Target(source string, scm scm.ScmHandler, dryRun bool) (bool, []string, string, error) {
-	return false, []string{}, "", fmt.Errorf("target not supported for the plugin Gitlab branch")
+func (g Gitlab) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
+	return fmt.Errorf("target not supported for the plugin Gitlab branch")
 }

--- a/pkg/plugins/resources/gitlab/release/target.go
+++ b/pkg/plugins/resources/gitlab/release/target.go
@@ -13,10 +13,12 @@ import (
 )
 
 // Target ensure that a specific release exist on Gitlab, otherwise creates it
-func (g Gitlab) Target(source string, scm scm.ScmHandler, dryRun bool) (bool, []string, string, error) {
+func (g Gitlab) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
 	if len(g.spec.Tag) == 0 {
 		g.spec.Tag = source
 	}
+
+	resultTarget.NewInformation = g.spec.Tag
 
 	if len(g.spec.Title) == 0 {
 		g.spec.Title = g.spec.Tag
@@ -47,23 +49,28 @@ func (g Gitlab) Target(source string, scm scm.ScmHandler, dryRun bool) (bool, []
 
 	if err != nil {
 		logrus.Debugf("Gitlab Api Response:\nReturn Code: %q\nBody:\n%s", resp.Status, resp.Body)
-		return false, []string{}, "", err
+		return err
 	}
 
 	for _, r := range releases {
 		if r.Tag == g.spec.Tag {
-			logrus.Infof("%s Release Tag %q already exist, nothing else to do", result.SUCCESS, g.spec.Tag)
-			return false, []string{}, "", nil
+			resultTarget.Result = result.SUCCESS
+			resultTarget.OldInformation = g.spec.Tag
+			resultTarget.Description = fmt.Sprintf("Gitlab release tag %q already exist", g.spec.Tag)
+			return nil
 		}
 	}
 
+	resultTarget.Result = result.ATTENTION
+	resultTarget.Changed = true
+
 	if dryRun {
-		logrus.Infof("%s Release Tag %q doesn't exist, we need to create it", result.SUCCESS, g.spec.Tag)
-		return true, []string{}, "", nil
+		resultTarget.Description = fmt.Sprintf("Gitlab release tag %q doesn't exist, we need to create it", g.spec.Tag)
+		return nil
 	}
 
 	if len(g.spec.Token) == 0 {
-		return true, []string{}, "", fmt.Errorf("wrong configuration, missing parameter %q", "token")
+		return fmt.Errorf("wrong configuration, missing parameter %q", "token")
 	}
 
 	// Create a new release as it doesn't exist yet
@@ -87,14 +94,15 @@ func (g Gitlab) Target(source string, scm scm.ScmHandler, dryRun bool) (bool, []
 	)
 
 	if err != nil {
-		return false, []string{}, "", err
+		return err
 	}
 
 	if resp.Status >= 400 {
 		logrus.Debugf("RC: %q\nBody:\n%s", resp.Status, resp.Body)
-		return false, []string{}, "", fmt.Errorf("error from Gitlab api: %v", resp.Status)
+		return fmt.Errorf("error from Gitlab api: %v", resp.Status)
 	}
 
-	logrus.Infof("Gitlab Release %q successfully open on %q", release.Title, release.Link)
-	return false, []string{}, "", fmt.Errorf("target not supported for the plugin Gitlab Release")
+	resultTarget.Description = fmt.Sprintf("Gitlab Release %q successfully opened on %q", release.Title, release.Link)
+
+	return nil
 }

--- a/pkg/plugins/resources/gitlab/tag/target.go
+++ b/pkg/plugins/resources/gitlab/tag/target.go
@@ -7,10 +7,6 @@ import (
 )
 
 // Target ensure that a specific release exist on Gitlab, otherwise creates it
-func (g *Gitlab) Target(source string, dryRun bool) (bool, error) {
-	return false, fmt.Errorf("target not supported for the plugin Gitlab Tags")
-}
-
-func (g Gitlab) TargetFromSCM(source string, scm scm.ScmHandler, dryRun bool) (bool, []string, string, error) {
+func (g Gitlab) Target(source string, scm scm.ScmHandler, dryRun bool) (bool, []string, string, error) {
 	return false, []string{}, "", fmt.Errorf("target not supported for the plugin Gitlab Tags")
 }

--- a/pkg/plugins/resources/gitlab/tag/target.go
+++ b/pkg/plugins/resources/gitlab/tag/target.go
@@ -4,9 +4,10 @@ import (
 	"fmt"
 
 	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
+	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
 // Target ensure that a specific release exist on Gitlab, otherwise creates it
-func (g Gitlab) Target(source string, scm scm.ScmHandler, dryRun bool) (bool, []string, string, error) {
-	return false, []string{}, "", fmt.Errorf("target not supported for the plugin Gitlab Tags")
+func (g Gitlab) Target(source string, scm scm.ScmHandler, dryRun bool, releaseTarget *result.Target) error {
+	return fmt.Errorf("target not supported for the plugin Gitlab Tags")
 }

--- a/pkg/plugins/resources/gittag/target.go
+++ b/pkg/plugins/resources/gittag/target.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Target creates a tag if needed from a local git repository, without pushing the tag
-func (gt *GitTag) Target(source string, scm scm.ScmHandler, dryRun bool) (changed bool, files []string, message string, err error) {
+func (gt *GitTag) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
 	if scm != nil {
 		if len(gt.spec.Path) > 0 {
 			logrus.Warningf("Path setting value %q overridden by the scm configuration (value %q)",
@@ -19,21 +19,30 @@ func (gt *GitTag) Target(source string, scm scm.ScmHandler, dryRun bool) (change
 		gt.spec.Path = scm.GetDirectory()
 	}
 
-	changed, files, message, err = gt.target(source, dryRun)
-	if err != nil {
-		return changed, files, message, err
+	if err := gt.target(source, dryRun, resultTarget); err != nil {
+		return err
 	}
 
-	err = scm.PushTag(source)
-	if err != nil {
-		logrus.Errorf("Git push tag error: %s", err)
-		return changed, files, message, err
+	if dryRun || !resultTarget.Changed {
+		return nil
 	}
-	logrus.Infof("%s The git tag %q was pushed successfully to the specified remote.", result.ATTENTION, source)
-	return changed, files, message, err
+
+	if scm != nil {
+		if err := scm.PushTag(source); err != nil {
+			logrus.Errorf("Git push tag error: %s", err)
+			return err
+		}
+	}
+
+	resultTarget.Description = fmt.Sprintf("git tag %q successfully created and pushed", source)
+	if gt.spec.Message != "" {
+		resultTarget.Description = gt.spec.Message
+	}
+
+	return nil
 }
 
-func (gt *GitTag) target(source string, dryRun bool) (bool, []string, string, error) {
+func (gt *GitTag) target(source string, dryRun bool, resultTarget *result.Target) error {
 	// Ensure that a git message is present to annotate the tag to create
 	if len(gt.spec.Message) == 0 {
 		// absence of a message is not blocking: warn the user and continue
@@ -43,54 +52,59 @@ func (gt *GitTag) target(source string, dryRun bool) (bool, []string, string, er
 
 	// cfr https://github.com/updatecli/updatecli/issues/1126
 	// to know why the following line is needed at the moment
-	files := []string{""}
-	message := gt.spec.Message
+	resultTarget.Files = []string{""}
 
 	// Fail if a pattern is specified
 	if gt.versionFilter.Pattern != "" {
-		return false, files, message, fmt.Errorf("target validation error: spec.versionfilter.pattern is not allowed for targets of type gittag")
+		return fmt.Errorf("target validation error: spec.versionfilter.pattern is not allowed for targets of type gittag")
 	}
 
 	// Fail if the git tag resource cannot be validated
 	err := gt.Validate()
 	if err != nil {
-		logrus.Errorln(err)
-		return false, files, message, err
+		return err
 	}
 
 	// Check if the provided tag (from source input value) already exists
 	gt.versionFilter.Pattern = source
 	tags, err := gt.nativeGitHandler.Tags(gt.spec.Path)
 	if err != nil {
-		return false, files, message, err
-	}
-	gt.foundVersion, err = gt.versionFilter.Search(tags)
-	if err != nil && err.Error() != fmt.Sprintf("No version found matching pattern %q", source) {
-		// Something went wrong during the tag search.
-		return false, files, message, err
-	}
-	if gt.foundVersion.GetVersion() == source {
-		// No error, but no change
-		logrus.Printf("%s The Git Tag %q already exists, nothing else to do.",
-			result.SUCCESS,
-			source)
-		return false, files, message, nil
+		return err
 	}
 
-	// Otherwise proceed to create this new tag
-	logrus.Printf("%s The git tag %q does not exist: creating it.", result.ATTENTION, source)
+	gt.foundVersion, err = gt.versionFilter.Search(tags)
+	if err != nil && err.Error() != fmt.Sprintf("No version found matching pattern %q", source) {
+		return err
+	}
+
+	if gt.foundVersion.GetVersion() == source {
+		resultTarget.OldInformation = source
+		resultTarget.NewInformation = source
+		resultTarget.Result = result.SUCCESS
+		resultTarget.Description = fmt.Sprintf("git tag %q already exists", source)
+		return nil
+	}
+
+	resultTarget.NewInformation = source
+	resultTarget.Result = result.ATTENTION
+	resultTarget.Changed = true
 
 	if dryRun {
 		// Dry run: no changes to apply.
 		// Return early without creating tag but notify that a change should be made.
-		return true, files, message, nil
+		resultTarget.Description = fmt.Sprintf("git tag %q should be created", source)
+		return nil
 	}
 
-	changed, err := gt.nativeGitHandler.NewTag(source, gt.spec.Message, gt.spec.Path)
+	_, err = gt.nativeGitHandler.NewTag(source, gt.spec.Message, gt.spec.Path)
 	if err != nil {
-		return changed, files, message, err
+		return err
 	}
-	logrus.Printf("%s The git tag %q has been created.", result.ATTENTION, source)
 
-	return changed, files, message, nil
+	resultTarget.Description = fmt.Sprintf("git tag %q created", source)
+	if gt.spec.Message != "" {
+		resultTarget.Description = gt.spec.Message
+	}
+
+	return nil
 }

--- a/pkg/plugins/resources/gittag/target.go
+++ b/pkg/plugins/resources/gittag/target.go
@@ -9,20 +9,15 @@ import (
 )
 
 // Target creates a tag if needed from a local git repository, without pushing the tag
-func (gt *GitTag) Target(source string, dryRun bool) (changed bool, err error) {
-	changed, _, _, err = gt.target(source, dryRun)
-
-	return changed, err
-}
-
-// TargetFromSCM creates and pushes a git tag based on the SCM configuration
-func (gt *GitTag) TargetFromSCM(source string, scm scm.ScmHandler, dryRun bool) (changed bool, files []string, message string, err error) {
-	if len(gt.spec.Path) > 0 {
-		logrus.Warningf("Path setting value %q overridden by the scm configuration (value %q)",
-			gt.spec.Path,
-			scm.GetDirectory())
+func (gt *GitTag) Target(source string, scm scm.ScmHandler, dryRun bool) (changed bool, files []string, message string, err error) {
+	if scm != nil {
+		if len(gt.spec.Path) > 0 {
+			logrus.Warningf("Path setting value %q overridden by the scm configuration (value %q)",
+				gt.spec.Path,
+				scm.GetDirectory())
+		}
+		gt.spec.Path = scm.GetDirectory()
 	}
-	gt.spec.Path = scm.GetDirectory()
 
 	changed, files, message, err = gt.target(source, dryRun)
 	if err != nil {

--- a/pkg/plugins/resources/go/gomod/target.go
+++ b/pkg/plugins/resources/go/gomod/target.go
@@ -9,15 +9,7 @@ import (
 )
 
 // Target is not supported for the Golang resource
-func (g *GoMod) Target(source string, dryRun bool) (changed bool, err error) {
-
-	changed, _, _, err = g.TargetFromSCM(source, nil, dryRun)
-	return changed, err
-
-}
-
-// TargetFromSCM is not supported for the Golang resource
-func (g *GoMod) TargetFromSCM(source string, scm scm.ScmHandler, dryRun bool) (changed bool, files []string, message string, err error) {
+func (g *GoMod) Target(source string, scm scm.ScmHandler, dryRun bool) (changed bool, files []string, message string, err error) {
 
 	version := source
 	if g.spec.Version != "" {

--- a/pkg/plugins/resources/go/gomod/target.go
+++ b/pkg/plugins/resources/go/gomod/target.go
@@ -3,61 +3,76 @@ package gomod
 import (
 	"fmt"
 
-	"github.com/sirupsen/logrus"
 	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
+	"github.com/updatecli/updatecli/pkg/core/result"
 	"github.com/updatecli/updatecli/pkg/plugins/utils"
 )
 
 // Target is not supported for the Golang resource
-func (g *GoMod) Target(source string, scm scm.ScmHandler, dryRun bool) (changed bool, files []string, message string, err error) {
+func (g *GoMod) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) (err error) {
 
 	version := source
 	if g.spec.Version != "" {
 		version = g.spec.Version
 	}
 
+	resultTarget.NewInformation = version
+
 	filename := g.filename
 	if scm != nil {
 		filename = utils.JoinFilePathWithWorkingDirectoryPath(g.filename, scm.GetDirectory())
 	}
 
-	oldVersion, newVersion, changed, err := g.setVersion(version, filename, dryRun)
+	resultTarget.OldInformation, resultTarget.NewInformation, resultTarget.Changed, err = g.setVersion(version, filename, dryRun)
 	if err != nil {
-		return false, files, message, err
+		return err
 	}
 
-	if !changed {
+	if !resultTarget.Changed {
 		switch g.kind {
 		case kindGolang:
-			message = fmt.Sprintf("go.mod already set Golang version to %q", newVersion)
+			resultTarget.Description = fmt.Sprintf("go.mod already set Golang version to %q", version)
 		case kindModule:
-			message = fmt.Sprintf("go.mod already has Module %q set to version %q", g.spec.Module, newVersion)
+			resultTarget.Description = fmt.Sprintf("go.mod already has Module %q set to version %q", g.spec.Module, version)
 		}
 
-		logrus.Infoln(message)
-		return changed, files, message, nil
+		resultTarget.Result = result.SUCCESS
+
+		return nil
 	}
+
+	resultTarget.Result = result.ATTENTION
 
 	if dryRun {
 		switch g.kind {
 		case kindGolang:
-			message = fmt.Sprintf("go.mod should update Golang version from %q to %q", oldVersion, newVersion)
+			resultTarget.Description = fmt.Sprintf("go.mod should update Golang version from %q to %q",
+				resultTarget.OldInformation,
+				resultTarget.NewInformation)
 		case kindModule:
-			message = fmt.Sprintf("go.mod should update Module path %q version from %q to %q", g.spec.Module, oldVersion, newVersion)
+			resultTarget.Description = fmt.Sprintf("go.mod should update Module path %q version from %q to %q",
+				g.spec.Module,
+				resultTarget.OldInformation,
+				resultTarget.NewInformation)
 		}
 
-		logrus.Infoln(message)
-		return changed, files, message, nil
+		return nil
 	}
 
-	files = []string{filename}
+	resultTarget.Files = append(resultTarget.Files, filename)
+
 	switch g.kind {
 	case kindGolang:
-		message = fmt.Sprintf("go.mod updated Golang version from %q to %q", oldVersion, newVersion)
+		resultTarget.Description = fmt.Sprintf("go.mod updated Golang version from %q to %q",
+			resultTarget.OldInformation,
+			resultTarget.NewInformation)
+
 	case kindModule:
-		message = fmt.Sprintf("go.mod updated Module path %q version from %q to %q", g.spec.Module, oldVersion, newVersion)
+		resultTarget.Description = fmt.Sprintf("go.mod updated Module path %q version from %q to %q",
+			g.spec.Module,
+			resultTarget.OldInformation,
+			resultTarget.NewInformation)
 	}
 
-	logrus.Infoln(message)
-	return changed, files, message, nil
+	return nil
 }

--- a/pkg/plugins/resources/go/gomod/target_test.go
+++ b/pkg/plugins/resources/go/gomod/target_test.go
@@ -62,7 +62,7 @@ func TestTarget(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := New(tt.spec)
 			require.NoError(t, err)
-			gotChanged, err := got.Target("", true)
+			gotChanged, _, _, err := got.Target("", nil, true)
 			if tt.expectedError {
 				assert.Error(t, err)
 				return

--- a/pkg/plugins/resources/go/gomod/target_test.go
+++ b/pkg/plugins/resources/go/gomod/target_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
 func TestTarget(t *testing.T) {
@@ -62,13 +63,15 @@ func TestTarget(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := New(tt.spec)
 			require.NoError(t, err)
-			gotChanged, _, _, err := got.Target("", nil, true)
+			gotResult := result.Target{}
+
+			err = got.Target("", nil, true, &gotResult)
 			if tt.expectedError {
 				assert.Error(t, err)
 				return
 			}
 			require.NoError(t, err)
-			assert.Equal(t, tt.expectedChanged, gotChanged)
+			assert.Equal(t, tt.expectedChanged, gotResult.Changed)
 		})
 	}
 

--- a/pkg/plugins/resources/go/language/target.go
+++ b/pkg/plugins/resources/go/language/target.go
@@ -7,11 +7,6 @@ import (
 )
 
 // Target is not supported for the Golang resource
-func (l *Language) Target(source string, dryRun bool) (bool, error) {
-	return false, fmt.Errorf("Target not supported for the plugin Go")
-}
-
-// TargetFromSCM is not supported for the Golang resource
-func (l *Language) TargetFromSCM(source string, scm scm.ScmHandler, dryRun bool) (bool, []string, string, error) {
+func (l *Language) Target(source string, scm scm.ScmHandler, dryRun bool) (bool, []string, string, error) {
 	return false, []string{}, "", fmt.Errorf("Target not supported for the plugin Go")
 }

--- a/pkg/plugins/resources/go/language/target.go
+++ b/pkg/plugins/resources/go/language/target.go
@@ -4,9 +4,10 @@ import (
 	"fmt"
 
 	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
+	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
 // Target is not supported for the Golang resource
-func (l *Language) Target(source string, scm scm.ScmHandler, dryRun bool) (bool, []string, string, error) {
-	return false, []string{}, "", fmt.Errorf("Target not supported for the plugin Go")
+func (l *Language) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
+	return fmt.Errorf("Target not supported for the plugin Go")
 }

--- a/pkg/plugins/resources/go/module/target.go
+++ b/pkg/plugins/resources/go/module/target.go
@@ -7,11 +7,6 @@ import (
 )
 
 // Target is not support for gomodule
-func (g *GoModule) Target(source string, dryRun bool) (bool, error) {
-	return false, fmt.Errorf("Target not supported for the plugin Go module")
-}
-
-// TargetFromSCM is not support for gomodule
-func (g *GoModule) TargetFromSCM(source string, scm scm.ScmHandler, dryRun bool) (bool, []string, string, error) {
+func (g *GoModule) Target(source string, scm scm.ScmHandler, dryRun bool) (bool, []string, string, error) {
 	return false, []string{}, "", fmt.Errorf("Target not supported for the plugin GO module")
 }

--- a/pkg/plugins/resources/go/module/target.go
+++ b/pkg/plugins/resources/go/module/target.go
@@ -4,9 +4,10 @@ import (
 	"fmt"
 
 	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
+	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
 // Target is not support for gomodule
-func (g *GoModule) Target(source string, scm scm.ScmHandler, dryRun bool) (bool, []string, string, error) {
-	return false, []string{}, "", fmt.Errorf("Target not supported for the plugin GO module")
+func (g *GoModule) Target(source string, scm scm.ScmHandler, dryRun bool, releaseTarget *result.Target) error {
+	return fmt.Errorf("Target not supported for the plugin GO module")
 }

--- a/pkg/plugins/resources/helm/target.go
+++ b/pkg/plugins/resources/helm/target.go
@@ -11,65 +11,7 @@ import (
 
 // Target updates helm chart, it receives the default source value and a "dry-run" flag
 // then return if it changed something or failed
-func (c *Chart) Target(source string, dryRun bool) (changed bool, err error) {
-	var out bytes.Buffer
-
-	err = c.ValidateTarget()
-	if err != nil {
-		return false, err
-	}
-
-	yamlSpec := yaml.Spec{
-		File: filepath.Join(c.spec.Name, c.spec.File),
-		Key:  c.spec.Key,
-	}
-	if len(c.spec.Value) == 0 {
-		c.spec.Value = source
-		c.spec.Value = source
-	} else {
-		yamlSpec.Value = c.spec.Value
-	}
-
-	yamlResource, err := yaml.New(yamlSpec)
-	if err != nil {
-		return false, err
-	}
-
-	changed, err = yamlResource.Target(source, dryRun)
-
-	if err != nil {
-		return false, err
-	} else if err == nil && !changed {
-		return false, nil
-	}
-
-	// Update Chart.yaml file new Chart Version and the chart app version if needed
-	err = c.MetadataUpdate(c.spec.Name, dryRun)
-	if err != nil {
-		return false, err
-	}
-
-	err = c.RequirementsUpdate(c.spec.Name)
-	if err != nil {
-		return false, err
-	}
-
-	if !dryRun {
-		err = c.DependencyUpdate(&out, c.spec.Name)
-
-		logrus.Debugf("%s", out.String())
-
-		if err != nil {
-			return false, err
-		}
-	}
-
-	return true, nil
-}
-
-// TargetFromSCM updates helm chart then push changed to a scm repository, it receives the default source value and "dry run" flag
-// then return if it changed something or failed
-func (c *Chart) TargetFromSCM(source string, scm scm.ScmHandler, dryRun bool) (
+func (c *Chart) Target(source string, scm scm.ScmHandler, dryRun bool) (
 	changed bool, files []string, message string, err error) {
 
 	var out bytes.Buffer
@@ -93,14 +35,17 @@ func (c *Chart) TargetFromSCM(source string, scm scm.ScmHandler, dryRun bool) (
 		return false, files, message, err
 	}
 
-	changed, files, message, err = yamlResource.TargetFromSCM(source, scm, dryRun)
+	changed, files, message, err = yamlResource.Target(source, scm, dryRun)
 	if err != nil {
 		return false, files, message, err
 	} else if err == nil && !changed {
 		return false, files, message, nil
 	}
 
-	chartPath := filepath.Join(scm.GetDirectory(), c.spec.Name)
+	chartPath := c.spec.Name
+	if scm != nil {
+		chartPath = filepath.Join(scm.GetDirectory(), c.spec.Name)
+	}
 
 	err = c.MetadataUpdate(chartPath, dryRun)
 	if err != nil {

--- a/pkg/plugins/resources/jenkins/target.go
+++ b/pkg/plugins/resources/jenkins/target.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 
 	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
+	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
-func (j Jenkins) Target(source string, scm scm.ScmHandler, dryRun bool) (bool, []string, string, error) {
-	return false, []string{}, "", fmt.Errorf("Target not supported for the plugin Jenkins")
+func (j Jenkins) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
+	return fmt.Errorf("Target not supported for the plugin Jenkins")
 }

--- a/pkg/plugins/resources/jenkins/target.go
+++ b/pkg/plugins/resources/jenkins/target.go
@@ -6,10 +6,6 @@ import (
 	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
 )
 
-func (j Jenkins) Target(source string, dryRun bool) (bool, error) {
-	return false, fmt.Errorf("Target not supported for the plugin Jenkins")
-}
-
-func (j Jenkins) TargetFromSCM(source string, scm scm.ScmHandler, dryRun bool) (bool, []string, string, error) {
+func (j Jenkins) Target(source string, scm scm.ScmHandler, dryRun bool) (bool, []string, string, error) {
 	return false, []string{}, "", fmt.Errorf("Target not supported for the plugin Jenkins")
 }

--- a/pkg/plugins/resources/json/target.go
+++ b/pkg/plugins/resources/json/target.go
@@ -10,18 +10,8 @@ import (
 	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
-func (j *Json) Target(source string, dryRun bool) (changed bool, err error) {
-
-	changed, _, _, err = j.TargetFromSCM(source, nil, dryRun)
-	if err != nil {
-		return changed, err
-	}
-
-	return changed, err
-}
-
-// TargetFromSCM updates a scm repository based on the modified yaml file.
-func (j *Json) TargetFromSCM(source string, scm scm.ScmHandler, dryRun bool) (changed bool, files []string, message string, err error) {
+// Target updates a scm repository based on the modified yaml file.
+func (j *Json) Target(source string, scm scm.ScmHandler, dryRun bool) (changed bool, files []string, message string, err error) {
 
 	rootDir := ""
 	if scm != nil {

--- a/pkg/plugins/resources/json/target_test.go
+++ b/pkg/plugins/resources/json/target_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/updatecli/updatecli/pkg/core/result"
 	"gotest.tools/assert"
 )
 
@@ -53,7 +54,8 @@ func TestTarget(t *testing.T) {
 
 			require.NoError(t, err)
 
-			gotResult, _, _, err := j.Target(tt.sourceInput, nil, true)
+			gotResult := result.Target{}
+			err = j.Target(tt.sourceInput, nil, true, &gotResult)
 
 			if tt.wantErr {
 				assert.Equal(t, tt.expectedErrorMsg.Error(), err.Error())
@@ -61,7 +63,7 @@ func TestTarget(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			assert.Equal(t, tt.expectedResult, gotResult)
+			assert.Equal(t, tt.expectedResult, gotResult.Changed)
 		})
 	}
 }

--- a/pkg/plugins/resources/json/target_test.go
+++ b/pkg/plugins/resources/json/target_test.go
@@ -53,7 +53,7 @@ func TestTarget(t *testing.T) {
 
 			require.NoError(t, err)
 
-			gotResult, err := j.Target(tt.sourceInput, true)
+			gotResult, _, _, err := j.Target(tt.sourceInput, nil, true)
 
 			if tt.wantErr {
 				assert.Equal(t, tt.expectedErrorMsg.Error(), err.Error())

--- a/pkg/plugins/resources/maven/target.go
+++ b/pkg/plugins/resources/maven/target.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 
 	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
+	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
-func (m Maven) Target(source string, scm scm.ScmHandler, dryRun bool) (bool, []string, string, error) {
-	return false, []string{}, "", fmt.Errorf("Target not supported for the plugin Maven")
+func (m Maven) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
+	return fmt.Errorf("Target not supported for the plugin Maven")
 }

--- a/pkg/plugins/resources/maven/target.go
+++ b/pkg/plugins/resources/maven/target.go
@@ -6,10 +6,6 @@ import (
 	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
 )
 
-func (m Maven) Target(source string, dryRun bool) (bool, error) {
-	return false, fmt.Errorf("Target not supported for the plugin Maven")
-}
-
-func (m Maven) TargetFromSCM(source string, scm scm.ScmHandler, dryRun bool) (bool, []string, string, error) {
+func (m Maven) Target(source string, scm scm.ScmHandler, dryRun bool) (bool, []string, string, error) {
 	return false, []string{}, "", fmt.Errorf("Target not supported for the plugin Maven")
 }

--- a/pkg/plugins/resources/npm/main.go
+++ b/pkg/plugins/resources/npm/main.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httputil"
 	"os"
@@ -248,7 +248,7 @@ func (n *Npm) getPackageData(packageName string) (Data, error) {
 		return Data{}, err
 	}
 
-	data, err := ioutil.ReadAll(res.Body)
+	data, err := io.ReadAll(res.Body)
 	if err != nil {
 		logrus.Errorf("something went wrong while getting npm api data%q\n", err)
 		return Data{}, err

--- a/pkg/plugins/resources/npm/target.go
+++ b/pkg/plugins/resources/npm/target.go
@@ -6,10 +6,6 @@ import (
 	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
 )
 
-func (n Npm) Target(source string, dryRun bool) (bool, error) {
-	return false, fmt.Errorf("Target not supported for the plugin Npm")
-}
-
-func (n Npm) TargetFromSCM(source string, scm scm.ScmHandler, dryRun bool) (bool, []string, string, error) {
+func (n Npm) Target(source string, scm scm.ScmHandler, dryRun bool) (bool, []string, string, error) {
 	return false, []string{}, "", fmt.Errorf("Target not supported for the plugin Npm")
 }

--- a/pkg/plugins/resources/npm/target.go
+++ b/pkg/plugins/resources/npm/target.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 
 	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
+	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
-func (n Npm) Target(source string, scm scm.ScmHandler, dryRun bool) (bool, []string, string, error) {
-	return false, []string{}, "", fmt.Errorf("Target not supported for the plugin Npm")
+func (n Npm) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
+	return fmt.Errorf("Target not supported for the plugin Npm")
 }

--- a/pkg/plugins/resources/npm/test_utils.go
+++ b/pkg/plugins/resources/npm/test_utils.go
@@ -3,7 +3,7 @@ package npm
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -34,7 +34,7 @@ func GetMockClient(baseUrl string, mockedToken string, mockedBody string, mocked
 			}
 			return &http.Response{
 				StatusCode: statusCode,
-				Body:       ioutil.NopCloser(strings.NewReader(body)),
+				Body:       io.NopCloser(strings.NewReader(body)),
 			}, httpError
 		},
 	}

--- a/pkg/plugins/resources/shell/target.go
+++ b/pkg/plugins/resources/shell/target.go
@@ -7,22 +7,26 @@ import (
 	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
 )
 
-func (s *Shell) Target(source string, dryRun bool) (bool, error) {
-	changed, _, err := s.target(source, "", dryRun)
-	return changed, err
-}
+func (s *Shell) Target(source string, scm scm.ScmHandler, dryRun bool) (bool, []string, string, error) {
+	getDir := ""
+	if scm != nil {
+		getDir = scm.GetDirectory()
+	}
 
-func (s *Shell) TargetFromSCM(source string, scm scm.ScmHandler, dryRun bool) (bool, []string, string, error) {
-	changed, message, err := s.target(source, scm.GetDirectory(), dryRun)
+	changed, message, err := s.target(source, getDir, dryRun)
 	if err != nil {
 		return false, []string{}, "", err
 	}
 
-	// Once the changes have been applied inside the scm's temp directory, then we have to get the list of these changes
-	files, err := scm.GetChangedFiles(scm.GetDirectory())
-	if err != nil {
-		return false, []string{}, "", err
+	files := []string{}
+	if scm != nil {
+		// Once the changes have been applied inside the scm's temp directory, then we have to get the list of these changes
+		files, err = scm.GetChangedFiles(scm.GetDirectory())
+		if err != nil {
+			return false, files, message, err
+		}
 	}
+
 	return changed, files, message, err
 }
 

--- a/pkg/plugins/resources/shell/target_test.go
+++ b/pkg/plugins/resources/shell/target_test.go
@@ -81,7 +81,7 @@ func TestShell_Target(t *testing.T) {
 			err := s.InitChangedIf()
 			require.NoError(t, err)
 
-			gotChanged, err := s.Target(tt.source, tt.dryrun)
+			gotChanged, _, _, err := s.Target(tt.source, nil, tt.dryrun)
 
 			if tt.wantErr {
 				assert.Error(t, err)
@@ -155,7 +155,7 @@ func TestShell_TargetFromSCM(t *testing.T) {
 			err := s.InitChangedIf()
 			require.NoError(t, err)
 
-			gotChanged, gotFilesChanged, gotMessage, err := s.TargetFromSCM(tt.source, &ms, tt.dryrun)
+			gotChanged, gotFilesChanged, gotMessage, err := s.Target(tt.source, &ms, tt.dryrun)
 
 			if tt.wantErr {
 				assert.Error(t, err)

--- a/pkg/plugins/resources/shell/target_test.go
+++ b/pkg/plugins/resources/shell/target_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
+	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
 func TestShell_Target(t *testing.T) {
@@ -81,16 +82,18 @@ func TestShell_Target(t *testing.T) {
 			err := s.InitChangedIf()
 			require.NoError(t, err)
 
-			gotChanged, _, _, err := s.Target(tt.source, nil, tt.dryrun)
+			gotResult := result.Target{}
+
+			err = s.Target(tt.source, nil, tt.dryrun, &gotResult)
 
 			if tt.wantErr {
 				assert.Error(t, err)
-				assert.False(t, gotChanged)
+				assert.False(t, gotResult.Changed)
 				return
 			}
 
 			require.NoError(t, err)
-			assert.Equal(t, tt.wantChanged, gotChanged)
+			assert.Equal(t, tt.wantChanged, gotResult.Changed)
 
 			assert.Equal(t, tt.wantCommandInMock, mock.GotCommand.Cmd)
 			for _, wantEnv := range tt.commandEnv {
@@ -155,19 +158,20 @@ func TestShell_TargetFromSCM(t *testing.T) {
 			err := s.InitChangedIf()
 			require.NoError(t, err)
 
-			gotChanged, gotFilesChanged, gotMessage, err := s.Target(tt.source, &ms, tt.dryrun)
+			gotResult := result.Target{}
+			err = s.Target(tt.source, &ms, tt.dryrun, &gotResult)
 
 			if tt.wantErr {
 				assert.Error(t, err)
-				assert.False(t, gotChanged)
+				assert.False(t, gotResult.Changed)
 				return
 			}
 
 			require.NoError(t, err)
 
-			assert.Equal(t, len(tt.wantFilesChanged) > 0, gotChanged)
-			assert.Equal(t, tt.wantFilesChanged, gotFilesChanged)
-			assert.Equal(t, tt.wantMessage, gotMessage)
+			assert.Equal(t, len(tt.wantFilesChanged) > 0, gotResult.Changed)
+			assert.Equal(t, tt.wantFilesChanged, gotResult.Files)
+			assert.Equal(t, tt.wantMessage, gotResult.Description)
 
 			assert.Equal(t, tt.wantCommandInMock, mock.GotCommand.Cmd)
 			for _, wantEnv := range tt.commandEnv {

--- a/pkg/plugins/resources/stash/branch/target.go
+++ b/pkg/plugins/resources/stash/branch/target.go
@@ -4,9 +4,10 @@ import (
 	"fmt"
 
 	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
+	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
 // Target ensure that a specific release exist on bitbucket, otherwise creates it
-func (g Stash) Target(source string, scm scm.ScmHandler, dryRun bool) (bool, []string, string, error) {
-	return false, []string{}, "", fmt.Errorf("target not supported for the plugin GitHub Release")
+func (g Stash) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
+	return fmt.Errorf("target not supported for the plugin stash branch")
 }

--- a/pkg/plugins/resources/stash/branch/target.go
+++ b/pkg/plugins/resources/stash/branch/target.go
@@ -7,11 +7,6 @@ import (
 )
 
 // Target ensure that a specific release exist on bitbucket, otherwise creates it
-func (g *Stash) Target(source string, dryRun bool) (bool, error) {
-	return false, fmt.Errorf("target not supported for the plugin Bitbucket branch")
-
-}
-
-func (g Stash) TargetFromSCM(source string, scm scm.ScmHandler, dryRun bool) (bool, []string, string, error) {
+func (g Stash) Target(source string, scm scm.ScmHandler, dryRun bool) (bool, []string, string, error) {
 	return false, []string{}, "", fmt.Errorf("target not supported for the plugin GitHub Release")
 }

--- a/pkg/plugins/resources/stash/release/target.go
+++ b/pkg/plugins/resources/stash/release/target.go
@@ -12,9 +12,7 @@ import (
 	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
-// Target ensure that a specific release exist on bitbucket, otherwise creates it
-func (g *Stash) Target(source string, dryRun bool) (bool, error) {
-
+func (g Stash) Target(source string, scm scm.ScmHandler, dryRun bool) (bool, []string, string, error) {
 	if len(g.spec.Tag) == 0 {
 		g.spec.Tag = source
 	}
@@ -48,23 +46,23 @@ func (g *Stash) Target(source string, dryRun bool) (bool, error) {
 
 	if err != nil {
 		logrus.Debugf("Bitbucket Api Response:\nReturn Code: %q\nBody:\n%s", resp.Status, resp.Body)
-		return false, err
+		return false, []string{}, "", err
 	}
 
 	for _, r := range releases {
 		if r.Tag == g.spec.Tag {
 			logrus.Infof("%s Release Tag %q already exist, nothing else to do", result.SUCCESS, g.spec.Tag)
-			return false, nil
+			return false, []string{}, "", nil
 		}
 	}
 
 	if dryRun {
 		logrus.Infof("%s Release Tag %q doesn't exist, we need to create it", result.SUCCESS, g.spec.Tag)
-		return true, nil
+		return true, []string{}, "", nil
 	}
 
 	if len(g.spec.Token) == 0 {
-		return true, fmt.Errorf("wrong configuration, missing parameter %q", "token")
+		return true, []string{}, "", fmt.Errorf("wrong configuration, missing parameter %q", "token")
 	}
 
 	// Create a new release as it doesn't exist yet
@@ -88,19 +86,14 @@ func (g *Stash) Target(source string, dryRun bool) (bool, error) {
 	)
 
 	if err != nil {
-		return false, err
+		return false, []string{}, "", err
 	}
 
 	if resp.Status >= 400 {
 		logrus.Debugf("RC: %q\nBody:\n%s", resp.Status, resp.Body)
-		return false, fmt.Errorf("error from Bitbucket api: %v", resp.Status)
+		return false, []string{}, "", fmt.Errorf("error from Bitbucket api: %v", resp.Status)
 	}
 
 	logrus.Infof("Bitbucket Release %q successfully open on %q", release.Title, release.Link)
-
-	return true, nil
-}
-
-func (g Stash) TargetFromSCM(source string, scm scm.ScmHandler, dryRun bool) (bool, []string, string, error) {
-	return false, []string{}, "", fmt.Errorf("target not supported for the plugin Bitbucket Release")
+	return false, []string{}, "", nil
 }

--- a/pkg/plugins/resources/stash/tag/target.go
+++ b/pkg/plugins/resources/stash/tag/target.go
@@ -7,10 +7,6 @@ import (
 )
 
 // Target ensure that a specific release exist on bitbucket, otherwise creates it
-func (g *Stash) Target(source string, dryRun bool) (bool, error) {
-	return false, fmt.Errorf("target not supported for the plugin Bitbucket Tags")
-}
-
-func (g Stash) TargetFromSCM(source string, scm scm.ScmHandler, dryRun bool) (bool, []string, string, error) {
+func (g Stash) Target(source string, scm scm.ScmHandler, dryRun bool) (bool, []string, string, error) {
 	return false, []string{}, "", fmt.Errorf("target not supported for the plugin Bitbucket Tags")
 }

--- a/pkg/plugins/resources/stash/tag/target.go
+++ b/pkg/plugins/resources/stash/tag/target.go
@@ -4,9 +4,10 @@ import (
 	"fmt"
 
 	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
+	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
 // Target ensure that a specific release exist on bitbucket, otherwise creates it
-func (g Stash) Target(source string, scm scm.ScmHandler, dryRun bool) (bool, []string, string, error) {
-	return false, []string{}, "", fmt.Errorf("target not supported for the plugin Bitbucket Tags")
+func (g Stash) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
+	return fmt.Errorf("target not supported for the plugin Stash Tags")
 }

--- a/pkg/plugins/resources/toml/target.go
+++ b/pkg/plugins/resources/toml/target.go
@@ -10,18 +10,8 @@ import (
 	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
-func (t *Toml) Target(source string, dryRun bool) (changed bool, err error) {
-
-	changed, _, _, err = t.TargetFromSCM(source, nil, dryRun)
-	if err != nil {
-		return changed, err
-	}
-
-	return changed, err
-}
-
-// TargetFromSCM updates a scm repository based on the modified yaml file.
-func (t *Toml) TargetFromSCM(source string, scm scm.ScmHandler, dryRun bool) (changed bool, files []string, message string, err error) {
+// Target updates a scm repository based on the modified yaml file.
+func (t *Toml) Target(source string, scm scm.ScmHandler, dryRun bool) (changed bool, files []string, message string, err error) {
 
 	rootDir := ""
 	if scm != nil {

--- a/pkg/plugins/resources/toml/target_test.go
+++ b/pkg/plugins/resources/toml/target_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/updatecli/updatecli/pkg/core/result"
 	"gotest.tools/assert"
 )
 
@@ -109,7 +110,9 @@ func TestTarget(t *testing.T) {
 
 			require.NoError(t, err)
 
-			gotResult, _, _, err := j.Target(tt.sourceInput, nil, true)
+			gotResult := result.Target{}
+
+			err = j.Target(tt.sourceInput, nil, true, &gotResult)
 
 			if tt.wantErr {
 				assert.Equal(t, tt.expectedErrorMsg.Error(), err.Error())
@@ -117,7 +120,7 @@ func TestTarget(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			assert.Equal(t, tt.expectedResult, gotResult)
+			assert.Equal(t, tt.expectedResult, gotResult.Changed)
 		})
 	}
 }

--- a/pkg/plugins/resources/toml/target_test.go
+++ b/pkg/plugins/resources/toml/target_test.go
@@ -109,7 +109,7 @@ func TestTarget(t *testing.T) {
 
 			require.NoError(t, err)
 
-			gotResult, err := j.Target(tt.sourceInput, true)
+			gotResult, _, _, err := j.Target(tt.sourceInput, nil, true)
 
 			if tt.wantErr {
 				assert.Equal(t, tt.expectedErrorMsg.Error(), err.Error())

--- a/pkg/plugins/resources/xml/target.go
+++ b/pkg/plugins/resources/xml/target.go
@@ -5,24 +5,25 @@ import (
 	"strings"
 
 	"github.com/beevik/etree"
-	"github.com/sirupsen/logrus"
 
 	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
 	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
 // Target updates a scm repository based on the modified yaml file.
-func (x *XML) Target(source string, scm scm.ScmHandler, dryRun bool) (changed bool, files []string, message string, err error) {
+func (x *XML) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) (err error) {
 
 	if strings.HasPrefix(x.spec.File, "https://") ||
 		strings.HasPrefix(x.spec.File, "http://") {
-		return false, files, message, fmt.Errorf("URL scheme is not supported for XML target: %q", x.spec.File)
+		return fmt.Errorf("URL scheme is not supported for XML target: %q", x.spec.File)
 	}
 
 	value := source
-	if len(x.spec.Value) > 0 {
+	if x.spec.Value != "" {
 		value = x.spec.Value
 	}
+
+	resultTarget.NewInformation = value
 
 	resourceFile := x.spec.File
 	if scm != nil {
@@ -31,53 +32,53 @@ func (x *XML) Target(source string, scm scm.ScmHandler, dryRun bool) (changed bo
 
 	// Test at runtime if a file exist
 	if !x.contentRetriever.FileExists(resourceFile) {
-		return false, files, message, fmt.Errorf("file %q does not exist", resourceFile)
+		return fmt.Errorf("file %q does not exist", resourceFile)
 	}
 
 	if err := x.Read(resourceFile); err != nil {
-		return false, []string{}, "", err
+		return err
 	}
 
 	doc := etree.NewDocument()
 
 	if err := doc.ReadFromString(x.currentContent); err != nil {
-		return false, []string{}, "", err
+		return err
 	}
 
 	elem := doc.FindElement(x.spec.Path)
 	if elem == nil {
-		return false, []string{}, "", fmt.Errorf("%s nothing found at path %q from file %q",
-			result.FAILURE,
-			x.spec.Path,
-			resourceFile)
+		return fmt.Errorf("nothing found at path %q from file %q", x.spec.Path, resourceFile)
 	}
 
+	resultTarget.OldInformation = elem.Text()
+	resultTarget.NewInformation = value
+
 	if elem.Text() == value {
-		logrus.Infof("%s Path %q, from file %q, already set to %q, nothing else to do",
-			result.SUCCESS,
+		resultTarget.Result = result.SUCCESS
+		resultTarget.Description = fmt.Sprintf("path %q already set to %q in file %q",
 			x.spec.Path,
-			resourceFile,
-			value)
-		return false, []string{}, "", nil
+			value,
+			resourceFile)
+		return nil
 	}
-	logrus.Infof("%s Key %q, from file '%v', was updated from %q to %q",
-		result.ATTENTION,
+	resultTarget.Result = result.ATTENTION
+	resultTarget.Changed = true
+
+	resultTarget.Description = fmt.Sprintf("path %q updated from %q to %q in file %q",
 		x.spec.Path,
-		resourceFile,
 		elem.Text(),
-		value)
+		value,
+		resourceFile)
 
 	if !dryRun {
 		elem.SetText(value)
 
 		if err := doc.WriteToFile(resourceFile); err != nil {
-			return false, []string{}, "", err
+			return err
 		}
 	}
 
-	files = append(files, x.spec.File)
-	message = fmt.Sprintf("Update key %q from file %q",
-		x.spec.Path, x.spec.File)
+	resultTarget.Files = append(resultTarget.Files, x.spec.File)
 
-	return true, files, message, nil
+	return nil
 }

--- a/pkg/plugins/resources/xml/target.go
+++ b/pkg/plugins/resources/xml/target.go
@@ -11,18 +11,8 @@ import (
 	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
-func (x *XML) Target(source string, dryRun bool) (changed bool, err error) {
-
-	changed, _, _, err = x.TargetFromSCM(source, nil, dryRun)
-	if err != nil {
-		return changed, err
-	}
-
-	return changed, err
-}
-
-// TargetFromSCM updates a scm repository based on the modified yaml file.
-func (x *XML) TargetFromSCM(source string, scm scm.ScmHandler, dryRun bool) (changed bool, files []string, message string, err error) {
+// Target updates a scm repository based on the modified yaml file.
+func (x *XML) Target(source string, scm scm.ScmHandler, dryRun bool) (changed bool, files []string, message string, err error) {
 
 	if strings.HasPrefix(x.spec.File, "https://") ||
 		strings.HasPrefix(x.spec.File, "http://") {

--- a/pkg/plugins/resources/xml/target_test.go
+++ b/pkg/plugins/resources/xml/target_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/updatecli/updatecli/pkg/core/result"
 	"gotest.tools/assert"
 )
 
@@ -64,7 +65,7 @@ func TestTarget(t *testing.T) {
 			},
 			expectedResult:   false,
 			wantErr:          true,
-			expectedErrorMsg: errors.New("✗ nothing found at path \"/name/donotexist\" from file \"testdata/data_2.xml\""),
+			expectedErrorMsg: errors.New("nothing found at path \"/name/donotexist\" from file \"testdata/data_2.xml\""),
 		},
 		{
 			name: "Test 6",
@@ -95,7 +96,8 @@ func TestTarget(t *testing.T) {
 
 			require.NoError(t, err)
 
-			gotResult, _, _, err := x.Target("", nil, true)
+			gotResult := result.Target{}
+			err = x.Target("", nil, true, &gotResult)
 
 			if tt.wantErr {
 				assert.Equal(t, tt.expectedErrorMsg.Error(), err.Error())
@@ -103,7 +105,7 @@ func TestTarget(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			assert.Equal(t, tt.expectedResult, gotResult)
+			assert.Equal(t, tt.expectedResult, gotResult.Changed)
 		})
 	}
 

--- a/pkg/plugins/resources/xml/target_test.go
+++ b/pkg/plugins/resources/xml/target_test.go
@@ -95,7 +95,7 @@ func TestTarget(t *testing.T) {
 
 			require.NoError(t, err)
 
-			gotResult, err := x.Target("", true)
+			gotResult, _, _, err := x.Target("", nil, true)
 
 			if tt.wantErr {
 				assert.Equal(t, tt.expectedErrorMsg.Error(), err.Error())

--- a/pkg/plugins/resources/yaml/condition.go
+++ b/pkg/plugins/resources/yaml/condition.go
@@ -25,7 +25,7 @@ func (y *Yaml) ConditionFromSCM(source string, scm scm.ScmHandler) (bool, error)
 
 func (y *Yaml) condition(source string) (bool, error) {
 	var fileContent string
-	var filePath string
+	var originalFilePath string
 
 	// Start by retrieving the specified file's content
 	if err := y.Read(); err != nil {
@@ -36,7 +36,7 @@ func (y *Yaml) condition(source string) (bool, error) {
 	// loop over the only file
 	for theFilePath := range y.files {
 		fileContent = y.files[theFilePath].content
-		filePath = y.files[theFilePath].filePath
+		originalFilePath = y.files[theFilePath].originalFilePath
 	}
 
 	err := yaml.Unmarshal([]byte(fileContent), &out)
@@ -82,7 +82,7 @@ func (y *Yaml) condition(source string) (bool, error) {
 			logrus.Infof("%s Key %q, in YAML file %q, is correctly set to %q",
 				result.SUCCESS,
 				y.spec.Key,
-				filePath,
+				originalFilePath,
 				valueToCheck)
 			return true, nil
 		}
@@ -90,7 +90,7 @@ func (y *Yaml) condition(source string) (bool, error) {
 		logrus.Infof("%s Key %q, in YAML file %q, is incorrectly set to %s and should be %q",
 			result.FAILURE,
 			y.spec.Key,
-			filePath,
+			originalFilePath,
 			oldVersion,
 			valueToCheck)
 		return false, nil
@@ -98,5 +98,6 @@ func (y *Yaml) condition(source string) (bool, error) {
 	return false, fmt.Errorf("%s cannot find key %q in the YAML file %q",
 		result.FAILURE,
 		y.spec.Key,
-		filePath)
+		originalFilePath,
+	)
 }

--- a/pkg/plugins/resources/yaml/condition_test.go
+++ b/pkg/plugins/resources/yaml/condition_test.go
@@ -14,7 +14,7 @@ func Test_Condition(t *testing.T) {
 	tests := []struct {
 		name             string
 		spec             Spec
-		files            map[string]string
+		files            map[string]file
 		inputSourceValue string
 		mockedContents   map[string]string
 		mockedError      error
@@ -28,8 +28,11 @@ func Test_Condition(t *testing.T) {
 				File: "test.yaml",
 				Key:  "annotations.github\\.owner",
 			},
-			files: map[string]string{
-				"test.yaml": "",
+			files: map[string]file{
+				"test.yaml": {
+					originalFilePath: "test.yaml",
+					filePath:         "test.yaml",
+				},
 			},
 			inputSourceValue: "olblak",
 			mockedContents: map[string]string{
@@ -54,8 +57,11 @@ annotations:
 				File: "test.yaml",
 				Key:  "github.owner",
 			},
-			files: map[string]string{
-				"test.yaml": "",
+			files: map[string]file{
+				"test.yaml": {
+					originalFilePath: "test.yaml",
+					filePath:         "test.yaml",
+				},
 			},
 			inputSourceValue: "olblak",
 			mockedContents: map[string]string{
@@ -83,8 +89,11 @@ github:
 				Key:   "github.owner",
 				Value: "olblak",
 			},
-			files: map[string]string{
-				"test.yaml": "",
+			files: map[string]file{
+				"test.yaml": {
+					originalFilePath: "test.yaml",
+					filePath:         "test.yaml",
+				},
 			},
 			mockedContents: map[string]string{
 				"test.yaml": `---
@@ -112,9 +121,15 @@ github:
 				Key:   "github.owner",
 				Value: "olblak",
 			},
-			files: map[string]string{
-				"test.yaml":     "",
-				"too-much.yaml": "",
+			files: map[string]file{
+				"test.yaml": {
+					filePath:         "test.yaml",
+					originalFilePath: "test.yaml",
+				},
+				"too-much.yaml": {
+					filePath:         "too-much.yaml",
+					originalFilePath: "too-much.yaml",
+				},
 			},
 			isErrorWanted: true,
 		},
@@ -127,8 +142,11 @@ github:
 				Key:   "github.owner",
 				Value: "olblak",
 			},
-			files: map[string]string{
-				"test.yaml": "",
+			files: map[string]file{
+				"test.yaml": {
+					filePath:         "test.yaml",
+					originalFilePath: "test.yaml",
+				},
 			},
 			mockedContents: map[string]string{
 				"test.yaml": `---
@@ -145,8 +163,11 @@ github:
 				File: "test.yaml",
 				Key:  "github.owner",
 			},
-			files: map[string]string{
-				"test.yaml": "",
+			files: map[string]file{
+				"test.yaml": {
+					filePath:         "test.yaml",
+					originalFilePath: "test.yaml",
+				},
 			},
 			inputSourceValue: "olblak",
 			mockedContents: map[string]string{
@@ -165,8 +186,10 @@ github:
 				Key:     "github.owner",
 				KeyOnly: true,
 			},
-			files: map[string]string{
-				"test.yaml": "",
+			files: map[string]file{
+				"test.yaml": {
+					filePath:         "test.yaml",
+					originalFilePath: "test.yaml"},
 			},
 			inputSourceValue: "olblak",
 			mockedContents: map[string]string{
@@ -192,8 +215,11 @@ github:
 				Key:     "github.country",
 				KeyOnly: true,
 			},
-			files: map[string]string{
-				"test.yaml": "",
+			files: map[string]file{
+				"test.yaml": {
+					originalFilePath: "test.yaml",
+					filePath:         "test.yaml",
+				},
 			},
 			inputSourceValue: "",
 			mockedContents: map[string]string{
@@ -220,8 +246,11 @@ github:
 				KeyOnly: true,
 				Value:   "olblak",
 			},
-			files: map[string]string{
-				"test.yaml": "",
+			files: map[string]file{
+				"test.yaml": {
+					filePath:         "test.yaml",
+					originalFilePath: "test.yaml",
+				},
 			},
 			inputSourceValue: "",
 			mockedContents: map[string]string{
@@ -238,8 +267,11 @@ github:
 			spec: Spec{
 				File: "not_existing.yaml",
 			},
-			files: map[string]string{
-				"not_existing.yaml": "",
+			files: map[string]file{
+				"not_existing.yaml": {
+					filePath:         "not_existing.yaml",
+					originalFilePath: "not_existing.yaml",
+				},
 			},
 			mockedError:   fmt.Errorf("no such file or directory"),
 			isErrorWanted: true,
@@ -250,8 +282,11 @@ github:
 				File: "test.yaml",
 				Key:  "github.owner",
 			},
-			files: map[string]string{
-				"test.yaml": "",
+			files: map[string]file{
+				"test.yaml": {
+					originalFilePath: "test.yaml",
+					filePath:         "test.yaml",
+				},
 			},
 			inputSourceValue: "asterix",
 			mockedContents: map[string]string{
@@ -276,8 +311,11 @@ github:
 				File: "test.yaml",
 				Key:  "github.admin",
 			},
-			files: map[string]string{
-				"test.yaml": "",
+			files: map[string]file{
+				"test.yaml": {
+					filePath:         "test.yaml",
+					originalFilePath: "test.yaml",
+				},
 			},
 			inputSourceValue: "asterix",
 			mockedContents: map[string]string{
@@ -296,8 +334,11 @@ github:
 				Key:   "github.owner",
 				Value: "asterix",
 			},
-			files: map[string]string{
-				"test.yaml": "",
+			files: map[string]file{
+				"test.yaml": {
+					filePath:         "test.yaml",
+					originalFilePath: "test.yaml",
+				},
 			},
 			inputSourceValue: "olblak",
 			isErrorWanted:    true,
@@ -309,8 +350,11 @@ github:
 				Key:   "github.owner",
 				Value: "olblak",
 			},
-			files: map[string]string{
-				"test.yaml": "",
+			files: map[string]file{
+				"test.yaml": {
+					originalFilePath: "test.yaml",
+					filePath:         "test.yaml",
+				},
 			},
 			mockedContents: map[string]string{
 				"test.yaml": `---
@@ -359,7 +403,7 @@ func Test_ConditionFromSCM(t *testing.T) {
 	tests := []struct {
 		name             string
 		spec             Spec
-		files            map[string]string
+		files            map[string]file
 		inputSourceValue string
 		mockedContents   map[string]string
 		mockedError      error
@@ -375,8 +419,11 @@ func Test_ConditionFromSCM(t *testing.T) {
 				Key:   "github.owner",
 				Value: "olblak",
 			},
-			files: map[string]string{
-				"/tmp/test.yaml": "",
+			files: map[string]file{
+				"/tmp/test.yaml": {
+					filePath:         "/tmp/test.yaml",
+					originalFilePath: "/tmp/test.yaml",
+				},
 			},
 			scm: &scm.MockScm{
 				WorkingDir: "/tmp",
@@ -406,8 +453,11 @@ github:
 				Key:   "github.owner",
 				Value: "olblak",
 			},
-			files: map[string]string{
-				"/tmp/test.yaml": "",
+			files: map[string]file{
+				"/tmp/test.yaml": {
+					filePath:         "/tmp/test.yaml",
+					originalFilePath: "/tmp/test.yaml",
+				},
 			},
 			scm: &scm.MockScm{
 				WorkingDir: "/tmp",

--- a/pkg/plugins/resources/yaml/source.go
+++ b/pkg/plugins/resources/yaml/source.go
@@ -14,7 +14,6 @@ import (
 // Source return the latest version
 func (y *Yaml) Source(workingDir string) (string, error) {
 	// By default workingDir is set to local directory
-	var fileContent string
 	var filePath string
 
 	// By the default workingdir is set to the current working directory
@@ -49,26 +48,32 @@ func (y *Yaml) Source(workingDir string) (string, error) {
 		return "", err
 	}
 
-	fileContent = y.files[filePath].content
+	fileContent := y.files[filePath].content
+	originalFilePath := y.files[filePath].originalFilePath
 
 	var out yaml.Node
 
 	err = yaml.Unmarshal([]byte(fileContent), &out)
 	if err != nil {
-		return "", fmt.Errorf("cannot unmarshal content of file %s: %v", filePath, err)
+		return "", fmt.Errorf("cannot unmarshal content of file %s: %v", originalFilePath, err)
 	}
 
 	valueFound, value, _ := replace(&out, parseKey(y.spec.Key), y.spec.Value, 1)
 
 	if valueFound {
-		logrus.Infof("%s Value '%v' found for key %v in the yaml file %v", result.SUCCESS, value, y.spec.Key, filePath)
+		logrus.Infof("%s Value '%v' found for key %v in the yaml file %v",
+			result.SUCCESS,
+			value,
+			y.spec.Key,
+			originalFilePath,
+		)
 		return value, nil
 	}
 
 	logrus.Infof("%s cannot find key '%s' from file '%s'",
 		result.FAILURE,
 		y.spec.Key,
-		filePath)
+		originalFilePath)
 	return "", nil
 
 }

--- a/pkg/plugins/resources/yaml/source.go
+++ b/pkg/plugins/resources/yaml/source.go
@@ -36,23 +36,20 @@ func (y *Yaml) Source(workingDir string) (string, error) {
 	}
 
 	// loop over the only file
-	files := make(map[string]string)
 	for f := range y.files {
 		filePath = f
 
 		// Ideally currentWorkingDirectory should be empty
 		if workingDir != currentWorkingDirectory {
-			filePath = joinPathWithWorkingDirectoryPath(f, workingDir)
+			y.UpdateAbsoluteFilePath(workingDir)
 		}
-		files[filePath] = y.files[f]
 	}
-	y.files = files
 
 	if err = y.Read(); err != nil {
 		return "", err
 	}
 
-	fileContent = y.files[filePath]
+	fileContent = y.files[filePath].content
 
 	var out yaml.Node
 

--- a/pkg/plugins/resources/yaml/source_test.go
+++ b/pkg/plugins/resources/yaml/source_test.go
@@ -13,7 +13,7 @@ func Test_Source(t *testing.T) {
 	tests := []struct {
 		name           string
 		spec           Spec
-		files          map[string]string
+		files          map[string]file
 		mockedContents map[string]string
 		mockedError    error
 		wantedContents map[string]string
@@ -26,8 +26,11 @@ func Test_Source(t *testing.T) {
 				File: "test.yaml",
 				Key:  "annotations.github\\.owner",
 			},
-			files: map[string]string{
-				"test.yaml": "",
+			files: map[string]file{
+				"test.yaml": {
+					originalFilePath: "test.yaml",
+					filePath:         "test.yaml",
+				},
 			},
 			mockedContents: map[string]string{
 				"test.yaml": `---
@@ -47,8 +50,11 @@ annotations:
 				File: "test.yaml",
 				Key:  "github.owner",
 			},
-			files: map[string]string{
-				"test.yaml": "",
+			files: map[string]file{
+				"test.yaml": {
+					filePath:         "test.yaml",
+					originalFilePath: "test.yaml",
+				},
 			},
 			mockedContents: map[string]string{
 				"test.yaml": `---
@@ -70,8 +76,11 @@ github:
 				},
 				Key: "github.owner",
 			},
-			files: map[string]string{
-				"test.yaml": "",
+			files: map[string]file{
+				"test.yaml": {
+					filePath:         "test.yaml",
+					originalFilePath: "test.yaml",
+				},
 			},
 			mockedContents: map[string]string{
 				"test.yaml": `---
@@ -94,9 +103,15 @@ github:
 				},
 				Key: "github.owner",
 			},
-			files: map[string]string{
-				"test.yaml":     "",
-				"too-much.yaml": "",
+			files: map[string]file{
+				"test.yaml": {
+					filePath:         "test.yaml",
+					originalFilePath: "test.yaml",
+				},
+				"too-much.yaml": {
+					filePath:         "too-much.yaml",
+					originalFilePath: "too-much.yaml",
+				},
 			},
 			isErrorWanted: true,
 		},
@@ -109,8 +124,10 @@ github:
 				Key:   "github.owner",
 				Value: "olblak",
 			},
-			files: map[string]string{
-				"test.yaml": "",
+			files: map[string]file{
+				"test.yaml": {
+					filePath:         "test.yaml",
+					originalFilePath: "test.yaml"},
 			},
 			mockedContents: map[string]string{
 				"test.yaml": `---
@@ -130,8 +147,11 @@ github:
 				File: "test.yaml",
 				Key:  "github.owner",
 			},
-			files: map[string]string{
-				"test.yaml": "",
+			files: map[string]file{
+				"test.yaml": {
+					filePath:         "test.yaml",
+					originalFilePath: "test.yaml",
+				},
 			},
 			mockedContents: map[string]string{
 				"test.yaml": `---
@@ -148,8 +168,11 @@ github:
 				File: "test.yaml",
 				Key:  "github.country",
 			},
-			files: map[string]string{
-				"test.yaml": "",
+			files: map[string]file{
+				"test.yaml": {
+					filePath:         "test.yaml",
+					originalFilePath: "test.yaml",
+				},
 			},
 			mockedContents: map[string]string{
 				"test.yaml": `---
@@ -166,8 +189,11 @@ github:
 			spec: Spec{
 				File: "not_existing.yaml",
 			},
-			files: map[string]string{
-				"not_existing.yaml": "",
+			files: map[string]file{
+				"not_existing.yaml": {
+					filePath:         "not_existing.yaml",
+					originalFilePath: "not_existing.yaml",
+				},
 			},
 			mockedError:   fmt.Errorf("no such file or directory"),
 			isErrorWanted: true,

--- a/pkg/plugins/resources/yaml/target.go
+++ b/pkg/plugins/resources/yaml/target.go
@@ -16,13 +16,7 @@ import (
 )
 
 // Target updates a scm repository based on the modified yaml file.
-func (y *Yaml) Target(source string, dryRun bool) (bool, error) {
-	changed, _, _, err := y.target(source, dryRun)
-	return changed, err
-}
-
-// TargetFromSCM updates a scm repository based on the modified yaml file.
-func (y *Yaml) TargetFromSCM(source string, scm scm.ScmHandler, dryRun bool) (bool, []string, string, error) {
+func (y *Yaml) Target(source string, scm scm.ScmHandler, dryRun bool) (bool, []string, string, error) {
 	joignedFiles := make(map[string]string)
 	for filePath := range y.files {
 		joignedFilePath := filePath

--- a/pkg/plugins/resources/yaml/target.go
+++ b/pkg/plugins/resources/yaml/target.go
@@ -111,7 +111,7 @@ func (y *Yaml) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarg
 		resultTarget.Files = append(resultTarget.Files, y.files[filePath].filePath)
 		resultTarget.Result = result.ATTENTION
 
-		logrus.Infof("%s\nkey %q%supdated from %q to %q, in file %q",
+		resultTarget.Description = fmt.Sprintf("%s\nkey %q%supdated from %q to %q, in file %q",
 			resultTarget.Description,
 			y.spec.Key,
 			shouldMsg,

--- a/pkg/plugins/resources/yaml/target.go
+++ b/pkg/plugins/resources/yaml/target.go
@@ -17,41 +17,30 @@ import (
 
 // Target updates a scm repository based on the modified yaml file.
 func (y *Yaml) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
-	joignedFiles := make(map[string]string)
-	for filePath := range y.files {
-		joignedFilePath := filePath
-		if scm != nil {
-			joignedFilePath = joinPathWithWorkingDirectoryPath(joignedFilePath, scm.GetDirectory())
-			logrus.Debugf("Relative path detected: changing from %q to absolute path from SCM: %q", filePath, joignedFilePath)
-		}
-		joignedFiles[joignedFilePath] = y.files[filePath]
+
+	if scm != nil {
+		y.UpdateAbsoluteFilePath(scm.GetDirectory())
 	}
-	y.files = joignedFiles
-
-	return y.target(source, dryRun, resultTarget)
-}
-
-func (y *Yaml) target(source string, dryRun bool, resultTarget *result.Target) error {
 
 	// Test if target reference a file with a prefix like https:// or file://, as we don't know how to update those files.
-	for filePath := range y.files {
-		if text.IsURL(filePath) {
-			return fmt.Errorf("unsupported filename prefix for %s", filePath)
+	for _, file := range y.files {
+		if text.IsURL(file.originalFilePath) {
+			return fmt.Errorf("unsupported filename prefix for %s", file.originalFilePath)
 		}
 
-		if strings.HasPrefix(filePath, "https://") ||
-			strings.HasPrefix(filePath, "http://") {
-			return fmt.Errorf("URL scheme is not supported for YAML target: %q", filePath)
+		if strings.HasPrefix(file.originalFilePath, "https://") ||
+			strings.HasPrefix(file.originalFilePath, "http://") {
+			return fmt.Errorf("URL scheme is not supported for YAML target: %q", file.originalFilePath)
 		}
 
 		// Test at runtime if a file exist (no ForceCreate for kind: yaml)
-		if !y.contentRetriever.FileExists(filePath) {
-			return fmt.Errorf("the yaml file %q does not exist", filePath)
+		if !y.contentRetriever.FileExists(file.filePath) {
+			return fmt.Errorf("the yaml file %q does not exist", file.originalFilePath)
 		}
 	}
 
 	if err := y.Read(); err != nil {
-		return err
+		return fmt.Errorf("loading yaml file(s): %w", err)
 	}
 
 	valueToWrite := source
@@ -62,19 +51,23 @@ func (y *Yaml) target(source string, dryRun bool, resultTarget *result.Target) e
 
 	resultTarget.NewInformation = valueToWrite
 
-	shouldMsg := "should be"
+	// Use to craft message depending if we run Updatelci in dryrun mode or not
+	shouldMsg := " should be "
 
 	// loop over file(s)
 	notChanged := 0
-	originalContents := make(map[string]string)
+	//originalContents := make(map[string]string)
+
 	for filePath := range y.files {
-		originalContents[filePath] = y.files[filePath]
+		originFilePath := y.files[filePath].originalFilePath
+
+		//originalContents[filePath] = y.files[filePath].content
 
 		out := yaml.Node{}
-		err := yaml.Unmarshal([]byte(y.files[filePath]), &out)
+		err := yaml.Unmarshal([]byte(y.files[filePath].content), &out)
 
 		if err != nil {
-			return fmt.Errorf("cannot unmarshal content of file %s: %v", filePath, err)
+			return fmt.Errorf("cannot unmarshal content of file %s: %w", originFilePath, err)
 		}
 
 		keyFound, oldVersion, _ := replace(&out, parseKey(y.spec.Key), valueToWrite, 1)
@@ -84,7 +77,7 @@ func (y *Yaml) target(source string, dryRun bool, resultTarget *result.Target) e
 		if !keyFound {
 			return fmt.Errorf("couldn't find key %q from file %q",
 				y.spec.Key,
-				filePath)
+				originFilePath)
 		}
 
 		if oldVersion == valueToWrite {
@@ -93,7 +86,7 @@ func (y *Yaml) target(source string, dryRun bool, resultTarget *result.Target) e
 				resultTarget.Description,
 				y.spec.Key,
 				valueToWrite,
-				filePath)
+				originFilePath)
 			notChanged++
 			continue
 		}
@@ -102,40 +95,47 @@ func (y *Yaml) target(source string, dryRun bool, resultTarget *result.Target) e
 		encoder := yaml.NewEncoder(buf)
 		defer encoder.Close()
 		encoder.SetIndent(y.indent)
-		err = encoder.Encode(&out)
 
+		err = encoder.Encode(&out)
 		if err != nil {
-			return err
+			return fmt.Errorf("encoding yaml file: %w", err)
 		}
-		y.files[filePath] = buf.String()
+
+		f := y.files[filePath]
+		f.content = buf.String()
+		y.files[filePath] = f
+
 		buf.Reset()
 
 		resultTarget.Changed = true
-		resultTarget.Files = append(resultTarget.Files, filePath)
+		resultTarget.Files = append(resultTarget.Files, y.files[filePath].filePath)
 		resultTarget.Result = result.ATTENTION
 
-		logrus.Infof("%s\nkey %q %supdated from %q to %q, in file %q",
+		logrus.Infof("%s\nkey %q%supdated from %q to %q, in file %q",
 			resultTarget.Description,
 			y.spec.Key,
-			oldVersion,
 			shouldMsg,
+			oldVersion,
 			valueToWrite,
-			filePath)
+			originFilePath)
 
 		if !dryRun {
-			newFile, err := os.Create(filePath)
+			newFile, err := os.Create(y.files[filePath].filePath)
 
 			// https://staticcheck.io/docs/checks/#SA5001
 			//lint:ignore SA5001 We want to defer the file closing before exiting the function
 			defer newFile.Close()
 
 			if err != nil {
-				return err
+				return fmt.Errorf("creating file %q: %w", originFilePath, err)
 			}
 
-			err = y.contentRetriever.WriteToFile(y.files[filePath], filePath)
+			err = y.contentRetriever.WriteToFile(
+				y.files[filePath].content,
+				y.files[filePath].filePath)
+
 			if err != nil {
-				return err
+				return fmt.Errorf("saving file %q: %w", originFilePath, err)
 			}
 		}
 	}

--- a/pkg/plugins/resources/yaml/target_test.go
+++ b/pkg/plugins/resources/yaml/target_test.go
@@ -256,7 +256,7 @@ github:
 				files:            tt.files,
 				indent:           tt.spec.Indent,
 			}
-			gotResult, gotErr := y.Target(tt.inputSourceValue, tt.dryRun)
+			gotResult, _, _, gotErr := y.Target(tt.inputSourceValue, nil, tt.dryRun)
 			if tt.wantedError {
 				assert.Error(t, gotErr)
 				return
@@ -378,7 +378,7 @@ github:
 				files:            tt.files,
 				indent:           tt.spec.Indent,
 			}
-			gotResult, gotFiles, _, gotErr := y.TargetFromSCM(tt.inputSourceValue, tt.scm, tt.dryRun)
+			gotResult, gotFiles, _, gotErr := y.Target(tt.inputSourceValue, tt.scm, tt.dryRun)
 			if tt.wantedError {
 				assert.Error(t, gotErr)
 				return

--- a/pkg/plugins/resources/yaml/target_test.go
+++ b/pkg/plugins/resources/yaml/target_test.go
@@ -15,7 +15,7 @@ func Test_Target(t *testing.T) {
 	tests := []struct {
 		name             string
 		spec             Spec
-		files            map[string]string
+		files            map[string]file
 		inputSourceValue string
 		mockedContents   map[string]string
 		mockedError      error
@@ -32,8 +32,11 @@ func Test_Target(t *testing.T) {
 				Value:  "obiwankenobi",
 				Indent: 4,
 			},
-			files: map[string]string{
-				"test.yaml": "",
+			files: map[string]file{
+				"test.yaml": {
+					filePath:         "test.yaml",
+					originalFilePath: "test.yaml",
+				},
 			},
 			inputSourceValue: "olblak",
 			mockedContents: map[string]string{
@@ -60,8 +63,11 @@ annotations:
 				Value:  "obiwankenobi",
 				Indent: 2,
 			},
-			files: map[string]string{
-				"test.yaml": "",
+			files: map[string]file{
+				"test.yaml": {
+					filePath:         "test.yaml",
+					originalFilePath: "test.yaml",
+				},
 			},
 			inputSourceValue: "olblak",
 			mockedContents: map[string]string{
@@ -91,9 +97,15 @@ github:
 				Value:  "obiwankenobi",
 				Indent: 2,
 			},
-			files: map[string]string{
-				"test.yaml": "",
-				"bar.yaml":  "",
+			files: map[string]file{
+				"test.yaml": {
+					filePath:         "test.yaml",
+					originalFilePath: "test.yaml",
+				},
+				"bar.yaml": {
+					filePath:         "bar.yaml",
+					originalFilePath: "bar.yaml",
+				},
 			},
 			inputSourceValue: "olblak",
 			mockedContents: map[string]string{
@@ -132,9 +144,15 @@ github:
 				Value:  "obiwankenobi",
 				Indent: 2,
 			},
-			files: map[string]string{
-				"test.yaml": "",
-				"bar.yaml":  "",
+			files: map[string]file{
+				"test.yaml": {
+					filePath:         "test.yaml",
+					originalFilePath: "test.yaml",
+				},
+				"bar.yaml": {
+					filePath:         "test.yaml",
+					originalFilePath: "bar.yaml",
+				},
 			},
 			inputSourceValue: "olblak",
 			mockedContents: map[string]string{
@@ -171,8 +189,11 @@ github:
 				Value:  "obiwankenobi",
 				Indent: 2,
 			},
-			files: map[string]string{
-				"test.yaml": "",
+			files: map[string]file{
+				"test.yaml": {
+					filePath:         "test.yaml",
+					originalFilePath: "test.yaml",
+				},
 			},
 			wantedResult: false,
 			wantedError:  true,
@@ -183,8 +204,11 @@ github:
 				File: "test.yaml",
 				Key:  "github.owner",
 			},
-			files: map[string]string{
-				"test.yaml": "",
+			files: map[string]file{
+				"test.yaml": {
+					filePath:         "test.yaml",
+					originalFilePath: "test.yaml",
+				},
 			},
 			inputSourceValue: "olblak",
 			mockedContents: map[string]string{
@@ -209,8 +233,11 @@ github:
 				Key:   "github.ship",
 				Value: "obiwankenobi",
 			},
-			files: map[string]string{
-				"test.yaml": "",
+			files: map[string]file{
+				"test.yaml": {
+					filePath:         "test.yaml",
+					originalFilePath: "test.yaml",
+				},
 			},
 			inputSourceValue: "olblak",
 			mockedContents: map[string]string{
@@ -230,8 +257,11 @@ github:
 				Key:   "github.ship",
 				Value: "obiwankenobi",
 			},
-			files: map[string]string{
-				"test.yaml": "",
+			files: map[string]file{
+				"test.yaml": {
+					filePath:         "test.yaml",
+					originalFilePath: "test.yaml",
+				},
 			},
 			inputSourceValue: "olblak",
 			mockedContents: map[string]string{
@@ -279,7 +309,7 @@ func Test_TargetFromSCM(t *testing.T) {
 	tests := []struct {
 		name             string
 		spec             Spec
-		files            map[string]string
+		files            map[string]file
 		scm              scm.ScmHandler
 		inputSourceValue string
 		mockedContents   map[string]string
@@ -298,8 +328,11 @@ func Test_TargetFromSCM(t *testing.T) {
 				Value:  "obiwankenobi",
 				Indent: 2,
 			},
-			files: map[string]string{
-				"/tmp/test.yaml": "",
+			files: map[string]file{
+				"/tmp/test.yaml": {
+					filePath:         "/tmp/test.yaml",
+					originalFilePath: "/tmp/test.yaml",
+				},
 			},
 			inputSourceValue: "olblak",
 			mockedContents: map[string]string{
@@ -332,9 +365,15 @@ github:
 				Value:  "obiwankenobi",
 				Indent: 2,
 			},
-			files: map[string]string{
-				"/tmp/test.yaml": "",
-				"/tmp/bar.yaml":  "",
+			files: map[string]file{
+				"/tmp/test.yaml": {
+					filePath:         "/tmp/test.yaml",
+					originalFilePath: "/tmp/test.yaml",
+				},
+				"/tmp/bar.yaml": {
+					filePath:         "/tmp/bar.yaml",
+					originalFilePath: "/tmp/bar.yaml",
+				},
 			},
 			inputSourceValue: "olblak",
 			mockedContents: map[string]string{

--- a/pkg/plugins/resources/yaml/target_test.go
+++ b/pkg/plugins/resources/yaml/target_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
+	"github.com/updatecli/updatecli/pkg/core/result"
 	"github.com/updatecli/updatecli/pkg/core/text"
 )
 
@@ -256,14 +257,15 @@ github:
 				files:            tt.files,
 				indent:           tt.spec.Indent,
 			}
-			gotResult, _, _, gotErr := y.Target(tt.inputSourceValue, nil, tt.dryRun)
+			gotResult := result.Target{}
+			gotErr := y.Target(tt.inputSourceValue, nil, tt.dryRun, &gotResult)
 			if tt.wantedError {
 				assert.Error(t, gotErr)
 				return
 			}
 
 			require.NoError(t, gotErr)
-			assert.Equal(t, tt.wantedResult, gotResult)
+			assert.Equal(t, tt.wantedResult, gotResult.Changed)
 
 			for filePath := range y.files {
 				defer os.Remove(filePath)
@@ -378,15 +380,16 @@ github:
 				files:            tt.files,
 				indent:           tt.spec.Indent,
 			}
-			gotResult, gotFiles, _, gotErr := y.Target(tt.inputSourceValue, tt.scm, tt.dryRun)
+			gotResult := result.Target{}
+			gotErr := y.Target(tt.inputSourceValue, tt.scm, tt.dryRun, &gotResult)
 			if tt.wantedError {
 				assert.Error(t, gotErr)
 				return
 			}
 
 			require.NoError(t, gotErr)
-			assert.Equal(t, tt.wantedResult, gotResult)
-			assert.Equal(t, tt.wantedFiles, gotFiles)
+			assert.Equal(t, tt.wantedResult, gotResult.Changed)
+			assert.Equal(t, tt.wantedFiles, gotResult.Files)
 
 			for filePath := range y.files {
 				defer os.Remove(filePath)


### PR DESCRIPTION
In an attempt to generate better report out of Updatecli execution, I am refactoring target resources with following compopents:

* Merge the functions Target() and TargetFromSCM

As the Updatecli project evolved, I realize that those two functions are useless code duplication, and introduce more complexity. Therefor I went over all plugin to simplify those two functions into one named `Target()`

The risk associated with this refactoring is that a target plugin working with scm repositories can be broken and this hard to fully tests in dev environment. 

* Target function now return additional metadata during execution

I modify both the target function parameters and returned values. Target uses the new struct `result.Target` to store\

* Old value
* New Value
* execution result (success, attention, failure, skipped)
* message such as `update yaml key "version" from x to y in file z`
-----
In very short 

```
-       Target(source string, dryRun bool) (bool, error)
-       TargetFromSCM(source string, scm scm.ScmHandler, dryRun bool) (changed bool, files []string, message string, err error)
+       Target(source string, scm scm.ScmHandler, dryRun bool, targetResult *result.Target) (err error)
```

Where result.Target is:
```
// Target holds target execution result
type Target struct {
    // Name holds the target name
    Name string
    /*  
        Result holds the target result, accepted values must be one:
            * "SUCCESS"
            * "FAILURE"
            * "ATTENTION"
            * "SKIPPED"
    */
    Result string
    // OldInformation stores the old information detected by the target execution
    OldInformation string
    // NewInformation stores the new information updated by during the target execution
    NewInformation string
    // Description stores the target execution description
    Description string
    // Files holds the list of files modified by a target execution
    Files   []string
    Changed bool
}
```
----

## Test

Considering that this pullrequest modifies all target plugin, we need as many tests as possible 

## Additional Information

### Tradeoff

Not every target plugin has the ability to retrieve the old value before updating.
For example the shell plugin allows to run whatever scripts needed. For those situation, I decided to use the default value "unkown"

### Potential improvement

We need similar refactoring for the condition and source plugins but I prefer to do as stage at the time considering the amount of files changed.