### PR TITLE
Allow Maven autodiscovery to override default version filter

### DIFF
--- a/e2e/updatecli.d/warning.d/autodiscovery/maven/git.yaml
+++ b/e2e/updatecli.d/warning.d/autodiscovery/maven/git.yaml
@@ -16,6 +16,9 @@ autodiscovery:
   scmid: default
   crawlers:
     maven:
+      versionfilter:
+        kind: semver
+        pattern: majoronly
       # To ignore specific path
       #ignore:
       #  - path: <filepath relative to scm repository>

--- a/pkg/plugins/autodiscovery/maven/manifestTemplate.go
+++ b/pkg/plugins/autodiscovery/maven/manifestTemplate.go
@@ -15,6 +15,9 @@ sources:
   {{- range $repo := .SourceRepositories }}
         - '{{ $repo }}'
   {{- end }}
+      versionfilter:
+        kind: '{{ .SourceVersionFilterKind }}'
+        pattern: '{{ .SourceVersionFilterPattern }}'
   {{- end }}
 conditions:
   {{ .ConditionArtifactID }}:

--- a/pkg/plugins/autodiscovery/maven/parentPomdependency.go
+++ b/pkg/plugins/autodiscovery/maven/parentPomdependency.go
@@ -92,8 +92,8 @@ func (m Maven) discoverParentPomDependencyManifests() ([][]byte, error) {
 			repos = append(repos, repo.URL)
 		}
 
-		sourceVersionFilterKind := "latest"
-		sourceVersionFilterPattern := "latest"
+		sourceVersionFilterKind := m.versionFilter.Kind
+		sourceVersionFilterPattern := m.versionFilter.Pattern
 		if !m.spec.VersionFilter.IsZero() {
 			sourceVersionFilterKind = m.versionFilter.Kind
 			sourceVersionFilterPattern, err = m.versionFilter.GreaterThanPattern(parentPom.Version)

--- a/pkg/plugins/autodiscovery/maven/parentPomdependency.go
+++ b/pkg/plugins/autodiscovery/maven/parentPomdependency.go
@@ -92,6 +92,17 @@ func (m Maven) discoverParentPomDependencyManifests() ([][]byte, error) {
 			repos = append(repos, repo.URL)
 		}
 
+		sourceVersionFilterKind := "latest"
+		sourceVersionFilterPattern := "latest"
+		if !m.spec.VersionFilter.IsZero() {
+			sourceVersionFilterKind = m.versionFilter.Kind
+			sourceVersionFilterPattern, err = m.versionFilter.GreaterThanPattern(parentPom.Version)
+			if err != nil {
+				logrus.Debugf("building version filter pattern: %s", err)
+				sourceVersionFilterPattern = "*"
+			}
+		}
+
 		tmpl, err := template.New("manifest").Parse(manifestTemplate)
 		if err != nil {
 			logrus.Debugln(err)
@@ -99,49 +110,53 @@ func (m Maven) discoverParentPomDependencyManifests() ([][]byte, error) {
 		}
 
 		params := struct {
-			ManifestName             string
-			ConditionID              string
-			ConditionGroupID         string
-			ConditionGroupIDName     string
-			ConditionGroupIDPath     string
-			ConditionGroupIDValue    string
-			ConditionArtifactID      string
-			ConditionArtifactIDName  string
-			ConditionArtifactIDPath  string
-			ConditionArtifactIDValue string
-			SourceID                 string
-			SourceName               string
-			SourceKind               string
-			SourceGroupID            string
-			SourceArtifactID         string
-			SourceRepositories       []string
-			TargetID                 string
-			TargetName               string
-			TargetXMLPath            string
-			File                     string
-			ScmID                    string
+			ManifestName               string
+			ConditionID                string
+			ConditionGroupID           string
+			ConditionGroupIDName       string
+			ConditionGroupIDPath       string
+			ConditionGroupIDValue      string
+			ConditionArtifactID        string
+			ConditionArtifactIDName    string
+			ConditionArtifactIDPath    string
+			ConditionArtifactIDValue   string
+			SourceID                   string
+			SourceName                 string
+			SourceKind                 string
+			SourceGroupID              string
+			SourceArtifactID           string
+			SourceRepositories         []string
+			SourceVersionFilterKind    string
+			SourceVersionFilterPattern string
+			TargetID                   string
+			TargetName                 string
+			TargetXMLPath              string
+			File                       string
+			ScmID                      string
 		}{
-			ManifestName:             fmt.Sprintf("Bump Maven parent Pom %s/%s", parentPom.GroupID, parentPom.ArtifactID),
-			ConditionID:              artifactFullName,
-			ConditionGroupID:         "groupid",
-			ConditionGroupIDName:     fmt.Sprintf("Ensure parent pom.xml groupId %q is specified", parentPom.GroupID),
-			ConditionGroupIDPath:     "/project/parent/groupId",
-			ConditionGroupIDValue:    parentPom.GroupID,
-			ConditionArtifactID:      "artifactid",
-			ConditionArtifactIDName:  fmt.Sprintf("Ensure parent artifactId %q is specified", parentPom.ArtifactID),
-			ConditionArtifactIDPath:  "/project/parent/artifactId",
-			ConditionArtifactIDValue: parentPom.ArtifactID,
-			SourceID:                 artifactFullName,
-			SourceName:               fmt.Sprintf("Get latest Parent Pom Artifact version %q", artifactFullName),
-			SourceKind:               "maven",
-			SourceGroupID:            parentPom.GroupID,
-			SourceArtifactID:         parentPom.ArtifactID,
-			SourceRepositories:       repos,
-			TargetID:                 artifactFullName,
-			TargetName:               fmt.Sprintf("Bump parent pom version for %q", artifactFullName),
-			TargetXMLPath:            "/project/parent/version",
-			File:                     relativePomFile,
-			ScmID:                    m.scmID,
+			ManifestName:               fmt.Sprintf("Bump Maven parent Pom %s/%s", parentPom.GroupID, parentPom.ArtifactID),
+			ConditionID:                artifactFullName,
+			ConditionGroupID:           "groupid",
+			ConditionGroupIDName:       fmt.Sprintf("Ensure parent pom.xml groupId %q is specified", parentPom.GroupID),
+			ConditionGroupIDPath:       "/project/parent/groupId",
+			ConditionGroupIDValue:      parentPom.GroupID,
+			ConditionArtifactID:        "artifactid",
+			ConditionArtifactIDName:    fmt.Sprintf("Ensure parent artifactId %q is specified", parentPom.ArtifactID),
+			ConditionArtifactIDPath:    "/project/parent/artifactId",
+			ConditionArtifactIDValue:   parentPom.ArtifactID,
+			SourceID:                   artifactFullName,
+			SourceName:                 fmt.Sprintf("Get latest Parent Pom Artifact version %q", artifactFullName),
+			SourceKind:                 "maven",
+			SourceGroupID:              parentPom.GroupID,
+			SourceArtifactID:           parentPom.ArtifactID,
+			SourceRepositories:         repos,
+			SourceVersionFilterKind:    sourceVersionFilterKind,
+			SourceVersionFilterPattern: sourceVersionFilterPattern,
+			TargetID:                   artifactFullName,
+			TargetName:                 fmt.Sprintf("Bump parent pom version for %q", artifactFullName),
+			TargetXMLPath:              "/project/parent/version",
+			File:                       relativePomFile,
+			ScmID:                      m.scmID,
 		}
 
 		manifest := bytes.Buffer{}

--- a/pkg/plugins/autodiscovery/maven/test/main_test.go
+++ b/pkg/plugins/autodiscovery/maven/test/main_test.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"github.com/updatecli/updatecli/pkg/plugins/utils/version"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -40,6 +41,10 @@ func TestDiscoverManifests(t *testing.T) {
 									},
 									GroupID:    "com.jcraft",
 									ArtifactID: "jsch",
+									VersionFilter: version.Filter{
+										Kind:    "latest",
+										Pattern: "latest",
+									},
 								},
 							},
 						},
@@ -100,6 +105,10 @@ func TestDiscoverManifests(t *testing.T) {
 									},
 									GroupID:    "io.jenkins.tools.bom",
 									ArtifactID: "bom-2.346.x",
+									VersionFilter: version.Filter{
+										Kind:    "latest",
+										Pattern: "latest",
+									},
 								},
 							},
 						},
@@ -159,6 +168,10 @@ func TestDiscoverManifests(t *testing.T) {
 									},
 									GroupID:    "org.jenkins-ci.plugins",
 									ArtifactID: "plugin",
+									VersionFilter: version.Filter{
+										Kind:    "latest",
+										Pattern: "latest",
+									},
 								},
 							},
 						},
@@ -212,13 +225,13 @@ func TestDiscoverManifests(t *testing.T) {
 	for _, tt := range testdata {
 
 		t.Run(tt.name, func(t *testing.T) {
-			resource, err := m.New(
+			r, err := m.New(
 				m.Spec{
 					RootDir: tt.rootDir,
 				}, "", "")
 			require.NoError(t, err)
 
-			pipelines, err := resource.DiscoverManifests()
+			pipelines, err := r.DiscoverManifests()
 			require.NoError(t, err)
 
 			for i := range pipelines {

--- a/pkg/plugins/autodiscovery/maven/test/main_test.go
+++ b/pkg/plugins/autodiscovery/maven/test/main_test.go
@@ -1,7 +1,6 @@
 package test
 
 import (
-	"github.com/updatecli/updatecli/pkg/plugins/utils/version"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -14,6 +13,7 @@ import (
 	"github.com/updatecli/updatecli/pkg/plugins/resources/maven"
 	"github.com/updatecli/updatecli/pkg/plugins/resources/xml"
 	"github.com/updatecli/updatecli/pkg/plugins/utils/test"
+	"github.com/updatecli/updatecli/pkg/plugins/utils/version"
 )
 
 func TestDiscoverManifests(t *testing.T) {

--- a/pkg/plugins/resources/xml/condition.go
+++ b/pkg/plugins/resources/xml/condition.go
@@ -51,8 +51,7 @@ func (x *XML) Condition(source string, scm scm.ScmHandler, resultCondition *resu
 	}
 
 	if value == elem.Text() {
-		resultCondition.Description = fmt.Sprintf("%s Path %q, from file %q, is correctly set to %s",
-			result.SUCCESS,
+		resultCondition.Description = fmt.Sprintf("Path %q, from file %q, is correctly set to %s",
 			x.spec.Path,
 			resourceFile,
 			value)


### PR DESCRIPTION

* Fix minor xml message
* Allow Maven autodiscovery to override default version filter

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
cp <to_package_directory>
go test
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
