### PR TITLE
wip: add gitpush action

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -127,6 +127,7 @@ GITLABDOMAIN
 gitlabscm
 gitops
 gittag
+gitpush
 gocognit
 goconst
 gocritic

--- a/e2e/updatecli.d/success.d/gitpush.yaml
+++ b/e2e/updatecli.d/success.d/gitpush.yaml
@@ -1,0 +1,33 @@
+name: End to end testing for the GitPush resource
+
+scms:
+  updatecli-github:
+    kind: github
+    spec:
+      branch: main
+      owner: updatecli
+      repository: updatecli
+      token: '{{ requiredEnv "GITHUB_TOKEN" }}'
+      username: '{{ requiredEnv "GITHUB_ACTOR" }}'
+  updatecli-git:
+    kind: git
+    spec:
+      branch: main
+      url: https://github.com/updatecli/updatecli.git
+
+targets:
+  default:
+    kind: shell
+    disablesourceinput: true
+    spec:
+      command: echo OK
+
+actions:
+  push-to-github-without-tags:
+    kind: git/push
+    scmid: updatecli-github
+    spec:
+      tags: false
+  push-to-git-with-tags:
+    kind: git/push
+    scmid: updatecli-git

--- a/e2e/updatecli.d/success.d/gittag.yaml
+++ b/e2e/updatecli.d/success.d/gittag.yaml
@@ -42,7 +42,6 @@ sources:
       path: "./"
 
 
-
 conditions:
   check-git:
     name: Check the tag 'v0.30.0' exists in the git repository
@@ -115,3 +114,11 @@ targets:
       # Relative path are relative to where Updatecli is executed
       path: "./"
       message: "Created by Updatecli"
+
+actions:
+  push-to-git:
+    kind: git/push
+    scmid: git-repo
+  push-to-github:
+    kind: git/push
+    scmid: github-repo

--- a/e2e/updatecli.d/warning.d/gittag.yaml
+++ b/e2e/updatecli.d/warning.d/gittag.yaml
@@ -1,0 +1,24 @@
+name: End to end test of the gittag resource without any gitpush action
+
+scms:
+  git-repo:
+    kind: git
+    spec:
+      branch: main
+      url: https://github.com/updatecli/updatecli.git
+
+sources:
+  echo-version:
+    name: Returns a (SemVer) valid version to be used with the gittag target, which must not exist in the repositories
+    kind: shell
+    spec:
+      command: echo "0.0.1"
+
+targets:
+  create-git-tag:
+    name: Create the git tag 'v0.0.1' in the git repository
+    kind: gittag
+    scmid: git-repo
+    sourceid: echo-version
+    spec:
+      message: "Created by Updatecli"

--- a/pkg/core/pipeline/scm/config.go
+++ b/pkg/core/pipeline/scm/config.go
@@ -17,6 +17,16 @@ import (
 	"github.com/updatecli/updatecli/pkg/plugins/utils/gitgeneric"
 )
 
+// Supported SCMs (used by different action packages)
+const (
+	GitIdentifier       = "git"
+	GitlabIdentifier    = "gitlab"
+	GithubIdentifier    = "github"
+	GiteaIdentifier     = "gitea"
+	StashIdentifier     = "stash"
+	BitbucketIdentifier = "bitbucket"
+)
+
 type ConfigSpec interface {
 	Merge(interface{}) error
 }

--- a/pkg/plugins/resources/gitpush/main.go
+++ b/pkg/plugins/resources/gitpush/main.go
@@ -1,0 +1,47 @@
+package gitpush
+
+import (
+	"fmt"
+
+	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
+	"github.com/updatecli/updatecli/pkg/core/reports"
+)
+
+// GitPush defines a GitPush action
+type GitPush struct {
+	scmHandler scm.ScmHandler
+}
+
+// NewAction Initializes a new GitPush action
+func NewAction(s scm.Scm) (GitPush, error) {
+	supportedScms := map[string]int{
+		scm.GitIdentifier:    1,
+		scm.GithubIdentifier: 1,
+		scm.StashIdentifier:  1,
+		scm.GitlabIdentifier: 1,
+		scm.GiteaIdentifier:  1,
+	}
+	_, exists := supportedScms[s.Config.Kind]
+	if !exists {
+		return GitPush{}, fmt.Errorf("scm of kind %q is not compatible with action of kind %q",
+			s.Config.Kind,
+			"git")
+	}
+	return GitPush{
+		scmHandler: s.Handler,
+	}, nil
+}
+
+// CreateAction executes a "push" on the associated SCM
+func (gp *GitPush) CreateAction(report *reports.Action, resetDescription bool) error {
+	_, err := gp.scmHandler.Push()
+	return err
+}
+
+func (gp *GitPush) CleanAction(report *reports.Action) error {
+	return nil
+}
+
+func (gp *GitPush) CheckActionExist(report *reports.Action) error {
+	return nil
+}

--- a/pkg/plugins/resources/gittag/target.go
+++ b/pkg/plugins/resources/gittag/target.go
@@ -92,6 +92,7 @@ func (gt *GitTag) Target(source string, scm scm.ScmHandler, dryRun bool, resultT
 		tagName,
 	)
 
+	resultTarget.Description = fmt.Sprintf("git tag %q successfully created", source)
 	if gt.spec.Message != "" {
 		resultTarget.Description = gt.spec.Message
 	}


### PR DESCRIPTION
Related to https://github.com/updatecli/updatecli/issues/465

This PR introduces a new kind of action: `git/push`.


Please note that the targets of type `git/tag` and `git/branch` have a changed (fixed!) behavior: they now won't perform the `git push` operation as it is the responsibility of the the newly introduced `gitpush` action.


## Test

To test this pull request, you can run the following commands:

```shell
cp <to_package_directory>
go test
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
