### PR TITLE
Use updatecli@main config as a fallback

### DIFF
--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -94,7 +94,7 @@ jobs:
         suppress_push_for_open_pull_request: 1
         checkout: true
         check_file_names: 1
-        spell_check_this: check-spelling/spell-check-this@v0.0.21
+        spell_check_this: updatecli/updatecli@main
         post_comment: 0
         use_magic_file: 1
         use_sarif: ${{ (!github.event.pull_request || (github.event.pull_request.head.repo.full_name == github.repository)) && 1 }}


### PR DESCRIPTION
Sets the fallback for check-spelling for when it can't find its configuration.

## Test

To test this pull request, you can run the following commands:

Refresh a currently unhappy PR (e.g. https://github.com/updatecli/updatecli/pull/1319)

## Additional Information

When someone creates a PR from before check-spelling (v0.0.21) has been added, check-spelling doesn't have access to its configuration (unless you tell it what fallback to use). Using the `main` branch is a pretty sound fallback (any future branches for releases will almost certainly be long past the addition of check-spelling), and I don't expect someone to be creating a PR from before the addition of check-spelling into a branch with check-spelling.

### Tradeoff

It looks a bit odd

### Potential improvement

I should have caught that the value wasn't quite right, sorry, I'm human :).

In a future version of check spelling, I hope that check-spelling won't be confused and lose track of its configuration. I can't remember if I've fixed this, but I'll definitely make an effort to ensure the behavior is reasonable.