### PR TITLE
Conditional targets

### DIFF
--- a/pkg/plugins/scms/stash/scm.go
+++ b/pkg/plugins/scms/stash/scm.go
@@ -45,7 +45,7 @@ func (s *Stash) Clone() (string, error) {
 	s.setDirectory()
 
 	err := s.nativeGitHandler.Clone(
-		s.Spec.User,
+		s.Spec.Username,
 		s.Spec.Token,
 		s.GetURL(),
 		s.GetDirectory())


### PR DESCRIPTION
This PR proposes the addition of conditions at target level.

As of now, the `conditions` are all or nothing: they need to all pass before we go on with the pipeline and all its defined targets.

However, in some circumstances, we may want to run a target only if a given condition is met (for example: not updating all the files when only a patch). In this case, we'd need to be able to specify a condition at target level.

This would look like:

```yaml
targets:
   my-target:
      ...
      spec:
         ...
         condition:
             any-condition...
```

For now, opening as a draft since I'd like to discuss the concept, the approach and also the testability of this. Of course, documentation & tests would have to be added.