### PR TITLE
Fix dockerfile target result in case of success

### DIFF
--- a/pkg/plugins/resources/dockerfile/target.go
+++ b/pkg/plugins/resources/dockerfile/target.go
@@ -38,7 +38,9 @@ func (d *Dockerfile) target(source string, dryRun bool, resultTarget *result.Tar
 	}
 
 	if len(changedLines) == 0 {
-		logrus.Debugf("empty file detected %q, nothing to do", d.spec.File)
+		logrus.Debugf("no change detected %q, nothing else to do", d.spec.File)
+		resultTarget.Changed = false
+		resultTarget.Result = result.SUCCESS
 		return nil
 	}
 


### PR DESCRIPTION
While doing some test with the dockerfile autodiscovery, I noticed a regression in the dockerfile plugin resource.
Where the result is not set if nothing change 

```
TARGETS
========

registry.access.redhat.com/ubi9/ubi
-----------------------------------

**Dry Run enabled**

✔ The line #12, matched by the keyword "FROM" and the matcher "registry.access.redhat.com/ubi9/ubi", is correctly set to "FROM registry.access.redhat.com/ubi9/ubi:9.2-489".
- - 


```

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
cp <to_package_directory>
go test
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
