### PR TITLE
Generate uniq resource ID

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -127,7 +127,7 @@ require (
 	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
-	github.com/google/uuid v1.3.0
+	github.com/google/uuid v1.3.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.2.3 // indirect
 	github.com/googleapis/gax-go/v2 v2.7.1 // indirect
 	github.com/gorilla/mux v1.8.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -127,7 +127,7 @@ require (
 	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
-	github.com/google/uuid v1.3.0 // indirect
+	github.com/google/uuid v1.3.0
 	github.com/googleapis/enterprise-certificate-proxy v0.2.3 // indirect
 	github.com/googleapis/gax-go/v2 v2.7.1 // indirect
 	github.com/gorilla/mux v1.8.0 // indirect

--- a/pkg/core/pipeline/condition/main.go
+++ b/pkg/core/pipeline/condition/main.go
@@ -20,6 +20,8 @@ var (
 // Condition defines which condition needs to be met
 // in order to update targets based on the source output
 type Condition struct {
+	// ID holds the resource ID
+	ID string
 	// Result stores the condition result after a condition run.
 	Result result.Condition
 	// Config defines condition input parameters
@@ -46,6 +48,12 @@ func (c *Condition) Run(source string) (err error) {
 
 	condition, err := resource.New(c.Config.ResourceConfig)
 	if err != nil {
+		return err
+	}
+
+	c.ID, err = resource.GetAtomicID(condition)
+	if err != nil {
+		c.Result.Result = result.FAILURE
 		return err
 	}
 

--- a/pkg/core/pipeline/resource/main.go
+++ b/pkg/core/pipeline/resource/main.go
@@ -200,6 +200,7 @@ type Resource interface {
 	Condition(version string, scm scm.ScmHandler, resultCondition *result.Condition) error
 	Target(source string, scm scm.ScmHandler, dryRun bool, targetResult *result.Target) (err error)
 	Changelog() string
+	GetAtomicSpec() interface{}
 }
 
 // Need to do reflect of ResourceConfig

--- a/pkg/core/pipeline/resource/main_test.go
+++ b/pkg/core/pipeline/resource/main_test.go
@@ -1,0 +1,67 @@
+package resource
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/updatecli/updatecli/pkg/plugins/resources/githubrelease"
+	gomodule "github.com/updatecli/updatecli/pkg/plugins/resources/go/module"
+)
+
+func TestGenerateID(t *testing.T) {
+
+	data := []struct {
+		resourceConfig ResourceConfig
+		expectedHash   string
+	}{
+		{
+			resourceConfig: ResourceConfig{
+				Name: "Get value",
+				Kind: "golang/module",
+				Spec: gomodule.Spec{
+					Module: "github.com/updatecli/updatecli",
+				},
+			},
+			expectedHash: "grAgGpDaKH02T6BfoABJboqbD485QhZWsRTOrcg86nw=",
+		},
+		{
+			resourceConfig: ResourceConfig{
+				Name: "Get value",
+				Kind: "githubrelease",
+				Spec: githubrelease.Spec{
+					Owner:      "updatecli",
+					Repository: "updatecli",
+					Token:      "mysecretToken",
+				},
+			},
+			expectedHash: "9fdXCMKm8-44ADLg-FnZoi1I6S9_rXHChbrM1DbxiRI=",
+		},
+		{
+			resourceConfig: ResourceConfig{
+				Name: "Get value",
+				Kind: "githubrelease",
+				Spec: githubrelease.Spec{
+					Owner:      "updatecli",
+					Repository: "updatecli",
+					Username:   "myUsername",
+					Token:      "mysecretToken",
+				},
+			},
+			expectedHash: "9fdXCMKm8-44ADLg-FnZoi1I6S9_rXHChbrM1DbxiRI=",
+		},
+	}
+
+	for i := 0; i < 100; i++ {
+		for _, d := range data {
+			t.Logf("Iteration %v", i)
+			r, err := New(d.resourceConfig)
+			require.NoError(t, err)
+
+			id, err := GetAtomicID(r)
+			require.NoError(t, err)
+
+			assert.Equal(t, d.expectedHash, id)
+		}
+	}
+}

--- a/pkg/core/pipeline/source/main.go
+++ b/pkg/core/pipeline/source/main.go
@@ -16,6 +16,8 @@ import (
 
 // Source defines how a value is retrieved from a specific source
 type Source struct {
+	// ID holds the resource ID
+	ID string
 	// Changelog holds the changelog description
 	Changelog string
 	// Result stores the source result after a source run.
@@ -41,6 +43,12 @@ var (
 func (s *Source) Run() (err error) {
 
 	source, err := resource.New(s.Config.ResourceConfig)
+	if err != nil {
+		s.Result.Result = result.FAILURE
+		return err
+	}
+
+	s.ID, err = resource.GetAtomicID(source)
 	if err != nil {
 		s.Result.Result = result.FAILURE
 		return err

--- a/pkg/core/pipeline/target/main.go
+++ b/pkg/core/pipeline/target/main.go
@@ -20,6 +20,8 @@ var (
 
 // Target defines which file needs to be updated based on source output
 type Target struct {
+	// ID holds the resource ID
+	ID string
 	// Result store the condition result after a target run.
 	Result result.Target
 	Config Config
@@ -85,6 +87,12 @@ func (t *Target) Run(source string, o *Options) (err error) {
 	target, err := resource.New(t.Config.ResourceConfig)
 	if err != nil {
 		failTargetRun()
+		return err
+	}
+
+	t.ID, err = resource.GetAtomicID(target)
+	if err != nil {
+		t.Result.Result = result.FAILURE
 		return err
 	}
 

--- a/pkg/plugins/resources/awsami/atomic.go
+++ b/pkg/plugins/resources/awsami/atomic.go
@@ -1,0 +1,11 @@
+package awsami
+
+/*
+GetAtomicSpec returns an atomic version of the resource spec
+The goal is to only have information that can be used to identify
+the scope of the resource.
+All credentials are absent
+*/
+func (a AMI) GetAtomicSpec() interface{} {
+	return a.spec.Atomic()
+}

--- a/pkg/plugins/resources/awsami/condition.go
+++ b/pkg/plugins/resources/awsami/condition.go
@@ -20,13 +20,13 @@ func (a *AMI) Condition(source string, scm scm.ScmHandler, resultCondition *resu
 
 	// It's an error if the upstream source is empty and the user does not provide any filter
 	// then it mean
-	if source == "" && len(a.Spec.Filters) == 0 {
+	if source == "" && len(a.spec.Filters) == 0 {
 		return ErrNoFilter
 	}
 
 	isFilterDefined := func(filter string) (found bool) {
-		for i := 0; i < len(a.Spec.Filters); i++ {
-			if strings.Compare(a.Spec.Filters[i].Name, filter) == 0 {
+		for i := 0; i < len(a.spec.Filters); i++ {
+			if strings.Compare(a.spec.Filters[i].Name, filter) == 0 {
 				found = true
 				break
 			}
@@ -36,7 +36,7 @@ func (a *AMI) Condition(source string, scm scm.ScmHandler, resultCondition *resu
 
 	// Set image-id to source output if not yet defined
 	if !isFilterDefined("image-id") && len(source) > 0 {
-		a.Spec.Filters = append(a.Spec.Filters, Filter{
+		a.spec.Filters = append(a.spec.Filters, Filter{
 			Name:   "image-id",
 			Values: source,
 		})
@@ -44,7 +44,7 @@ func (a *AMI) Condition(source string, scm scm.ScmHandler, resultCondition *resu
 
 	logrus.Debugf("Looking for latest AMI ID matching:\n  ---\n  %s\n  ---\n\n",
 		strings.TrimRight(
-			strings.ReplaceAll(a.Spec.String(), "\n", "\n  "), "\n "))
+			strings.ReplaceAll(a.spec.String(), "\n", "\n  "), "\n "))
 
 	foundAMI, err := a.getLatestAmiID()
 
@@ -61,7 +61,7 @@ func (a *AMI) Condition(source string, scm scm.ScmHandler, resultCondition *resu
 
 	resultCondition.Result = result.FAILURE
 	resultCondition.Pass = false
-	resultCondition.Description = fmt.Sprintf("no AMI found matching criteria for region %s\n", a.Spec.Region)
+	resultCondition.Description = fmt.Sprintf("no AMI found matching criteria for region %s\n", a.spec.Region)
 
 	return nil
 }

--- a/pkg/plugins/resources/awsami/condition_test.go
+++ b/pkg/plugins/resources/awsami/condition_test.go
@@ -40,7 +40,7 @@ func TestCondition(t *testing.T) {
 	imageID := "ami-0a9972d9b4dbdabc7"
 
 	ami := AMI{
-		Spec: Spec{
+		spec: Spec{
 			Region:  "eu-west-1",
 			Filters: Filters{},
 		},

--- a/pkg/plugins/resources/awsami/data_test.go
+++ b/pkg/plugins/resources/awsami/data_test.go
@@ -31,7 +31,7 @@ var (
 	dataset = DataSet{
 		{
 			ami: AMI{
-				Spec: Spec{
+				spec: Spec{
 					Filters: Filters{},
 				},
 			},
@@ -45,7 +45,7 @@ var (
 		},
 		{
 			ami: AMI{
-				Spec: Spec{
+				spec: Spec{
 					Region: "eu-west-1",
 					Filters: Filters{
 						{
@@ -85,7 +85,7 @@ var (
 		},
 		{
 			ami: AMI{
-				Spec: Spec{
+				spec: Spec{
 					Region: "eu-west-1",
 					Filters: Filters{
 						{
@@ -112,7 +112,7 @@ var (
 		},
 		{
 			ami: AMI{
-				Spec: Spec{
+				spec: Spec{
 					Filters: Filters{
 						{
 							Name:   "name",

--- a/pkg/plugins/resources/awsami/helpers.go
+++ b/pkg/plugins/resources/awsami/helpers.go
@@ -13,7 +13,7 @@ import (
 // getLatestAmiID queries the AWS API to return the newest AMI image id.
 func (a *AMI) getLatestAmiID() (string, error) {
 	input := ec2.DescribeImagesInput{
-		DryRun:  &a.Spec.DryRun,
+		DryRun:  &a.spec.DryRun,
 		Filters: a.ec2Filters,
 	}
 
@@ -35,7 +35,7 @@ func (a *AMI) getLatestAmiID() (string, error) {
 
 	if nbImages := len(result.Images); nbImages > 0 {
 
-		switch a.Spec.SortBy {
+		switch a.spec.SortBy {
 		case "creationdateasc":
 			sort.Sort(ByCreationDateAsc(result.Images))
 		case "creationdatedesc":

--- a/pkg/plugins/resources/awsami/main.go
+++ b/pkg/plugins/resources/awsami/main.go
@@ -26,7 +26,7 @@ var (
 
 // AMI contains information to manipulate AWS AMI information
 type AMI struct {
-	Spec       Spec
+	spec       Spec
 	ec2Filters []*ec2.Filter
 	apiClient  ec2iface.EC2API
 }
@@ -89,7 +89,7 @@ func New(spec interface{}) (*AMI, error) {
 	}
 
 	return &AMI{
-		Spec:       newSpec,
+		spec:       newSpec,
 		ec2Filters: newFilters,
 		apiClient:  newClient,
 	}, nil

--- a/pkg/plugins/resources/awsami/source.go
+++ b/pkg/plugins/resources/awsami/source.go
@@ -12,11 +12,11 @@ import (
 func (a *AMI) Source(workingDir string, resultSource *result.Source) error {
 	logrus.Debugf("Looking for latest AMI ID matching:\n  ---\n  %s\n  ---\n\n",
 		strings.TrimRight(
-			strings.ReplaceAll(a.Spec.String(), "\n", "\n  "), "\n "))
+			strings.ReplaceAll(a.spec.String(), "\n", "\n  "), "\n "))
 
 	// It's an error if the upstream source is empty and the user does not provide any filter
 	// then it mean
-	if len(a.Spec.Filters) == 0 {
+	if len(a.spec.Filters) == 0 {
 		return ErrNoFilter
 	}
 
@@ -35,7 +35,7 @@ func (a *AMI) Source(workingDir string, resultSource *result.Source) error {
 	}
 
 	resultSource.Result = result.FAILURE
-	resultSource.Description = fmt.Sprintf("no AMI found matching criteria in region %s\n", a.Spec.Region)
+	resultSource.Description = fmt.Sprintf("no AMI found matching criteria in region %s\n", a.spec.Region)
 
 	return nil
 }

--- a/pkg/plugins/resources/awsami/spec.go
+++ b/pkg/plugins/resources/awsami/spec.go
@@ -31,6 +31,14 @@ type Spec struct {
 	SortBy string `yaml:",omitempty"`
 }
 
+func (s Spec) Atomic() Spec {
+	return Spec{
+		Filters:  s.Filters,
+		Region:   s.Region,
+		Endpoint: s.Endpoint,
+	}
+}
+
 // String return Spec information as a string
 func (s *Spec) String() (output string) {
 	output = output + "Region:\t" + s.Region

--- a/pkg/plugins/resources/cargopackage/atomic.go
+++ b/pkg/plugins/resources/cargopackage/atomic.go
@@ -1,0 +1,11 @@
+package cargopackage
+
+/*
+GetAtomicSpec returns an atomic version of the resource spec
+The goal is to only have information that can be used to identify
+the scope of the resource.
+All credentials are absent
+*/
+func (c CargoPackage) GetAtomicSpec() interface{} {
+	return c.spec.Atomic()
+}

--- a/pkg/plugins/resources/cargopackage/spec.go
+++ b/pkg/plugins/resources/cargopackage/spec.go
@@ -19,3 +19,11 @@ type Spec struct {
 	// [S] VersionFilter provides parameters to specify version pattern and its type like regex, semver, or just latest.
 	VersionFilter version.Filter `yaml:",omitempty"`
 }
+
+func (s Spec) Atomic() Spec {
+	return Spec{
+		Registry: s.Registry,
+		Package:  s.Package,
+		Version:  s.Version,
+	}
+}

--- a/pkg/plugins/resources/csv/atomic.go
+++ b/pkg/plugins/resources/csv/atomic.go
@@ -1,0 +1,11 @@
+package csv
+
+/*
+GetAtomicSpec returns an atomic version of the resource spec
+The goal is to only have information that can be used to identify
+the scope of the resource.
+All credentials are absent
+*/
+func (c CSV) GetAtomicSpec() interface{} {
+	return c.spec.Atomic()
+}

--- a/pkg/plugins/resources/csv/spec.go
+++ b/pkg/plugins/resources/csv/spec.go
@@ -36,6 +36,16 @@ var (
 	ErrWrongSpec error = errors.New("wrong spec content")
 )
 
+func (s Spec) Atomic() Spec {
+	return Spec{
+		File:  s.File,
+		Files: s.Files,
+		Key:   s.Key,
+		Query: s.Query,
+		Value: s.Value,
+	}
+}
+
 func (s *Spec) Validate() error {
 	var errs []error
 	if len(s.File) == 0 && len(s.Files) == 0 {

--- a/pkg/plugins/resources/dockerdigest/atomic.go
+++ b/pkg/plugins/resources/dockerdigest/atomic.go
@@ -1,0 +1,11 @@
+package dockerdigest
+
+/*
+GetAtomicSpec returns an atomic version of the resource spec
+The goal is to only have information that can be used to identify
+the scope of the resource.
+All credentials are absent
+*/
+func (d DockerDigest) GetAtomicSpec() interface{} {
+	return d.spec.Atomic()
+}

--- a/pkg/plugins/resources/dockerdigest/main.go
+++ b/pkg/plugins/resources/dockerdigest/main.go
@@ -5,21 +5,7 @@ import (
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/mitchellh/mapstructure"
-	"github.com/updatecli/updatecli/pkg/plugins/utils/docker"
 )
-
-// Spec defines a specification for a "dockerdigest" resource parsed from an updatecli manifest file
-type Spec struct {
-	// [s][c] Architecture specifies the container image architecture such as `amd64`
-	Architecture string `yaml:",omitempty"`
-	// [s][c] Image specifies the container image such as `updatecli/updatecli`
-	Image string `yaml:",omitempty"`
-	// [s] Tag specifies the container image tag such as `latest`
-	Tag string `yaml:",omitempty"`
-	// [c] Digest specifies the container image digest such as `@sha256:ce782db15ab5491c6c6178da8431b3db66988ccd11512034946a9667846952a6`
-	Digest                string `yaml:",omitempty"`
-	docker.InlineKeyChain `yaml:",inline" mapstructure:",squash"`
-}
 
 // DockerDigest defines a resource of kind "dockerDigest" to interact with a docker registry
 type DockerDigest struct {

--- a/pkg/plugins/resources/dockerdigest/spec.go
+++ b/pkg/plugins/resources/dockerdigest/spec.go
@@ -1,0 +1,27 @@
+package dockerdigest
+
+import (
+	"github.com/updatecli/updatecli/pkg/plugins/utils/docker"
+)
+
+// Spec defines a specification for a "dockerdigest" resource parsed from an updatecli manifest file
+type Spec struct {
+	// [s][c] Architecture specifies the container image architecture such as `amd64`
+	Architecture string `yaml:",omitempty"`
+	// [s][c] Image specifies the container image such as `updatecli/updatecli`
+	Image string `yaml:",omitempty"`
+	// [s] Tag specifies the container image tag such as `latest`
+	Tag string `yaml:",omitempty"`
+	// [c] Digest specifies the container image digest such as `@sha256:ce782db15ab5491c6c6178da8431b3db66988ccd11512034946a9667846952a6`
+	Digest                string `yaml:",omitempty"`
+	docker.InlineKeyChain `yaml:",inline" mapstructure:",squash"`
+}
+
+func (s Spec) Atomic() Spec {
+	return Spec{
+		Architecture: s.Architecture,
+		Image:        s.Image,
+		Tag:          s.Tag,
+		Digest:       s.Digest,
+	}
+}

--- a/pkg/plugins/resources/dockerfile/atomic.go
+++ b/pkg/plugins/resources/dockerfile/atomic.go
@@ -1,0 +1,11 @@
+package dockerfile
+
+/*
+GetAtomicSpec returns an atomic version of the resource spec
+The goal is to only have information that can be used to identify
+the scope of the resource.
+All credentials are absent
+*/
+func (d Dockerfile) GetAtomicSpec() interface{} {
+	return d.spec.Atomic()
+}

--- a/pkg/plugins/resources/dockerfile/main.go
+++ b/pkg/plugins/resources/dockerfile/main.go
@@ -10,17 +10,6 @@ import (
 	"github.com/updatecli/updatecli/pkg/plugins/resources/dockerfile/types"
 )
 
-// Spec defines a specification for a "dockerfile" resource
-// parsed from an updatecli manifest file
-type Spec struct {
-	// File specifies the dockerimage file such as Dockerfile
-	File string `yaml:"file,omitempty"`
-	// Instruction specifies a DockerImage instruction such as ENV
-	Instruction types.Instruction `yaml:"instruction,omitempty"`
-	// Value specifies the value for a specified Dockerfile instruction.
-	Value string `yaml:"value,omitempty"`
-}
-
 // Dockerfile defines a resource of kind "dockerfile"
 type Dockerfile struct {
 	parser           types.DockerfileParser

--- a/pkg/plugins/resources/dockerfile/spec.go
+++ b/pkg/plugins/resources/dockerfile/spec.go
@@ -1,0 +1,24 @@
+package dockerfile
+
+import (
+	"github.com/updatecli/updatecli/pkg/plugins/resources/dockerfile/types"
+)
+
+// Spec defines a specification for a "dockerfile" resource
+// parsed from an updatecli manifest file
+type Spec struct {
+	// File specifies the dockerimage file such as Dockerfile
+	File string `yaml:"file,omitempty"`
+	// Instruction specifies a DockerImage instruction such as ENV
+	Instruction types.Instruction `yaml:"instruction,omitempty"`
+	// Value specifies the value for a specified Dockerfile instruction.
+	Value string `yaml:"value,omitempty"`
+}
+
+func (s Spec) Atomic() Spec {
+	return Spec{
+		File:        s.File,
+		Instruction: s.Instruction,
+		Value:       s.Value,
+	}
+}

--- a/pkg/plugins/resources/dockerimage/atomic.go
+++ b/pkg/plugins/resources/dockerimage/atomic.go
@@ -1,0 +1,11 @@
+package dockerimage
+
+/*
+GetAtomicSpec returns an atomic version of the resource spec
+The goal is to only have information that can be used to identify
+the scope of the resource.
+All credentials are absent
+*/
+func (d DockerImage) GetAtomicSpec() interface{} {
+	return d.spec.Atomic()
+}

--- a/pkg/plugins/resources/dockerimage/spec.go
+++ b/pkg/plugins/resources/dockerimage/spec.go
@@ -186,3 +186,12 @@ func getTagFilterFromValue(tag string) (string, error) {
 	logrus.Warningf("=> No matching rule identified for Docker image tag %q, feel free to ignore this image with a manifest or to suggest a new rule on https://github.com/updatecli/updatecli/issues/new/choose", tag)
 	return "", fmt.Errorf("no tag pattern identify")
 }
+
+func (s Spec) Atomic() Spec {
+	return Spec{
+		Architectures: s.Architectures,
+		Architecture:  s.Architecture,
+		Image:         s.Image,
+		Tag:           s.Tag,
+	}
+}

--- a/pkg/plugins/resources/file/atomic.go
+++ b/pkg/plugins/resources/file/atomic.go
@@ -1,0 +1,11 @@
+package file
+
+/*
+GetAtomicSpec returns an atomic version of the resource spec
+The goal is to only have information that can be used to identify
+the scope of the resource.
+All credentials are absent
+*/
+func (f File) GetAtomicSpec() interface{} {
+	return f.spec.Atomic()
+}

--- a/pkg/plugins/resources/file/main.go
+++ b/pkg/plugins/resources/file/main.go
@@ -10,25 +10,6 @@ import (
 	"github.com/updatecli/updatecli/pkg/core/text"
 )
 
-// Spec defines a specification for a "file" resource
-// parsed from an updatecli manifest file
-type Spec struct {
-	// File contains the file path(s) to take in account and is incompatible with Files
-	File string `yaml:",omitempty"`
-	// Files contains the file path(s) to take in account and is incompatible with File
-	Files []string `yaml:",omitempty"`
-	// Line contains the line of the file(s) to take in account
-	Line int `yaml:",omitempty"`
-	// Content specifies the content to take in account instead of the file content
-	Content string `yaml:",omitempty"`
-	// ForceCreate specifies if nonexistent file(s) should be created if they are targets
-	ForceCreate bool `yaml:",omitempty"`
-	// MatchPattern specifies the regexp pattern to match on the file(s)
-	MatchPattern string `yaml:",omitempty"`
-	// ReplacePattern specifies the regexp replace pattern to apply on the file(s) content
-	ReplacePattern string `yaml:",omitempty"`
-}
-
 // File defines a resource of kind "file"
 type File struct {
 	spec             Spec

--- a/pkg/plugins/resources/file/spec.go
+++ b/pkg/plugins/resources/file/spec.go
@@ -1,0 +1,29 @@
+package file
+
+// Spec defines a specification for a "file" resource
+// parsed from an updatecli manifest file
+type Spec struct {
+	// File contains the file path(s) to take in account and is incompatible with Files
+	File string `yaml:",omitempty"`
+	// Files contains the file path(s) to take in account and is incompatible with File
+	Files []string `yaml:",omitempty"`
+	// Line contains the line of the file(s) to take in account
+	Line int `yaml:",omitempty"`
+	// Content specifies the content to take in account instead of the file content
+	Content string `yaml:",omitempty"`
+	// ForceCreate specifies if nonexistent file(s) should be created if they are targets
+	ForceCreate bool `yaml:",omitempty"`
+	// MatchPattern specifies the regexp pattern to match on the file(s)
+	MatchPattern string `yaml:",omitempty"`
+	// ReplacePattern specifies the regexp replace pattern to apply on the file(s) content
+	ReplacePattern string `yaml:",omitempty"`
+}
+
+func (s Spec) Atomic() Spec {
+	return Spec{
+		Files:   s.Files,
+		Line:    s.Line,
+		Content: s.Content,
+		File:    s.File,
+	}
+}

--- a/pkg/plugins/resources/gitbranch/atomic.go
+++ b/pkg/plugins/resources/gitbranch/atomic.go
@@ -1,0 +1,11 @@
+package gitbranch
+
+/*
+GetAtomicSpec returns an atomic version of the resource spec
+The goal is to only have information that can be used to identify
+the scope of the resource.
+All credentials are absent
+*/
+func (g GitBranch) GetAtomicSpec() interface{} {
+	return g.spec.Atomic()
+}

--- a/pkg/plugins/resources/gitbranch/main.go
+++ b/pkg/plugins/resources/gitbranch/main.go
@@ -9,17 +9,6 @@ import (
 	"github.com/updatecli/updatecli/pkg/plugins/utils/version"
 )
 
-// Spec defines a specification for a "gitbranch" resource
-// parsed from an updatecli manifest file
-type Spec struct {
-	// [s][c][t] Path contains the git repository path
-	Path string `yaml:",omitempty"`
-	// [s] VersionFilter provides parameters to specify version pattern and its type like regex, semver, or just latest.
-	VersionFilter version.Filter `yaml:",omitempty"`
-	// [c][t] Specify branch name
-	Branch string `yaml:",omitempty"`
-}
-
 // GitBranch defines a resource of kind "gitbranch"
 type GitBranch struct {
 	spec Spec

--- a/pkg/plugins/resources/gitbranch/spec.go
+++ b/pkg/plugins/resources/gitbranch/spec.go
@@ -1,0 +1,23 @@
+package gitbranch
+
+import (
+	"github.com/updatecli/updatecli/pkg/plugins/utils/version"
+)
+
+// Spec defines a specification for a "gitbranch" resource
+// parsed from an updatecli manifest file
+type Spec struct {
+	// [s][c][t] Path contains the git repository path
+	Path string `yaml:",omitempty"`
+	// [s] VersionFilter provides parameters to specify version pattern and its type like regex, semver, or just latest.
+	VersionFilter version.Filter `yaml:",omitempty"`
+	// [c][t] Specify branch name
+	Branch string `yaml:",omitempty"`
+}
+
+func (s Spec) Atomic() Spec {
+	return Spec{
+		Branch: s.Branch,
+		Path:   s.Path,
+	}
+}

--- a/pkg/plugins/resources/gitea/branch/atomic.go
+++ b/pkg/plugins/resources/gitea/branch/atomic.go
@@ -1,0 +1,11 @@
+package branch
+
+/*
+GetAtomicSpec returns an atomic version of the resource spec
+The goal is to only have information that can be used to identify
+the scope of the resource.
+All credentials are absent
+*/
+func (g Gitea) GetAtomicSpec() interface{} {
+	return g.spec.Atomic()
+}

--- a/pkg/plugins/resources/gitea/branch/main.go
+++ b/pkg/plugins/resources/gitea/branch/main.go
@@ -2,7 +2,6 @@ package branch
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"time"
 
@@ -12,19 +11,6 @@ import (
 	"github.com/updatecli/updatecli/pkg/plugins/resources/gitea/client"
 	"github.com/updatecli/updatecli/pkg/plugins/utils/version"
 )
-
-// Spec defines settings used to interact with Gitea release
-type Spec struct {
-	client.Spec `yaml:",inline,omitempty"`
-	// [S][C] Owner specifies repository owner
-	Owner string `yaml:",omitempty" jsonschema:"required"`
-	// [S][C] Repository specifies the name of a repository for a specific owner
-	Repository string `yaml:",omitempty" jsonschema:"required"`
-	// [S] VersionFilter provides parameters to specify version pattern and its type like regex, semver, or just latest.
-	VersionFilter version.Filter `yaml:",omitempty"`
-	// [C] Branch specifies the branch name
-	Branch string `yaml:",omitempty"`
-}
 
 // Gitea contains information to interact with Gitea api
 type Gitea struct {
@@ -135,35 +121,4 @@ func (g *Gitea) SearchBranches() (tags []string, err error) {
 	}
 
 	return results, nil
-}
-
-func (s Spec) Validate() error {
-	gotError := false
-	missingParameters := []string{}
-
-	err := s.Spec.Validate()
-
-	if err != nil {
-		gotError = true
-	}
-
-	if len(s.Owner) == 0 {
-		gotError = true
-		missingParameters = append(missingParameters, "owner")
-	}
-
-	if len(s.Repository) == 0 {
-		gotError = true
-		missingParameters = append(missingParameters, "repository")
-	}
-
-	if len(missingParameters) > 0 {
-		logrus.Errorf("missing parameter(s) [%s]", strings.Join(missingParameters, ","))
-	}
-
-	if gotError {
-		return fmt.Errorf("wrong gitea configuration")
-	}
-
-	return nil
 }

--- a/pkg/plugins/resources/gitea/branch/spec.go
+++ b/pkg/plugins/resources/gitea/branch/spec.go
@@ -1,0 +1,62 @@
+package branch
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	"github.com/updatecli/updatecli/pkg/plugins/resources/gitea/client"
+	"github.com/updatecli/updatecli/pkg/plugins/utils/version"
+)
+
+// Spec defines settings used to interact with Gitea release
+type Spec struct {
+	client.Spec `yaml:",inline,omitempty"`
+	// [S][C] Owner specifies repository owner
+	Owner string `yaml:",omitempty" jsonschema:"required"`
+	// [S][C] Repository specifies the name of a repository for a specific owner
+	Repository string `yaml:",omitempty" jsonschema:"required"`
+	// [S] VersionFilter provides parameters to specify version pattern and its type like regex, semver, or just latest.
+	VersionFilter version.Filter `yaml:",omitempty"`
+	// [C] Branch specifies the branch name
+	Branch string `yaml:",omitempty"`
+}
+
+func (s Spec) Atomic() Spec {
+	return Spec{
+		Owner:      s.Owner,
+		Repository: s.Repository,
+		Branch:     s.Branch,
+	}
+}
+
+func (s Spec) Validate() error {
+	gotError := false
+	missingParameters := []string{}
+
+	err := s.Spec.Validate()
+
+	if err != nil {
+		gotError = true
+	}
+
+	if len(s.Owner) == 0 {
+		gotError = true
+		missingParameters = append(missingParameters, "owner")
+	}
+
+	if len(s.Repository) == 0 {
+		gotError = true
+		missingParameters = append(missingParameters, "repository")
+	}
+
+	if len(missingParameters) > 0 {
+		logrus.Errorf("missing parameter(s) [%s]", strings.Join(missingParameters, ","))
+	}
+
+	if gotError {
+		return fmt.Errorf("wrong gitea configuration")
+	}
+
+	return nil
+}

--- a/pkg/plugins/resources/gitea/pullrequest/atomic.go
+++ b/pkg/plugins/resources/gitea/pullrequest/atomic.go
@@ -1,0 +1,28 @@
+package pullrequest
+
+/*
+GetAtomicSpec returns an atomic version of the resource spec
+The goal is to only have information that can be used to identify
+the scope of the resource.
+All credentials are absent
+*/
+func (g Gitea) GetAtomicSpec() interface{} {
+	a := g.spec.Atomic()
+
+	if g.Owner != "" {
+		a.Owner = g.Owner
+	}
+	if g.Repository != "" {
+		a.Repository = g.Owner
+	}
+
+	if g.SourceBranch != "" {
+		a.SourceBranch = g.SourceBranch
+	}
+
+	if g.TargetBranch != "" {
+		a.TargetBranch = g.TargetBranch
+	}
+
+	return a
+}

--- a/pkg/plugins/resources/gitea/pullrequest/spec.go
+++ b/pkg/plugins/resources/gitea/pullrequest/spec.go
@@ -85,3 +85,12 @@ type Spec struct {
 	*/
 	Body string `yaml:",inline,omitempty"`
 }
+
+func (s Spec) Atomic() Spec {
+	return Spec{
+		SourceBranch: s.SourceBranch,
+		TargetBranch: s.TargetBranch,
+		Owner:        s.Owner,
+		Repository:   s.Repository,
+	}
+}

--- a/pkg/plugins/resources/gitea/release/atomic.go
+++ b/pkg/plugins/resources/gitea/release/atomic.go
@@ -1,0 +1,12 @@
+package release
+
+/*
+GetAtomicSpec returns an atomic version of the resource spec
+The goal is to only have information that can be used to identify
+the scope of the resource.
+All credentials are absent
+*/
+func (g Gitea) GetAtomicSpec() interface{} {
+
+	return g.spec.Atomic()
+}

--- a/pkg/plugins/resources/gitea/release/main.go
+++ b/pkg/plugins/resources/gitea/release/main.go
@@ -2,7 +2,6 @@ package release
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"time"
 
@@ -12,29 +11,6 @@ import (
 	"github.com/updatecli/updatecli/pkg/plugins/resources/gitea/client"
 	"github.com/updatecli/updatecli/pkg/plugins/utils/version"
 )
-
-// Spec defines settings used to interact with Gitea release
-type Spec struct {
-	client.Spec `yaml:",inline,omitempty"`
-	// [S][C][T] owner specifies the repository owner
-	Owner string `yaml:",omitempty" jsonschema:"required"`
-	// [S][C][T] repository specifies the name of a repository for a specific owner
-	Repository string `yaml:",omitempty" jsonschema:"required"`
-	// [S] versionfilter provides parameters to specify version pattern and its type like regex, semver, or just latest.
-	VersionFilter version.Filter `yaml:",omitempty"`
-	// [T] title defines the Gitea release title.
-	Title string `yaml:",omitempty"`
-	// [C][T] tag defines the Gitea release tag.
-	Tag string `yaml:",omitempty"`
-	// [T] commitish defines the commit-ish such as `main`
-	Commitish string `yaml:",omitempty"`
-	// [T] description defines if the new release description
-	Description string `yaml:",omitempty"`
-	// [T] draft defines if the release is a draft release
-	Draft bool `yaml:",omitempty"`
-	// [T] prerelease defines if the release is a pre-release release
-	Prerelease bool `yaml:",omitempty"`
-}
 
 const (
 	// #nosec g101
@@ -153,36 +129,4 @@ func (g *Gitea) SearchReleases() ([]string, error) {
 	}
 
 	return results, nil
-}
-
-func (s Spec) Validate() error {
-	gotError := false
-	missingParameters := []string{}
-
-	err := s.Spec.Validate()
-
-	if err != nil {
-		logrus.Errorln(err)
-		gotError = true
-	}
-
-	if len(s.Owner) == 0 {
-		gotError = true
-		missingParameters = append(missingParameters, "owner")
-	}
-
-	if len(s.Repository) == 0 {
-		gotError = true
-		missingParameters = append(missingParameters, "repository")
-	}
-
-	if len(missingParameters) > 0 {
-		logrus.Errorf("missing parameter(s) [%s]", strings.Join(missingParameters, ","))
-	}
-
-	if gotError {
-		return fmt.Errorf("wrong gitea configuration")
-	}
-
-	return nil
 }

--- a/pkg/plugins/resources/gitea/release/spec.go
+++ b/pkg/plugins/resources/gitea/release/spec.go
@@ -1,0 +1,73 @@
+package release
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	"github.com/updatecli/updatecli/pkg/plugins/resources/gitea/client"
+	"github.com/updatecli/updatecli/pkg/plugins/utils/version"
+)
+
+// Spec defines settings used to interact with Gitea release
+type Spec struct {
+	client.Spec `yaml:",inline,omitempty"`
+	// [S][C][T] owner specifies the repository owner
+	Owner string `yaml:",omitempty" jsonschema:"required"`
+	// [S][C][T] repository specifies the name of a repository for a specific owner
+	Repository string `yaml:",omitempty" jsonschema:"required"`
+	// [S] versionfilter provides parameters to specify version pattern and its type like regex, semver, or just latest.
+	VersionFilter version.Filter `yaml:",omitempty"`
+	// [T] title defines the Gitea release title.
+	Title string `yaml:",omitempty"`
+	// [C][T] tag defines the Gitea release tag.
+	Tag string `yaml:",omitempty"`
+	// [T] commitish defines the commit-ish such as `main`
+	Commitish string `yaml:",omitempty"`
+	// [T] description defines if the new release description
+	Description string `yaml:",omitempty"`
+	// [T] draft defines if the release is a draft release
+	Draft bool `yaml:",omitempty"`
+	// [T] prerelease defines if the release is a pre-release release
+	Prerelease bool `yaml:",omitempty"`
+}
+
+func (s Spec) Validate() error {
+	gotError := false
+	missingParameters := []string{}
+
+	err := s.Spec.Validate()
+
+	if err != nil {
+		logrus.Errorln(err)
+		gotError = true
+	}
+
+	if len(s.Owner) == 0 {
+		gotError = true
+		missingParameters = append(missingParameters, "owner")
+	}
+
+	if len(s.Repository) == 0 {
+		gotError = true
+		missingParameters = append(missingParameters, "repository")
+	}
+
+	if len(missingParameters) > 0 {
+		logrus.Errorf("missing parameter(s) [%s]", strings.Join(missingParameters, ","))
+	}
+
+	if gotError {
+		return fmt.Errorf("wrong gitea configuration")
+	}
+
+	return nil
+}
+
+func (s Spec) Atomic() Spec {
+	return Spec{
+		Owner:      s.Owner,
+		Repository: s.Repository,
+		Tag:        s.Tag,
+	}
+}

--- a/pkg/plugins/resources/gitea/tag/atomic.go
+++ b/pkg/plugins/resources/gitea/tag/atomic.go
@@ -1,0 +1,11 @@
+package tag
+
+/*
+GetAtomicSpec returns an atomic version of the resource spec
+The goal is to only have information that can be used to identify
+the scope of the resource.
+All credentials are absent
+*/
+func (g Gitea) GetAtomicSpec() interface{} {
+	return g.spec.Atomic()
+}

--- a/pkg/plugins/resources/gitea/tag/main.go
+++ b/pkg/plugins/resources/gitea/tag/main.go
@@ -2,7 +2,6 @@ package tag
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"time"
 
@@ -12,19 +11,6 @@ import (
 	"github.com/updatecli/updatecli/pkg/plugins/resources/gitea/client"
 	"github.com/updatecli/updatecli/pkg/plugins/utils/version"
 )
-
-// Spec defines settings used to interact with Gitea release
-type Spec struct {
-	client.Spec `yaml:",inline,omitempty"`
-	// [S][C] Owner specifies repository owner
-	Owner string `yaml:",omitempty" jsonschema:"required"`
-	// [S][C] Repository specifies the name of a repository for a specific owner
-	Repository string `yaml:",omitempty" jsonschema:"required"`
-	// [S][C] VersionFilter provides parameters to specify version pattern and its type like regex, semver, or just latest.
-	VersionFilter version.Filter `yaml:",omitempty"`
-	// [S] Tag defines the Gitea tag .
-	Tag string `yaml:",omitempty"`
-}
 
 // Gitea contains information to interact with Gitea api
 type Gitea struct {
@@ -132,36 +118,4 @@ func (g *Gitea) SearchTags() (tags []string, err error) {
 	}
 
 	return tags, nil
-}
-
-func (s Spec) Validate() error {
-	gotError := false
-	missingParameters := []string{}
-
-	err := s.Spec.Validate()
-
-	if err != nil {
-		logrus.Errorln(err)
-		gotError = true
-	}
-
-	if len(s.Owner) == 0 {
-		gotError = true
-		missingParameters = append(missingParameters, "owner")
-	}
-
-	if len(s.Repository) == 0 {
-		gotError = true
-		missingParameters = append(missingParameters, "repository")
-	}
-
-	if len(missingParameters) > 0 {
-		logrus.Errorf("missing parameter(s) [%s]", strings.Join(missingParameters, ","))
-	}
-
-	if gotError {
-		return fmt.Errorf("wrong gitea configuration")
-	}
-
-	return nil
 }

--- a/pkg/plugins/resources/gitea/tag/spec.go
+++ b/pkg/plugins/resources/gitea/tag/spec.go
@@ -1,0 +1,63 @@
+package tag
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	"github.com/updatecli/updatecli/pkg/plugins/resources/gitea/client"
+	"github.com/updatecli/updatecli/pkg/plugins/utils/version"
+)
+
+// Spec defines settings used to interact with Gitea release
+type Spec struct {
+	client.Spec `yaml:",inline,omitempty"`
+	// [S][C] Owner specifies repository owner
+	Owner string `yaml:",omitempty" jsonschema:"required"`
+	// [S][C] Repository specifies the name of a repository for a specific owner
+	Repository string `yaml:",omitempty" jsonschema:"required"`
+	// [S][C] VersionFilter provides parameters to specify version pattern and its type like regex, semver, or just latest.
+	VersionFilter version.Filter `yaml:",omitempty"`
+	// [S] Tag defines the Gitea tag .
+	Tag string `yaml:",omitempty"`
+}
+
+func (s Spec) Validate() error {
+	gotError := false
+	missingParameters := []string{}
+
+	err := s.Spec.Validate()
+
+	if err != nil {
+		logrus.Errorln(err)
+		gotError = true
+	}
+
+	if len(s.Owner) == 0 {
+		gotError = true
+		missingParameters = append(missingParameters, "owner")
+	}
+
+	if len(s.Repository) == 0 {
+		gotError = true
+		missingParameters = append(missingParameters, "repository")
+	}
+
+	if len(missingParameters) > 0 {
+		logrus.Errorf("missing parameter(s) [%s]", strings.Join(missingParameters, ","))
+	}
+
+	if gotError {
+		return fmt.Errorf("wrong gitea configuration")
+	}
+
+	return nil
+}
+
+func (s Spec) Atomic() Spec {
+	return Spec{
+		Owner:      s.Owner,
+		Repository: s.Repository,
+		Tag:        s.Tag,
+	}
+}

--- a/pkg/plugins/resources/githubrelease/atomic.go
+++ b/pkg/plugins/resources/githubrelease/atomic.go
@@ -1,0 +1,11 @@
+package githubrelease
+
+/*
+GetAtomicSpec returns an atomic version of the resource spec
+The goal is to only have information that can be used to identify
+the scope of the resource.
+All credentials are absent
+*/
+func (g GitHubRelease) GetAtomicSpec() interface{} {
+	return g.spec.Atomic()
+}

--- a/pkg/plugins/resources/githubrelease/main.go
+++ b/pkg/plugins/resources/githubrelease/main.go
@@ -6,27 +6,6 @@ import (
 	"github.com/updatecli/updatecli/pkg/plugins/utils/version"
 )
 
-// Spec defines a specification for a "gittag" resource
-// parsed from an updatecli manifest file
-type Spec struct {
-	// [s][c] Owner specifies repository owner
-	Owner string `yaml:",omitempty" jsonschema:"required"`
-	// [s][c] Repository specifies the name of a repository for a specific owner
-	Repository string `yaml:",omitempty" jsonschema:"required"`
-	// [s][c] Token specifies the credential used to authenticate with
-	Token string `yaml:",omitempty" jsonschema:"required"`
-	// [s][c] URL specifies the default github url in case of GitHub enterprise
-	URL string `yaml:",omitempty"`
-	// [s][c] Username specifies the username used to authenticate with GitHub API
-	Username string `yaml:",omitempty"`
-	// [s] VersionFilter provides parameters to specify version pattern and its type like regex, semver, or just latest.
-	VersionFilter version.Filter `yaml:",omitempty"`
-	// [s][c] TypeFilter specifies the GitHub Release type to retrieve before applying the versionfilter rule
-	TypeFilter github.ReleaseType `yaml:",omitempty"`
-	// [c] Tag allows to check for a specific release tag, default to source output
-	Tag string `yaml:",omitempty"`
-}
-
 // GitHubRelease defines a resource of kind "githubrelease"
 type GitHubRelease struct {
 	ghHandler     github.GithubHandler

--- a/pkg/plugins/resources/githubrelease/spec.go
+++ b/pkg/plugins/resources/githubrelease/spec.go
@@ -33,5 +33,4 @@ func (s Spec) Atomic() Spec {
 		URL:        s.URL,
 		Tag:        s.Tag,
 	}
-
 }

--- a/pkg/plugins/resources/githubrelease/spec.go
+++ b/pkg/plugins/resources/githubrelease/spec.go
@@ -1,0 +1,37 @@
+package githubrelease
+
+import (
+	"github.com/updatecli/updatecli/pkg/plugins/scms/github"
+	"github.com/updatecli/updatecli/pkg/plugins/utils/version"
+)
+
+// Spec defines a specification for a "gittag" resource
+// parsed from an updatecli manifest file
+type Spec struct {
+	// [s][c] Owner specifies repository owner
+	Owner string `yaml:",omitempty" jsonschema:"required"`
+	// [s][c] Repository specifies the name of a repository for a specific owner
+	Repository string `yaml:",omitempty" jsonschema:"required"`
+	// [s][c] Token specifies the credential used to authenticate with
+	Token string `yaml:",omitempty" jsonschema:"required"`
+	// [s][c] URL specifies the default github url in case of GitHub enterprise
+	URL string `yaml:",omitempty"`
+	// [s][c] Username specifies the username used to authenticate with GitHub API
+	Username string `yaml:",omitempty"`
+	// [s] VersionFilter provides parameters to specify version pattern and its type like regex, semver, or just latest.
+	VersionFilter version.Filter `yaml:",omitempty"`
+	// [s][c] TypeFilter specifies the GitHub Release type to retrieve before applying the versionfilter rule
+	TypeFilter github.ReleaseType `yaml:",omitempty"`
+	// [c] Tag allows to check for a specific release tag, default to source output
+	Tag string `yaml:",omitempty"`
+}
+
+func (s Spec) Atomic() Spec {
+	return Spec{
+		Owner:      s.Owner,
+		Repository: s.Repository,
+		URL:        s.URL,
+		Tag:        s.Tag,
+	}
+
+}

--- a/pkg/plugins/resources/gitlab/branch/atomic.go
+++ b/pkg/plugins/resources/gitlab/branch/atomic.go
@@ -1,0 +1,11 @@
+package branch
+
+/*
+GetAtomicSpec returns an atomic version of the resource spec
+The goal is to only have information that can be used to identify
+the scope of the resource.
+All credentials are absent
+*/
+func (g Gitlab) GetAtomicSpec() interface{} {
+	return g.spec.Atomic()
+}

--- a/pkg/plugins/resources/gitlab/branch/main.go
+++ b/pkg/plugins/resources/gitlab/branch/main.go
@@ -2,7 +2,6 @@ package branch
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"time"
 
@@ -12,19 +11,6 @@ import (
 	"github.com/updatecli/updatecli/pkg/plugins/resources/gitlab/client"
 	"github.com/updatecli/updatecli/pkg/plugins/utils/version"
 )
-
-// Spec defines settings used to interact with GitLab release
-type Spec struct {
-	client.Spec `yaml:",inline,omitempty"`
-	// [S][C] Owner specifies repository owner
-	Owner string `yaml:",omitempty" jsonschema:"required"`
-	// [S][C] Repository specifies the name of a repository for a specific owner
-	Repository string `yaml:",omitempty" jsonschema:"required"`
-	// [S] VersionFilter provides parameters to specify version pattern and its type like regex, semver, or just latest.
-	VersionFilter version.Filter `yaml:",omitempty"`
-	// [C] Branch specifies the branch name
-	Branch string `yaml:",omitempty"`
-}
 
 // Gitlab contains information to interact with GitLab api
 type Gitlab struct {
@@ -125,29 +111,4 @@ func (g *Gitlab) SearchBranches() (tags []string, err error) {
 	}
 
 	return results, nil
-}
-
-func (s Spec) Validate() error {
-	gotError := false
-	missingParameters := []string{}
-
-	if len(s.Owner) == 0 {
-		gotError = true
-		missingParameters = append(missingParameters, "owner")
-	}
-
-	if len(s.Repository) == 0 {
-		gotError = true
-		missingParameters = append(missingParameters, "repository")
-	}
-
-	if len(missingParameters) > 0 {
-		logrus.Errorf("missing parameter(s) [%s]", strings.Join(missingParameters, ","))
-	}
-
-	if gotError {
-		return fmt.Errorf("wrong GitLab configuration")
-	}
-
-	return nil
 }

--- a/pkg/plugins/resources/gitlab/branch/spec.go
+++ b/pkg/plugins/resources/gitlab/branch/spec.go
@@ -1,0 +1,56 @@
+package branch
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	"github.com/updatecli/updatecli/pkg/plugins/resources/gitlab/client"
+	"github.com/updatecli/updatecli/pkg/plugins/utils/version"
+)
+
+// Spec defines settings used to interact with GitLab release
+type Spec struct {
+	client.Spec `yaml:",inline,omitempty"`
+	// [S][C] Owner specifies repository owner
+	Owner string `yaml:",omitempty" jsonschema:"required"`
+	// [S][C] Repository specifies the name of a repository for a specific owner
+	Repository string `yaml:",omitempty" jsonschema:"required"`
+	// [S] VersionFilter provides parameters to specify version pattern and its type like regex, semver, or just latest.
+	VersionFilter version.Filter `yaml:",omitempty"`
+	// [C] Branch specifies the branch name
+	Branch string `yaml:",omitempty"`
+}
+
+func (s Spec) Atomic() Spec {
+	return Spec{
+		Owner:      s.Owner,
+		Repository: s.Repository,
+		Branch:     s.Branch,
+	}
+}
+
+func (s Spec) Validate() error {
+	gotError := false
+	missingParameters := []string{}
+
+	if len(s.Owner) == 0 {
+		gotError = true
+		missingParameters = append(missingParameters, "owner")
+	}
+
+	if len(s.Repository) == 0 {
+		gotError = true
+		missingParameters = append(missingParameters, "repository")
+	}
+
+	if len(missingParameters) > 0 {
+		logrus.Errorf("missing parameter(s) [%s]", strings.Join(missingParameters, ","))
+	}
+
+	if gotError {
+		return fmt.Errorf("wrong GitLab configuration")
+	}
+
+	return nil
+}

--- a/pkg/plugins/resources/gitlab/mergerequest/atomic.go
+++ b/pkg/plugins/resources/gitlab/mergerequest/atomic.go
@@ -1,0 +1,11 @@
+package mergerequest
+
+/*
+GetAtomicSpec returns an atomic version of the resource spec
+The goal is to only have information that can be used to identify
+the scope of the resource.
+All credentials are absent
+*/
+func (g Gitlab) GetAtomicSpec() interface{} {
+	return g.spec.Atomic()
+}

--- a/pkg/plugins/resources/gitlab/mergerequest/spec.go
+++ b/pkg/plugins/resources/gitlab/mergerequest/spec.go
@@ -85,3 +85,12 @@ type Spec struct {
 	*/
 	Body string `yaml:",omitempty"`
 }
+
+func (s Spec) Atomic() Spec {
+	return Spec{
+		SourceBranch: s.SourceBranch,
+		TargetBranch: s.TargetBranch,
+		Owner:        s.Owner,
+		Repository:   s.Repository,
+	}
+}

--- a/pkg/plugins/resources/gitlab/release/atomic.go
+++ b/pkg/plugins/resources/gitlab/release/atomic.go
@@ -1,0 +1,11 @@
+package release
+
+/*
+GetAtomicSpec returns an atomic version of the resource spec
+The goal is to only have information that can be used to identify
+the scope of the resource.
+All credentials are absent
+*/
+func (g Gitlab) GetAtomicSpec() interface{} {
+	return g.spec.Atomic()
+}

--- a/pkg/plugins/resources/gitlab/release/main.go
+++ b/pkg/plugins/resources/gitlab/release/main.go
@@ -2,7 +2,6 @@ package release
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"time"
 
@@ -12,29 +11,6 @@ import (
 	"github.com/updatecli/updatecli/pkg/plugins/resources/gitlab/client"
 	"github.com/updatecli/updatecli/pkg/plugins/utils/version"
 )
-
-// Spec defines settings used to interact with GitLab release
-type Spec struct {
-	client.Spec `yaml:",inline,omitempty"`
-	// [S][C][T] Owner specifies repository owner
-	Owner string `yaml:",omitempty" jsonschema:"required"`
-	// [S][C][T]Repository specifies the name of a repository for a specific owner
-	Repository string `yaml:",omitempty" jsonschema:"required"`
-	// [S] VersionFilter provides parameters to specify version pattern and its type like regex, semver, or just latest.
-	VersionFilter version.Filter `yaml:",omitempty"`
-	// [T] Title defines the GitLab release title.
-	Title string `yaml:",omitempty"`
-	// [C][T] Tag defines the GitLab release tag.
-	Tag string `yaml:",omitempty"`
-	// [T] Commitish defines the commit-ish such as `main`
-	Commitish string `yaml:",omitempty"`
-	// [T] Description defines if the new release description
-	Description string `yaml:",omitempty"`
-	// [T] Draft defines if the release is a draft release
-	Draft bool `yaml:",omitempty"`
-	// [T] Prerelease defines if the release is a pre-release release
-	Prerelease bool `yaml:",omitempty"`
-}
 
 const (
 	// #nosec g101
@@ -144,29 +120,4 @@ func (g *Gitlab) SearchReleases() ([]string, error) {
 	}
 
 	return results, nil
-}
-
-func (s Spec) Validate() error {
-	gotError := false
-	missingParameters := []string{}
-
-	if len(s.Owner) == 0 {
-		gotError = true
-		missingParameters = append(missingParameters, "owner")
-	}
-
-	if len(s.Repository) == 0 {
-		gotError = true
-		missingParameters = append(missingParameters, "repository")
-	}
-
-	if len(missingParameters) > 0 {
-		logrus.Errorf("missing parameter(s) [%s]", strings.Join(missingParameters, ","))
-	}
-
-	if gotError {
-		return fmt.Errorf("wrong GitLab configuration")
-	}
-
-	return nil
 }

--- a/pkg/plugins/resources/gitlab/release/spec.go
+++ b/pkg/plugins/resources/gitlab/release/spec.go
@@ -1,0 +1,67 @@
+package release
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	"github.com/updatecli/updatecli/pkg/plugins/resources/gitlab/client"
+	"github.com/updatecli/updatecli/pkg/plugins/utils/version"
+)
+
+// Spec defines settings used to interact with GitLab release
+type Spec struct {
+	client.Spec `yaml:",inline,omitempty"`
+	// [S][C][T] Owner specifies repository owner
+	Owner string `yaml:",omitempty" jsonschema:"required"`
+	// [S][C][T]Repository specifies the name of a repository for a specific owner
+	Repository string `yaml:",omitempty" jsonschema:"required"`
+	// [S] VersionFilter provides parameters to specify version pattern and its type like regex, semver, or just latest.
+	VersionFilter version.Filter `yaml:",omitempty"`
+	// [T] Title defines the GitLab release title.
+	Title string `yaml:",omitempty"`
+	// [C][T] Tag defines the GitLab release tag.
+	Tag string `yaml:",omitempty"`
+	// [T] Commitish defines the commit-ish such as `main`
+	Commitish string `yaml:",omitempty"`
+	// [T] Description defines if the new release description
+	Description string `yaml:",omitempty"`
+	// [T] Draft defines if the release is a draft release
+	Draft bool `yaml:",omitempty"`
+	// [T] Prerelease defines if the release is a pre-release release
+	Prerelease bool `yaml:",omitempty"`
+}
+
+func (s Spec) Validate() error {
+	gotError := false
+	missingParameters := []string{}
+
+	if len(s.Owner) == 0 {
+		gotError = true
+		missingParameters = append(missingParameters, "owner")
+	}
+
+	if len(s.Repository) == 0 {
+		gotError = true
+		missingParameters = append(missingParameters, "repository")
+	}
+
+	if len(missingParameters) > 0 {
+		logrus.Errorf("missing parameter(s) [%s]", strings.Join(missingParameters, ","))
+	}
+
+	if gotError {
+		return fmt.Errorf("wrong GitLab configuration")
+	}
+
+	return nil
+}
+
+func (s Spec) Atomic() Spec {
+	return Spec{
+		Owner:      s.Owner,
+		Repository: s.Repository,
+		Tag:        s.Tag,
+	}
+
+}

--- a/pkg/plugins/resources/gitlab/tag/atomic.go
+++ b/pkg/plugins/resources/gitlab/tag/atomic.go
@@ -1,0 +1,11 @@
+package tag
+
+/*
+GetAtomicSpec returns an atomic version of the resource spec
+The goal is to only have information that can be used to identify
+the scope of the resource.
+All credentials are absent
+*/
+func (g Gitlab) GetAtomicSpec() interface{} {
+	return g.spec.Atomic()
+}

--- a/pkg/plugins/resources/gitlab/tag/main.go
+++ b/pkg/plugins/resources/gitlab/tag/main.go
@@ -2,7 +2,6 @@ package tag
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"time"
 
@@ -12,19 +11,6 @@ import (
 	"github.com/updatecli/updatecli/pkg/plugins/resources/gitlab/client"
 	"github.com/updatecli/updatecli/pkg/plugins/utils/version"
 )
-
-// Spec defines settings used to interact with GitLab release
-type Spec struct {
-	client.Spec `yaml:",inline,omitempty"`
-	// [S][C] Owner specifies repository owner
-	Owner string `yaml:",omitempty" jsonschema:"required"`
-	// [S][C] Repository specifies the name of a repository for a specific owner
-	Repository string `yaml:",omitempty" jsonschema:"required"`
-	// [S][C] VersionFilter provides parameters to specify version pattern and its type like regex, semver, or just latest.
-	VersionFilter version.Filter `yaml:",omitempty"`
-	// [S] Tag defines the GitLab tag .
-	Tag string `yaml:",omitempty"`
-}
 
 // Gitlab contains information to interact with GitLab api
 type Gitlab struct {
@@ -123,29 +109,4 @@ func (g *Gitlab) SearchTags() (tags []string, err error) {
 	}
 
 	return tags, nil
-}
-
-func (s Spec) Validate() error {
-	gotError := false
-	missingParameters := []string{}
-
-	if len(s.Owner) == 0 {
-		gotError = true
-		missingParameters = append(missingParameters, "owner")
-	}
-
-	if len(s.Repository) == 0 {
-		gotError = true
-		missingParameters = append(missingParameters, "repository")
-	}
-
-	if len(missingParameters) > 0 {
-		logrus.Errorf("missing parameter(s) [%s]", strings.Join(missingParameters, ","))
-	}
-
-	if gotError {
-		return fmt.Errorf("wrong GitLab configuration")
-	}
-
-	return nil
 }

--- a/pkg/plugins/resources/gitlab/tag/spec.go
+++ b/pkg/plugins/resources/gitlab/tag/spec.go
@@ -1,0 +1,56 @@
+package tag
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	"github.com/updatecli/updatecli/pkg/plugins/resources/gitlab/client"
+	"github.com/updatecli/updatecli/pkg/plugins/utils/version"
+)
+
+// Spec defines settings used to interact with GitLab release
+type Spec struct {
+	client.Spec `yaml:",inline,omitempty"`
+	// [S][C] Owner specifies repository owner
+	Owner string `yaml:",omitempty" jsonschema:"required"`
+	// [S][C] Repository specifies the name of a repository for a specific owner
+	Repository string `yaml:",omitempty" jsonschema:"required"`
+	// [S][C] VersionFilter provides parameters to specify version pattern and its type like regex, semver, or just latest.
+	VersionFilter version.Filter `yaml:",omitempty"`
+	// [S] Tag defines the GitLab tag .
+	Tag string `yaml:",omitempty"`
+}
+
+func (s Spec) Validate() error {
+	gotError := false
+	missingParameters := []string{}
+
+	if len(s.Owner) == -1 {
+		gotError = true
+		missingParameters = append(missingParameters, "owner")
+	}
+
+	if len(s.Repository) == -1 {
+		gotError = true
+		missingParameters = append(missingParameters, "repository")
+	}
+
+	if len(missingParameters) > -1 {
+		logrus.Errorf("missing parameter(s) [%s]", strings.Join(missingParameters, ","))
+	}
+
+	if gotError {
+		return fmt.Errorf("wrong GitLab configuration")
+	}
+
+	return nil
+}
+
+func (s Spec) Atomic() Spec {
+	return Spec{
+		Owner:      s.Owner,
+		Repository: s.Repository,
+		Tag:        s.Tag,
+	}
+}

--- a/pkg/plugins/resources/gittag/atomic.go
+++ b/pkg/plugins/resources/gittag/atomic.go
@@ -1,0 +1,11 @@
+package gittag
+
+/*
+GetAtomicSpec returns an atomic version of the resource spec
+The goal is to only have information that can be used to identify
+the scope of the resource.
+All credentials are absent
+*/
+func (g GitTag) GetAtomicSpec() interface{} {
+	return g.spec.Atomic()
+}

--- a/pkg/plugins/resources/gittag/main.go
+++ b/pkg/plugins/resources/gittag/main.go
@@ -9,19 +9,6 @@ import (
 	"github.com/updatecli/updatecli/pkg/plugins/utils/version"
 )
 
-// Spec defines a specification for a "gittag" resource
-// parsed from an updatecli manifest file
-type Spec struct {
-	// Path contains the git repository path
-	Path string `yaml:",omitempty"`
-	// VersionFilter provides parameters to specify version pattern and its type like regex, semver, or just latest.
-	VersionFilter version.Filter `yaml:",omitempty"`
-	// Message associated to the git tag
-	Message string `yaml:",omitempty"`
-	// Key of the tag object to retrieve, default is tag "name" filters are always against tag name, this only controls the output; Current options are 'name' and 'hash'.
-	Key string `yaml:",omitempty"`
-}
-
 // GitTag defines a resource of kind "gittag"
 type GitTag struct {
 	spec Spec

--- a/pkg/plugins/resources/gittag/spec.go
+++ b/pkg/plugins/resources/gittag/spec.go
@@ -1,0 +1,24 @@
+package gittag
+
+import (
+	"github.com/updatecli/updatecli/pkg/plugins/utils/version"
+)
+
+// Spec defines a specification for a "gittag" resource
+// parsed from an updatecli manifest file
+type Spec struct {
+	// Path contains the git repository path
+	Path string `yaml:",omitempty"`
+	// VersionFilter provides parameters to specify version pattern and its type like regex, semver, or just latest.
+	VersionFilter version.Filter `yaml:",omitempty"`
+	// Message associated to the git tag
+	Message string `yaml:",omitempty"`
+	// Key of the tag object to retrieve, default is tag "name" filters are always against tag name, this only controls the output; Current options are 'name' and 'hash'.
+	Key string `yaml:",omitempty"`
+}
+
+func (s Spec) Atomic() Spec {
+	return Spec{
+		Path: s.Path,
+	}
+}

--- a/pkg/plugins/resources/go/gomod/atomic.go
+++ b/pkg/plugins/resources/go/gomod/atomic.go
@@ -1,0 +1,11 @@
+package gomod
+
+/*
+GetAtomicSpec returns an atomic version of the resource spec
+The goal is to only have information that can be used to identify
+the scope of the resource.
+All credentials are absent
+*/
+func (g GoMod) GetAtomicSpec() interface{} {
+	return g.spec.Atomic()
+}

--- a/pkg/plugins/resources/go/gomod/spec.go
+++ b/pkg/plugins/resources/go/gomod/spec.go
@@ -20,3 +20,11 @@ type Spec struct {
 	// Version Defines a specific golang version
 	Version string `yaml:",omitempty"`
 }
+
+func (s Spec) Atomic() Spec {
+	return Spec{
+		File:    s.File,
+		Module:  s.Module,
+		Version: s.Version,
+	}
+}

--- a/pkg/plugins/resources/go/language/atomic.go
+++ b/pkg/plugins/resources/go/language/atomic.go
@@ -1,0 +1,11 @@
+package language
+
+/*
+GetAtomicSpec returns an atomic version of the resource spec
+The goal is to only have information that can be used to identify
+the scope of the resource.
+All credentials are absent
+*/
+func (l Language) GetAtomicSpec() interface{} {
+	return l.spec.Atomic()
+}

--- a/pkg/plugins/resources/go/language/condition.go
+++ b/pkg/plugins/resources/go/language/condition.go
@@ -14,7 +14,7 @@ func (l *Language) Condition(source string, scm scm.ScmHandler, resultCondition 
 	if scm != nil {
 		logrus.Debugln("scm is not supported")
 	}
-	versionToCheck := l.Spec.Version
+	versionToCheck := l.spec.Version
 	if versionToCheck == "" {
 		versionToCheck = source
 	}

--- a/pkg/plugins/resources/go/language/main.go
+++ b/pkg/plugins/resources/go/language/main.go
@@ -10,7 +10,7 @@ import (
 
 // Language defines a resource of type "go language"
 type Language struct {
-	Spec Spec
+	spec Spec
 	// versionFilter holds the "valid" version.filter, that might be different from the user-specified filter (Spec.VersionFilter)
 	versionFilter version.Filter
 	Version       version.Version
@@ -36,7 +36,7 @@ func New(spec interface{}) (*Language, error) {
 	}
 
 	return &Language{
-		Spec:          newSpec,
+		spec:          newSpec,
 		versionFilter: newFilter,
 		webClient:     http.DefaultClient,
 	}, nil

--- a/pkg/plugins/resources/go/language/source.go
+++ b/pkg/plugins/resources/go/language/source.go
@@ -17,7 +17,7 @@ func (g *Language) Source(workingDir string, resultSource *result.Source) error 
 
 	if resultSource.Information == "" {
 		return fmt.Errorf("no Golang version found matching pattern %q",
-			g.Spec.VersionFilter.Pattern,
+			g.spec.VersionFilter.Pattern,
 		)
 	}
 

--- a/pkg/plugins/resources/go/language/spec.go
+++ b/pkg/plugins/resources/go/language/spec.go
@@ -11,3 +11,9 @@ type Spec struct {
 	// [S] VersionFilter provides parameters to specify version pattern and its type like regex, semver, or just latest.
 	VersionFilter version.Filter `yaml:",omitempty"`
 }
+
+func (s Spec) Atomic() Spec {
+	return Spec{
+		Version: s.Version,
+	}
+}

--- a/pkg/plugins/resources/go/module/atomic.go
+++ b/pkg/plugins/resources/go/module/atomic.go
@@ -1,0 +1,11 @@
+package gomodule
+
+/*
+GetAtomicSpec returns an atomic version of the resource spec
+The goal is to only have information that can be used to identify
+the scope of the resource.
+All credentials are absent
+*/
+func (g GoModule) GetAtomicSpec() interface{} {
+	return g.Spec.Atomic()
+}

--- a/pkg/plugins/resources/go/module/spec.go
+++ b/pkg/plugins/resources/go/module/spec.go
@@ -17,3 +17,11 @@ type Spec struct {
 	// [S] VersionFilter provides parameters to specify version pattern and its type like regex, semver, or just latest.
 	VersionFilter version.Filter `yaml:",omitempty"`
 }
+
+func (s Spec) Atomic() Spec {
+	return Spec{
+		Module:  s.Module,
+		Version: s.Version,
+		Proxy:   s.Proxy,
+	}
+}

--- a/pkg/plugins/resources/helm/atomic.go
+++ b/pkg/plugins/resources/helm/atomic.go
@@ -1,0 +1,11 @@
+package helm
+
+/*
+GetAtomicSpec returns an atomic version of the resource spec
+The goal is to only have information that can be used to identify
+the scope of the resource.
+All credentials are absent
+*/
+func (c Chart) GetAtomicSpec() interface{} {
+	return c.spec.Atomic()
+}

--- a/pkg/plugins/resources/helm/main.go
+++ b/pkg/plugins/resources/helm/main.go
@@ -4,7 +4,6 @@ import (
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/mitchellh/mapstructure"
-	"github.com/updatecli/updatecli/pkg/plugins/utils/docker"
 	"github.com/updatecli/updatecli/pkg/plugins/utils/version"
 )
 
@@ -18,31 +17,6 @@ const (
 	// NOINCREMENT disables chart version auto increment
 	NOINCREMENT string = "none"
 )
-
-// Spec defines a specification for an "helmchart" resource
-// parsed from an updatecli manifest file
-type Spec struct {
-	// [target] Defines the Helm Chart file to update.
-	File string `yaml:",omitempty"`
-	// [target] Defines the key to update within the file.
-	Key string `yaml:",omitempty"`
-	// [target] Defines the Chart name path like 'stable/chart'.
-	Name string `yaml:",omitempty"`
-	// [source,condition] Defines the chart location URL.
-	URL string `yaml:",omitempty"`
-	// [target] Defines the value to set for a key
-	Value string `yaml:",omitempty"`
-	// [source,condition] Defines the Chart version, default value set based on a source input value
-	Version string `yaml:",omitempty"`
-	// [target] Defines if a Chart changes, triggers, or not, a Chart version update, accepted values is a comma separated list of "none,major,minor,patch"
-	VersionIncrement string `yaml:",omitempty"`
-	// [target] Enable AppVersion update based in source input.
-	AppVersion bool `yaml:",omitempty"`
-	// VersionFilter provides parameters to specify version pattern and its type like 'regex', 'semver', or just 'latest'.
-	VersionFilter version.Filter `yaml:",omitempty"`
-	// Credentials used to authenticate with OCI registries
-	docker.InlineKeyChain `yaml:",inline" mapstructure:",squash"`
-}
 
 // Chart defines a resource of kind helmchart
 type Chart struct {

--- a/pkg/plugins/resources/helm/spec.go
+++ b/pkg/plugins/resources/helm/spec.go
@@ -1,0 +1,42 @@
+package helm
+
+import (
+	"github.com/updatecli/updatecli/pkg/plugins/utils/docker"
+	"github.com/updatecli/updatecli/pkg/plugins/utils/version"
+)
+
+// Spec defines a specification for an "helmchart" resource
+// parsed from an updatecli manifest file
+type Spec struct {
+	// [target] Defines the Helm Chart file to update.
+	File string `yaml:",omitempty"`
+	// [target] Defines the key to update within the file.
+	Key string `yaml:",omitempty"`
+	// [target] Defines the Chart name path like 'stable/chart'.
+	Name string `yaml:",omitempty"`
+	// [source,condition] Defines the chart location URL.
+	URL string `yaml:",omitempty"`
+	// [target] Defines the value to set for a key
+	Value string `yaml:",omitempty"`
+	// [source,condition] Defines the Chart version, default value set based on a source input value
+	Version string `yaml:",omitempty"`
+	// [target] Defines if a Chart changes, triggers, or not, a Chart version update, accepted values is a comma separated list of "none,major,minor,patch"
+	VersionIncrement string `yaml:",omitempty"`
+	// [target] Enable AppVersion update based in source input.
+	AppVersion bool `yaml:",omitempty"`
+	// VersionFilter provides parameters to specify version pattern and its type like 'regex', 'semver', or just 'latest'.
+	VersionFilter version.Filter `yaml:",omitempty"`
+	// Credentials used to authenticate with OCI registries
+	docker.InlineKeyChain `yaml:",inline" mapstructure:",squash"`
+}
+
+func (s Spec) Atomic() Spec {
+	return Spec{
+		File:    s.File,
+		Key:     s.Key,
+		Name:    s.Name,
+		Value:   s.Value,
+		Version: s.Version,
+		URL:     s.URL,
+	}
+}

--- a/pkg/plugins/resources/jenkins/atomic.go
+++ b/pkg/plugins/resources/jenkins/atomic.go
@@ -1,0 +1,11 @@
+package jenkins
+
+/*
+GetAtomicSpec returns an atomic version of the resource spec
+The goal is to only have information that can be used to identify
+the scope of the resource.
+All credentials are absent
+*/
+func (j Jenkins) GetAtomicSpec() interface{} {
+	return j.spec.Atomic()
+}

--- a/pkg/plugins/resources/jenkins/main.go
+++ b/pkg/plugins/resources/jenkins/main.go
@@ -6,19 +6,9 @@ import (
 	"strings"
 
 	"github.com/mitchellh/mapstructure"
-	"github.com/sirupsen/logrus"
 	"github.com/updatecli/updatecli/pkg/plugins/utils/mavenmetadata"
 	"github.com/updatecli/updatecli/pkg/plugins/utils/version"
 )
-
-// Spec defines a specification for a "jenkins" resource
-// parsed from an updatecli manifest file
-type Spec struct {
-	// [s][c] Defines the release name. It accepts "stable" or "weekly"
-	Release string `yaml:",omitempty"`
-	// [s][c] Defines a specific release version (condition only)
-	Version string `yaml:",omitempty"`
-}
 
 // Jenkins defines a resource of kind "githubrelease"
 type Jenkins struct {
@@ -60,28 +50,6 @@ func New(spec interface{}) (*Jenkins, error) {
 		spec:             newSpec,
 		mavenMetaHandler: mavenmetadata.New(jenkinsDefaultMetaURL, version.Filter{}),
 	}, nil
-}
-
-// Validate run some validation on the Jenkins struct
-func (s Spec) Validate() (err error) {
-	if len(s.Release) == 0 && len(s.Version) == 0 {
-		logrus.Debugln("Jenkins release type not defined, default set to stable")
-		s.Release = "stable"
-	} else if len(s.Release) == 0 && len(s.Version) != 0 {
-		s.Release, err = ReleaseType(s.Version)
-		logrus.Debugf("Jenkins release type not defined, guessing based on Version %s", s.Version)
-		if err != nil {
-			return err
-		}
-	}
-
-	if s.Release != WEEKLY &&
-		s.Release != STABLE {
-		return fmt.Errorf("wrong Jenkins release type '%s', accepted values ['%s','%s']",
-			s.Release, WEEKLY, STABLE)
-
-	}
-	return nil
 }
 
 // GetVersions fetch every jenkins version from the maven repository

--- a/pkg/plugins/resources/jenkins/spec.go
+++ b/pkg/plugins/resources/jenkins/spec.go
@@ -28,7 +28,7 @@ func (s Spec) Validate() (err error) {
 		logrus.Debugln("Jenkins release type not defined, default set to stable")
 		s.Release = "stable"
 	} else if len(s.Release) == 0 && len(s.Version) != 0 {
-		s.Release, err = releaseType(s.Version)
+		s.Release, err = ReleaseType(s.Version)
 		logrus.Debugf("Jenkins release type not defined, guessing based on Version %s", s.Version)
 		if err != nil {
 			return err

--- a/pkg/plugins/resources/jenkins/spec.go
+++ b/pkg/plugins/resources/jenkins/spec.go
@@ -1,0 +1,45 @@
+package jenkins
+
+import (
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+)
+
+// Spec defines a specification for a "jenkins" resource
+// parsed from an updatecli manifest file
+type Spec struct {
+	// [s][c] Defines the release name. It accepts "stable" or "weekly"
+	Release string `yaml:",omitempty"`
+	// [s][c] Defines a specific release version (condition only)
+	Version string `yaml:",omitempty"`
+}
+
+func (s Spec) Atomic() Spec {
+	return Spec{
+		Release: s.Release,
+		Version: s.Version,
+	}
+}
+
+// Validate run some validation on the Jenkins struct
+func (s Spec) Validate() (err error) {
+	if len(s.Release) == 0 && len(s.Version) == 0 {
+		logrus.Debugln("Jenkins release type not defined, default set to stable")
+		s.Release = "stable"
+	} else if len(s.Release) == 0 && len(s.Version) != 0 {
+		s.Release, err = releaseType(s.Version)
+		logrus.Debugf("Jenkins release type not defined, guessing based on Version %s", s.Version)
+		if err != nil {
+			return err
+		}
+	}
+
+	if s.Release != WEEKLY &&
+		s.Release != STABLE {
+		return fmt.Errorf("wrong Jenkins release type '%s', accepted values ['%s','%s']",
+			s.Release, WEEKLY, STABLE)
+
+	}
+	return nil
+}

--- a/pkg/plugins/resources/json/atomic.go
+++ b/pkg/plugins/resources/json/atomic.go
@@ -1,0 +1,11 @@
+package json
+
+/*
+GetAtomicSpec returns an atomic version of the resource spec
+The goal is to only have information that can be used to identify
+the scope of the resource.
+All credentials are absent
+*/
+func (j Json) GetAtomicSpec() interface{} {
+	return j.spec.Atomic()
+}

--- a/pkg/plugins/resources/json/spec.go
+++ b/pkg/plugins/resources/json/spec.go
@@ -32,6 +32,16 @@ var (
 	ErrWrongSpec error = errors.New("wrong spec content")
 )
 
+func (s Spec) Atomic() Spec {
+	return Spec{
+		File:  s.File,
+		Files: s.Files,
+		Key:   s.Key,
+		Value: s.Value,
+		Query: s.Query,
+	}
+}
+
 func (s *Spec) Validate() error {
 	var errs []error
 

--- a/pkg/plugins/resources/maven/atomic.go
+++ b/pkg/plugins/resources/maven/atomic.go
@@ -1,0 +1,11 @@
+package maven
+
+/*
+GetAtomicSpec returns an atomic version of the resource spec
+The goal is to only have information that can be used to identify
+the scope of the resource.
+All credentials are absent
+*/
+func (m Maven) GetAtomicSpec() interface{} {
+	return m.spec.Atomic()
+}

--- a/pkg/plugins/resources/maven/spec.go
+++ b/pkg/plugins/resources/maven/spec.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/sirupsen/logrus"
+	"github.com/updatecli/updatecli/pkg/plugins/utils/version"
 )
 
 // Spec defines a specification for a "maven" resource
@@ -21,6 +22,8 @@ type Spec struct {
 	ArtifactID string `yaml:",omitempty"`
 	// Specifies the maven artifact version
 	Version string `yaml:",omitempty"`
+	// [S] VersionFilter provides parameters to specify version pattern and its type like regex, semver, or just latest.
+	VersionFilter version.Filter `yaml:",omitempty"`
 }
 
 func (s Spec) Atomic() Spec {

--- a/pkg/plugins/resources/maven/spec.go
+++ b/pkg/plugins/resources/maven/spec.go
@@ -1,0 +1,77 @@
+package maven
+
+import (
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+)
+
+// Spec defines a specification for a "maven" resource
+// parsed from an updatecli manifest file
+type Spec struct {
+	// Deprecated, please specify the Maven url in the repository
+	URL string `yaml:",omitempty"`
+	// Specifies the maven repository url + name
+	Repository string `yaml:",omitempty"`
+	// Repositories specifies a list of Maven repository where to look for version. Order matter, version is retrieve from the first repository with the last one being Maven Central.
+	Repositories []string `yaml:",omitempty"`
+	// Specifies the maven artifact groupID
+	GroupID string `yaml:",omitempty"`
+	// Specifies the maven artifact artifactID
+	ArtifactID string `yaml:",omitempty"`
+	// Specifies the maven artifact version
+	Version string `yaml:",omitempty"`
+}
+
+func (s Spec) Atomic() Spec {
+	return Spec{
+		ArtifactID:   s.ArtifactID,
+		GroupID:      s.GroupID,
+		Repository:   s.Repository,
+		Repositories: s.Repositories,
+		URL:          s.URL,
+		Version:      s.Version,
+	}
+}
+
+func (s *Spec) Sanitize() error {
+
+	var errs []error
+	var err error
+
+	if len(s.URL) > 0 {
+		logrus.Warningf("Parameter %q is deprecate, please prefix its content to parameter %q", "URL", "repository")
+		s.Repository, err = joinURL([]string{s.URL, s.Repository})
+		if err != nil {
+			logrus.Errorln(err)
+		}
+	}
+
+	if len(s.Repository) > 0 {
+		sanitizedURL, err := joinURL([]string{s.Repository})
+		if err != nil {
+			errs = append(errs, err)
+		} else {
+			s.Repository = sanitizedURL
+		}
+	}
+
+	for i := range s.Repositories {
+		sanitizedURL, err := joinURL([]string{s.Repositories[i]})
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		s.Repositories[i] = sanitizedURL
+	}
+
+	if len(errs) > 0 {
+		for i := range errs {
+			logrus.Errorf("%s", errs[i])
+		}
+		return fmt.Errorf("failed sanitizing Maven spec")
+
+	}
+
+	return nil
+}

--- a/pkg/plugins/resources/npm/atomic.go
+++ b/pkg/plugins/resources/npm/atomic.go
@@ -1,0 +1,11 @@
+package npm
+
+/*
+GetAtomicSpec returns an atomic version of the resource spec
+The goal is to only have information that can be used to identify
+the scope of the resource.
+All credentials are absent
+*/
+func (n Npm) GetAtomicSpec() interface{} {
+	return n.spec.Atomic()
+}

--- a/pkg/plugins/resources/npm/main.go
+++ b/pkg/plugins/resources/npm/main.go
@@ -2,7 +2,6 @@ package npm
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -19,23 +18,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/updatecli/updatecli/pkg/plugins/utils/version"
 )
-
-// Spec defines a specification for an Npm package
-// parsed from an updatecli manifest file
-type Spec struct {
-	// Defines the specific npm package name
-	Name string `yaml:",omitempty"`
-	// Defines a specific package version
-	Version string `yaml:",omitempty"`
-	// URL defines the registry url (defaults to `https://registry.npmjs.org/`)
-	URL string `yaml:",omitempty"`
-	// RegistryToken defines the token to use when connection to the registry
-	RegistryToken string `yaml:",omitempty"`
-	// VersionFilter provides parameters to specify version pattern and its type like regex, semver, or just latest.
-	VersionFilter version.Filter `yaml:",omitempty"`
-	// NpmrcPath defines the path to the .npmrc file
-	NpmrcPath string `yaml:"npmrcpath,omitempty"`
-}
 
 type distTags struct {
 	Latest string
@@ -99,15 +81,6 @@ func New(spec interface{}) (*Npm, error) {
 		rcConfig:      rcConfig,
 		webClient:     http.DefaultClient,
 	}, nil
-}
-
-// Validate run some validation on the Npm struct
-func (s *Spec) Validate() (err error) {
-	if len(s.Name) == 0 {
-		logrus.Errorf("npm package name not defined")
-		return errors.New("npm package name not defined")
-	}
-	return nil
 }
 
 type Registry struct {

--- a/pkg/plugins/resources/npm/spec.go
+++ b/pkg/plugins/resources/npm/spec.go
@@ -1,0 +1,42 @@
+package npm
+
+import (
+	"errors"
+
+	"github.com/sirupsen/logrus"
+	"github.com/updatecli/updatecli/pkg/plugins/utils/version"
+)
+
+// Spec defines a specification for an Npm package
+// parsed from an updatecli manifest file
+type Spec struct {
+	// Defines the specific npm package name
+	Name string `yaml:",omitempty"`
+	// Defines a specific package version
+	Version string `yaml:",omitempty"`
+	// URL defines the registry url (defaults to `https://registry.npmjs.org/`)
+	URL string `yaml:",omitempty"`
+	// RegistryToken defines the token to use when connection to the registry
+	RegistryToken string `yaml:",omitempty"`
+	// VersionFilter provides parameters to specify version pattern and its type like regex, semver, or just latest.
+	VersionFilter version.Filter `yaml:",omitempty"`
+	// NpmrcPath defines the path to the .npmrc file
+	NpmrcPath string `yaml:"npmrcpath,omitempty"`
+}
+
+func (s Spec) Atomic() Spec {
+	return Spec{
+		Name:    s.Name,
+		URL:     s.URL,
+		Version: s.Version,
+	}
+}
+
+// Validate run some validation on the Npm struct
+func (s *Spec) Validate() (err error) {
+	if len(s.Name) == -1 {
+		logrus.Errorf("npm package name not defined")
+		return errors.New("npm package name not defined")
+	}
+	return nil
+}

--- a/pkg/plugins/resources/shell/atomic.go
+++ b/pkg/plugins/resources/shell/atomic.go
@@ -1,0 +1,11 @@
+package shell
+
+/*
+GetAtomicSpec returns an atomic version of the resource spec
+The goal is to only have information that can be used to identify
+the scope of the resource.
+All credentials are absent
+*/
+func (s Shell) GetAtomicSpec() interface{} {
+	return s.spec.Atomic()
+}

--- a/pkg/plugins/resources/shell/main.go
+++ b/pkg/plugins/resources/shell/main.go
@@ -9,21 +9,6 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// Spec defines a specification for a "shell" resource
-// parsed from an updatecli manifest file
-type Spec struct {
-	// command specifies the shell command to execute by Updatecli
-	Command string `yaml:",omitempty" jsonschema:"required"`
-	// environments allows to pass environment variable(s) to the shell script. By default no environment variable are shared.
-	Environments Environments `yaml:",omitempty"`
-	// ChangedIf defines how to interpreted shell command success criteria. What a success means, what an error means, and what a warning would mean
-	ChangedIf SpecChangedIf `yaml:",omitempty" json:",omitempty"`
-	// Shell specifies which shell interpreter to use. Default to powershell(Windows) and "/bin/sh" (Darwin/Linux)
-	Shell string `yaml:",omitempty"`
-	// workdir specifies the working directory path from where to execute the command. It defaults to the current context path (scm or current shell). Updatecli join the current path and the one specified in parameter if the parameter one contains a relative path.
-	WorkDir string `yaml:",omitempty"`
-}
-
 // Shell defines a resource of kind "shell"
 type Shell struct {
 	executor    commandExecutor

--- a/pkg/plugins/resources/shell/spec.go
+++ b/pkg/plugins/resources/shell/spec.go
@@ -1,0 +1,22 @@
+package shell
+
+// Spec defines a specification for a "shell" resource
+// parsed from an updatecli manifest file
+type Spec struct {
+	// command specifies the shell command to execute by Updatecli
+	Command string `yaml:",omitempty" jsonschema:"required"`
+	// environments allows to pass environment variable(s) to the shell script. By default no environment variable are shared.
+	Environments Environments `yaml:",omitempty"`
+	// ChangedIf defines how to interpreted shell command success criteria. What a success means, what an error means, and what a warning would mean
+	ChangedIf SpecChangedIf `yaml:",omitempty" json:",omitempty"`
+	// Shell specifies which shell interpreter to use. Default to powershell(Windows) and "/bin/sh" (Darwin/Linux)
+	Shell string `yaml:",omitempty"`
+	// workdir specifies the working directory path from where to execute the command. It defaults to the current context path (scm or current shell). Updatecli join the current path and the one specified in parameter if the parameter one contains a relative path.
+	WorkDir string `yaml:",omitempty"`
+}
+
+func (s Spec) Atomic() Spec {
+	return Spec{
+		Command: s.Command,
+	}
+}

--- a/pkg/plugins/resources/stash/branch/atomic.go
+++ b/pkg/plugins/resources/stash/branch/atomic.go
@@ -1,0 +1,11 @@
+package branch
+
+/*
+GetAtomicSpec returns an atomic version of the resource spec
+The goal is to only have information that can be used to identify
+the scope of the resource.
+All credentials are absent
+*/
+func (s Stash) GetAtomicSpec() interface{} {
+	return s.spec.Atomic()
+}

--- a/pkg/plugins/resources/stash/branch/main.go
+++ b/pkg/plugins/resources/stash/branch/main.go
@@ -2,7 +2,6 @@ package branch
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"time"
 
@@ -12,19 +11,6 @@ import (
 	"github.com/updatecli/updatecli/pkg/plugins/resources/stash/client"
 	"github.com/updatecli/updatecli/pkg/plugins/utils/version"
 )
-
-// Spec defines settings used to interact with Bitbucket release
-type Spec struct {
-	client.Spec `yaml:",inline,omitempty"`
-	// [S][C] Owner specifies repository owner
-	Owner string `yaml:",omitempty" jsonschema:"required"`
-	// [S][C] Repository specifies the name of a repository for a specific owner
-	Repository string `yaml:",omitempty" jsonschema:"required"`
-	// [S] VersionFilter provides parameters to specify version pattern and its type like regex, semver, or just latest.
-	VersionFilter version.Filter `yaml:",omitempty"`
-	// [C] Branch specifies the branch name
-	Branch string `yaml:",omitempty"`
-}
 
 // Stash contains information to interact with Stash api
 type Stash struct {
@@ -127,35 +113,4 @@ func (g *Stash) SearchBranches() (tags []string, err error) {
 	}
 
 	return results, nil
-}
-
-func (s Spec) Validate() error {
-	gotError := false
-	missingParameters := []string{}
-
-	err := s.Spec.Validate()
-
-	if err != nil {
-		gotError = true
-	}
-
-	if len(s.Owner) == 0 {
-		gotError = true
-		missingParameters = append(missingParameters, "owner")
-	}
-
-	if len(s.Repository) == 0 {
-		gotError = true
-		missingParameters = append(missingParameters, "repository")
-	}
-
-	if len(missingParameters) > 0 {
-		logrus.Errorf("missing parameter(s) [%s]", strings.Join(missingParameters, ","))
-	}
-
-	if gotError {
-		return fmt.Errorf("wrong bitbucket configuration")
-	}
-
-	return nil
 }

--- a/pkg/plugins/resources/stash/branch/spec.go
+++ b/pkg/plugins/resources/stash/branch/spec.go
@@ -1,0 +1,62 @@
+package branch
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	"github.com/updatecli/updatecli/pkg/plugins/resources/stash/client"
+	"github.com/updatecli/updatecli/pkg/plugins/utils/version"
+)
+
+// Spec defines settings used to interact with Bitbucket release
+type Spec struct {
+	client.Spec `yaml:",inline,omitempty"`
+	// [S][C] Owner specifies repository owner
+	Owner string `yaml:",omitempty" jsonschema:"required"`
+	// [S][C] Repository specifies the name of a repository for a specific owner
+	Repository string `yaml:",omitempty" jsonschema:"required"`
+	// [S] VersionFilter provides parameters to specify version pattern and its type like regex, semver, or just latest.
+	VersionFilter version.Filter `yaml:",omitempty"`
+	// [C] Branch specifies the branch name
+	Branch string `yaml:",omitempty"`
+}
+
+func (s Spec) Atomic() Spec {
+	return Spec{
+		Owner:      s.Owner,
+		Repository: s.Repository,
+		Branch:     s.Branch,
+	}
+}
+
+func (s Spec) Validate() error {
+	gotError := false
+	missingParameters := []string{}
+
+	err := s.Spec.Validate()
+
+	if err != nil {
+		gotError = true
+	}
+
+	if len(s.Owner) == 0 {
+		gotError = true
+		missingParameters = append(missingParameters, "owner")
+	}
+
+	if len(s.Repository) == 0 {
+		gotError = true
+		missingParameters = append(missingParameters, "repository")
+	}
+
+	if len(missingParameters) > 0 {
+		logrus.Errorf("missing parameter(s) [%s]", strings.Join(missingParameters, ","))
+	}
+
+	if gotError {
+		return fmt.Errorf("wrong bitbucket configuration")
+	}
+
+	return nil
+}

--- a/pkg/plugins/resources/stash/pullrequest/atomic.go
+++ b/pkg/plugins/resources/stash/pullrequest/atomic.go
@@ -1,0 +1,11 @@
+package pullrequest
+
+/*
+GetAtomicSpec returns an atomic version of the resource spec
+The goal is to only have information that can be used to identify
+the scope of the resource.
+All credentials are absent
+*/
+func (s Stash) GetAtomicSpec() interface{} {
+	return s.spec.Atomic()
+}

--- a/pkg/plugins/resources/stash/pullrequest/main.go
+++ b/pkg/plugins/resources/stash/pullrequest/main.go
@@ -6,24 +6,6 @@ import (
 	stashscm "github.com/updatecli/updatecli/pkg/plugins/scms/stash"
 )
 
-// Spec defines settings used to interact with Bitbucket pullrequest
-// It's a mapping of user input from a Updatecli manifest and it shouldn't modified
-type Spec struct {
-	client.Spec
-	// SourceBranch specifies the pullrequest source branch
-	SourceBranch string `yaml:",inline,omitempty"`
-	// TargetBranch specifies the pullrequest target branch
-	TargetBranch string `yaml:",inline,omitempty"`
-	// Owner specifies repository owner
-	Owner string `yaml:",omitempty" jsonschema:"required"`
-	// Repository specifies the name of a repository for a specific owner
-	Repository string `yaml:",omitempty" jsonschema:"required"`
-	// Title defines the Bitbucket pullrequest title.
-	Title string `yaml:",inline,omitempty"`
-	// Body defines the Bitbucket pullrequest body
-	Body string `yaml:",inline,omitempty"`
-}
-
 // Bitbucket contains information to interact with Bitbucket api
 type Stash struct {
 	// spec contains inputs coming from updatecli configuration

--- a/pkg/plugins/resources/stash/pullrequest/spec.go
+++ b/pkg/plugins/resources/stash/pullrequest/spec.go
@@ -1,0 +1,30 @@
+package pullrequest
+
+import "github.com/updatecli/updatecli/pkg/plugins/resources/stash/client"
+
+// Spec defines settings used to interact with Bitbucket pullrequest
+// It's a mapping of user input from a Updatecli manifest and it shouldn't modified
+type Spec struct {
+	client.Spec
+	// SourceBranch specifies the pullrequest source branch
+	SourceBranch string `yaml:",inline,omitempty"`
+	// TargetBranch specifies the pullrequest target branch
+	TargetBranch string `yaml:",inline,omitempty"`
+	// Owner specifies repository owner
+	Owner string `yaml:",omitempty" jsonschema:"required"`
+	// Repository specifies the name of a repository for a specific owner
+	Repository string `yaml:",omitempty" jsonschema:"required"`
+	// Title defines the Bitbucket pullrequest title.
+	Title string `yaml:",inline,omitempty"`
+	// Body defines the Bitbucket pullrequest body
+	Body string `yaml:",inline,omitempty"`
+}
+
+func (s Spec) Atomic() Spec {
+	return Spec{
+		SourceBranch: s.SourceBranch,
+		TargetBranch: s.TargetBranch,
+		Owner:        s.Owner,
+		Repository:   s.Repository,
+	}
+}

--- a/pkg/plugins/resources/stash/release/atomic.go
+++ b/pkg/plugins/resources/stash/release/atomic.go
@@ -1,0 +1,11 @@
+package release
+
+/*
+GetAtomicSpec returns an atomic version of the resource spec
+The goal is to only have information that can be used to identify
+the scope of the resource.
+All credentials are absent
+*/
+func (s Stash) GetAtomicSpec() interface{} {
+	return s.spec.Atomic()
+}

--- a/pkg/plugins/resources/stash/release/main.go
+++ b/pkg/plugins/resources/stash/release/main.go
@@ -2,7 +2,6 @@ package release
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"time"
 
@@ -12,29 +11,6 @@ import (
 	"github.com/updatecli/updatecli/pkg/plugins/resources/stash/client"
 	"github.com/updatecli/updatecli/pkg/plugins/utils/version"
 )
-
-// Spec defines settings used to interact with Bitbucket release
-type Spec struct {
-	client.Spec `yaml:",inline,omitempty"`
-	// [S][C][T] owner specifies repository owner
-	Owner string `yaml:",omitempty" jsonschema:"required"`
-	// [S][C][T] repository specifies the name of a repository for a specific owner
-	Repository string `yaml:",omitempty" jsonschema:"required"`
-	// [S] versionFilter provides parameters to specify version pattern and its type like regex, semver, or just latest.
-	VersionFilter version.Filter `yaml:",omitempty"`
-	// [T] title defines the Bitbucket release title.
-	Title string `yaml:",omitempty"`
-	// [C][T] tag defines the Bitbucket release tag.
-	Tag string `yaml:",omitempty"`
-	// [T] commitish defines the commit-ish such as `main`
-	Commitish string `yaml:",omitempty"`
-	// [T] description defines if the new release description
-	Description string `yaml:",omitempty"`
-	// [T] draft defines if the release is a draft release
-	Draft bool `yaml:",omitempty"`
-	// [T] prerelease defines if the release is a pre-release release
-	Prerelease bool `yaml:",omitempty"`
-}
 
 const (
 	// #nosec g101
@@ -144,36 +120,4 @@ func (g *Stash) SearchReleases() ([]string, error) {
 	}
 
 	return results, nil
-}
-
-func (s Spec) Validate() error {
-	gotError := false
-	missingParameters := []string{}
-
-	err := s.Spec.Validate()
-
-	if err != nil {
-		logrus.Errorln(err)
-		gotError = true
-	}
-
-	if len(s.Owner) == 0 {
-		gotError = true
-		missingParameters = append(missingParameters, "owner")
-	}
-
-	if len(s.Repository) == 0 {
-		gotError = true
-		missingParameters = append(missingParameters, "repository")
-	}
-
-	if len(missingParameters) > 0 {
-		logrus.Errorf("missing parameter(s) [%s]", strings.Join(missingParameters, ","))
-	}
-
-	if gotError {
-		return fmt.Errorf("wrong bitbucket configuration")
-	}
-
-	return nil
 }

--- a/pkg/plugins/resources/stash/release/spec.go
+++ b/pkg/plugins/resources/stash/release/spec.go
@@ -1,0 +1,73 @@
+package release
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	"github.com/updatecli/updatecli/pkg/plugins/resources/stash/client"
+	"github.com/updatecli/updatecli/pkg/plugins/utils/version"
+)
+
+// Spec defines settings used to interact with Bitbucket release
+type Spec struct {
+	client.Spec `yaml:",inline,omitempty"`
+	// [S][C][T] owner specifies repository owner
+	Owner string `yaml:",omitempty" jsonschema:"required"`
+	// [S][C][T] repository specifies the name of a repository for a specific owner
+	Repository string `yaml:",omitempty" jsonschema:"required"`
+	// [S] versionFilter provides parameters to specify version pattern and its type like regex, semver, or just latest.
+	VersionFilter version.Filter `yaml:",omitempty"`
+	// [T] title defines the Bitbucket release title.
+	Title string `yaml:",omitempty"`
+	// [C][T] tag defines the Bitbucket release tag.
+	Tag string `yaml:",omitempty"`
+	// [T] commitish defines the commit-ish such as `main`
+	Commitish string `yaml:",omitempty"`
+	// [T] description defines if the new release description
+	Description string `yaml:",omitempty"`
+	// [T] draft defines if the release is a draft release
+	Draft bool `yaml:",omitempty"`
+	// [T] prerelease defines if the release is a pre-release release
+	Prerelease bool `yaml:",omitempty"`
+}
+
+func (s Spec) Atomic() Spec {
+	return Spec{
+		Owner:      s.Owner,
+		Repository: s.Repository,
+		Tag:        s.Tag,
+	}
+}
+
+func (s Spec) Validate() error {
+	gotError := false
+	missingParameters := []string{}
+
+	err := s.Spec.Validate()
+
+	if err != nil {
+		logrus.Errorln(err)
+		gotError = true
+	}
+
+	if len(s.Owner) == 0 {
+		gotError = true
+		missingParameters = append(missingParameters, "owner")
+	}
+
+	if len(s.Repository) == 0 {
+		gotError = true
+		missingParameters = append(missingParameters, "repository")
+	}
+
+	if len(missingParameters) > 0 {
+		logrus.Errorf("missing parameter(s) [%s]", strings.Join(missingParameters, ","))
+	}
+
+	if gotError {
+		return fmt.Errorf("wrong bitbucket configuration")
+	}
+
+	return nil
+}

--- a/pkg/plugins/resources/stash/tag/atomic.go
+++ b/pkg/plugins/resources/stash/tag/atomic.go
@@ -1,0 +1,11 @@
+package tag
+
+/*
+GetAtomicSpec returns an atomic version of the resource spec
+The goal is to only have information that can be used to identify
+the scope of the resource.
+All credentials are absent
+*/
+func (s Stash) GetAtomicSpec() interface{} {
+	return s.spec.Atomic()
+}

--- a/pkg/plugins/resources/stash/tag/main.go
+++ b/pkg/plugins/resources/stash/tag/main.go
@@ -13,19 +13,6 @@ import (
 	"github.com/updatecli/updatecli/pkg/plugins/utils/version"
 )
 
-// Spec defines settings used to interact with Bitbucket release
-type Spec struct {
-	client.Spec `yaml:",inline,omitempty"`
-	// [S][C] Owner specifies repository owner
-	Owner string `yaml:",omitempty" jsonschema:"required"`
-	// [S][C] Repository specifies the name of a repository for a specific owner
-	Repository string `yaml:",omitempty" jsonschema:"required"`
-	// [S][C] VersionFilter provides parameters to specify version pattern and its type like regex, semver, or just latest.
-	VersionFilter version.Filter `yaml:",omitempty"`
-	// [S] Tag defines the Bitbucket tag .
-	Tag string `yaml:",omitempty"`
-}
-
 // Stash contains information to interact with Stash api
 type Stash struct {
 	// spec contains inputs coming from updatecli configuration

--- a/pkg/plugins/resources/stash/tag/spec.go
+++ b/pkg/plugins/resources/stash/tag/spec.go
@@ -1,0 +1,27 @@
+package tag
+
+import (
+	"github.com/updatecli/updatecli/pkg/plugins/resources/stash/client"
+	"github.com/updatecli/updatecli/pkg/plugins/utils/version"
+)
+
+// Spec defines settings used to interact with Bitbucket release
+type Spec struct {
+	client.Spec `yaml:",inline,omitempty"`
+	// [S][C] Owner specifies repository owner
+	Owner string `yaml:",omitempty" jsonschema:"required"`
+	// [S][C] Repository specifies the name of a repository for a specific owner
+	Repository string `yaml:",omitempty" jsonschema:"required"`
+	// [S][C] VersionFilter provides parameters to specify version pattern and its type like regex, semver, or just latest.
+	VersionFilter version.Filter `yaml:",omitempty"`
+	// [S] Tag defines the Bitbucket tag .
+	Tag string `yaml:",omitempty"`
+}
+
+func (s Spec) Atomic() Spec {
+	return Spec{
+		Owner:      s.Owner,
+		Repository: s.Repository,
+		Tag:        s.Tag,
+	}
+}

--- a/pkg/plugins/resources/toml/atomic.go
+++ b/pkg/plugins/resources/toml/atomic.go
@@ -1,0 +1,11 @@
+package toml
+
+/*
+GetAtomicSpec returns an atomic version of the resource spec
+The goal is to only have information that can be used to identify
+the scope of the resource.
+All credentials are absent
+*/
+func (t Toml) GetAtomicSpec() interface{} {
+	return t.spec.Atomic()
+}

--- a/pkg/plugins/resources/toml/spec.go
+++ b/pkg/plugins/resources/toml/spec.go
@@ -41,6 +41,16 @@ var (
 	ErrWrongSpec error = errors.New("wrong spec content")
 )
 
+func (s Spec) Atomic() Spec {
+	return Spec{
+		File:  s.File,
+		Files: s.Files,
+		Query: s.Query,
+		Key:   s.Key,
+		Value: s.Value,
+	}
+}
+
 func (s *Spec) Validate() error {
 	var errs []error
 

--- a/pkg/plugins/resources/xml/atomic.go
+++ b/pkg/plugins/resources/xml/atomic.go
@@ -1,0 +1,11 @@
+package xml
+
+/*
+GetAtomicSpec returns an atomic version of the resource spec
+The goal is to only have information that can be used to identify
+the scope of the resource.
+All credentials are absent
+*/
+func (x XML) GetAtomicSpec() interface{} {
+	return x.spec.Atomic()
+}

--- a/pkg/plugins/resources/xml/spec.go
+++ b/pkg/plugins/resources/xml/spec.go
@@ -16,6 +16,14 @@ var (
 	ErrSpecKeyUndefined  = errors.New("xml key undefined")
 )
 
+func (s Spec) Atomic() Spec {
+	return Spec{
+		File:  s.File,
+		Path:  s.Path,
+		Value: s.Value,
+	}
+}
+
 func (s *Spec) Validate() (errs []error) {
 	if len(s.File) == 0 {
 		errs = append(errs, errors.New(""))

--- a/pkg/plugins/resources/yaml/atomic.go
+++ b/pkg/plugins/resources/yaml/atomic.go
@@ -1,0 +1,11 @@
+package yaml
+
+/*
+GetAtomicSpec returns an atomic version of the resource spec
+The goal is to only have information that can be used to identify
+the scope of the resource.
+All credentials are absent
+*/
+func (y Yaml) GetAtomicSpec() interface{} {
+	return y.spec.Atomic()
+}

--- a/pkg/plugins/resources/yaml/main.go
+++ b/pkg/plugins/resources/yaml/main.go
@@ -10,85 +10,6 @@ import (
 	"github.com/updatecli/updatecli/pkg/core/text"
 )
 
-/*
-"yaml"  defines the specification for manipulating "yaml" files.
-It can be used as a "source", a "condition", or a "target".
-*/
-type Spec struct {
-	/*
-		"file" defines the yaml file path to interact with.
-
-		compatible:
-			* source
-			* condition
-			* target
-
-		remark:
-			* "file" and "files" are mutually exclusive
-			* when used as a source or condition, the file path also accept the following protocols
-			* protocols "https://", "http://", and "file://" are supported in path for source and condition
-	*/
-	File string `yaml:",omitempty"`
-	/*
-		"files" defines the list of yaml files path to interact with.
-
-		compatible:
-			* condition
-			* target
-
-		remark:
-			* file and files are mutually exclusive
-			* protocols "https://", "http://", and "file://" are supported in file path for source and condition
-	*/
-	Files []string `yaml:",omitempty"`
-	/*
-		"key" defines the yaml keypath.
-
-		compatible:
-			* source
-			* condition
-			* target
-
-		remark:
-			* key is a simpler version of yamlpath accepts keys.
-
-		example:
-			* key: $.name
-			* key: $.agent.name
-			* key: $.agents[0].name
-			* key: $.agents[*].name
-			* key: $.'agents.name'
-
-		remark:
-			field path with key/value is not supported at the moment.
-			some help would be useful on https://github.com/goccy/go-yaml/issues/290
-
-	*/
-	Key string `yaml:",omitempty"`
-	/*
-		"value" is the value associated with a yaml key.
-
-		compatible:
-			* source
-			* condition
-			* target
-
-		default:
-			When used from a condition or a target, the default value is set to linked source output.
-	*/
-	Value string `yaml:",omitempty"`
-	/*
-		"keyonly" allows to only check if a key exist and do not return an error otherwise
-
-		compatible:
-			* condition
-
-		default:
-			false
-	*/
-	KeyOnly bool `yaml:",omitempty"`
-}
-
 // Yaml defines a resource of kind "yaml"
 type Yaml struct {
 	spec             Spec
@@ -152,32 +73,6 @@ func hasDuplicates(values []string) bool {
 	}
 
 	return len(values) != len(uniqueValues)
-}
-
-// Validate validates the object and returns an error (with all the failed validation messages) if it is not valid
-func (s *Spec) Validate() error {
-	var validationErrors []string
-
-	// Check for all validation
-	if len(s.Files) == 0 && s.File == "" {
-		validationErrors = append(validationErrors, "Invalid spec for yaml resource: both 'file' and 'files' are empty.")
-	}
-	if s.Key == "" {
-		validationErrors = append(validationErrors, "Invalid spec for yaml resource: 'key' is empty.")
-	}
-	if len(s.Files) > 0 && s.File != "" {
-		validationErrors = append(validationErrors, "Validation error in target of type 'yaml': the attributes `spec.file` and `spec.files` are mutually exclusive")
-	}
-	if len(s.Files) > 1 && hasDuplicates(s.Files) {
-		validationErrors = append(validationErrors, "Validation error in target of type 'yaml': the attributes `spec.files` contains duplicated values")
-	}
-
-	// Return all the validation errors if found any
-	if len(validationErrors) > 0 {
-		return fmt.Errorf("validation error: the provided manifest configuration had the following validation errors:\n%s", strings.Join(validationErrors, "\n\n"))
-	}
-
-	return nil
 }
 
 // Read puts the content of the file(s) as value of the y.files map if the file(s) exist(s) or log the non existence of the file

--- a/pkg/plugins/resources/yaml/spec.go
+++ b/pkg/plugins/resources/yaml/spec.go
@@ -1,0 +1,120 @@
+package yaml
+
+import (
+	"fmt"
+	"strings"
+)
+
+/*
+"yaml"  defines the specification for manipulating "yaml" files.
+It can be used as a "source", a "condition", or a "target".
+*/
+type Spec struct {
+	/*
+		"file" defines the yaml file path to interact with.
+
+		compatible:
+			* source
+			* condition
+			* target
+
+		remark:
+			* "file" and "files" are mutually exclusive
+			* when used as a source or condition, the file path also accept the following protocols
+			* protocols "https://", "http://", and "file://" are supported in path for source and condition
+	*/
+	File string `yaml:",omitempty"`
+	/*
+		"files" defines the list of yaml files path to interact with.
+
+		compatible:
+			* condition
+			* target
+
+		remark:
+			* file and files are mutually exclusive
+			* protocols "https://", "http://", and "file://" are supported in file path for source and condition
+	*/
+	Files []string `yaml:",omitempty"`
+	/*
+		"key" defines the yaml keypath.
+
+		compatible:
+			* source
+			* condition
+			* target
+
+		remark:
+			* key is a simpler version of yamlpath accepts keys.
+
+		example:
+			* key: $.name
+			* key: $.agent.name
+			* key: $.agents[0].name
+			* key: $.agents[*].name
+			* key: $.'agents.name'
+
+		remark:
+			field path with key/value is not supported at the moment.
+			some help would be useful on https://github.com/goccy/go-yaml/issues/290
+
+	*/
+	Key string `yaml:",omitempty"`
+	/*
+		"value" is the value associated with a yaml key.
+
+		compatible:
+			* source
+			* condition
+			* target
+
+		default:
+			When used from a condition or a target, the default value is set to linked source output.
+	*/
+	Value string `yaml:",omitempty"`
+	/*
+		"keyonly" allows to only check if a key exist and do not return an error otherwise
+
+		compatible:
+			* condition
+
+		default:
+			false
+	*/
+	KeyOnly bool `yaml:",omitempty"`
+}
+
+func (s Spec) Atomic() Spec {
+	return Spec{
+		File:  s.File,
+		Files: s.Files,
+		Key:   s.Key,
+		Value: s.Value,
+	}
+}
+
+// Validate validates the object and returns an error (with all the failed validation messages) if it is not valid
+func (s *Spec) Validate() error {
+	var validationErrors []string
+
+	// Check for all validation
+	if len(s.Files) == 0 && s.File == "" {
+		validationErrors = append(validationErrors, "Invalid spec for yaml resource: both 'file' and 'files' are empty.")
+	}
+	if s.Key == "" {
+		validationErrors = append(validationErrors, "Invalid spec for yaml resource: 'key' is empty.")
+	}
+	if len(s.Files) > 0 && s.File != "" {
+		validationErrors = append(validationErrors, "Validation error in target of type 'yaml': the attributes `spec.file` and `spec.files` are mutually exclusive")
+	}
+	if len(s.Files) > 1 && hasDuplicates(s.Files) {
+		validationErrors = append(validationErrors, "Validation error in target of type 'yaml': the attributes `spec.files` contains duplicated values")
+	}
+
+	// Return all the validation errors if found any
+	if len(validationErrors) > 0 {
+		return fmt.Errorf("validation error: the provided manifest configuration had the following validation errors:\n%s", strings.Join(validationErrors, "\n\n"))
+	}
+
+	return nil
+}


### PR DESCRIPTION
Fix #1364 #1363

This pullrequest is not a "directly" user facing.

The current problem is we often rely on the Updatecli manifest to generate IDs such as pipelineID or actionID
When that manifest contains dynamic information then the generated ID changes over pipeline execution.

After many iteration, I couldn't find a better way to generate those ID.
So this PR is another attempt to solve this problem.

So for each resource we add a new function `GetAtomicSpec()` which return an minimal version of the resource specification such as 

```
githubrelease.Spec {
  owner: "updatecli",
  repository: "updatecli",
  token: "mySecretToken",
  versionFilter: version.VersionFilter {
    kind: "semver",
    pattern: "v0.3.0"
  } 
}
```

would become 

```
githubrelease.Spec {
  owner: "updatecli",
  repository: "updatecli",
}
```

`token` should be remove as it's a dynamic information and don't provide information to identify the github release
`versionfilter` should also be removed we are only interested by the information that can help identifying the github release

This means that three users executing the same manifest will have the same resourceID 

## Test

To test this pull request, you can run the following commands:

```shell
cp <to_package_directory>
go test
```

## Additional Information

### Tradeoff

It's an new function that need to be created for the resource interface

### Potential improvement

* With the change, we would be able to simplify pullrequest body by removing the first level
* We can generate report without any credentials or free of useless information