### PR TITLE
reset tagfilter when helm autodiscovery rely on versionfilter

### DIFF
--- a/pkg/plugins/autodiscovery/helm/container.go
+++ b/pkg/plugins/autodiscovery/helm/container.go
@@ -144,6 +144,8 @@ func (h Helm) discoverHelmContainerManifests() ([][]byte, error) {
 			if !h.spec.VersionFilter.IsZero() {
 				sourceSpec.VersionFilter.Kind = h.versionFilter.Kind
 				sourceSpec.VersionFilter.Pattern, err = h.versionFilter.GreaterThanPattern(image.tag)
+				sourceSpec.TagFilter = ""
+
 				if err != nil {
 					logrus.Debugf("building version filter pattern: %s", err)
 					sourceSpec.VersionFilter.Pattern = "*"


### PR DESCRIPTION
After additional thought we should detect a tagfilter if a versionfilter is provided

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
cp <to_package_directory>
go test
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
