### PR TITLE
Fix file path

### DIFF
--- a/e2e/updatecli.d/success.d/file/noscm.yaml
+++ b/e2e/updatecli.d/success.d/file/noscm.yaml
@@ -1,0 +1,36 @@
+name: Test file resource without scm
+
+sources:
+  adopters: 
+    name: "Get content from ADOPTERS.md"
+    kind: file
+    spec:
+      file: ADOPTERS.md
+
+  adoptersFileScheme: 
+    name: "Get content from ADOPTERS.md using file scheme"
+    kind: file
+    spec:
+      file: file://ADOPTERS.md
+
+  adoptersHTTPSScheme: 
+    name: "Get content from ADOPTERS.md using https scheme"
+    kind: file
+    spec:
+      file: https://raw.githubusercontent.com/updatecli/updatecli/main/ADOPTERS.md
+
+conditions:
+  adopters: 
+    name: "Validate ADOTPERS.md content"
+    sourceid: adopters
+    kind: file
+    spec:
+      file: ADOPTERS.md
+
+targets:
+  adopters: 
+    name: "Update ADOPTERS.md content"
+    sourceid: adopters
+    kind: file
+    spec:
+      file: ADOPTERS.md

--- a/e2e/updatecli.d/success.d/file/scm.yaml
+++ b/e2e/updatecli.d/success.d/file/scm.yaml
@@ -1,0 +1,48 @@
+name: Test file resource without scm
+
+sources:
+  adopters: 
+    name: "Get content from ADOPTERS.md"
+    kind: file
+    scmid: updatecli
+    spec:
+      file: ADOPTERS.md
+
+  adoptersFileScheme: 
+    name: "Get content from ADOPTERS.md using file scheme"
+    kind: file
+    scmid: updatecli
+    spec:
+      file: file://ADOPTERS.md
+
+  adoptersHTTPSScheme: 
+    name: "Get content from ADOPTERS.md using https scheme"
+    kind: file
+    scmid: updatecli
+    spec:
+      file: https://raw.githubusercontent.com/updatecli/updatecli/main/ADOPTERS.md
+
+conditions:
+  adopters: 
+    name: "Validate ADOTPERS.md content"
+    sourceid: adopters
+    scmid: updatecli
+    kind: file
+    spec:
+      file: ADOPTERS.md
+
+targets:
+  adopters: 
+    name: "Update ADOPTERS.md content"
+    sourceid: adopters
+    kind: file
+    scmid: updatecli
+    spec:
+      file: ADOPTERS.md
+
+scms:
+  updatecli:
+    kind: git
+    spec:
+      url: https://github.com/updatecli/updatecli.git
+    

--- a/pkg/plugins/resources/file/main.go
+++ b/pkg/plugins/resources/file/main.go
@@ -65,6 +65,7 @@ func New(spec interface{}) (*File, error) {
 	// File as unique element of newResource.files
 	if len(newResource.spec.File) > 0 {
 		f := fileMetadata{
+			path:         strings.TrimPrefix(newResource.spec.File, "file://"),
 			originalPath: strings.TrimPrefix(newResource.spec.File, "file://"),
 		}
 		newResource.files[newResource.spec.File] = f
@@ -72,6 +73,7 @@ func New(spec interface{}) (*File, error) {
 
 	for _, filePath := range newResource.spec.Files {
 		f := fileMetadata{
+			path:         strings.TrimPrefix(filePath, "file://"),
 			originalPath: strings.TrimPrefix(filePath, "file://"),
 		}
 		newResource.files[filePath] = f


### PR DESCRIPTION
Fix #1320 

* Fix file path used by file plugin
* Add missing e2e tests for the file resource

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
go build -o bin/updatecli .
./bin/updatecli diff --config e2e/updatecli.d/success.d/file/
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
