### PR TITLE
fix: goreleaser deprecation

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,11 +1,11 @@
 ---
 archives:
-  - name_template: '{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
-    replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-      amd64: x86_64
+  - name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
     format_overrides:
       - goos: windows
         format: zip
@@ -46,7 +46,7 @@ before:
 brews:
   - name: updatecli
     folder: Formula
-    tap:
+    repository:
       owner: updatecli
       name: homebrew-updatecli
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"

--- a/Makefile
+++ b/Makefile
@@ -18,19 +18,19 @@ clean: ## Clean go test cache
 
 .PHONY: build
 build: ## Build updatecli as a "dirty snapshot" (no tag, no release, but all OS/arch combinations)
-	goreleaser build --snapshot --rm-dist
+	goreleaser build --snapshot --clean
 
 .PHONY: build.all
 build.all: ## Build updatecli for "release" (tag or release and all OS/arch combinations)
-	goreleaser --rm-dist --skip-publish
+	goreleaser --clean --skip-publish
 
 .PHONY: release ## Create a new updatecli release including packages
 release: ## release.snapshot generate a snapshot release but do not published it (no tag, but all OS/arch combinations)
-	goreleaser --rm-dist
+	goreleaser --clean
 
 .PHONY: release.snapshot ## Create a new snapshot release without publishing assets
 release.snapshot: ## release.snapshot generate a snapshot release but do not published it (no tag, but all OS/arch combinations)
-	goreleaser --snapshot --rm-dist --skip-publish
+	goreleaser --snapshot --clean --skip-publish
 
 .PHONY: diff
 diff: ## Run the "diff" updatecli's subcommand for smoke test


### PR DESCRIPTION
Due to https://goreleaser.com/deprecations/#archivesreplacements

It's not possible to build Updatecli.
I am also fixing various deprecation warnings

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
cp <to_package_directory>
go test
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
