### PR TITLE
Pin golang autodiscovery e2e tests

### DIFF
--- a/e2e/updatecli.d/warning.d/autodiscovery/golang/golangOnly.yaml
+++ b/e2e/updatecli.d/warning.d/autodiscovery/golang/golangOnly.yaml
@@ -3,11 +3,11 @@ scms:
   default:
     kind: github
     spec:
-      owner: olblak
+      owner: updatecli-test
       repository: updatecli
-      token: {{ requiredEnv "GITHUB_TOKEN" }}
-      username: {{ requiredEnv "GITHUB_ACTOR" }}
-      branch: main
+      token: '{{ requiredEnv "GITHUB_TOKEN" }}'
+      username: '{{ requiredEnv "GITHUB_ACTOR" }}'
+      branch: e2e-tests-golang
 
 actions:
     default:
@@ -26,4 +26,5 @@ autodiscovery:
         kind: semver
         pattern: minor
       only:
-        - goversion: "*"
+        - goversion: "1.16"
+

--- a/e2e/updatecli.d/warning.d/autodiscovery/golang/minorOnly.yaml
+++ b/e2e/updatecli.d/warning.d/autodiscovery/golang/minorOnly.yaml
@@ -3,11 +3,11 @@ scms:
   default:
     kind: github
     spec:
-      owner: olblak
+      owner: updatecli-test
       repository: updatecli
       token: {{ requiredEnv "GITHUB_TOKEN" }}
       username: {{ requiredEnv "GITHUB_ACTOR" }}
-      branch: main
+      branch: e2e-tests-golang
 
 actions:
     default:
@@ -30,4 +30,6 @@ autodiscovery:
         - modules:
             github.com/ProtonMail/go-crypto:
             github.com/shurcooL/githubv4:
+            github.com/nirasan/go-oauth-pkce-code-verifier:
+            github.com/skratchdot/open-golang:
 

--- a/e2e/updatecli.d/warning.d/autodiscovery/golang/patchOnly.yaml
+++ b/e2e/updatecli.d/warning.d/autodiscovery/golang/patchOnly.yaml
@@ -3,11 +3,11 @@ scms:
   default:
     kind: github
     spec:
-      owner: olblak
+      owner: updatecli-test
       repository: updatecli
       token: {{ requiredEnv "GITHUB_TOKEN" }}
       username: {{ requiredEnv "GITHUB_ACTOR" }}
-      branch: main
+      branch: e2e-tests-golang
 
 actions:
     default:
@@ -43,3 +43,6 @@ autodiscovery:
             github.com/iancoleman/orderedmap:
             # Same for https://pkg.go.dev/golang.org/x/time?tab=versions
             golang.org/x/time:
+            github.com/nirasan/go-oauth-pkce-code-verifier:
+            github.com/skratchdot/open-golang:
+


### PR DESCRIPTION
Recently I updated my fork of Updatecli, which apparently was used by the Golang e2e tests.
This PR updated the e2e test to use the org updatecli-test with a pin branch

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
cp <to_package_directory>
go test
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
