### PR TITLE
Refactor condition result

### DIFF
--- a/e2e/updatecli.d/success.d/gitlab/scm.yaml
+++ b/e2e/updatecli.d/success.d/gitlab/scm.yaml
@@ -1,4 +1,4 @@
-name: Test Gitea scm
+name: Test Gitlab scm
 
 scms:
   gitlab:

--- a/e2e/updatecli.d/success.d/gitlab/tag.yaml
+++ b/e2e/updatecli.d/success.d/gitlab/tag.yaml
@@ -1,4 +1,4 @@
-name: "Test Gitea tag"
+name: "Test Gitlab tag"
 
 sources:
   default:

--- a/pkg/core/pipeline/condition/main.go
+++ b/pkg/core/pipeline/condition/main.go
@@ -21,7 +21,7 @@ var (
 // in order to update targets based on the source output
 type Condition struct {
 	// Result stores the condition result after a condition run.
-	Result string
+	Result result.Condition
 	// Config defines condition input parameters
 	Config Config
 	Scm    *scm.ScmHandler
@@ -42,7 +42,7 @@ type Config struct {
 
 // Run tests if a specific condition is true
 func (c *Condition) Run(source string) (err error) {
-	c.Result = result.FAILURE
+	c.Result.Result = result.FAILURE
 	ok := false
 
 	condition, err := resource.New(c.Config.ResourceConfig)
@@ -59,7 +59,7 @@ func (c *Condition) Run(source string) (err error) {
 
 	switch c.Scm == nil {
 	case true:
-		ok, err = condition.Condition(source)
+		err = condition.Condition(source, nil, &c.Result)
 		if err != nil {
 			return err
 		}
@@ -75,7 +75,7 @@ func (c *Condition) Run(source string) (err error) {
 			return err
 		}
 
-		ok, err = condition.ConditionFromSCM(source, s)
+		err = condition.Condition(source, s, &c.Result)
 		if err != nil {
 			return err
 		}
@@ -86,7 +86,7 @@ func (c *Condition) Run(source string) (err error) {
 		return nil
 	}
 
-	c.Result = result.SUCCESS
+	c.Result.Result = result.SUCCESS
 	return nil
 }
 

--- a/pkg/core/pipeline/condition/main.go
+++ b/pkg/core/pipeline/condition/main.go
@@ -43,7 +43,6 @@ type Config struct {
 // Run tests if a specific condition is true
 func (c *Condition) Run(source string) (err error) {
 	c.Result.Result = result.FAILURE
-	ok := false
 
 	condition, err := resource.New(c.Config.ResourceConfig)
 	if err != nil {
@@ -81,12 +80,21 @@ func (c *Condition) Run(source string) (err error) {
 		}
 	}
 
-	if ok == c.Config.FailWhen {
-		logrus.Printf("\t => expected condition result %t, got %t", c.Config.FailWhen, ok)
-		return nil
+	// FailWhen is used to reverse the expected condition value
+	// If failwhen is set to true, then we expected a condition returning "true" would be considered as a failure
+	if c.Config.FailWhen {
+		logrus.Debugf("Expected successful condition result to be %v", !c.Config.FailWhen)
+		if c.Result.Pass {
+			c.Result.Result = result.FAILURE
+			c.Result.Pass = false
+		} else {
+			c.Result.Result = result.SUCCESS
+			c.Result.Pass = true
+		}
 	}
 
-	c.Result.Result = result.SUCCESS
+	logrus.Infof("%s %s", c.Result.Result, c.Result.Description)
+
 	return nil
 }
 

--- a/pkg/core/pipeline/conditions.go
+++ b/pkg/core/pipeline/conditions.go
@@ -46,10 +46,10 @@ func (p *Pipeline) RunConditions() (globalResult bool, err error) {
 		}
 
 		// Reports the result of the execution of this condition
-		rpt.Result = condition.Result
+		rpt.Result = condition.Result.Result
 
 		// If there was an error OR if the condition is not successful then defines the global result as false
-		if err != nil || condition.Result != result.SUCCESS {
+		if err != nil || condition.Result.Result != result.SUCCESS {
 			globalResult = false
 		}
 

--- a/pkg/core/pipeline/main.go
+++ b/pkg/core/pipeline/main.go
@@ -59,7 +59,7 @@ func (p *Pipeline) Init(config *config.Config, options Options) error {
 
 	// Init context resource size
 	p.Report.Sources = make(map[string]*result.Source, len(config.Spec.Sources))
-	p.Report.Conditions = make(map[string]reports.Stage, len(config.Spec.Conditions))
+	p.Report.Conditions = make(map[string]*result.Condition, len(config.Spec.Conditions))
 	p.Report.Targets = make(map[string]*result.Target, len(config.Spec.Targets))
 	p.Report.Name = config.Spec.Name
 	p.Report.Result = result.SKIPPED
@@ -148,15 +148,15 @@ func (p *Pipeline) Init(config *config.Config, options Options) error {
 
 		p.Conditions[id] = condition.Condition{
 			Config: config.Spec.Conditions[id],
-			Result: result.SKIPPED,
-			Scm:    scmPointer,
+			Result: result.Condition{
+				Result: result.SKIPPED,
+			},
+			Scm: scmPointer,
 		}
 
-		p.Report.Conditions[id] = reports.Stage{
-			Name:   config.Spec.Conditions[id].Name,
-			Kind:   config.Spec.Conditions[id].Kind,
-			Result: result.SKIPPED,
-		}
+		r := p.Conditions[id].Result
+		p.Report.Conditions[id] = &r
+
 	}
 
 	// Init target report
@@ -256,7 +256,7 @@ func (p *Pipeline) String() string {
 	result = result + fmt.Sprintf("%q:\n", "Conditions")
 	for key, value := range p.Conditions {
 		result = result + fmt.Sprintf("\t%q:\n", key)
-		result = result + fmt.Sprintf("\t\t%q: %q\n", "Result", value.Result)
+		result = result + fmt.Sprintf("\t\t%q: %q\n", "Result", value.Result.Result)
 	}
 	result = result + fmt.Sprintf("%q:\n", "Targets")
 	for key, value := range p.Targets {

--- a/pkg/core/pipeline/resource/main.go
+++ b/pkg/core/pipeline/resource/main.go
@@ -69,66 +69,127 @@ func New(rs ResourceConfig) (resource Resource, err error) {
 
 	switch kind {
 	case "aws/ami":
+
 		return awsami.New(rs.Spec)
+
 	case "cargopackage":
+
 		return cargopackage.New(rs.Spec, rs.SCMID != "")
+
 	case "csv":
+
 		return csv.New(rs.Spec)
+
 	case "dockerdigest":
+
 		return dockerdigest.New(rs.Spec)
+
 	case "dockerfile":
+
 		return dockerfile.New(rs.Spec)
+
 	case "dockerimage":
+
 		return dockerimage.New(rs.Spec)
-	case "githubrelease":
-		return githubrelease.New(rs.Spec)
+
 	case "gitbranch":
+
 		return gitbranch.New(rs.Spec)
-	case "gittag":
-		return gittag.New(rs.Spec)
+
 	case "gitea/branch":
+
 		return giteaBranch.New(rs.Spec)
+
 	case "gitea/tag":
+
 		return giteaTag.New(rs.Spec)
+
 	case "gitea/release":
+
 		return giteaRelease.New(rs.Spec)
+
+	case "githubrelease":
+
+		return githubrelease.New(rs.Spec)
+
 	case "gitlab/branch":
+
 		return gitlabBranch.New(rs.Spec)
+
 	case "gitlab/tag":
+
 		return gitlabTag.New(rs.Spec)
+
 	case "gitlab/release":
+
 		return gitlabRelease.New(rs.Spec)
+
+	case "gittag":
+
+		return gittag.New(rs.Spec)
+
 	case "golang":
+
 		return golang.New(rs.Spec)
+
 	case "golang/gomod":
+
 		return gomod.New(rs.Spec)
+
 	case "golang/module":
+
 		return gomodule.New(rs.Spec)
+
 	case "file":
+
 		return file.New(rs.Spec)
+
 	case "helmchart":
+
 		return helm.New(rs.Spec)
+
 	case "jenkins":
+
 		return jenkins.New(rs.Spec)
+
 	case "json":
+
 		return json.New(rs.Spec)
+
 	case "maven":
+
 		return maven.New(rs.Spec)
+
 	case "shell":
+
 		return shell.New(rs.Spec)
+
 	case "stash/branch":
+
 		return stashBranch.New(rs.Spec)
+
 	case "stash/tag":
+
 		return stashTag.New(rs.Spec)
+
 	case "toml":
+
 		return toml.New(rs.Spec)
+
 	case "yaml":
+
 		return yaml.New(rs.Spec)
+
 	case "xml":
+
 		return xml.New(rs.Spec)
+
 	case "npm":
+
 		return npm.New(rs.Spec)
+
 	default:
+
 		return nil, fmt.Errorf("%s Don't support resource kind: %v", result.FAILURE, rs.Kind)
 	}
 }
@@ -136,8 +197,7 @@ func New(rs ResourceConfig) (resource Resource, err error) {
 // Resource allow to manipulate a resource that can be a source, a condition or a target
 type Resource interface {
 	Source(workingDir string, sourceResult *result.Source) error
-	Condition(version string) (bool, error)
-	ConditionFromSCM(version string, scm scm.ScmHandler) (bool, error)
+	Condition(version string, scm scm.ScmHandler, resultCondition *result.Condition) error
 	Target(source string, scm scm.ScmHandler, dryRun bool, targetResult *result.Target) (err error)
 	Changelog() string
 }

--- a/pkg/core/reports/main.go
+++ b/pkg/core/reports/main.go
@@ -30,7 +30,7 @@ REPORTS:
 {{- if .Conditions -}}
 {{- "\t" }}Condition:
 {{ range $ID, $condition := .Conditions }}
-{{- "\t" }}{{"\t"}}{{- $condition.Result }} [{{ $ID }}] {{ $condition.Name }} (kind: {{ $condition.Kind -}}){{"\n"}}
+{{- "\t" }}{{"\t"}}{{- $condition.Result }} [{{ $ID }}] {{ $condition.Name }}{{"\n"}}
 {{- end -}}
 {{- end -}}
 {{- if .Targets -}}

--- a/pkg/core/reports/report.go
+++ b/pkg/core/reports/report.go
@@ -69,7 +69,7 @@ type Report struct {
 	Err        string
 	Result     string
 	Sources    map[string]*result.Source
-	Conditions map[string]Stage
+	Conditions map[string]*result.Condition
 	Targets    map[string]*result.Target
 }
 
@@ -80,7 +80,7 @@ func (r *Report) Init(name string, sourceNbr, conditionNbr, targetNbr int) {
 	r.Result = result.FAILURE
 
 	r.Sources = make(map[string]*result.Source, sourceNbr)
-	r.Conditions = make(map[string]Stage, conditionNbr)
+	r.Conditions = make(map[string]*result.Condition, conditionNbr)
 	r.Targets = make(map[string]*result.Target, targetNbr)
 }
 

--- a/pkg/core/result/condition.go
+++ b/pkg/core/result/condition.go
@@ -1,0 +1,19 @@
+package result
+
+// Conditions holds condition execution result
+type Condition struct {
+	//Name holds the condition name
+	Name string
+	/*
+		Result holds the condition result, accepted values must be one:
+			* "SUCCESS"
+			* "FAILURE"
+			* "ATTENTION"
+			* "SKIPPED"
+	*/
+	Result string
+	// Pass stores the information detected by the condition execution.
+	Pass bool
+	// Description stores the condition execution description.
+	Description string
+}

--- a/pkg/core/result/source.go
+++ b/pkg/core/result/source.go
@@ -2,7 +2,7 @@ package result
 
 // Source holds source execution result
 type Source struct {
-	// Name holds the target name
+	// Name holds the source name
 	Name string
 	/*
 		Result holds the source result, accepted values must be one:

--- a/pkg/plugins/resources/awsami/condition.go
+++ b/pkg/plugins/resources/awsami/condition.go
@@ -60,6 +60,7 @@ func (a *AMI) Condition(source string, scm scm.ScmHandler, resultCondition *resu
 	}
 
 	resultCondition.Result = result.FAILURE
+	resultCondition.Pass = false
 	resultCondition.Description = fmt.Sprintf("no AMI found matching criteria for region %s\n", a.Spec.Region)
 
 	return nil

--- a/pkg/plugins/resources/awsami/condition.go
+++ b/pkg/plugins/resources/awsami/condition.go
@@ -11,13 +11,17 @@ import (
 )
 
 // Condition tests if an image matching the specific filters exists.
-func (a *AMI) Condition(source string) (bool, error) {
+func (a *AMI) Condition(source string, scm scm.ScmHandler, resultCondition *result.Condition) error {
+
+	if scm != nil {
+		logrus.Warningf("condition with SCM is not supported, please remove the scm block")
+		return errors.New("condition with SCM is not supported")
+	}
 
 	// It's an error if the upstream source is empty and the user does not provide any filter
 	// then it mean
 	if source == "" && len(a.Spec.Filters) == 0 {
-		logrus.Errorln(ErrNoFilter)
-		return false, ErrSpecNotValid
+		return ErrNoFilter
 	}
 
 	isFilterDefined := func(filter string) (found bool) {
@@ -45,23 +49,18 @@ func (a *AMI) Condition(source string) (bool, error) {
 	foundAMI, err := a.getLatestAmiID()
 
 	if err != nil {
-		return false, err
+		return fmt.Errorf("getting latest AMI ID: %w", err)
 	}
 
 	if len(foundAMI) > 0 {
-		logrus.Infof("%s AMI %q found\n", result.SUCCESS, foundAMI)
-		return true, nil
+		resultCondition.Description = fmt.Sprintf("AMI %q found\n", foundAMI)
+		resultCondition.Result = result.SUCCESS
+		resultCondition.Pass = true
+		return nil
 	}
 
-	fmt.Printf("%s No AMI found matching criteria for region %s\n", result.FAILURE, a.Spec.Region)
+	resultCondition.Result = result.FAILURE
+	resultCondition.Description = fmt.Sprintf("no AMI found matching criteria for region %s\n", a.Spec.Region)
 
-	return false, nil
-}
-
-// ConditionFromSCM is a placeholder to validate the condition interface
-func (a *AMI) ConditionFromSCM(source string, scm scm.ScmHandler) (bool, error) {
-
-	fmt.Printf("%s Condition with SCM is not supported, please remove the scm block \n", result.FAILURE)
-
-	return false, errors.New("condition with SCM is not supported")
+	return nil
 }

--- a/pkg/plugins/resources/awsami/data_test.go
+++ b/pkg/plugins/resources/awsami/data_test.go
@@ -41,7 +41,7 @@ var (
 			expectedGetAMI:    "",
 			expectedSource:    "",
 			expectedCondition: false,
-			expectedError:     ErrSpecNotValid,
+			expectedError:     ErrNoFilter,
 		},
 		{
 			ami: AMI{

--- a/pkg/plugins/resources/cargopackage/condition.go
+++ b/pkg/plugins/resources/cargopackage/condition.go
@@ -56,6 +56,7 @@ func (cp *CargoPackage) condition(source string, resultCondition *result.Conditi
 
 	resultCondition.Result = result.FAILURE
 	resultCondition.Description = fmt.Sprintf("version %q doesn't exist\n", versionToCheck)
+	resultCondition.Pass = false
 
 	return nil
 }

--- a/pkg/plugins/resources/cargopackage/condition.go
+++ b/pkg/plugins/resources/cargopackage/condition.go
@@ -2,60 +2,60 @@ package cargopackage
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/sirupsen/logrus"
 	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
 	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
-// Condition checks that a git tag exists
-func (cp *CargoPackage) Condition(source string) (bool, error) {
-	return cp.condition(source)
-}
-
-// ConditionFromSCM test if a tag exists from a git repository specific from SCM
-func (cp *CargoPackage) ConditionFromSCM(source string, scm scm.ScmHandler) (bool, error) {
-	path := scm.GetDirectory()
-
-	if cp.spec.Registry.RootDir != "" {
-		logrus.Warningf("Registry.RootDir is defined and set to %q but is overridden by the scm definition %q",
-			cp.spec.Registry.RootDir,
-			path)
+// Condition test if a tag exists from a git repository specific from SCM
+func (cp *CargoPackage) Condition(source string, scm scm.ScmHandler, resultCondition *result.Condition) error {
+	if scm != nil {
+		path := scm.GetDirectory()
+		if cp.spec.Registry.RootDir != "" {
+			logrus.Warningf("Registry.RootDir is defined and set to %q but is overridden by the scm definition %q",
+				cp.spec.Registry.RootDir,
+				path)
+		}
+		if cp.spec.Registry.URL != "" {
+			logrus.Warningf("Registry.URL is defined and set to %q but is overridden by the scm definition %q",
+				cp.spec.Registry.URL,
+				path)
+		}
+		cp.registry.RootDir = path
 	}
-	if cp.spec.Registry.URL != "" {
-		logrus.Warningf("Registry.URL is defined and set to %q but is overridden by the scm definition %q",
-			cp.spec.Registry.URL,
-			path)
-	}
-	cp.registry.RootDir = path
 
-	return cp.condition(source)
+	return cp.condition(source, resultCondition)
 }
 
 // Condition checks if a cargo package with a specific version is published
 // We assume that if we can't find the package version in the index, then it means it doesn't exist.
-func (cp *CargoPackage) condition(source string) (bool, error) {
+func (cp *CargoPackage) condition(source string, resultCondition *result.Condition) error {
 	versionToCheck := cp.spec.Version
 	if versionToCheck == "" {
 		versionToCheck = source
 	}
 	if len(versionToCheck) == 0 {
-		return false, errors.New("no version defined")
+		return errors.New("no version defined")
 	}
 
 	_, versions, err := cp.getVersions()
 	if err != nil {
-		return false, err
+		return fmt.Errorf("getting cargo package version: %w", err)
 	}
 
 	for _, v := range versions {
 		if v == versionToCheck {
-			logrus.Infof("%s release version '%s' available\n", result.SUCCESS, versionToCheck)
-			return true, nil
+			resultCondition.Result = result.SUCCESS
+			resultCondition.Pass = true
+			resultCondition.Description = fmt.Sprintf("release version %q available\n", versionToCheck)
+			return nil
 		}
 	}
 
-	logrus.Infof("%s Version %q doesn't exist\n", result.FAILURE, versionToCheck)
+	resultCondition.Result = result.FAILURE
+	resultCondition.Description = fmt.Sprintf("version %q doesn't exist\n", versionToCheck)
 
-	return false, nil
+	return nil
 }

--- a/pkg/plugins/resources/cargopackage/condition_test.go
+++ b/pkg/plugins/resources/cargopackage/condition_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/updatecli/updatecli/pkg/core/result"
 	"github.com/updatecli/updatecli/pkg/plugins/utils/cargo"
 
 	"github.com/stretchr/testify/assert"
@@ -136,13 +137,15 @@ func TestCondition(t *testing.T) {
 			if tt.mockedResponse {
 				got.webClient = GetMockClient(tt.mockedUrl, tt.mockedToken, tt.mockedBody, tt.mockedHTTPStatusCode, tt.mockedHeaderFormat)
 			}
-			gotVersion, err := got.Condition("")
+			gotResult := result.Condition{}
+
+			err = got.Condition("", nil, &gotResult)
 			if tt.expectedError {
 				assert.Error(t, err)
 				return
 			}
 			require.NoError(t, err)
-			assert.Equal(t, tt.expectedResult, gotVersion)
+			assert.Equal(t, tt.expectedResult, gotResult.Pass)
 		})
 	}
 }

--- a/pkg/plugins/resources/csv/condition_test.go
+++ b/pkg/plugins/resources/csv/condition_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
 func TestCondition(t *testing.T) {
@@ -82,7 +83,7 @@ func TestCondition(t *testing.T) {
 			},
 			expectedResult:   false,
 			wantErr:          true,
-			expectedErrorMsg: errors.New("could not find value for query \".doNotExist\" from file \"testdata/data.csv\""),
+			expectedErrorMsg: errors.New("running query: could not find value for query \".doNotExist\" from file \"testdata/data.csv\""),
 		},
 	}
 
@@ -93,7 +94,8 @@ func TestCondition(t *testing.T) {
 
 			require.NoError(t, err)
 
-			gotResult, err := c.Condition("")
+			gotResult := result.Condition{}
+			err = c.Condition("", nil, &gotResult)
 
 			if tt.wantErr {
 				assert.Equal(t, tt.expectedErrorMsg.Error(), err.Error())
@@ -101,7 +103,7 @@ func TestCondition(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			assert.Equal(t, tt.expectedResult, gotResult)
+			assert.Equal(t, tt.expectedResult, gotResult.Pass)
 		})
 	}
 }

--- a/pkg/plugins/resources/dockerfile/condition.go
+++ b/pkg/plugins/resources/dockerfile/condition.go
@@ -6,34 +6,44 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
+	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
 // Condition test if the Dockerfile contains the correct key/value
-func (d *Dockerfile) Condition(source string) (bool, error) {
+func (d *Dockerfile) Condition(source string, scm scm.ScmHandler, resultCondition *result.Condition) error {
+
+	if scm != nil {
+		d.spec.File = path.Join(scm.GetDirectory(), d.spec.File)
+	}
 
 	if !d.contentRetriever.FileExists(d.spec.File) {
-		return false, fmt.Errorf("the file %s does not exist", d.spec.File)
+		return fmt.Errorf("the file %s does not exist", d.spec.File)
 	}
 	dockerfileContent, err := d.contentRetriever.ReadAll(d.spec.File)
 	if err != nil {
-		return false, err
+		return fmt.Errorf("reading dockerfile: %w", err)
 	}
 
-	logrus.Infof("\n🐋 On (Docker)file %q:\n\n", d.spec.File)
+	logrus.Debugf("\n🐋 On (Docker)file %q:\n\n", d.spec.File)
 
 	found := d.parser.FindInstruction([]byte(dockerfileContent))
 
-	return found, nil
-}
-
-// ConditionFromSCM run based on a file from SCM
-func (d *Dockerfile) ConditionFromSCM(source string, scm scm.ScmHandler) (bool, error) {
-	d.spec.File = path.Join(scm.GetDirectory(), d.spec.File)
-
-	found, err := d.Condition(source)
-	if err != nil {
-		return false, err
+	switch found {
+	case true:
+		resultCondition.Pass = true
+		resultCondition.Result = result.SUCCESS
+		resultCondition.Description = fmt.Sprintf("key %q found in Dockerfile %q",
+			d.spec.Instruction,
+			d.spec.File,
+		)
+	case false:
+		resultCondition.Pass = false
+		resultCondition.Result = result.FAILURE
+		resultCondition.Description = fmt.Sprintf("key %q not found in Dockerfile %q",
+			d.spec.Instruction,
+			d.spec.File,
+		)
 	}
 
-	return found, nil
+	return nil
 }

--- a/pkg/plugins/resources/dockerfile/condition_test.go
+++ b/pkg/plugins/resources/dockerfile/condition_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
+	"github.com/updatecli/updatecli/pkg/core/result"
 	"github.com/updatecli/updatecli/pkg/core/text"
 )
 
@@ -76,7 +77,8 @@ func TestDockerfile_Condition(t *testing.T) {
 				contentRetriever: &mockText,
 			}
 
-			gotChanged, gotErr := d.Condition(tt.inputSourceValue)
+			gotResult := result.Condition{}
+			gotErr := d.Condition(tt.inputSourceValue, nil, &gotResult)
 			if tt.wantErr != nil {
 				assert.Equal(t, tt.wantErr, gotErr)
 				return
@@ -84,7 +86,7 @@ func TestDockerfile_Condition(t *testing.T) {
 
 			require.NoError(t, gotErr)
 
-			assert.Equal(t, tt.wantChanged, gotChanged)
+			assert.Equal(t, tt.wantChanged, gotResult.Pass)
 		})
 	}
 }
@@ -148,7 +150,8 @@ func TestDockerfile_ConditionFromSCM(t *testing.T) {
 				contentRetriever: &mockText,
 			}
 
-			gotChanged, gotErr := d.ConditionFromSCM(tt.inputSourceValue, tt.scm)
+			gotResult := result.Condition{}
+			gotErr := d.Condition(tt.inputSourceValue, tt.scm, &gotResult)
 			if tt.wantErr != nil {
 				assert.Equal(t, tt.wantErr, gotErr)
 				return
@@ -156,7 +159,7 @@ func TestDockerfile_ConditionFromSCM(t *testing.T) {
 
 			require.NoError(t, gotErr)
 
-			assert.Equal(t, tt.wantChanged, gotChanged)
+			assert.Equal(t, tt.wantChanged, gotResult.Pass)
 		})
 	}
 }

--- a/pkg/plugins/resources/file/condition_test.go
+++ b/pkg/plugins/resources/file/condition_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
+	"github.com/updatecli/updatecli/pkg/core/result"
 	"github.com/updatecli/updatecli/pkg/core/text"
 )
 
@@ -290,13 +291,14 @@ func TestFile_Condition(t *testing.T) {
 				files:            tt.files,
 			}
 
-			gotResult, gotErr := f.Condition(tt.inputSourceValue)
+			gotResult := result.Condition{}
+			gotErr := f.Condition(tt.inputSourceValue, nil, &gotResult)
 			if tt.wantedErr {
 				assert.Error(t, gotErr)
 				return
 			}
 			require.NoError(t, gotErr)
-			assert.Equal(t, tt.wantedResult, gotResult)
+			assert.Equal(t, tt.wantedResult, gotResult.Pass)
 		})
 	}
 }
@@ -442,14 +444,15 @@ func TestFile_ConditionFromSCM(t *testing.T) {
 				files:            tt.files,
 			}
 
-			gotResult, gotErr := f.ConditionFromSCM(tt.inputSourceValue, tt.scm)
+			gotResult := result.Condition{}
+			gotErr := f.Condition(tt.inputSourceValue, tt.scm, &gotResult)
 			if tt.wantedErr {
 				assert.Error(t, gotErr)
 				return
 			}
 
 			require.NoError(t, gotErr)
-			assert.Equal(t, tt.wantedResult, gotResult)
+			assert.Equal(t, tt.wantedResult, gotResult.Pass)
 			for filePath := range tt.files {
 				assert.Equal(t, tt.wantedContents[filePath], mockedText.Contents[filePath])
 			}

--- a/pkg/plugins/resources/gitbranch/condition.go
+++ b/pkg/plugins/resources/gitbranch/condition.go
@@ -9,17 +9,7 @@ import (
 )
 
 // Condition checks that a git branch exists
-func (gt *GitBranch) Condition(source string) error {
-	return gt.condition(source, nil, &result.Condition{})
-}
-
-// ConditionFromSCM test if a branch exists from a git repository specific from SCM
-func (gt *GitBranch) ConditionFromSCM(source string, scm scm.ScmHandler) error {
-
-	return gt.condition(source, nil, &result.Condition{})
-}
-
-func (gt *GitBranch) condition(source string, scm scm.ScmHandler, resultCondition *result.Condition) error {
+func (gt *GitBranch) Condition(source string, scm scm.ScmHandler, resultCondition *result.Condition) error {
 
 	if scm != nil {
 		path := scm.GetDirectory()

--- a/pkg/plugins/resources/gitbranch/condition.go
+++ b/pkg/plugins/resources/gitbranch/condition.go
@@ -1,31 +1,36 @@
 package gitbranch
 
 import (
+	"fmt"
+
 	"github.com/sirupsen/logrus"
 	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
 	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
 // Condition checks that a git branch exists
-func (gt *GitBranch) Condition(source string) (bool, error) {
-	return gt.condition(source)
+func (gt *GitBranch) Condition(source string) error {
+	return gt.condition(source, nil, &result.Condition{})
 }
 
 // ConditionFromSCM test if a branch exists from a git repository specific from SCM
-func (gt *GitBranch) ConditionFromSCM(source string, scm scm.ScmHandler) (bool, error) {
-	path := scm.GetDirectory()
+func (gt *GitBranch) ConditionFromSCM(source string, scm scm.ScmHandler) error {
 
-	if len(gt.spec.Path) > 0 {
-		logrus.Warningf("Path is defined and set to %q but is overridden by the scm definition %q",
-			gt.spec.Path,
-			path)
-	}
-	gt.spec.Path = path
-
-	return gt.condition(source)
+	return gt.condition(source, nil, &result.Condition{})
 }
 
-func (gt *GitBranch) condition(source string) (bool, error) {
+func (gt *GitBranch) condition(source string, scm scm.ScmHandler, resultCondition *result.Condition) error {
+
+	if scm != nil {
+		path := scm.GetDirectory()
+
+		if len(gt.spec.Path) > 0 {
+			logrus.Warningf("Path is defined and set to %q but is overridden by the scm definition %q",
+				gt.spec.Path,
+				path)
+		}
+		gt.spec.Path = path
+	}
 
 	gt.branch = gt.spec.Branch
 	// If source input is empty, then it means that it was disabled by the user with `disablesourceinput: true`
@@ -36,29 +41,26 @@ func (gt *GitBranch) condition(source string) (bool, error) {
 
 	err := gt.Validate()
 	if err != nil {
-		return false, err
+		return fmt.Errorf("git tag validation: %w", err)
 	}
 
 	branches, err := gt.nativeGitHandler.Branches(gt.spec.Path)
 	if err != nil {
-		return false, err
+		return fmt.Errorf("searching git branches: %w", err)
 	}
 
-	found := false
 	for _, b := range branches {
 		if b == gt.branch {
-			found = true
+			resultCondition.Pass = true
+			resultCondition.Result = result.SUCCESS
+			resultCondition.Description = fmt.Sprintf("git branch %q matching", gt.branch)
+			return nil
 		}
 	}
 
-	if found {
-		logrus.Printf("%s Git branch %q matching\n", result.SUCCESS, gt.branch)
-		return true, nil
-	}
+	resultCondition.Pass = false
+	resultCondition.Result = result.FAILURE
+	resultCondition.Description = fmt.Sprintf("git branch %q not found", gt.branch)
 
-	logrus.Printf("%s Git branch %q not found\n",
-		result.FAILURE,
-		gt.branch)
-
-	return false, nil
+	return nil
 }

--- a/pkg/plugins/resources/gitea/branch/condition_test.go
+++ b/pkg/plugins/resources/gitea/branch/condition_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
 func TestCondition(t *testing.T) {
@@ -66,7 +67,8 @@ func TestCondition(t *testing.T) {
 			g, gotErr := New(tt.manifest)
 			require.NoError(t, gotErr)
 
-			gotResult, gotErr := g.Condition("")
+			gotResult := result.Condition{}
+			gotErr = g.Condition("", nil, &gotResult)
 
 			if tt.wantErr {
 				require.Error(t, gotErr)
@@ -74,7 +76,7 @@ func TestCondition(t *testing.T) {
 				require.NoError(t, gotErr)
 			}
 
-			assert.Equal(t, tt.wantResult, gotResult)
+			assert.Equal(t, tt.wantResult, gotResult.Pass)
 
 		})
 

--- a/pkg/plugins/resources/gitea/release/condition.go
+++ b/pkg/plugins/resources/gitea/release/condition.go
@@ -38,5 +38,9 @@ func (g *Gitea) Condition(source string, scm scm.ScmHandler, resultCondition *re
 		}
 	}
 
-	return fmt.Errorf("no Gitea Release tag found matching pattern %q", g.versionFilter.Pattern)
+	resultCondition.Description = fmt.Sprintf("no Gitea Release tag found matching pattern %q", g.versionFilter.Pattern)
+	resultCondition.Result = result.FAILURE
+	resultCondition.Pass = false
+
+	return nil
 }

--- a/pkg/plugins/resources/gitea/release/condition.go
+++ b/pkg/plugins/resources/gitea/release/condition.go
@@ -8,35 +8,35 @@ import (
 	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
-func (g *Gitea) Condition(source string) (bool, error) {
-	releases, err := g.SearchReleases()
+func (g *Gitea) Condition(source string, scm scm.ScmHandler, resultCondition *result.Condition) error {
 
-	if len(g.spec.Tag) == 0 {
-		g.spec.Tag = source
+	if scm != nil {
+		logrus.Warningf("Condition not supported for the plugin Gitea Release")
 	}
 
+	releases, err := g.SearchReleases()
 	if err != nil {
-		logrus.Error(err)
-		return false, err
+		return fmt.Errorf("looking for Gitea release: %w", err)
+	}
+
+	release := source
+	if g.spec.Tag != "" {
+		release = g.spec.Tag
 	}
 
 	if len(releases) == 0 {
-		logrus.Infof("%s No Gitea release found. As a fallback you may be looking for git tags", result.ATTENTION)
-		return false, nil
+		return fmt.Errorf("no Gitea release found")
 	}
 
-	for _, release := range releases {
-		if release == g.spec.Tag {
-			logrus.Infof("%s Gitea Release tag %q found", result.SUCCESS, release)
-			return true, nil
+	for _, r := range releases {
+		if r == release {
+			resultCondition.Pass = true
+			resultCondition.Description = fmt.Sprintf("Gitea release %q found", release)
+			resultCondition.Result = result.SUCCESS
+
+			return nil
 		}
 	}
 
-	logrus.Infof("%s No Gitea Release tag found matching pattern %q", result.FAILURE, g.versionFilter.Pattern)
-	return false, nil
-
-}
-
-func (g *Gitea) ConditionFromSCM(source string, scm scm.ScmHandler) (bool, error) {
-	return false, fmt.Errorf("Condition not supported for the plugin Gitea Release")
+	return fmt.Errorf("no Gitea Release tag found matching pattern %q", g.versionFilter.Pattern)
 }

--- a/pkg/plugins/resources/gitea/tag/condition.go
+++ b/pkg/plugins/resources/gitea/tag/condition.go
@@ -36,5 +36,9 @@ func (g *Gitea) Condition(source string, scm scm.ScmHandler, resultCondition *re
 		}
 	}
 
-	return fmt.Errorf("no Gitea tag found matching %q", g.spec.Tag)
+	resultCondition.Description = fmt.Sprintf("no Gitea tag found matching %q", g.spec.Tag)
+	resultCondition.Pass = false
+	resultCondition.Result = result.FAILURE
+
+	return nil
 }

--- a/pkg/plugins/resources/gitea/tag/condition.go
+++ b/pkg/plugins/resources/gitea/tag/condition.go
@@ -8,36 +8,33 @@ import (
 	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
-func (g *Gitea) Condition(source string) (bool, error) {
+func (g *Gitea) Condition(source string, scm scm.ScmHandler, resultCondition *result.Condition) error {
+	if scm != nil {
+		logrus.Warningf("Condition not supported for the plugin Gitea tag")
+	}
 
-	if len(g.spec.Tag) == 0 {
-		g.spec.Tag = source
+	tag := source
+	if g.spec.Tag != "" {
+		tag = g.spec.Tag
 	}
 
 	tags, err := g.SearchTags()
-
 	if err != nil {
-		logrus.Error(err)
-		return false, err
+		return fmt.Errorf("looking for Gitea tag: %w", err)
 	}
 
 	if len(tags) == 0 {
-		logrus.Infof("%s No Gitea Tags found.", result.ATTENTION)
-		return false, nil
+		return fmt.Errorf("no Gitea Tags found")
 	}
 
-	for _, tag := range tags {
-		if tag == g.spec.Tag {
-			logrus.Infof("%s Gitea tag %q found", result.SUCCESS, tag)
-			return true, nil
+	for _, t := range tags {
+		if t == tag {
+			resultCondition.Pass = true
+			resultCondition.Result = result.SUCCESS
+			resultCondition.Description = fmt.Sprintf("Gitea tag %q found", t)
+			return nil
 		}
 	}
 
-	logrus.Infof("%s No Gitea Tags found matching  %q", result.FAILURE, g.spec.Tag)
-	return false, nil
-
-}
-
-func (g *Gitea) ConditionFromSCM(source string, scm scm.ScmHandler) (bool, error) {
-	return false, fmt.Errorf("Condition not supported for the plugin GitHub Release")
+	return fmt.Errorf("no Gitea tag found matching %q", g.spec.Tag)
 }

--- a/pkg/plugins/resources/gitea/tag/condition_test.go
+++ b/pkg/plugins/resources/gitea/tag/condition_test.go
@@ -56,9 +56,7 @@ func TestCondition(t *testing.T) {
 				Owner:      "updatecli",
 				Repository: "updatecli-action",
 			},
-			wantResult:     false,
-			wantErr:        true,
-			wantErrMessage: fmt.Errorf("no Gitea tag found matching \"\""),
+			wantResult: false,
 		},
 		{
 			name: "repository should exist with no tag v2.15.0",
@@ -93,9 +91,8 @@ func TestCondition(t *testing.T) {
 				Repository: "updatecli-action",
 				Tag:        "0.0.35",
 			},
-			wantResult:     false,
-			wantErr:        true,
-			wantErrMessage: fmt.Errorf("no Gitea tag found matching \"0.0.35\""),
+			wantResult: false,
+			wantErr:    false,
 		},
 	}
 

--- a/pkg/plugins/resources/gitea/tag/condition_test.go
+++ b/pkg/plugins/resources/gitea/tag/condition_test.go
@@ -1,10 +1,12 @@
 package tag
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
 func TestCondition(t *testing.T) {
@@ -18,8 +20,9 @@ func TestCondition(t *testing.T) {
 			Repository string
 			Tag        string
 		}
-		wantResult bool
-		wantErr    bool
+		wantResult     bool
+		wantErr        bool
+		wantErrMessage error
 	}{
 		{
 			name: "repository olblak/updatecli should not exist",
@@ -35,8 +38,9 @@ func TestCondition(t *testing.T) {
 				Owner:      "updatecli",
 				Repository: "updatecli-donotexist",
 			},
-			wantResult: false,
-			wantErr:    true,
+			wantResult:     false,
+			wantErr:        true,
+			wantErrMessage: fmt.Errorf("looking for Gitea tag: Not Found"),
 		},
 		{
 			name: "repository olblak/updatecli-mirror should exist with tags",
@@ -52,8 +56,9 @@ func TestCondition(t *testing.T) {
 				Owner:      "updatecli",
 				Repository: "updatecli-action",
 			},
-			wantResult: false,
-			wantErr:    false,
+			wantResult:     false,
+			wantErr:        true,
+			wantErrMessage: fmt.Errorf("no Gitea tag found matching \"\""),
 		},
 		{
 			name: "repository should exist with no tag v2.15.0",
@@ -88,8 +93,9 @@ func TestCondition(t *testing.T) {
 				Repository: "updatecli-action",
 				Tag:        "0.0.35",
 			},
-			wantResult: false,
-			wantErr:    false,
+			wantResult:     false,
+			wantErr:        true,
+			wantErrMessage: fmt.Errorf("no Gitea tag found matching \"0.0.35\""),
 		},
 	}
 
@@ -100,16 +106,18 @@ func TestCondition(t *testing.T) {
 			g, gotErr := New(tt.manifest)
 			require.NoError(t, gotErr)
 
-			gotResult, gotErr := g.Condition("")
+			gotResult := result.Condition{}
+			gotErr = g.Condition("", nil, &gotResult)
 
 			if tt.wantErr {
-				require.Error(t, gotErr)
+				if assert.Error(t, gotErr) {
+					assert.Equal(t, gotErr.Error(), tt.wantErrMessage.Error())
+				}
 			} else {
 				require.NoError(t, gotErr)
 			}
 
-			assert.Equal(t, tt.wantResult, gotResult)
-
+			assert.Equal(t, tt.wantResult, gotResult.Pass)
 		})
 
 	}

--- a/pkg/plugins/resources/gitlab/branch/condition.go
+++ b/pkg/plugins/resources/gitlab/branch/condition.go
@@ -18,7 +18,10 @@ func (g *Gitlab) Condition(source string, scm scm.ScmHandler, resultCondition *r
 	}
 
 	if len(branches) == 0 {
-		return fmt.Errorf("no Gitlab branch found")
+		resultCondition.Pass = false
+		resultCondition.Result = result.FAILURE
+		resultCondition.Description = "no Gitlab branch found"
+		return nil
 	}
 
 	branch := source
@@ -34,5 +37,9 @@ func (g *Gitlab) Condition(source string, scm scm.ScmHandler, resultCondition *r
 		}
 	}
 
-	return fmt.Errorf("no Gitlab branch found matching pattern %q", g.versionFilter.Pattern)
+	resultCondition.Result = result.FAILURE
+	resultCondition.Pass = false
+	resultCondition.Description = fmt.Sprintf("no Gitlab branch found matching pattern %q", g.versionFilter.Pattern)
+
+	return nil
 }

--- a/pkg/plugins/resources/gitlab/branch/condition_test.go
+++ b/pkg/plugins/resources/gitlab/branch/condition_test.go
@@ -74,7 +74,7 @@ func TestCondition(t *testing.T) {
 				Branch:     "donotexist",
 			},
 			wantResult: false,
-			wantErr:    true,
+			wantErr:    false,
 		},
 	}
 

--- a/pkg/plugins/resources/gitlab/branch/condition_test.go
+++ b/pkg/plugins/resources/gitlab/branch/condition_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
 func TestCondition(t *testing.T) {
@@ -73,7 +74,7 @@ func TestCondition(t *testing.T) {
 				Branch:     "donotexist",
 			},
 			wantResult: false,
-			wantErr:    false,
+			wantErr:    true,
 		},
 	}
 
@@ -84,7 +85,8 @@ func TestCondition(t *testing.T) {
 			g, gotErr := New(tt.manifest)
 			require.NoError(t, gotErr)
 
-			gotResult, gotErr := g.Condition("")
+			gotResult := result.Condition{}
+			gotErr = g.Condition("", nil, &gotResult)
 
 			if tt.wantErr {
 				require.Error(t, gotErr)
@@ -92,7 +94,7 @@ func TestCondition(t *testing.T) {
 				require.NoError(t, gotErr)
 			}
 
-			assert.Equal(t, tt.wantResult, gotResult)
+			assert.Equal(t, tt.wantResult, gotResult.Pass)
 
 		})
 

--- a/pkg/plugins/resources/gitlab/release/condition.go
+++ b/pkg/plugins/resources/gitlab/release/condition.go
@@ -8,35 +8,33 @@ import (
 	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
-func (g *Gitlab) Condition(source string) (bool, error) {
-	releases, err := g.SearchReleases()
-
-	if len(g.spec.Tag) == 0 {
-		g.spec.Tag = source
+func (g *Gitlab) Condition(source string, scm scm.ScmHandler, resultCondition *result.Condition) error {
+	if scm != nil {
+		logrus.Warningf("Condition not supported for the plugin Gitlab release")
 	}
 
+	releases, err := g.SearchReleases()
 	if err != nil {
-		logrus.Error(err)
-		return false, err
+		return fmt.Errorf("looking for Gitlab release: %w", err)
 	}
 
 	if len(releases) == 0 {
-		logrus.Infof("%s No Gitlab release found. As a fallback you may be looking for git tags", result.ATTENTION)
-		return false, nil
+		return fmt.Errorf("no Gitlab release found")
 	}
 
-	for _, release := range releases {
-		if release == g.spec.Tag {
-			logrus.Infof("%s Gitlab Release tag %q found", result.SUCCESS, release)
-			return true, nil
+	release := source
+	if g.spec.Tag != "" {
+		release = g.spec.Tag
+	}
+	for _, r := range releases {
+		if r == release {
+			resultCondition.Result = result.SUCCESS
+			resultCondition.Pass = true
+			resultCondition.Description = fmt.Sprintf("Gitlab release tag %q found", release)
+			return nil
 		}
 	}
 
-	logrus.Infof("%s No Gitlab Release tag found matching pattern %q", result.FAILURE, g.versionFilter.Pattern)
-	return false, nil
+	return fmt.Errorf("no Gitlab release tag found matching pattern %q of kind %q", g.versionFilter.Pattern, g.versionFilter.Kind)
 
-}
-
-func (g *Gitlab) ConditionFromSCM(source string, scm scm.ScmHandler) (bool, error) {
-	return false, fmt.Errorf("Condition not supported for the plugin Gitlab Release")
 }

--- a/pkg/plugins/resources/gitlab/release/condition.go
+++ b/pkg/plugins/resources/gitlab/release/condition.go
@@ -19,7 +19,11 @@ func (g *Gitlab) Condition(source string, scm scm.ScmHandler, resultCondition *r
 	}
 
 	if len(releases) == 0 {
-		return fmt.Errorf("no Gitlab release found")
+		resultCondition.Result = result.FAILURE
+		resultCondition.Pass = false
+		resultCondition.Description = "no Gitlab release found"
+
+		return nil
 	}
 
 	release := source
@@ -35,6 +39,9 @@ func (g *Gitlab) Condition(source string, scm scm.ScmHandler, resultCondition *r
 		}
 	}
 
-	return fmt.Errorf("no Gitlab release tag found matching pattern %q of kind %q", g.versionFilter.Pattern, g.versionFilter.Kind)
+	resultCondition.Result = result.FAILURE
+	resultCondition.Pass = false
+	resultCondition.Description = fmt.Sprintf("no Gitlab release tag found matching pattern %q of kind %q", g.versionFilter.Pattern, g.versionFilter.Kind)
 
+	return nil
 }

--- a/pkg/plugins/resources/gitlab/release/condition_test.go
+++ b/pkg/plugins/resources/gitlab/release/condition_test.go
@@ -54,7 +54,6 @@ func TestCondition(t *testing.T) {
 				Repository: "FOSDEM22",
 			},
 			wantResult: false,
-			wantErr:    true,
 		},
 		{
 			name: "repository should exist with no release 2.0.0",
@@ -72,7 +71,6 @@ func TestCondition(t *testing.T) {
 				Tag:        "2.0.0",
 			},
 			wantResult: false,
-			wantErr:    true,
 		},
 		{
 			name: "repository should exist with release v0.46.2",

--- a/pkg/plugins/resources/gitlab/release/condition_test.go
+++ b/pkg/plugins/resources/gitlab/release/condition_test.go
@@ -92,6 +92,24 @@ func TestCondition(t *testing.T) {
 			wantResult: true,
 			wantErr:    false,
 		},
+		{
+			name: "repository should exist with no release v0.0.99",
+			manifest: struct {
+				URL        string
+				Token      string
+				Owner      string
+				Repository string
+				Tag        string
+			}{
+				URL:        "gitlab.com",
+				Token:      "",
+				Owner:      "olblak",
+				Repository: "updatecli",
+				Tag:        "v0.0.99",
+			},
+			wantResult: false,
+			wantErr:    false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/plugins/resources/gitlab/release/condition_test.go
+++ b/pkg/plugins/resources/gitlab/release/condition_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
 func TestCondition(t *testing.T) {
@@ -53,7 +54,7 @@ func TestCondition(t *testing.T) {
 				Repository: "FOSDEM22",
 			},
 			wantResult: false,
-			wantErr:    false,
+			wantErr:    true,
 		},
 		{
 			name: "repository should exist with no release 2.0.0",
@@ -71,7 +72,7 @@ func TestCondition(t *testing.T) {
 				Tag:        "2.0.0",
 			},
 			wantResult: false,
-			wantErr:    false,
+			wantErr:    true,
 		},
 		{
 			name: "repository should exist with release v0.46.2",
@@ -100,7 +101,8 @@ func TestCondition(t *testing.T) {
 			g, gotErr := New(tt.manifest)
 			require.NoError(t, gotErr)
 
-			gotResult, gotErr := g.Condition("")
+			gotResult := result.Condition{}
+			gotErr = g.Condition("", nil, &gotResult)
 
 			if tt.wantErr {
 				require.Error(t, gotErr)
@@ -108,7 +110,7 @@ func TestCondition(t *testing.T) {
 				require.NoError(t, gotErr)
 			}
 
-			assert.Equal(t, tt.wantResult, gotResult)
+			assert.Equal(t, tt.wantResult, gotResult.Pass)
 
 		})
 

--- a/pkg/plugins/resources/gitlab/tag/condition.go
+++ b/pkg/plugins/resources/gitlab/tag/condition.go
@@ -19,7 +19,10 @@ func (g *Gitlab) Condition(source string, scm scm.ScmHandler, resultCondition *r
 	}
 
 	if len(tags) == 0 {
-		return fmt.Errorf("no Gitlab tag found")
+		resultCondition.Result = result.FAILURE
+		resultCondition.Pass = false
+		resultCondition.Description = "no Gitlab tag found"
+		return nil
 	}
 
 	tag := source
@@ -35,5 +38,9 @@ func (g *Gitlab) Condition(source string, scm scm.ScmHandler, resultCondition *r
 		}
 	}
 
-	return fmt.Errorf("no Gitlab tag found matching pattern %q of kind %q", g.spec.VersionFilter.Pattern, g.spec.VersionFilter.Kind)
+	resultCondition.Result = result.FAILURE
+	resultCondition.Pass = false
+	resultCondition.Description = fmt.Sprintf("no Gitlab tag found matching pattern %q of kind %q", g.spec.VersionFilter.Pattern, g.spec.VersionFilter.Kind)
+
+	return nil
 }

--- a/pkg/plugins/resources/gitlab/tag/condition_test.go
+++ b/pkg/plugins/resources/gitlab/tag/condition_test.go
@@ -54,7 +54,6 @@ func TestCondition(t *testing.T) {
 				Repository: "updatecli",
 			},
 			wantResult: false,
-			wantErr:    true,
 		},
 		{
 			name: "repository should exist with no tag v0.1.11",
@@ -72,7 +71,6 @@ func TestCondition(t *testing.T) {
 				Tag:        "v0.1.11",
 			},
 			wantResult: false,
-			wantErr:    true,
 		},
 		{
 			name: "repository should exist with tag v0.3.0",

--- a/pkg/plugins/resources/gitlab/tag/condition_test.go
+++ b/pkg/plugins/resources/gitlab/tag/condition_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
 func TestCondition(t *testing.T) {
@@ -53,7 +54,7 @@ func TestCondition(t *testing.T) {
 				Repository: "updatecli",
 			},
 			wantResult: false,
-			wantErr:    false,
+			wantErr:    true,
 		},
 		{
 			name: "repository should exist with no tag v0.1.11",
@@ -71,7 +72,7 @@ func TestCondition(t *testing.T) {
 				Tag:        "v0.1.11",
 			},
 			wantResult: false,
-			wantErr:    false,
+			wantErr:    true,
 		},
 		{
 			name: "repository should exist with tag v0.3.0",
@@ -100,7 +101,8 @@ func TestCondition(t *testing.T) {
 			g, gotErr := New(tt.manifest)
 			require.NoError(t, gotErr)
 
-			gotResult, gotErr := g.Condition("")
+			gotResult := result.Condition{}
+			gotErr = g.Condition("", nil, &gotResult)
 
 			if tt.wantErr {
 				require.Error(t, gotErr)
@@ -108,7 +110,7 @@ func TestCondition(t *testing.T) {
 				require.NoError(t, gotErr)
 			}
 
-			assert.Equal(t, tt.wantResult, gotResult)
+			assert.Equal(t, tt.wantResult, gotResult.Pass)
 
 		})
 

--- a/pkg/plugins/resources/go/gomod/condition.go
+++ b/pkg/plugins/resources/go/gomod/condition.go
@@ -2,24 +2,14 @@ package gomod
 
 import (
 	"errors"
+	"fmt"
 
-	"github.com/sirupsen/logrus"
 	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
 	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
-// Condition checks that a specific golang version exists
-func (g *GoMod) Condition(source string) (bool, error) {
-	return g.condition(source)
-}
-
-// ConditionFromSCM checks that a specific golang version exists. SCM doesn't affect the result
-func (g *GoMod) ConditionFromSCM(source string, scm scm.ScmHandler) (bool, error) {
-	return g.condition(source)
-}
-
 // Condition checks if a specific stable Golang version is published
-func (g *GoMod) condition(source string) (bool, error) {
+func (g *GoMod) Condition(source string, scm scm.ScmHandler, resultCondition *result.Condition) error {
 	var err error
 
 	versionToCheck := g.spec.Version
@@ -28,41 +18,40 @@ func (g *GoMod) condition(source string) (bool, error) {
 	}
 
 	if len(versionToCheck) == 0 {
-		return false, errors.New("no version defined")
+		return errors.New("no version defined")
 	}
 
 	g.foundVersion, err = g.version(g.filename)
 	if err != nil {
-
 		if err == ErrModuleNotFound {
-			logrus.Infof("%s module path %q not found\n",
-				result.FAILURE, g.spec.Module)
-			return false, nil
+			return fmt.Errorf("module path %q not found", g.spec.Module)
 		}
 
-		return false, err
+		return fmt.Errorf("looking for Golang version: %w", err)
 	}
 
 	if g.foundVersion == versionToCheck {
 		switch g.kind {
 		case kindGolang:
-			logrus.Infof("%s Golang version %q found",
-				result.SUCCESS, g.foundVersion)
+			resultCondition.Result = result.SUCCESS
+			resultCondition.Pass = true
+			resultCondition.Description = fmt.Sprintf("Golang version %q found", g.foundVersion)
+
 		case kindModule:
-			logrus.Infof("%s version %q found for module %q",
-				result.SUCCESS, g.foundVersion, g.spec.Module)
+			resultCondition.Result = result.SUCCESS
+			resultCondition.Pass = true
+			resultCondition.Description = fmt.Sprintf("Module version %q found for %q", g.foundVersion, g.spec.Module)
 		}
-		return true, nil
+		return nil
 	}
 
 	switch g.kind {
 	case kindGolang:
-		logrus.Infof("%s Golang version %q found, expected %q",
-			result.SUCCESS, g.foundVersion, versionToCheck)
+		return fmt.Errorf("golang version %q found, expecting %q",
+			g.foundVersion, versionToCheck)
 	case kindModule:
-		logrus.Infof("%s version %q found, expected %s for module path %q\n",
-			result.FAILURE, g.foundVersion, versionToCheck, g.spec.Module)
+		return fmt.Errorf("golang module version %q found for %q, expecting %q",
+			g.foundVersion, g.spec.Module, versionToCheck)
 	}
-
-	return false, nil
+	return fmt.Errorf("something unexpected happened")
 }

--- a/pkg/plugins/resources/go/language/condition.go
+++ b/pkg/plugins/resources/go/language/condition.go
@@ -24,7 +24,7 @@ func (l *Language) Condition(source string, scm scm.ScmHandler, resultCondition 
 
 	versions, err := l.versions()
 	if err != nil {
-		return fmt.Errorf("searchin golang version: %w", err)
+		return fmt.Errorf("searching golang version: %w", err)
 	}
 
 	for _, v := range versions {

--- a/pkg/plugins/resources/go/language/condition.go
+++ b/pkg/plugins/resources/go/language/condition.go
@@ -2,45 +2,39 @@ package language
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/sirupsen/logrus"
 	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
 	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
-// Condition checks that a specific golang version exists
-func (l *Language) Condition(source string) (bool, error) {
-	return l.condition(source)
-}
-
-// ConditionFromSCM checks that a specific golang version exists. SCM doesn't affect the result
-func (l *Language) ConditionFromSCM(source string, scm scm.ScmHandler) (bool, error) {
-	return l.condition(source)
-}
-
 // Condition checks if a specific stable Golang version is published
-func (l *Language) condition(source string) (bool, error) {
+func (l *Language) Condition(source string, scm scm.ScmHandler, resultCondition *result.Condition) error {
+	if scm != nil {
+		logrus.Debugln("scm is not supported")
+	}
 	versionToCheck := l.Spec.Version
 	if versionToCheck == "" {
 		versionToCheck = source
 	}
 	if len(versionToCheck) == 0 {
-		return false, errors.New("no version defined")
+		return errors.New("no version defined")
 	}
 
 	versions, err := l.versions()
 	if err != nil {
-		return false, err
+		return fmt.Errorf("searchin golang version: %w", err)
 	}
 
 	for _, v := range versions {
 		if v == versionToCheck {
-			logrus.Infof("%s Golang version %q available\n", result.SUCCESS, versionToCheck)
-			return true, nil
+			resultCondition.Pass = true
+			resultCondition.Result = result.SUCCESS
+			resultCondition.Description = fmt.Sprintf("Golang version %q available", versionToCheck)
+			return nil
 		}
 	}
 
-	logrus.Infof("%s Golang version %q doesn't exist\n", result.FAILURE, versionToCheck)
-
-	return false, nil
+	return fmt.Errorf("golang version %q doesn't exist", versionToCheck)
 }

--- a/pkg/plugins/resources/go/module/condition.go
+++ b/pkg/plugins/resources/go/module/condition.go
@@ -2,45 +2,35 @@ package gomodule
 
 import (
 	"errors"
+	"fmt"
 
-	"github.com/sirupsen/logrus"
 	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
 	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
-// Condition checks that a version exists for a specific golang module
-func (g *GoModule) Condition(source string) (bool, error) {
-	return g.condition(source)
-}
-
-// ConditionFromSCM is not support supported
-func (g *GoModule) ConditionFromSCM(source string, scm scm.ScmHandler) (bool, error) {
-	return g.condition(source)
-}
-
 // Condition checks if a go module with a specific version is published
-func (g *GoModule) condition(source string) (bool, error) {
+func (g *GoModule) Condition(source string, scm scm.ScmHandler, resultCondition *result.Condition) error {
 	versionToCheck := g.Spec.Version
 	if versionToCheck == "" {
 		versionToCheck = source
 	}
 	if len(versionToCheck) == 0 {
-		return false, errors.New("no version defined")
+		return errors.New("no version defined")
 	}
 
 	_, versions, err := g.versions()
 	if err != nil {
-		return false, err
+		return fmt.Errorf("searching version: %w", err)
 	}
 
 	for _, v := range versions {
 		if v == versionToCheck {
-			logrus.Infof("%s version %q available\n", result.SUCCESS, versionToCheck)
-			return true, nil
+			resultCondition.Pass = true
+			resultCondition.Result = result.SUCCESS
+			resultCondition.Description = fmt.Sprintf("version %q available", versionToCheck)
+			return nil
 		}
 	}
 
-	logrus.Infof("%s version %q doesn't exist\n", result.FAILURE, versionToCheck)
-
-	return false, nil
+	return fmt.Errorf("version %q doesn't exist", versionToCheck)
 }

--- a/pkg/plugins/resources/go/module/condition_test.go
+++ b/pkg/plugins/resources/go/module/condition_test.go
@@ -1,18 +1,21 @@
 package gomodule
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
 func TestCondition(t *testing.T) {
 	tests := []struct {
-		name           string
-		spec           Spec
-		expectedResult bool
-		expectedError  bool
+		name             string
+		spec             Spec
+		expectedResult   bool
+		expectedError    bool
+		expectedErrorMsg error
 	}{
 		{
 			name: "canonical test",
@@ -30,18 +33,31 @@ func TestCondition(t *testing.T) {
 			},
 			expectedResult: true,
 		},
+		{
+			name: "Test go module version do not exist",
+			spec: Spec{
+				Module:  "github.com/MakeNowJust/heredoc",
+				Version: "v0.0.0",
+			},
+			expectedResult:   true,
+			expectedError:    true,
+			expectedErrorMsg: errors.New("version \"v0.0.0\" doesn't exist"),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := New(tt.spec)
 			require.NoError(t, err)
-			gotVersion, err := got.Condition("")
+			gotResult := result.Condition{}
+			err = got.Condition("", nil, &gotResult)
 			if tt.expectedError {
-				assert.Error(t, err)
+				if assert.Error(t, err) {
+					assert.Equal(t, tt.expectedErrorMsg.Error(), err.Error())
+				}
 				return
 			}
 			require.NoError(t, err)
-			assert.Equal(t, tt.expectedResult, gotVersion)
+			assert.Equal(t, tt.expectedResult, gotResult.Pass)
 		})
 	}
 

--- a/pkg/plugins/resources/helm/condition_oci.go
+++ b/pkg/plugins/resources/helm/condition_oci.go
@@ -7,13 +7,13 @@ import (
 
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
-	"github.com/sirupsen/logrus"
+	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
 	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
 // Condition checks if a Helm chart version exists on a OCI registry
 // It assumes that not being able to retrieve the OCI digest, means, the helm chart doesn't exist.
-func (c *Chart) OCICondition(source string) (bool, error) {
+func (c *Chart) OCICondition(source string, scm scm.ScmHandler, resultCondition *result.Condition) error {
 
 	refName := filepath.Join(strings.TrimPrefix(c.spec.URL, "oci://"), c.spec.Name)
 	switch c.spec.Version == "" {
@@ -25,25 +25,20 @@ func (c *Chart) OCICondition(source string) (bool, error) {
 
 	ref, err := name.ParseReference(refName)
 	if err != nil {
-		return false, fmt.Errorf("invalid artifact %s: %w", refName, err)
+		return fmt.Errorf("invalid artifact %s: %w", refName, err)
 	}
 
 	_, err = remote.Head(ref, c.options...)
 	if err != nil {
 		if strings.Contains(err.Error(), "unexpected status code 404") {
-			logrus.Infof("%s The OCI Helm chart %s doesn't exist.",
-				result.FAILURE,
-				ref.Name(),
-			)
-			return false, nil
+			return fmt.Errorf("the OCI Helm chart %s doesn't exist", ref.Name())
 		}
-		return false, err
+		return err
 	}
 
-	logrus.Infof("%s The OCI Helm chart %s exists and is available.",
-		result.SUCCESS,
-		ref.Name(),
-	)
+	resultCondition.Pass = true
+	resultCondition.Result = result.SUCCESS
+	resultCondition.Description = fmt.Sprintf("The OCI Helm chart %s exists and is available", ref.Name())
 
-	return true, err
+	return nil
 }

--- a/pkg/plugins/resources/helm/condition_test.go
+++ b/pkg/plugins/resources/helm/condition_test.go
@@ -1,10 +1,12 @@
 package helm
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
 func TestCondition(t *testing.T) {
@@ -29,15 +31,19 @@ func TestCondition(t *testing.T) {
 				Name:    "jenkins",
 				Version: "999",
 			},
-			expected: false,
+			expected:             false,
+			expectedError:        true,
+			expectedErrorMessage: errors.New("the Helm chart \"jenkins\" isn't available on https://kubernetes-charts.storage.googleapis.com for version '999'"),
 		},
 		{
 			chart: Spec{
-				URL:     "https://example.com",
+				URL:     "https://charts.jenkins.io",
 				Name:    "jenkins",
 				Version: "999",
 			},
-			expected: false,
+			expected:             false,
+			expectedError:        true,
+			expectedErrorMessage: errors.New("the Helm chart \"jenkins\" isn't available on https://charts.jenkins.io for version '999'"),
 		},
 		// Disabling the test for now as the GitHub Action doesn't have credentials nor allowed to anonymously query the ghcr.io API
 		//{
@@ -56,7 +62,9 @@ func TestCondition(t *testing.T) {
 		//		Name:    "upgrade-responder",
 		//		Version: "v9.9.9",
 		//	},
-		//	expected: false,
+		//	expected:             false,
+		//	expectedError:        true,
+		//	expectedErrorMessage: errors.New("the OCI Helm chart ghcr.io/olblak/charts/upgrade-responder:v9.9.9 doesn't exist"),
 		//},
 	}
 
@@ -65,15 +73,19 @@ func TestCondition(t *testing.T) {
 			got, err := New(tt.chart)
 			require.NoError(t, err)
 
-			gotVersion, err := got.Condition("")
+			gotResult := result.Condition{}
+			err = got.Condition("", nil, &gotResult)
 
 			switch tt.expectedError {
 			case true:
-				assert.Error(t, err)
+				if assert.Error(t, err) {
+					assert.Equal(t, tt.expectedErrorMessage.Error(), err.Error())
+				}
+				return
 			case false:
 				require.NoError(t, err)
 			}
-			assert.Equal(t, tt.expected, gotVersion)
+			assert.Equal(t, tt.expected, gotResult.Pass)
 		})
 	}
 }

--- a/pkg/plugins/resources/jenkins/condition.go
+++ b/pkg/plugins/resources/jenkins/condition.go
@@ -3,13 +3,18 @@ package jenkins
 import (
 	"fmt"
 
+	"github.com/sirupsen/logrus"
 	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
 	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
 // Condition checks that a Jenkins version exists and that the version
 // match a valid release type
-func (j Jenkins) Condition(source string) (bool, error) {
+func (j Jenkins) Condition(source string, scm scm.ScmHandler, resultCondition *result.Condition) error {
+
+	if scm != nil {
+		logrus.Warningf("SCM configuration is not supported for Jenkins condition")
+	}
 
 	versionToCheck := j.spec.Version
 	// Override source input if version specified by parameter
@@ -19,11 +24,11 @@ func (j Jenkins) Condition(source string) (bool, error) {
 
 	releaseType, err := ReleaseType(versionToCheck)
 	if err != nil {
-		return false, err
+		return err
 	}
 
 	if releaseType != j.spec.Release {
-		return false, fmt.Errorf(
+		return fmt.Errorf(
 			"wrong Release Type '%s' detected : Jenkins version '%s' is a '%s' release",
 			j.spec.Release, versionToCheck, releaseType)
 	}
@@ -31,22 +36,21 @@ func (j Jenkins) Condition(source string) (bool, error) {
 	if len(versionToCheck) > 0 {
 		_, versions, err := j.getVersions()
 		if err != nil {
-			return false, err
+			return err
 		}
 
 		for _, v := range versions {
 			if v == versionToCheck {
-				fmt.Printf("%s %s release version '%s' available\n", result.SUCCESS, releaseType, versionToCheck)
-				return true, nil
+				resultCondition.Result = result.SUCCESS
+				resultCondition.Pass = true
+				resultCondition.Description = fmt.Sprintf("%s release version %q available\n", releaseType, versionToCheck)
+				return nil
 			}
 		}
 	}
 
-	fmt.Printf("%s Version '%v' doesn't exist\n", result.FAILURE, versionToCheck)
-	return false, nil
-}
-
-// ConditionFromSCM checks if a key exists in a yaml file
-func (j Jenkins) ConditionFromSCM(source string, scm scm.ScmHandler) (bool, error) {
-	return false, fmt.Errorf("SCM configuration is not supported for Jenkins condition, aborting")
+	resultCondition.Result = result.FAILURE
+	resultCondition.Pass = false
+	resultCondition.Description = fmt.Sprintf("version %q doesn't exist", versionToCheck)
+	return nil
 }

--- a/pkg/plugins/resources/jenkins/condition_test.go
+++ b/pkg/plugins/resources/jenkins/condition_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/updatecli/updatecli/pkg/core/result"
 	"github.com/updatecli/updatecli/pkg/plugins/utils/mavenmetadata"
 )
 
@@ -94,14 +95,15 @@ func TestJenkins_Condition(t *testing.T) {
 				mavenMetaHandler: tt.mockedMetadataHandler,
 			}
 
-			got, gotErr := sut.Condition(tt.source)
+			gotResult := result.Condition{}
+			gotErr := sut.Condition(tt.source, nil, &gotResult)
 			if tt.wantErr {
 				require.Error(t, gotErr)
 				return
 			}
 
 			require.NoError(t, gotErr)
-			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.want, gotResult.Pass)
 		})
 	}
 }

--- a/pkg/plugins/resources/json/condition_test.go
+++ b/pkg/plugins/resources/json/condition_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
 func TestCondition(t *testing.T) {
@@ -85,7 +86,8 @@ func TestCondition(t *testing.T) {
 
 			require.NoError(t, err)
 
-			gotResult, err := j.Condition("")
+			gotResult := result.Condition{}
+			err = j.Condition("", nil, &gotResult)
 
 			if tt.wantErr {
 				assert.Equal(t, tt.expectedErrorMsg.Error(), err.Error())
@@ -93,7 +95,7 @@ func TestCondition(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			assert.Equal(t, tt.expectedResult, gotResult)
+			assert.Equal(t, tt.expectedResult, gotResult.Pass)
 		})
 	}
 }

--- a/pkg/plugins/resources/maven/condition_test.go
+++ b/pkg/plugins/resources/maven/condition_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/updatecli/updatecli/pkg/core/result"
 	"github.com/updatecli/updatecli/pkg/plugins/utils/mavenmetadata"
 )
 
@@ -81,14 +82,15 @@ func TestCondition(t *testing.T) {
 				},
 			}
 
-			got, gotErr := sut.Condition(tt.source)
+			gotResult := result.Condition{}
+			gotErr := sut.Condition(tt.source, nil, &gotResult)
 			if tt.wantErr {
 				require.Error(t, gotErr)
 				return
 			}
 
 			require.NoError(t, gotErr)
-			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.want, gotResult.Pass)
 		})
 	}
 }

--- a/pkg/plugins/resources/npm/condition.go
+++ b/pkg/plugins/resources/npm/condition.go
@@ -33,7 +33,7 @@ func (n Npm) Condition(source string, scm scm.ScmHandler, resultCondition *resul
 	for _, v := range versions {
 		if v == versionToCheck {
 			resultCondition.Pass = true
-			resultCondition.Result = result.FAILURE
+			resultCondition.Result = result.SUCCESS
 			resultCondition.Description = fmt.Sprintf("release version %q available", versionToCheck)
 			return nil
 		}

--- a/pkg/plugins/resources/npm/condition.go
+++ b/pkg/plugins/resources/npm/condition.go
@@ -4,38 +4,44 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/sirupsen/logrus"
 	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
 	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
 // Condition checks that an Npm package version exist
-func (n Npm) Condition(source string) (bool, error) {
+func (n Npm) Condition(source string, scm scm.ScmHandler, resultCondition *result.Condition) error {
+
+	if scm != nil {
+		logrus.Warningf("SCM configuration is not supported for npm condition, aborting")
+
+	}
+
 	versionToCheck := n.spec.Version
 	if versionToCheck == "" {
 		versionToCheck = source
 	}
 	if len(versionToCheck) == 0 {
-		return false, errors.New("no version defined")
+		return errors.New("no version defined")
 	}
 
 	_, versions, err := n.getVersions()
 	if err != nil {
-		return false, err
+		return err
 	}
 
 	for _, v := range versions {
 		if v == versionToCheck {
-			fmt.Printf("%s release version '%s' available\n", result.SUCCESS, versionToCheck)
-			return true, nil
+			resultCondition.Pass = true
+			resultCondition.Result = result.FAILURE
+			resultCondition.Description = fmt.Sprintf("release version %q available", versionToCheck)
+			return nil
 		}
 	}
 
-	fmt.Printf("%s Version %q doesn't exist\n", result.FAILURE, versionToCheck)
+	resultCondition.Result = result.FAILURE
+	resultCondition.Pass = false
+	resultCondition.Description = fmt.Sprintf("Version %q doesn't exist\n", versionToCheck)
 
-	return false, nil
-}
-
-// ConditionFromSCM checks if a key exists in a yaml file
-func (n Npm) ConditionFromSCM(source string, scm scm.ScmHandler) (bool, error) {
-	return false, fmt.Errorf("SCM configuration is not supported for npm condition, aborting")
+	return nil
 }

--- a/pkg/plugins/resources/npm/condition_test.go
+++ b/pkg/plugins/resources/npm/condition_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
 func TestCondition(t *testing.T) {
@@ -119,9 +120,10 @@ func TestCondition(t *testing.T) {
 				assert.Error(t, err)
 				return
 			}
-			gotVersion, err := got.Condition("")
+			gotResult := result.Condition{}
+			err = got.Condition("", nil, &gotResult)
 			require.NoError(t, err)
-			assert.Equal(t, tt.expectedResult, gotVersion)
+			assert.Equal(t, tt.expectedResult, gotResult.Pass)
 		})
 	}
 

--- a/pkg/plugins/resources/shell/condition.go
+++ b/pkg/plugins/resources/shell/condition.go
@@ -68,7 +68,7 @@ func (s *Shell) Condition(source string, scm scm.ScmHandler, resultCondition *re
 	case false:
 		resultCondition.Pass = false
 		resultCondition.Result = result.SUCCESS
-		resultCondition.Description = fmt.Sprintf("shell condition of type %q not passing", s.spec.ChangedIf)
+		resultCondition.Description = fmt.Sprintf("shell condition of type %q not passing", s.spec.ChangedIf.Kind)
 	}
 
 	return nil

--- a/pkg/plugins/resources/shell/condition.go
+++ b/pkg/plugins/resources/shell/condition.go
@@ -67,7 +67,7 @@ func (s *Shell) Condition(source string, scm scm.ScmHandler, resultCondition *re
 		resultCondition.Description = fmt.Sprintf("shell condition of type %q, passing", s.spec.ChangedIf.Kind)
 	case false:
 		resultCondition.Pass = false
-		resultCondition.Result = result.SUCCESS
+		resultCondition.Result = result.FAILURE
 		resultCondition.Description = fmt.Sprintf("shell condition of type %q not passing", s.spec.ChangedIf.Kind)
 	}
 

--- a/pkg/plugins/resources/shell/condition_test.go
+++ b/pkg/plugins/resources/shell/condition_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
+	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
 func TestShell_Condition(t *testing.T) {
@@ -64,17 +65,17 @@ func TestShell_Condition(t *testing.T) {
 			gotErr := s.InitChangedIf()
 			require.NoError(t, gotErr)
 
-			gotResult, gotErr := s.Condition(tt.source)
+			gotResult := result.Condition{}
+			gotErr = s.Condition(tt.source, nil, &gotResult)
 
 			if tt.wantErr {
 				assert.Error(t, gotErr)
-				assert.False(t, gotResult)
+				assert.False(t, gotResult.Pass)
 				return
 			}
 
 			require.NoError(t, gotErr)
-			assert.Equal(t, tt.wantResult, gotResult)
-
+			assert.Equal(t, tt.wantResult, gotResult.Pass)
 			assert.Equal(t, tt.wantCommand, mock.GotCommand.Cmd)
 		})
 	}
@@ -128,16 +129,17 @@ func TestShell_ConditionFromSCM(t *testing.T) {
 			gotErr := s.InitChangedIf()
 			require.NoError(t, gotErr)
 
-			gotResult, gotErr := s.ConditionFromSCM(tt.source, &ms)
+			gotResult := result.Condition{}
+			gotErr = s.Condition(tt.source, &ms, &gotResult)
 
 			if tt.wantErr {
 				assert.Error(t, gotErr)
-				assert.False(t, gotResult)
+				assert.False(t, gotResult.Pass)
 				return
 			}
 
 			require.NoError(t, gotErr)
-			assert.Equal(t, tt.wantResult, gotResult)
+			assert.Equal(t, tt.wantResult, gotResult.Pass)
 
 			assert.Equal(t, tt.wantCommand, mce.GotCommand.Cmd)
 			assert.Equal(t, tt.scmDir, mce.GotCommand.Dir)

--- a/pkg/plugins/resources/toml/condition_test.go
+++ b/pkg/plugins/resources/toml/condition_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
 func TestCondition(t *testing.T) {
@@ -99,7 +100,8 @@ func TestCondition(t *testing.T) {
 
 			require.NoError(t, err)
 
-			gotResult, err := toml.Condition("")
+			gotResult := result.Condition{}
+			err = toml.Condition("", nil, &gotResult)
 
 			if tt.wantErr {
 				assert.Equal(t, tt.expectedErrorMsg.Error(), err.Error())
@@ -107,7 +109,7 @@ func TestCondition(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			assert.Equal(t, tt.expectedResult, gotResult)
+			assert.Equal(t, tt.expectedResult, gotResult.Pass)
 		})
 	}
 }

--- a/pkg/plugins/resources/xml/condition_test.go
+++ b/pkg/plugins/resources/xml/condition_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
 func TestCondition(t *testing.T) {
@@ -86,7 +87,8 @@ func TestCondition(t *testing.T) {
 
 			require.NoError(t, err)
 
-			gotResult, err := x.Condition("")
+			gotResult := result.Condition{}
+			err = x.Condition("", nil, &gotResult)
 
 			if tt.wantErr {
 				assert.Equal(t, tt.expectedErrorMsg.Error(), err.Error())
@@ -94,7 +96,7 @@ func TestCondition(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			assert.Equal(t, tt.expectedResult, gotResult)
+			assert.Equal(t, tt.expectedResult, gotResult.Pass)
 		})
 	}
 

--- a/pkg/plugins/resources/yaml/condition.go
+++ b/pkg/plugins/resources/yaml/condition.go
@@ -85,7 +85,7 @@ func (y *Yaml) Condition(source string, scm scm.ScmHandler, resultCondition *res
 			)
 
 			resultCondition.Pass = true
-			resultCondition.Result = result.FAILURE
+			resultCondition.Result = result.SUCCESS
 
 			return nil
 		}

--- a/pkg/plugins/resources/yaml/condition_test.go
+++ b/pkg/plugins/resources/yaml/condition_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
+	"github.com/updatecli/updatecli/pkg/core/result"
 	"github.com/updatecli/updatecli/pkg/core/text"
 )
 
@@ -384,14 +385,15 @@ github:
 				contentRetriever: &mockedText,
 				files:            tt.files,
 			}
-			gotResult, gotErr := y.Condition(tt.inputSourceValue)
+			gotResult := result.Condition{}
+			gotErr := y.Condition(tt.inputSourceValue, nil, &gotResult)
 			if tt.isErrorWanted {
 				assert.Error(t, gotErr)
 				return
 			}
 
 			require.NoError(t, gotErr)
-			assert.Equal(t, tt.isResultWanted, gotResult)
+			assert.Equal(t, tt.isResultWanted, gotResult.Pass)
 			for filePath := range tt.files {
 				assert.Equal(t, tt.wantedContents[filePath], mockedText.Contents[filePath])
 			}
@@ -490,14 +492,15 @@ github:
 				contentRetriever: &mockedText,
 				files:            tt.files,
 			}
-			gotResult, gotErr := y.ConditionFromSCM(tt.inputSourceValue, tt.scm)
+			gotResult := result.Condition{}
+			gotErr := y.Condition(tt.inputSourceValue, tt.scm, &gotResult)
 			if tt.isErrorWanted {
 				assert.Error(t, gotErr)
 				return
 			}
 
 			require.NoError(t, gotErr)
-			assert.Equal(t, tt.isResultWanted, gotResult)
+			assert.Equal(t, tt.isResultWanted, gotResult.Pass)
 			for filePath := range tt.files {
 				assert.Equal(t, tt.wantedContents[filePath], mockedText.Contents[filePath])
 			}


### PR DESCRIPTION
Refactor condition resource

This refactoring includes:

1. Merging the function `Condition` and `ConditionFromSCM`, over time I realized that it didn't make sense to have them separated
2. Condition stores its result execution in a struct which allows to gather more additional data for building a meaningful report at the end of a pipeline execution
3. Only use logrus.Infof to describe in one place a specific condition execution, and move everything else to warning, errorf, or debug 

Now a condition can result in of the following case:

* Condition successfull
* Condition failing without no error
* Condition failing with an erro

If the condition is failing with no error, then the final result can be changed with the `failwhen` parameter


## Test

You should run as many test as you could

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
