### PR TITLE
Add versionfilter to maven resource

### DIFF
--- a/e2e/updatecli.d/success.d/maven.yaml
+++ b/e2e/updatecli.d/success.d/maven.yaml
@@ -27,6 +27,17 @@ sources:
       groupid: "junit"
       artifactid: "junit"
 
+  getJunitVersion:
+    # https://repo.maven.apache.org/maven2/junit/junit/
+    kind: maven
+    spec:
+      repository: "repo.maven.apache.org/maven2"
+      groupid: "junit"
+      artifactid: "junit"
+      versionfilter:
+        kind: semver
+        pattern: "3.8.x"
+
 conditions:
   checkIfOlderJunitExist:
     kind: maven

--- a/pkg/plugins/resources/jenkins/main.go
+++ b/pkg/plugins/resources/jenkins/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/mitchellh/mapstructure"
 	"github.com/sirupsen/logrus"
 	"github.com/updatecli/updatecli/pkg/plugins/utils/mavenmetadata"
+	"github.com/updatecli/updatecli/pkg/plugins/utils/version"
 )
 
 // Spec defines a specification for a "jenkins" resource
@@ -57,7 +58,7 @@ func New(spec interface{}) (*Jenkins, error) {
 
 	return &Jenkins{
 		spec:             newSpec,
-		mavenMetaHandler: mavenmetadata.New(jenkinsDefaultMetaURL),
+		mavenMetaHandler: mavenmetadata.New(jenkinsDefaultMetaURL, version.Filter{}),
 	}, nil
 }
 

--- a/pkg/plugins/resources/jenkins/main_test.go
+++ b/pkg/plugins/resources/jenkins/main_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/updatecli/updatecli/pkg/plugins/utils/mavenmetadata"
+	"github.com/updatecli/updatecli/pkg/plugins/utils/version"
 )
 
 type Data struct {
@@ -88,7 +89,7 @@ func Test_New(t *testing.T) {
 				spec: Spec{
 					Release: STABLE,
 				},
-				mavenMetaHandler: mavenmetadata.New(jenkinsDefaultMetaURL),
+				mavenMetaHandler: mavenmetadata.New(jenkinsDefaultMetaURL, version.Filter{}),
 			},
 		},
 		{
@@ -100,7 +101,7 @@ func Test_New(t *testing.T) {
 				spec: Spec{
 					Release: WEEKLY,
 				},
-				mavenMetaHandler: mavenmetadata.New(jenkinsDefaultMetaURL),
+				mavenMetaHandler: mavenmetadata.New(jenkinsDefaultMetaURL, version.Filter{}),
 			},
 		},
 		{

--- a/pkg/plugins/resources/maven/main.go
+++ b/pkg/plugins/resources/maven/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/mitchellh/mapstructure"
 	"github.com/sirupsen/logrus"
 	"github.com/updatecli/updatecli/pkg/plugins/utils/mavenmetadata"
+	"github.com/updatecli/updatecli/pkg/plugins/utils/version"
 )
 
 var (
@@ -34,6 +35,8 @@ type Spec struct {
 	ArtifactID string `yaml:",omitempty"`
 	// Specifies the maven artifact version
 	Version string `yaml:",omitempty"`
+	// [S] VersionFilter provides parameters to specify version pattern and its type like regex, semver, or just latest.
+	VersionFilter version.Filter `yaml:",omitempty"`
 }
 
 // Maven defines a resource of kind "maven"
@@ -76,7 +79,7 @@ func New(spec interface{}) (*Maven, error) {
 
 		newResource.metadataHandlers = append(
 			newResource.metadataHandlers,
-			mavenmetadata.New(u.String()))
+			mavenmetadata.New(u.String(), newSpec.VersionFilter))
 
 		return newResource, nil
 	}
@@ -95,7 +98,7 @@ func New(spec interface{}) (*Maven, error) {
 
 		newResource.metadataHandlers = append(
 			newResource.metadataHandlers,
-			mavenmetadata.New(u.String()))
+			mavenmetadata.New(u.String(), newSpec.VersionFilter))
 	}
 
 	mavenCentralNotFound, err := isRepositoriesContainsMavenCentral(newSpec.Repositories)
@@ -114,7 +117,7 @@ func New(spec interface{}) (*Maven, error) {
 
 		newResource.metadataHandlers = append(
 			newResource.metadataHandlers,
-			mavenmetadata.New(u.String()))
+			mavenmetadata.New(u.String(), newSpec.VersionFilter))
 	}
 
 	return newResource, nil

--- a/pkg/plugins/utils/mavenmetadata/types.go
+++ b/pkg/plugins/utils/mavenmetadata/types.go
@@ -13,22 +13,22 @@ type Handler interface {
 
 // metadata hold maven repository Metadata
 type metadata struct {
-	Metadata   xml.Name `xml:"metadata"`
-	GroupID    string   `xml:"groupId"`
-	ArtifactID string   `xml:"artifactId"`
-	Versioning version  `xml:"versioning"`
+	Metadata   xml.Name        `xml:"metadata"`
+	GroupID    string          `xml:"groupId"`
+	ArtifactID string          `xml:"artifactId"`
+	Versioning artifactVersion `xml:"versioning"`
 }
 
 // version hold Version information
-type version struct {
-	Versioning xml.Name `xml:"versioning"`
-	Latest     string   `xml:"latest"`
-	Release    string   `xml:"release"`
-	Versions   versions `xml:"versions"`
+type artifactVersion struct {
+	Versioning xml.Name         `xml:"versioning"`
+	Latest     string           `xml:"latest"`
+	Release    string           `xml:"release"`
+	Versions   artifactVersions `xml:"versions"`
 }
 
 // versions contains the list of available version
-type versions struct {
+type artifactVersions struct {
 	ID      xml.Name `xml:"versions"`
 	Version []string `xml:"version"`
 }


### PR DESCRIPTION
Fix #1374 

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
cd pkg/plugins/utils/mavenmetadata
go test
go build -o bin/updatecli . 
./bin/updatecli diff --config e2e/updatecli.d/success.d/maven.yaml
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

I didn't bother adding support for Jenkins considering the time spent on this versus the usage and the benefit :) 
I may revisit this decision in the futur
