### PR TITLE
Allowing the support for missing keys in Toml

### DIFF
--- a/pkg/plugins/resources/toml/spec.go
+++ b/pkg/plugins/resources/toml/spec.go
@@ -23,7 +23,10 @@ type Spec struct {
 	// [s] VersionFilter provides parameters to specify version pattern and its type like regex, semver, or just latest.
 	VersionFilter version.Filter `yaml:",omitempty"`
 	// [t] AllowsMissingKey allows non-existing keys. If the key does not exist, the key is created if AllowsMissingKey is true, otherwise an error is raised (the default)
-	// Only supported if Key is used
+	/* 
+	  [t] AllowsMissingKey allows non-existing keys. If the key does not exist, the key is created if            AllowsMissingKey is true, otherwise an error is raised (the default)
+	  Only supported if Key is used
+	*/ 
 	AllowsMissingKey bool `yaml:",omitempty"`
 }
 

--- a/pkg/plugins/resources/toml/spec.go
+++ b/pkg/plugins/resources/toml/spec.go
@@ -22,12 +22,12 @@ type Spec struct {
 	Multiple bool `yaml:",omitempty" jsonschema:"-"`
 	// [s] VersionFilter provides parameters to specify version pattern and its type like regex, semver, or just latest.
 	VersionFilter version.Filter `yaml:",omitempty"`
-	// [t] AllowsMissingKey allows non-existing keys. If the key does not exist, the key is created if AllowsMissingKey is true, otherwise an error is raised (the default)
-	/* 
-	  [t] AllowsMissingKey allows non-existing keys. If the key does not exist, the key is created if            AllowsMissingKey is true, otherwise an error is raised (the default)
+	/*
+	  [t] CreateMissingKey allows non-existing keys. If the key does not exist, the key is created if AllowsMissingKey
+	  is true, otherwise an error is raised (the default).
 	  Only supported if Key is used
-	*/ 
-	AllowsMissingKey bool `yaml:",omitempty"`
+	*/
+	CreateMissingKey bool `yaml:",omitempty"`
 }
 
 var (

--- a/pkg/plugins/resources/toml/spec.go
+++ b/pkg/plugins/resources/toml/spec.go
@@ -20,8 +20,11 @@ type Spec struct {
 	Value string `yaml:",omitempty"`
 	// [c][t] *Deprecated* Please look at query parameter to achieve similar objective
 	Multiple bool `yaml:",omitempty" jsonschema:"-"`
-	// [s]VersionFilter provides parameters to specify version pattern and its type like regex, semver, or just latest.
+	// [s] VersionFilter provides parameters to specify version pattern and its type like regex, semver, or just latest.
 	VersionFilter version.Filter `yaml:",omitempty"`
+	// [t] AllowsMissingKey allows non existing keys. If the key does not exist, the key is created if AllowsMissingKey is true, otherwise an error is raised (the default)
+	// Only supported if 
+	AllowsMissingKey bool `yaml:",omitempty"`
 }
 
 var (

--- a/pkg/plugins/resources/toml/spec.go
+++ b/pkg/plugins/resources/toml/spec.go
@@ -22,8 +22,8 @@ type Spec struct {
 	Multiple bool `yaml:",omitempty" jsonschema:"-"`
 	// [s] VersionFilter provides parameters to specify version pattern and its type like regex, semver, or just latest.
 	VersionFilter version.Filter `yaml:",omitempty"`
-	// [t] AllowsMissingKey allows non existing keys. If the key does not exist, the key is created if AllowsMissingKey is true, otherwise an error is raised (the default)
-	// Only supported if 
+	// [t] AllowsMissingKey allows non-existing keys. If the key does not exist, the key is created if AllowsMissingKey is true, otherwise an error is raised (the default)
+	// Only supported if Key is used
 	AllowsMissingKey bool `yaml:",omitempty"`
 }
 

--- a/pkg/plugins/resources/toml/target.go
+++ b/pkg/plugins/resources/toml/target.go
@@ -52,7 +52,7 @@ func (t *Toml) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarg
 			}
 
 		case false:
-			if t.spec.AllowsMissingKey {
+			if t.spec.CreateMissingKey {
 				queryResults, err = t.contents[i].MultipleQuery(t.spec.Query)
 				if err != nil {
 					return err

--- a/pkg/plugins/resources/toml/target.go
+++ b/pkg/plugins/resources/toml/target.go
@@ -22,7 +22,7 @@ func (t *Toml) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarg
 		// Target doesn't support updating files on remote http location
 		if strings.HasPrefix(filename, "https://") ||
 			strings.HasPrefix(filename, "http://") {
-			return fmt.Errorf("URL scheme is not supported for Json target: %q", t.spec.File)
+			return fmt.Errorf("URL scheme is not supported for Toml target: %q", t.spec.File)
 		}
 
 		if err := t.contents[i].Read(rootDir); err != nil {
@@ -52,12 +52,18 @@ func (t *Toml) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarg
 			}
 
 		case false:
-			queryResult, err := t.contents[i].Query(t.spec.Key)
-			if err != nil {
-				return err
+			if t.spec.AllowsMissingKey {
+				queryResults, err = t.contents[i].MultipleQuery(t.spec.Query)
+				if err != nil {
+					return err
+				}
+			} else {
+				queryResult, err := t.contents[i].Query(t.spec.Key)
+				if err != nil {
+					return err
+				}
+				queryResults = append(queryResults, queryResult)
 			}
-
-			queryResults = append(queryResults, queryResult)
 
 		}
 

--- a/pkg/plugins/resources/toml/target_test.go
+++ b/pkg/plugins/resources/toml/target_test.go
@@ -101,6 +101,27 @@ func TestTarget(t *testing.T) {
 			sourceInput:    "Jack",
 			expectedResult: false,
 		},
+		{
+			name: "Failing on non existing key by default",
+			spec: Spec{
+				File: "testdata/data.toml",
+				Key:  ".owner.age",
+			},
+			sourceInput:      "50",
+			expectedResult:   false,
+			wantErr:          true,
+			expectedErrorMsg: errors.New("could not find value for query \".owner.age\" from file \"testdata/data.toml\""),
+		},
+		{
+			name: "Successful update on non existing key",
+			spec: Spec{
+				File:             "testdata/data.toml",
+				Key:              ".owner.age",
+				AllowsMissingKey: true,
+			},
+			sourceInput:    "50",
+			expectedResult: true,
+		},
 	}
 
 	for _, tt := range testData {

--- a/pkg/plugins/resources/toml/target_test.go
+++ b/pkg/plugins/resources/toml/target_test.go
@@ -102,7 +102,7 @@ func TestTarget(t *testing.T) {
 			expectedResult: false,
 		},
 		{
-			name: "Failing on non existing key by default",
+			name: "Failing on non-existing key by default",
 			spec: Spec{
 				File: "testdata/data.toml",
 				Key:  ".owner.age",
@@ -113,7 +113,7 @@ func TestTarget(t *testing.T) {
 			expectedErrorMsg: errors.New("could not find value for query \".owner.age\" from file \"testdata/data.toml\""),
 		},
 		{
-			name: "Successful update on non existing key",
+			name: "Successful update on non-existing key",
 			spec: Spec{
 				File:             "testdata/data.toml",
 				Key:              ".owner.age",

--- a/pkg/plugins/resources/toml/target_test.go
+++ b/pkg/plugins/resources/toml/target_test.go
@@ -117,7 +117,7 @@ func TestTarget(t *testing.T) {
 			spec: Spec{
 				File:             "testdata/data.toml",
 				Key:              ".owner.age",
-				AllowsMissingKey: true,
+				CreateMissingKey: true,
 			},
 			sourceInput:    "50",
 			expectedResult: true,


### PR DESCRIPTION
This PR proposes the support for missing keys when _targeting_ TOML files.

Use case:

* the key containing the version is in a Toml file but does not necessarily exist
* upon an update, we want this key to be created with the new version

Today, this fails because `updatecli` requires the key to be already there.

By adding `allowMissingKey: true` to the spec, the `target` won't fail but just create the key when missing. By default, `allowMissingKey` remains `false`, keeping the initial behavior (raising an error about the missing key).

Two tests have been added:

* checking the legacy behaviour (without `allowMissingKey`)
* checking the creation of the key when `allowMissingKey` is `true`

## Test

To test this pull request, you can run the following commands:

```shell
cp pkg/plugins/resources/toml
go test
```

## Additional Information

### Potential improvement

I did not find the documentation in the `updatecli` repository. Where can I edit the documentation?
