### PR TITLE
feat: add hcl resource plugin

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -20,3 +20,5 @@ oidc
 udash
 Udash
 CLIENTID
+minamijoyo
+hcledit

--- a/e2e/updatecli.d/success.d/hcl/noscm.yaml
+++ b/e2e/updatecli.d/success.d/hcl/noscm.yaml
@@ -1,37 +1,53 @@
 name: Test HCL resources
 
 sources:
-  scenario1:
-    name: Basic HCL source
+  file:
+    name: Read file
     kind: hcl
     spec:
       file: pkg/plugins/resources/hcl/testdata/data.hcl
       key: resource.person.john.first_name
+
+  https:
+    name: Read from HTTPs
+    kind: hcl
+    spec:
+      file: https://raw.githubusercontent.com/updatecli-test/jenkins-infra-aws/main/cik8s-cluster.tf
+      key: module.cik8s.version
 
 conditions:
-  scenario1:
+  using-source:
     name: Condition using source
     kind: hcl
-    sourceid: scenario1
+    sourceid: file
     spec:
       file: pkg/plugins/resources/hcl/testdata/data.hcl
       key: resource.person.john.first_name
 
-  scenario2:
+  using-value:
     name: Condition using value
     kind: hcl
-    sourceid: scenario1
+    sourceid: file
     spec:
       file: pkg/plugins/resources/hcl/testdata/data.hcl
       key: resource.person.john.surname
       value: Doe
 
+  https:
+    name: Condition using HTTP
+    kind: hcl
+    sourceid: file
+    spec:
+      file: https://raw.githubusercontent.com/updatecli-test/jenkins-infra-aws/main/cik8s-cluster.tf
+      key: module.cik8s.version
+      value: "19.15.3"
+
 
 targets:
   update-file:
-    name: Update files content
+    name: Update files content from source
     kind: hcl
-    sourceid: scenario1
+    sourceid: file
     transformers:
       - addsuffix: "y"
     spec:
@@ -39,17 +55,17 @@ targets:
       key: resource.person.john.first_name
 
   noop:
-    name: Update files content
+    name: No update to files content
     kind: hcl
-    sourceid: scenario1
+    sourceid: file
     spec:
       file: pkg/plugins/resources/hcl/testdata/data.hcl
       key: resource.person.john.first_name
 
   update-file-from-value:
-    name: Update files content
+    name: Update files content from value
     kind: hcl
-    sourceid: scenario1
+    sourceid: file
     spec:
       file: pkg/plugins/resources/hcl/testdata/data.hcl
       key: resource.person.john.first_name

--- a/e2e/updatecli.d/success.d/hcl/noscm.yaml
+++ b/e2e/updatecli.d/success.d/hcl/noscm.yaml
@@ -1,4 +1,4 @@
-name: Test HCL resources
+name: Test HCL plugin resource
 
 sources:
   file:
@@ -6,14 +6,14 @@ sources:
     kind: hcl
     spec:
       file: pkg/plugins/resources/hcl/testdata/data.hcl
-      key: resource.person.john.first_name
+      path: resource.person.john.first_name
 
   https:
     name: Read from HTTPs
     kind: hcl
     spec:
       file: https://raw.githubusercontent.com/updatecli-test/jenkins-infra-aws/main/cik8s-cluster.tf
-      key: module.cik8s.version
+      path: module.cik8s.version
 
 conditions:
   using-source:
@@ -22,7 +22,7 @@ conditions:
     sourceid: file
     spec:
       file: pkg/plugins/resources/hcl/testdata/data.hcl
-      key: resource.person.john.first_name
+      path: resource.person.john.first_name
 
   using-value:
     name: Condition using value
@@ -30,7 +30,7 @@ conditions:
     sourceid: file
     spec:
       file: pkg/plugins/resources/hcl/testdata/data.hcl
-      key: resource.person.john.surname
+      path: resource.person.john.surname
       value: Doe
 
   https:
@@ -39,7 +39,7 @@ conditions:
     sourceid: file
     spec:
       file: https://raw.githubusercontent.com/updatecli-test/jenkins-infra-aws/main/cik8s-cluster.tf
-      key: module.cik8s.version
+      path: module.cik8s.version
       value: "19.15.3"
 
 
@@ -52,7 +52,7 @@ targets:
       - addsuffix: "y"
     spec:
       file: pkg/plugins/resources/hcl/testdata/data.hcl
-      key: resource.person.john.first_name
+      path: resource.person.john.first_name
 
   noop:
     name: No update to files content
@@ -60,7 +60,7 @@ targets:
     sourceid: file
     spec:
       file: pkg/plugins/resources/hcl/testdata/data.hcl
-      key: resource.person.john.first_name
+      path: resource.person.john.first_name
 
   update-file-from-value:
     name: Update files content from value
@@ -68,5 +68,5 @@ targets:
     sourceid: file
     spec:
       file: pkg/plugins/resources/hcl/testdata/data.hcl
-      key: resource.person.john.first_name
+      path: resource.person.john.first_name
       value: Jonathon

--- a/e2e/updatecli.d/success.d/hcl/noscm.yaml
+++ b/e2e/updatecli.d/success.d/hcl/noscm.yaml
@@ -1,0 +1,56 @@
+name: Test HCL resources
+
+sources:
+  scenario1:
+    name: Basic HCL source
+    kind: hcl
+    spec:
+      file: pkg/plugins/resources/hcl/testdata/data.hcl
+      key: resource.person.john.first_name
+
+conditions:
+  scenario1:
+    name: Condition using source
+    kind: hcl
+    sourceid: scenario1
+    spec:
+      file: pkg/plugins/resources/hcl/testdata/data.hcl
+      key: resource.person.john.first_name
+
+  scenario2:
+    name: Condition using value
+    kind: hcl
+    sourceid: scenario1
+    spec:
+      file: pkg/plugins/resources/hcl/testdata/data.hcl
+      key: resource.person.john.surname
+      value: Doe
+
+
+targets:
+  update-file:
+    name: Update files content
+    kind: hcl
+    sourceid: scenario1
+    transformers:
+      - addsuffix: "y"
+    spec:
+      file: pkg/plugins/resources/hcl/testdata/data.hcl
+      key: resource.person.john.first_name
+
+  noop:
+    name: Update files content
+    kind: hcl
+    sourceid: scenario1
+    spec:
+      file: pkg/plugins/resources/hcl/testdata/data.hcl
+      key: resource.person.john.first_name
+
+  update-file-from-value:
+    name: Update files content
+    kind: hcl
+    sourceid: scenario1
+    spec:
+      file: pkg/plugins/resources/hcl/testdata/data.hcl
+      key: resource.person.john.first_name
+      value: Jonathon

--- a/e2e/updatecli.d/success.d/hcl/noscm.yaml
+++ b/e2e/updatecli.d/success.d/hcl/noscm.yaml
@@ -49,7 +49,7 @@ targets:
     kind: hcl
     sourceid: file
     transformers:
-      - addsuffix: "y"
+      - addsuffix: "ny"
     spec:
       file: pkg/plugins/resources/hcl/testdata/data.hcl
       path: resource.person.john.first_name
@@ -57,10 +57,11 @@ targets:
   noop:
     name: No update to files content
     kind: hcl
-    sourceid: file
+    disablesourceinput: true
     spec:
       file: pkg/plugins/resources/hcl/testdata/data.hcl
-      path: resource.person.john.first_name
+      path: resource.person.john.surname
+      value: Doe
 
   update-file-from-value:
     name: Update files content from value
@@ -68,5 +69,5 @@ targets:
     sourceid: file
     spec:
       file: pkg/plugins/resources/hcl/testdata/data.hcl
-      path: resource.person.john.first_name
-      value: Jonathon
+      path: resource.person.john.middle_name
+      value: Fred

--- a/e2e/updatecli.d/success.d/hcl/scm.yaml
+++ b/e2e/updatecli.d/success.d/hcl/scm.yaml
@@ -4,10 +4,10 @@ scms:
   default:
     kind: git
     spec:
-      url: https://github.com/jenkins-infra/aws.git
+      url: https://github.com/updatecli-test/jenkins-infra-aws.git
 
 sources:
-  scenario1:
+  file:
     name: HCL source
     kind: hcl
     scmid: default
@@ -16,20 +16,20 @@ sources:
       key: module.cik8s.version
 
 conditions:
-  scenario1:
+  using-source:
     name: Condition using source
     kind: hcl
     scmid: default
-    sourceid: scenario1
+    sourceid: file
     spec:
       file: cik8s-cluster.tf
       key: module.cik8s.version
 
-  scenario2:
+  using-value:
     name: Condition using value
     kind: hcl
     scmid: default
-    sourceid: scenario1
+    sourceid: file
     spec:
       file: cik8s-cluster.tf
       key: module.cik8s.source
@@ -40,7 +40,7 @@ targets:
   update-file:
     name: Update files content
     kind: hcl
-    sourceid: scenario1
+    sourceid: file
     scmid: default
     transformers:
       - addsuffix: -beta
@@ -51,7 +51,7 @@ targets:
   noop:
     name: No update to files content
     kind: hcl
-    sourceid: scenario1
+    sourceid: file
     scmid: default
     spec:
       file: cik8s-cluster.tf

--- a/e2e/updatecli.d/success.d/hcl/scm.yaml
+++ b/e2e/updatecli.d/success.d/hcl/scm.yaml
@@ -1,4 +1,4 @@
-name: Test HCL resources
+name: Test HCL plugin resource - SCM
 
 scms:
   default:
@@ -13,7 +13,7 @@ sources:
     scmid: default
     spec:
       file: cik8s-cluster.tf
-      key: module.cik8s.version
+      path: module.cik8s.version
 
 conditions:
   using-source:
@@ -23,7 +23,7 @@ conditions:
     sourceid: file
     spec:
       file: cik8s-cluster.tf
-      key: module.cik8s.version
+      path: module.cik8s.version
 
   using-value:
     name: Condition using value
@@ -32,7 +32,7 @@ conditions:
     sourceid: file
     spec:
       file: cik8s-cluster.tf
-      key: module.cik8s.source
+      path: module.cik8s.source
       value: terraform-aws-modules/eks/aws
 
 
@@ -46,7 +46,7 @@ targets:
       - addsuffix: -beta
     spec:
       file: cik8s-cluster.tf
-      key: module.cik8s.version
+      path: module.cik8s.version
 
   noop:
     name: No update to files content
@@ -55,4 +55,4 @@ targets:
     scmid: default
     spec:
       file: cik8s-cluster.tf
-      key: module.cik8s.version
+      path: module.cik8s.version

--- a/e2e/updatecli.d/success.d/hcl/scm.yaml
+++ b/e2e/updatecli.d/success.d/hcl/scm.yaml
@@ -1,0 +1,58 @@
+name: Test HCL resources
+
+scms:
+  default:
+    kind: git
+    spec:
+      url: https://github.com/jenkins-infra/aws.git
+
+sources:
+  scenario1:
+    name: HCL source
+    kind: hcl
+    scmid: default
+    spec:
+      file: cik8s-cluster.tf
+      key: module.cik8s.version
+
+conditions:
+  scenario1:
+    name: Condition using source
+    kind: hcl
+    scmid: default
+    sourceid: scenario1
+    spec:
+      file: cik8s-cluster.tf
+      key: module.cik8s.version
+
+  scenario2:
+    name: Condition using value
+    kind: hcl
+    scmid: default
+    sourceid: scenario1
+    spec:
+      file: cik8s-cluster.tf
+      key: module.cik8s.source
+      value: terraform-aws-modules/eks/aws
+
+
+targets:
+  update-file:
+    name: Update files content
+    kind: hcl
+    sourceid: scenario1
+    scmid: default
+    transformers:
+      - addsuffix: -beta
+    spec:
+      file: cik8s-cluster.tf
+      key: module.cik8s.version
+
+  noop:
+    name: No update to files content
+    kind: hcl
+    sourceid: scenario1
+    scmid: default
+    spec:
+      file: cik8s-cluster.tf
+      key: module.cik8s.version

--- a/go.mod
+++ b/go.mod
@@ -41,6 +41,7 @@ require (
 	github.com/google/go-containerregistry v0.15.2
 	github.com/goware/urlx v0.3.2
 	github.com/invopop/jsonschema v0.7.0
+	github.com/minamijoyo/hcledit v0.2.9
 	github.com/muesli/mango-cobra v1.2.0
 	github.com/muesli/roff v0.1.0
 	github.com/nirasan/go-oauth-pkce-code-verifier v0.0.0-20220510032225-4f9f17eaec4c
@@ -55,15 +56,19 @@ require (
 require (
 	cloud.google.com/go/compute/metadata v0.2.3 // indirect
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20230106234847-43070de90fa1 // indirect
+	github.com/agext/levenshtein v1.2.3 // indirect
+	github.com/apparentlymart/go-textseg/v13 v13.0.0 // indirect
 	github.com/containerd/stargz-snapshotter/estargz v0.14.3 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
+	github.com/hashicorp/hcl/v2 v2.17.0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.6 // indirect
 	github.com/spf13/afero v1.9.3 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/subosito/gotenv v1.4.2 // indirect
 	github.com/vbatts/tar-split v0.11.3 // indirect
+	github.com/zclconf/go-cty v1.13.0 // indirect
 	go.opentelemetry.io/otel v1.14.0 // indirect
 	go.opentelemetry.io/otel/trace v1.14.0 // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -115,6 +115,8 @@ github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d h1:UrqY+r/O
 github.com/a8m/expect v1.0.0/go.mod h1:4IwSCMumY49ScypDnjNbYEjgVeqy1/U2cEs3Lat96eA=
 github.com/acomagu/bufpipe v1.0.4 h1:e3H4WUzM3npvo5uv95QuJM3cQspFNtFBzvJ2oNjKIDQ=
 github.com/acomagu/bufpipe v1.0.4/go.mod h1:mxdxdup/WdsKVreO5GpW4+M/1CE2sMG4jeGJ2sYmHc4=
+github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=
+github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/alecthomas/assert v0.0.0-20170929043011-405dbfeb8e38 h1:smF2tmSOzy2Mm+0dGI2AIUHY+w0BUc+4tn40djz7+6U=
 github.com/alecthomas/assert v0.0.0-20170929043011-405dbfeb8e38/go.mod h1:r7bzyVFMNntcxPZXK3/+KdruV1H5KSlyVY0gc+NgInI=
 github.com/alecthomas/chroma v0.9.2 h1:yU1sE2+TZbLIQPMk30SolL2Hn53SR/Pv750f7qZ/XMs=
@@ -131,6 +133,8 @@ github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFIImctFaOjnTIavg87rW78vTPkQqLI8=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
+github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6iT90AvPUL1NNfNw=
+github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
@@ -518,6 +522,8 @@ github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+l
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
+github.com/hashicorp/hcl/v2 v2.17.0 h1:z1XvSUyXd1HP10U4lrLg5e0JMVz6CPaJvAgxM0KNZVY=
+github.com/hashicorp/hcl/v2 v2.17.0/go.mod h1:gJyW2PTShkJqQBKpAmPO3yxMxIuoXkOF2TpqXzrQyx4=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0mNTz8vQ=
 github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2pPBoIllUwCN7I=
@@ -605,6 +611,7 @@ github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 h1:SOEGU9fKiNWd/HOJuq6+3iTQz8KNCLtVX6idSoTLdUw=
 github.com/lann/builder v0.0.0-20180802200727-47ae307949d0/go.mod h1:dXGbAdH5GtBTC4WfIxhKZfyBF/HBFgRZSWwZ9g/He9o=
 github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 h1:P6pPBnrTSX3DEVR4fDembhRWSsG5rVo6hYhAB/ADZrk=
@@ -659,6 +666,8 @@ github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zk
 github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/dns v1.1.25 h1:dFwPR6SfLtrSwgDcIq2bcU/gVutB4sNApq2HBdqcakg=
+github.com/minamijoyo/hcledit v0.2.9 h1:HpZUwAjoYNHhkB4FjXHIRbAObi5jYanw9IOlDUTIZWo=
+github.com/minamijoyo/hcledit v0.2.9/go.mod h1:YAmkoZZk5dm0XLKhg6Quic74E2eSGic4dg6623M/0tg=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/cli v1.1.5/go.mod h1:v8+iFts2sPIKUV1ltktPXMCC8fumSKFItNcD2cLtRR4=
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=
@@ -924,6 +933,8 @@ github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5t
 github.com/yvasiyarov/go-metrics v0.0.0-20140926110328-57bccd1ccd43 h1:+lm10QQTNSBd8DVTNGHx7o/IKu9HYDvLMffDhbyLccI=
 github.com/yvasiyarov/gorelic v0.0.0-20141212073537-a9bba5b9ab50 h1:hlE8//ciYMztlGpl/VA+Zm1AcTPHYkHJPbHqE6WJUXE=
 github.com/yvasiyarov/newrelic_platform_go v0.0.0-20140908184405-b21fdbd4370f h1:ERexzlUfuTvpE74urLSbIQW0Z/6hF9t8U4NsJLaioAY=
+github.com/zclconf/go-cty v1.13.0 h1:It5dfKTTZHe9aeppbNOda3mN7Ag7sg6QkBNm6TkyFa0=
+github.com/zclconf/go-cty v1.13.0/go.mod h1:YKQzy/7pZ7iq2jNFzy5go57xdxdWoLLpaEp4u238AE0=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/etcd/api/v3 v3.5.0/go.mod h1:cbVKeC6lCfl7j/8jBhAK6aIYO9XOjdptoxU/nLQcPvs=
 go.etcd.io/etcd/client/pkg/v3 v3.5.0/go.mod h1:IJHfcCEKxYu1Os13ZdwCwIUTUVGYTSAM3YSwc9/Ac1g=

--- a/pkg/core/pipeline/resource/main.go
+++ b/pkg/core/pipeline/resource/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/updatecli/updatecli/pkg/plugins/resources/go/gomod"
 	golang "github.com/updatecli/updatecli/pkg/plugins/resources/go/language"
 	gomodule "github.com/updatecli/updatecli/pkg/plugins/resources/go/module"
+	"github.com/updatecli/updatecli/pkg/plugins/resources/hcl"
 	"github.com/updatecli/updatecli/pkg/plugins/resources/helm"
 	"github.com/updatecli/updatecli/pkg/plugins/resources/jenkins"
 	"github.com/updatecli/updatecli/pkg/plugins/resources/json"
@@ -60,7 +61,6 @@ type ResourceConfig struct {
 
 // New returns a newly initialized Resource or an error
 func New(rs ResourceConfig) (resource Resource, err error) {
-
 	kind := strings.ToLower(rs.Kind)
 
 	if _, ok := GetResourceMapping()[kind]; !ok {
@@ -144,6 +144,10 @@ func New(rs ResourceConfig) (resource Resource, err error) {
 
 		return file.New(rs.Spec)
 
+	case "hcl":
+
+		return hcl.New(rs.Spec)
+
 	case "helmchart":
 
 		return helm.New(rs.Spec)
@@ -204,7 +208,6 @@ type Resource interface {
 
 // Need to do reflect of ResourceConfig
 func GetResourceMapping() map[string]interface{} {
-
 	return map[string]interface{}{
 		"aws/ami":        &awsami.Spec{},
 		"cargopackage":   &cargopackage.Spec{},
@@ -225,6 +228,7 @@ func GetResourceMapping() map[string]interface{} {
 		"golang":         &golang.Spec{},
 		"golang/gomod":   &gomod.Spec{},
 		"golang/module":  &gomodule.Spec{},
+		"hcl":            &hcl.Spec{},
 		"helmchart":      &helm.Spec{},
 		"jenkins":        &jenkins.Spec{},
 		"json":           &json.Spec{},

--- a/pkg/plugins/resources/hcl/condition.go
+++ b/pkg/plugins/resources/hcl/condition.go
@@ -39,7 +39,7 @@ func (h *Hcl) Condition(source string, scm scm.ScmHandler, resultCondition *resu
 
 	if value == conditionOutput {
 		resultCondition.Description = fmt.Sprintf("Path %q, from file %q, is correctly set to %q",
-			h.spec.Key,
+			h.spec.Path,
 			resourceFile.originalFilePath,
 			value)
 
@@ -50,7 +50,7 @@ func (h *Hcl) Condition(source string, scm scm.ScmHandler, resultCondition *resu
 	}
 
 	resultCondition.Description = fmt.Sprintf("Path %q, from file %q, is incorrectly set to %q and should be %q",
-		h.spec.Key,
+		h.spec.Path,
 		resourceFile.originalFilePath,
 		conditionOutput,
 		value,

--- a/pkg/plugins/resources/hcl/condition.go
+++ b/pkg/plugins/resources/hcl/condition.go
@@ -1,0 +1,62 @@
+package hcl
+
+import (
+	"fmt"
+
+	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
+	"github.com/updatecli/updatecli/pkg/core/result"
+)
+
+func (h *Hcl) Condition(source string, scm scm.ScmHandler, resultCondition *result.Condition) error {
+	if len(h.files) > 1 {
+		return fmt.Errorf("%s HCL condition only supports one file", result.FAILURE)
+	}
+
+	if scm != nil {
+		h.UpdateAbsoluteFilePath(scm.GetDirectory())
+	}
+
+	if err := h.Read(); err != nil {
+		return fmt.Errorf("reading hcl file: %w", err)
+	}
+
+	// Always one
+	var filePath string
+	for f := range h.files {
+		filePath = f
+	}
+
+	resourceFile := h.files[filePath]
+	conditionOutput, err := h.Query(resourceFile)
+	if err != nil {
+		return err
+	}
+
+	value := source
+	if h.spec.Value != "" {
+		value = h.spec.Value
+	}
+
+	if value == conditionOutput {
+		resultCondition.Description = fmt.Sprintf("Path %q, from file %q, is correctly set to %q",
+			h.spec.Key,
+			resourceFile.originalFilePath,
+			value)
+
+		resultCondition.Pass = true
+		resultCondition.Result = result.SUCCESS
+
+		return nil
+	}
+
+	resultCondition.Description = fmt.Sprintf("Path %q, from file %q, is incorrectly set to %q and should be %q",
+		h.spec.Key,
+		resourceFile.originalFilePath,
+		conditionOutput,
+		value,
+	)
+	resultCondition.Pass = false
+	resultCondition.Result = result.FAILURE
+
+	return nil
+}

--- a/pkg/plugins/resources/hcl/condition_test.go
+++ b/pkg/plugins/resources/hcl/condition_test.go
@@ -1,0 +1,107 @@
+package hcl
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/updatecli/updatecli/pkg/core/result"
+)
+
+func TestCondition(t *testing.T) {
+	testData := []struct {
+		name             string
+		spec             Spec
+		source           string
+		expectedResult   bool
+		expectedErrorMsg error
+		wantErr          bool
+	}{
+		{
+			name: "Success - Using Value",
+			spec: Spec{
+				File:  "testdata/data.hcl",
+				Key:   "resource.person.john.first_name",
+				Value: "John",
+			},
+			source:         "",
+			expectedResult: true,
+		},
+		{
+			name: "Success - Using Source",
+			spec: Spec{
+				File: "testdata/data.hcl",
+				Key:  "resource.person.john.first_name",
+			},
+			source:         "John",
+			expectedResult: true,
+		},
+		{
+			name: "Failure - Using Source",
+			spec: Spec{
+				File: "testdata/data.hcl",
+				Key:  "resource.person.john.first_name",
+			},
+			source:         "Jack",
+			expectedResult: false,
+		},
+		{
+			name: "Success - Empty",
+			spec: Spec{
+				File: "testdata/data.hcl",
+				Key:  "resource.person.john.middle_name",
+			},
+			source:         "",
+			expectedResult: true,
+		},
+		{
+			name: "Failure - File does not exists",
+			spec: Spec{
+				File: "testdata/doNotExist.hcl",
+				Key:  "resource.person.john.first_name",
+			},
+			source:           "",
+			wantErr:          true,
+			expectedErrorMsg: errors.New("reading hcl file: ✗ The specified file \"testdata/doNotExist.hcl\" does not exist"),
+		},
+		{
+			name: "Failure - Path does not exists",
+			spec: Spec{
+				File: "testdata/data.hcl",
+				Key:  "resource.person.john.not_exist",
+			},
+			source:           "",
+			wantErr:          true,
+			expectedErrorMsg: errors.New("✗ cannot find value for path \"resource.person.john.not_exist\" from file \"testdata/data.hcl\""),
+		},
+		{
+			name: "Failure - Multiple Files",
+			spec: Spec{
+				Files: []string{"testdata/data.hcl", "testdata/data2.hcl"},
+				Key:   "resource.person.john.first_name",
+			},
+			wantErr:          true,
+			expectedErrorMsg: errors.New("✗ HCL condition only supports one file"),
+		},
+	}
+
+	for _, tt := range testData {
+		t.Run(tt.name, func(t *testing.T) {
+			h, err := New(tt.spec)
+
+			require.NoError(t, err)
+
+			gotResult := result.Condition{}
+			err = h.Condition(tt.source, nil, &gotResult)
+
+			if tt.wantErr {
+				assert.Equal(t, tt.expectedErrorMsg.Error(), err.Error())
+			} else {
+				require.NoError(t, err)
+			}
+
+			assert.Equal(t, tt.expectedResult, gotResult.Pass)
+		})
+	}
+}

--- a/pkg/plugins/resources/hcl/condition_test.go
+++ b/pkg/plugins/resources/hcl/condition_test.go
@@ -22,7 +22,7 @@ func TestCondition(t *testing.T) {
 			name: "Success - Using Value",
 			spec: Spec{
 				File:  "testdata/data.hcl",
-				Key:   "resource.person.john.first_name",
+				Path:  "resource.person.john.first_name",
 				Value: "John",
 			},
 			source:         "",
@@ -32,7 +32,7 @@ func TestCondition(t *testing.T) {
 			name: "Success - Using Source",
 			spec: Spec{
 				File: "testdata/data.hcl",
-				Key:  "resource.person.john.first_name",
+				Path: "resource.person.john.first_name",
 			},
 			source:         "John",
 			expectedResult: true,
@@ -41,7 +41,7 @@ func TestCondition(t *testing.T) {
 			name: "Failure - Using Source",
 			spec: Spec{
 				File: "testdata/data.hcl",
-				Key:  "resource.person.john.first_name",
+				Path: "resource.person.john.first_name",
 			},
 			source:         "Jack",
 			expectedResult: false,
@@ -50,7 +50,7 @@ func TestCondition(t *testing.T) {
 			name: "Success - Empty",
 			spec: Spec{
 				File: "testdata/data.hcl",
-				Key:  "resource.person.john.middle_name",
+				Path: "resource.person.john.middle_name",
 			},
 			source:         "",
 			expectedResult: true,
@@ -59,7 +59,7 @@ func TestCondition(t *testing.T) {
 			name: "Failure - File does not exists",
 			spec: Spec{
 				File: "testdata/doNotExist.hcl",
-				Key:  "resource.person.john.first_name",
+				Path: "resource.person.john.first_name",
 			},
 			source:           "",
 			wantErr:          true,
@@ -69,7 +69,7 @@ func TestCondition(t *testing.T) {
 			name: "Failure - Path does not exists",
 			spec: Spec{
 				File: "testdata/data.hcl",
-				Key:  "resource.person.john.not_exist",
+				Path: "resource.person.john.not_exist",
 			},
 			source:           "",
 			wantErr:          true,
@@ -79,7 +79,7 @@ func TestCondition(t *testing.T) {
 			name: "Failure - Multiple Files",
 			spec: Spec{
 				Files: []string{"testdata/data.hcl", "testdata/data2.hcl"},
-				Key:   "resource.person.john.first_name",
+				Path:  "resource.person.john.first_name",
 			},
 			wantErr:          true,
 			expectedErrorMsg: errors.New("✗ HCL condition only supports one file"),

--- a/pkg/plugins/resources/hcl/main.go
+++ b/pkg/plugins/resources/hcl/main.go
@@ -1,0 +1,131 @@
+package hcl
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	"github.com/minamijoyo/hcledit/editor"
+	"github.com/mitchellh/mapstructure"
+	"github.com/sirupsen/logrus"
+	"github.com/updatecli/updatecli/pkg/core/result"
+	"github.com/updatecli/updatecli/pkg/core/text"
+	"github.com/updatecli/updatecli/pkg/plugins/utils"
+)
+
+type Hcl struct {
+	spec             Spec
+	contentRetriever text.TextRetriever
+	files            map[string]file // map of file paths to file contents
+}
+
+type file struct {
+	originalFilePath string
+	filePath         string
+	content          string
+}
+
+func New(spec interface{}) (*Hcl, error) {
+	newSpec := Spec{}
+
+	err := mapstructure.Decode(spec, &newSpec)
+	if err != nil {
+		return nil, err
+	}
+
+	newResource := &Hcl{
+		spec:             newSpec,
+		contentRetriever: &text.Text{},
+	}
+
+	err = newResource.spec.Validate()
+	if err != nil {
+		return nil, err
+	}
+
+	newResource.files = make(map[string]file)
+	// File as unique element of newResource.files
+	if len(newResource.spec.File) > 0 {
+		filePath := strings.TrimPrefix(newResource.spec.File, "file://")
+		newResource.files[filePath] = file{
+			originalFilePath: filePath,
+			filePath:         filePath,
+		}
+	}
+	// Files
+	for _, filePath := range newResource.spec.Files {
+		filePath := strings.TrimPrefix(filePath, "file://")
+		newResource.files[filePath] = file{
+			originalFilePath: filePath,
+			filePath:         filePath,
+		}
+	}
+
+	return newResource, nil
+}
+
+func (h *Hcl) Query(resourceFile file) (string, error) {
+	query := h.spec.Key
+
+	sink := editor.NewAttributeGetSink(query)
+
+	inStream := strings.NewReader(resourceFile.content)
+	outStream := new(bytes.Buffer)
+	err := editor.DeriveStream(inStream, outStream, resourceFile.filePath, sink)
+	if err != nil {
+		return "", err
+	}
+
+	// When a value isn't found hcledit returns an empty byte array,
+	// where as result always has \n appended so will be > 0
+	if outStream.Len() == 0 {
+		err := fmt.Errorf("%s cannot find value for path %q from file %q",
+			result.FAILURE,
+			query,
+			resourceFile.originalFilePath)
+		return "", err
+	}
+
+	queryOutput := outStream.String()
+	queryOutput = strings.TrimSpace(queryOutput)
+	queryOutput = strings.Trim(queryOutput, "\"")
+	return queryOutput, nil
+}
+
+// Read puts the content of the file(s) as value of the y.files map if the file(s) exist(s) or log the non existence of the file
+func (h *Hcl) Read() error {
+	var err error
+
+	// Retrieve files content
+	for filePath := range h.files {
+		f := h.files[filePath]
+		if h.contentRetriever.FileExists(f.filePath) {
+			f.content, err = h.contentRetriever.ReadAll(f.filePath)
+			if err != nil {
+				return err
+			}
+			h.files[filePath] = f
+
+		} else {
+			return fmt.Errorf("%s The specified file %q does not exist", result.FAILURE, f.filePath)
+		}
+	}
+	return nil
+}
+
+func (h *Hcl) UpdateAbsoluteFilePath(workDir string) {
+	for filePath := range h.files {
+		if workDir != "" {
+			f := h.files[filePath]
+			f.filePath = utils.JoinFilePathWithWorkingDirectoryPath(f.originalFilePath, workDir)
+			logrus.Debugf(workDir)
+			logrus.Debugf("Relative path detected: changing from %q to absolute path from SCM: %q", f.originalFilePath, f.filePath)
+			h.files[filePath] = f
+		}
+	}
+}
+
+// Changelog returns the changelog for this resource, or an empty string if not supported
+func (h *Hcl) Changelog() string {
+	return ""
+}

--- a/pkg/plugins/resources/hcl/main.go
+++ b/pkg/plugins/resources/hcl/main.go
@@ -65,7 +65,7 @@ func New(spec interface{}) (*Hcl, error) {
 }
 
 func (h *Hcl) Query(resourceFile file) (string, error) {
-	query := h.spec.Key
+	query := h.spec.Path
 
 	sink := editor.NewAttributeGetSink(query)
 

--- a/pkg/plugins/resources/hcl/main_test.go
+++ b/pkg/plugins/resources/hcl/main_test.go
@@ -9,6 +9,102 @@ import (
 	"k8s.io/utils/strings/slices"
 )
 
+func TestQuery(t *testing.T) {
+	testData := []struct {
+		name             string
+		spec             Spec
+		value            string
+		workingDir       string
+		expectedErrorMsg error
+		wantErr          bool
+		expectedResult   string
+	}{
+		{
+			name: "Success - Update String",
+			spec: Spec{
+				File: "testdata/data.hcl",
+				Path: "resource.person.john.first_name",
+			},
+			value:      "Johnny",
+			wantErr:    false,
+			workingDir: "",
+			expectedResult: `resource "person" "john" {
+  first_name  = "Johnny"
+  middle_name = ""
+  surname     = "Doe"
+  age         = 30
+
+  nested {
+    attr1 = "val1"
+  }
+}
+`,
+		},
+		{
+			name: "Success - Update Integer",
+			spec: Spec{
+				File: "testdata/data.hcl",
+				Path: "resource.person.john.age",
+			},
+			value:      "31",
+			wantErr:    false,
+			workingDir: "",
+			expectedResult: `resource "person" "john" {
+  first_name  = "John"
+  middle_name = ""
+  surname     = "Doe"
+  age         = 31
+
+  nested {
+    attr1 = "val1"
+  }
+}
+`,
+		},
+		{
+			name: "Success - Update Integer",
+			spec: Spec{
+				File: "testdata/data.hcl",
+				Path: "resource.person.john.nested.attr1",
+			},
+			value:      "1.0.0",
+			wantErr:    false,
+			workingDir: "",
+			expectedResult: `resource "person" "john" {
+  first_name  = "John"
+  middle_name = ""
+  surname     = "Doe"
+  age         = 30
+
+  nested {
+    attr1 = "1.0.0"
+  }
+}
+`,
+		},
+	}
+
+	for _, tt := range testData {
+		t.Run(tt.name, func(t *testing.T) {
+			h, err := New(tt.spec)
+
+			require.NoError(t, err)
+
+			err = h.Read()
+
+			h.Apply("testdata/data.hcl", tt.value)
+
+			if tt.wantErr {
+				assert.Equal(t, tt.expectedErrorMsg.Error(), err.Error())
+			} else {
+				require.NoError(t, err)
+			}
+
+			assert.Equal(t, tt.expectedResult, h.files["testdata/data.hcl"].content)
+		})
+	}
+}
+
 func TestUpdateAbsoluteFilePath(t *testing.T) {
 	testData := []struct {
 		name           string

--- a/pkg/plugins/resources/hcl/main_test.go
+++ b/pkg/plugins/resources/hcl/main_test.go
@@ -1,0 +1,70 @@
+package hcl
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/utils/strings/slices"
+)
+
+func TestUpdateAbsoluteFilePath(t *testing.T) {
+	testData := []struct {
+		name           string
+		spec           Spec
+		workingDir     string
+		expectedResult []string
+	}{
+		{
+			name: "Success - Empty working directory",
+			spec: Spec{
+				File: "testdata/data.hcl",
+				Key:  "resource.person.john.first_name",
+			},
+			workingDir:     "",
+			expectedResult: []string{"testdata/data.hcl"},
+		},
+		{
+			name: "Success - Working directory",
+			spec: Spec{
+				File: "testdata/data.hcl",
+				Key:  "resource.person.john.first_name",
+			},
+			workingDir:     "/tmp",
+			expectedResult: []string{"/tmp/testdata/data.hcl"},
+		},
+		{
+			name: "Success - Files with empty working directory",
+			spec: Spec{
+				Files: []string{"testdata/data.hcl", "testdata/data2.hcl"},
+				Key:   "resource.person.john.first_name",
+			},
+			workingDir:     "",
+			expectedResult: []string{"testdata/data.hcl", "testdata/data2.hcl"},
+		},
+		{
+			name: "Success - Working directory",
+			spec: Spec{
+				Files: []string{"testdata/data.hcl", "testdata/data2.hcl"},
+				Key:   "resource.person.john.first_name",
+			},
+			workingDir:     "/tmp",
+			expectedResult: []string{"/tmp/testdata/data.hcl", "/tmp/testdata/data2.hcl"},
+		},
+	}
+
+	for _, tt := range testData {
+		t.Run(tt.name, func(t *testing.T) {
+			h, err := New(tt.spec)
+
+			require.NoError(t, err)
+
+			h.UpdateAbsoluteFilePath(tt.workingDir)
+
+			for _, v := range h.files {
+				assert.True(t, slices.Contains(tt.expectedResult, v.filePath), fmt.Sprintf("%s not in %v", v.filePath, tt.expectedResult))
+			}
+		})
+	}
+}

--- a/pkg/plugins/resources/hcl/main_test.go
+++ b/pkg/plugins/resources/hcl/main_test.go
@@ -92,7 +92,11 @@ func TestQuery(t *testing.T) {
 
 			err = h.Read()
 
-			h.Apply("testdata/data.hcl", tt.value)
+			require.NoError(t, err)
+
+			err = h.Apply("testdata/data.hcl", tt.value)
+
+			require.NoError(t, err)
 
 			if tt.wantErr {
 				assert.Equal(t, tt.expectedErrorMsg.Error(), err.Error())

--- a/pkg/plugins/resources/hcl/main_test.go
+++ b/pkg/plugins/resources/hcl/main_test.go
@@ -20,7 +20,7 @@ func TestUpdateAbsoluteFilePath(t *testing.T) {
 			name: "Success - Empty working directory",
 			spec: Spec{
 				File: "testdata/data.hcl",
-				Key:  "resource.person.john.first_name",
+				Path: "resource.person.john.first_name",
 			},
 			workingDir:     "",
 			expectedResult: []string{"testdata/data.hcl"},
@@ -29,7 +29,7 @@ func TestUpdateAbsoluteFilePath(t *testing.T) {
 			name: "Success - Working directory",
 			spec: Spec{
 				File: "testdata/data.hcl",
-				Key:  "resource.person.john.first_name",
+				Path: "resource.person.john.first_name",
 			},
 			workingDir:     "/tmp",
 			expectedResult: []string{"/tmp/testdata/data.hcl"},
@@ -38,7 +38,7 @@ func TestUpdateAbsoluteFilePath(t *testing.T) {
 			name: "Success - Files with empty working directory",
 			spec: Spec{
 				Files: []string{"testdata/data.hcl", "testdata/data2.hcl"},
-				Key:   "resource.person.john.first_name",
+				Path:  "resource.person.john.first_name",
 			},
 			workingDir:     "",
 			expectedResult: []string{"testdata/data.hcl", "testdata/data2.hcl"},
@@ -47,7 +47,7 @@ func TestUpdateAbsoluteFilePath(t *testing.T) {
 			name: "Success - Working directory",
 			spec: Spec{
 				Files: []string{"testdata/data.hcl", "testdata/data2.hcl"},
-				Key:   "resource.person.john.first_name",
+				Path:  "resource.person.john.first_name",
 			},
 			workingDir:     "/tmp",
 			expectedResult: []string{"/tmp/testdata/data.hcl", "/tmp/testdata/data2.hcl"},

--- a/pkg/plugins/resources/hcl/source.go
+++ b/pkg/plugins/resources/hcl/source.go
@@ -1,0 +1,40 @@
+package hcl
+
+import (
+	"fmt"
+
+	"github.com/updatecli/updatecli/pkg/core/result"
+)
+
+func (h *Hcl) Source(workingDir string, resultSource *result.Source) error {
+	if len(h.files) > 1 {
+		return fmt.Errorf("%s HCL source only supports one file", result.FAILURE)
+	}
+
+	h.UpdateAbsoluteFilePath(workingDir)
+
+	if err := h.Read(); err != nil {
+		return fmt.Errorf("reading hcl file: %w", err)
+	}
+
+	// Always one
+	var filePath string
+	for f := range h.files {
+		filePath = f
+	}
+
+	resourceFile := h.files[filePath]
+	sourceOutput, err := h.Query(resourceFile)
+	if err != nil {
+		return err
+	}
+
+	resultSource.Information = sourceOutput
+	resultSource.Result = result.SUCCESS
+	resultSource.Description = fmt.Sprintf("value %q, found in file %q, for key %q'",
+		sourceOutput,
+		resourceFile.originalFilePath,
+		h.spec.Key)
+
+	return nil
+}

--- a/pkg/plugins/resources/hcl/source.go
+++ b/pkg/plugins/resources/hcl/source.go
@@ -31,10 +31,10 @@ func (h *Hcl) Source(workingDir string, resultSource *result.Source) error {
 
 	resultSource.Information = sourceOutput
 	resultSource.Result = result.SUCCESS
-	resultSource.Description = fmt.Sprintf("value %q, found in file %q, for key %q'",
+	resultSource.Description = fmt.Sprintf("value %q, found in file %q, for path %q'",
 		sourceOutput,
 		resourceFile.originalFilePath,
-		h.spec.Key)
+		h.spec.Path)
 
 	return nil
 }

--- a/pkg/plugins/resources/hcl/source_test.go
+++ b/pkg/plugins/resources/hcl/source_test.go
@@ -1,0 +1,107 @@
+package hcl
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/updatecli/updatecli/pkg/core/result"
+)
+
+func TestSource(t *testing.T) {
+	testData := []struct {
+		name             string
+		spec             Spec
+		expectedResult   string
+		expectedErrorMsg error
+		wantErr          bool
+	}{
+		{
+			name: "Success - Query",
+			spec: Spec{
+				File: "testdata/data.hcl",
+				Key:  "resource.person.john.first_name",
+			},
+			expectedResult: "John",
+		},
+		{
+			name: "Success - Query empty value",
+			spec: Spec{
+				File: "testdata/data.hcl",
+				Key:  "resource.person.john.middle_name",
+			},
+			expectedResult: "",
+		},
+		{
+			name: "Success - Query integer",
+			spec: Spec{
+				File: "testdata/data.hcl",
+				Key:  "resource.person.john.age",
+			},
+			expectedResult: "30",
+		},
+		{
+			name: "Success - Query nested",
+			spec: Spec{
+				File: "testdata/data.hcl",
+				Key:  "resource.person.john.nested.attr1",
+			},
+			expectedResult: "val1",
+		},
+		{
+			name: "Success - Query using Files",
+			spec: Spec{
+				Files: []string{"testdata/data.hcl"},
+				Key:   "resource.person.john.first_name",
+			},
+			expectedResult: "John",
+		},
+		{
+			name: "Failure - File does not exists",
+			spec: Spec{
+				File: "testdata/doNotExist.hcl",
+				Key:  "resource.person.john.first_name",
+			},
+			wantErr:          true,
+			expectedErrorMsg: errors.New("reading hcl file: ✗ The specified file \"testdata/doNotExist.hcl\" does not exist"),
+		},
+		{
+			name: "Failure - Path does not exists",
+			spec: Spec{
+				File: "testdata/data.hcl",
+				Key:  "resource.person.john.not_exist",
+			},
+			wantErr:          true,
+			expectedErrorMsg: errors.New("✗ cannot find value for path \"resource.person.john.not_exist\" from file \"testdata/data.hcl\""),
+		},
+		{
+			name: "Failure - Multiple Files",
+			spec: Spec{
+				Files: []string{"testdata/data.hcl", "testdata/data2.hcl"},
+				Key:   "resource.person.john.first_name",
+			},
+			wantErr:          true,
+			expectedErrorMsg: errors.New("✗ HCL source only supports one file"),
+		},
+	}
+
+	for _, tt := range testData {
+		t.Run(tt.name, func(t *testing.T) {
+			h, err := New(tt.spec)
+
+			require.NoError(t, err)
+
+			gotResult := result.Source{}
+			err = h.Source("", &gotResult)
+
+			if tt.wantErr {
+				assert.Equal(t, tt.expectedErrorMsg.Error(), err.Error())
+			} else {
+				require.NoError(t, err)
+			}
+
+			assert.Equal(t, tt.expectedResult, gotResult.Information)
+		})
+	}
+}

--- a/pkg/plugins/resources/hcl/source_test.go
+++ b/pkg/plugins/resources/hcl/source_test.go
@@ -21,7 +21,7 @@ func TestSource(t *testing.T) {
 			name: "Success - Query",
 			spec: Spec{
 				File: "testdata/data.hcl",
-				Key:  "resource.person.john.first_name",
+				Path: "resource.person.john.first_name",
 			},
 			expectedResult: "John",
 		},
@@ -29,7 +29,7 @@ func TestSource(t *testing.T) {
 			name: "Success - Query empty value",
 			spec: Spec{
 				File: "testdata/data.hcl",
-				Key:  "resource.person.john.middle_name",
+				Path: "resource.person.john.middle_name",
 			},
 			expectedResult: "",
 		},
@@ -37,7 +37,7 @@ func TestSource(t *testing.T) {
 			name: "Success - Query integer",
 			spec: Spec{
 				File: "testdata/data.hcl",
-				Key:  "resource.person.john.age",
+				Path: "resource.person.john.age",
 			},
 			expectedResult: "30",
 		},
@@ -45,7 +45,7 @@ func TestSource(t *testing.T) {
 			name: "Success - Query nested",
 			spec: Spec{
 				File: "testdata/data.hcl",
-				Key:  "resource.person.john.nested.attr1",
+				Path: "resource.person.john.nested.attr1",
 			},
 			expectedResult: "val1",
 		},
@@ -53,7 +53,7 @@ func TestSource(t *testing.T) {
 			name: "Success - Query using Files",
 			spec: Spec{
 				Files: []string{"testdata/data.hcl"},
-				Key:   "resource.person.john.first_name",
+				Path:  "resource.person.john.first_name",
 			},
 			expectedResult: "John",
 		},
@@ -61,7 +61,7 @@ func TestSource(t *testing.T) {
 			name: "Failure - File does not exists",
 			spec: Spec{
 				File: "testdata/doNotExist.hcl",
-				Key:  "resource.person.john.first_name",
+				Path: "resource.person.john.first_name",
 			},
 			wantErr:          true,
 			expectedErrorMsg: errors.New("reading hcl file: ✗ The specified file \"testdata/doNotExist.hcl\" does not exist"),
@@ -70,7 +70,7 @@ func TestSource(t *testing.T) {
 			name: "Failure - Path does not exists",
 			spec: Spec{
 				File: "testdata/data.hcl",
-				Key:  "resource.person.john.not_exist",
+				Path: "resource.person.john.not_exist",
 			},
 			wantErr:          true,
 			expectedErrorMsg: errors.New("✗ cannot find value for path \"resource.person.john.not_exist\" from file \"testdata/data.hcl\""),
@@ -79,7 +79,7 @@ func TestSource(t *testing.T) {
 			name: "Failure - Multiple Files",
 			spec: Spec{
 				Files: []string{"testdata/data.hcl", "testdata/data2.hcl"},
-				Key:   "resource.person.john.first_name",
+				Path:  "resource.person.john.first_name",
 			},
 			wantErr:          true,
 			expectedErrorMsg: errors.New("✗ HCL source only supports one file"),

--- a/pkg/plugins/resources/hcl/spec.go
+++ b/pkg/plugins/resources/hcl/spec.go
@@ -39,7 +39,7 @@ type Spec struct {
 	*/
 	Files []string `yaml:",omitempty"`
 	/*
-		"key" defines the hcl attribute path.
+		"path" defines the hcl attribute path.
 
 		compatible:
 			* source
@@ -47,14 +47,14 @@ type Spec struct {
 			* target
 
 		example:
-			* key: resource.aws_instance.app_server.ami
-			* key: resource.helm_release.prometheus.version
-			* key: plugin.aws.version
+			* path: resource.aws_instance.app_server.ami
+			* path: resource.helm_release.prometheus.version
+			* path: plugin.aws.version
 
 	*/
-	Key string `yaml:",omitempty"`
+	Path string `yaml:",omitempty"`
 	/*
-		"value" is the value associated with a hcl key.
+		"value" is the value associated with a hcl path.
 
 		compatible:
 			* condition
@@ -69,8 +69,8 @@ type Spec struct {
 var (
 	// ErrSpecFileUndefined is returned if a file wasn't specified
 	ErrSpecFileUndefined = errors.New("hcl file undefined")
-	// ErrSpecKeyUndefined is returned if a key wasn't specified
-	ErrSpecKeyUndefined = errors.New("hcl key undefined")
+	// ErrSpecPathUndefined is returned if a path wasn't specified
+	ErrSpecPathUndefined = errors.New("hcl path undefined")
 	// ErrSpecFileAndFilesDefined when we both spec File and Files have been specified
 	ErrSpecFileAndFilesDefined = errors.New("parameter \"file\" and \"files\" are mutually exclusive")
 	// ErrWrongSpec is returned when the Spec has wrong content
@@ -83,8 +83,8 @@ func (s *Spec) Validate() error {
 	if len(s.File) == 0 && len(s.Files) == 0 {
 		errs = append(errs, ErrSpecFileUndefined)
 	}
-	if len(s.Key) == 0 {
-		errs = append(errs, ErrSpecKeyUndefined)
+	if len(s.Path) == 0 {
+		errs = append(errs, ErrSpecPathUndefined)
 	}
 
 	if len(s.File) > 0 && len(s.Files) > 0 {

--- a/pkg/plugins/resources/hcl/spec.go
+++ b/pkg/plugins/resources/hcl/spec.go
@@ -6,14 +6,63 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+/*
+"hcl"  defines the specification for manipulating "hcl" files.
+It can be used as a "source", a "condition", or a "target".
+*/
 type Spec struct {
-	// [s][c][t] File specifies the hcl file to manipulate
+	/*
+		"file" defines the hcl file path to interact with.
+
+		compatible:
+			* source
+			* condition
+			* target
+
+		remark:
+			* "file" and "files" are mutually exclusive
+			* protocols "https://", "http://", and "file://" are supported in path for source and condition
+	*/
 	File string `yaml:",omitempty"`
-	// [s][c][t] Files specifies a list of hcl file to manipulate
+	/*
+		"files" defines the list of hcl files path to interact with.
+
+		compatible:
+			* source
+			* condition
+			* target
+
+		remark:
+			* file and files are mutually exclusive
+			* when using as a source only one file is supported
+			* protocols "https://", "http://", and "file://" are supported in file path for source and condition
+	*/
 	Files []string `yaml:",omitempty"`
-	// [s][c][t] Key specifies the query to retrieve information from a hcl file
+	/*
+		"key" defines the hcl attribute path.
+
+		compatible:
+			* source
+			* condition
+			* target
+
+		example:
+			* key: resource.aws_instance.app_server.ami
+			* key: resource.helm_release.prometheus.version
+			* key: plugin.aws.version
+
+	*/
 	Key string `yaml:",omitempty"`
-	// [c][t] Value specifies the value for a specific key. Default to source output
+	/*
+		"value" is the value associated with a hcl key.
+
+		compatible:
+			* condition
+			* target
+
+		default:
+			When used from a condition or a target, the default value is set to linked source output.
+	*/
 	Value string `yaml:",omitempty"`
 }
 
@@ -22,7 +71,7 @@ var (
 	ErrSpecFileUndefined = errors.New("hcl file undefined")
 	// ErrSpecKeyUndefined is returned if a key wasn't specified
 	ErrSpecKeyUndefined = errors.New("hcl key undefined")
-	// ErrSpecFileAndFilesDefines when we both spec File and Files have been specified
+	// ErrSpecFileAndFilesDefined when we both spec File and Files have been specified
 	ErrSpecFileAndFilesDefined = errors.New("parameter \"file\" and \"files\" are mutually exclusive")
 	// ErrWrongSpec is returned when the Spec has wrong content
 	ErrWrongSpec error = errors.New("wrong spec content")

--- a/pkg/plugins/resources/hcl/spec.go
+++ b/pkg/plugins/resources/hcl/spec.go
@@ -1,0 +1,54 @@
+package hcl
+
+import (
+	"errors"
+
+	"github.com/sirupsen/logrus"
+)
+
+type Spec struct {
+	// [s][c][t] File specifies the hcl file to manipulate
+	File string `yaml:",omitempty"`
+	// [s][c][t] Files specifies a list of hcl file to manipulate
+	Files []string `yaml:",omitempty"`
+	// [s][c][t] Key specifies the query to retrieve information from a hcl file
+	Key string `yaml:",omitempty"`
+	// [c][t] Value specifies the value for a specific key. Default to source output
+	Value string `yaml:",omitempty"`
+}
+
+var (
+	// ErrSpecFileUndefined is returned if a file wasn't specified
+	ErrSpecFileUndefined = errors.New("hcl file undefined")
+	// ErrSpecKeyUndefined is returned if a key wasn't specified
+	ErrSpecKeyUndefined = errors.New("hcl key undefined")
+	// ErrSpecFileAndFilesDefines when we both spec File and Files have been specified
+	ErrSpecFileAndFilesDefined = errors.New("parameter \"file\" and \"files\" are mutually exclusive")
+	// ErrWrongSpec is returned when the Spec has wrong content
+	ErrWrongSpec error = errors.New("wrong spec content")
+)
+
+func (s *Spec) Validate() error {
+	var errs []error
+
+	if len(s.File) == 0 && len(s.Files) == 0 {
+		errs = append(errs, ErrSpecFileUndefined)
+	}
+	if len(s.Key) == 0 {
+		errs = append(errs, ErrSpecKeyUndefined)
+	}
+
+	if len(s.File) > 0 && len(s.Files) > 0 {
+		errs = append(errs, ErrSpecFileAndFilesDefined)
+	}
+
+	for _, e := range errs {
+		logrus.Errorln(e)
+	}
+
+	if len(errs) > 0 {
+		return ErrWrongSpec
+	}
+
+	return nil
+}

--- a/pkg/plugins/resources/hcl/spec_test.go
+++ b/pkg/plugins/resources/hcl/spec_test.go
@@ -19,7 +19,7 @@ func TestValidate(t *testing.T) {
 			name: "Success - File",
 			spec: Spec{
 				File: "testdata/data.hcl",
-				Key:  "resource.person.john.first_name",
+				Path: "resource.person.john.first_name",
 			},
 			wantErr: false,
 		},
@@ -27,20 +27,20 @@ func TestValidate(t *testing.T) {
 			name: "Success - Files",
 			spec: Spec{
 				Files: []string{"testdata/data.hcl"},
-				Key:   "resource.person.john.first_name",
+				Path:  "resource.person.john.first_name",
 			},
 			wantErr: false,
 		},
 		{
 			name: "Failure - No file or files",
 			spec: Spec{
-				Key: "resource.person.john.first_name",
+				Path: "resource.person.john.first_name",
 			},
 			wantErr:          true,
 			expectedErrorMsg: errors.New("wrong spec content"),
 		},
 		{
-			name: "Failure - No key",
+			name: "Failure - No path",
 			spec: Spec{
 				File: "testdata/data.hcl",
 			},
@@ -52,7 +52,7 @@ func TestValidate(t *testing.T) {
 			spec: Spec{
 				File:  "testdata/data.hcl",
 				Files: []string{"testdata/data.hcl"},
-				Key:   "resource.person.john.first_name",
+				Path:  "resource.person.john.first_name",
 			},
 			wantErr:          true,
 			expectedErrorMsg: errors.New("wrong spec content"),

--- a/pkg/plugins/resources/hcl/spec_test.go
+++ b/pkg/plugins/resources/hcl/spec_test.go
@@ -1,0 +1,73 @@
+package hcl
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidate(t *testing.T) {
+	testData := []struct {
+		name             string
+		spec             Spec
+		expectedErrorMsg error
+		wantErr          bool
+	}{
+		{
+			name: "Success - File",
+			spec: Spec{
+				File: "testdata/data.hcl",
+				Key:  "resource.person.john.first_name",
+			},
+			wantErr: false,
+		},
+		{
+			name: "Success - Files",
+			spec: Spec{
+				Files: []string{"testdata/data.hcl"},
+				Key:   "resource.person.john.first_name",
+			},
+			wantErr: false,
+		},
+		{
+			name: "Failure - No file or files",
+			spec: Spec{
+				Key: "resource.person.john.first_name",
+			},
+			wantErr:          true,
+			expectedErrorMsg: errors.New("wrong spec content"),
+		},
+		{
+			name: "Failure - No key",
+			spec: Spec{
+				File: "testdata/data.hcl",
+			},
+			wantErr:          true,
+			expectedErrorMsg: errors.New("wrong spec content"),
+		},
+		{
+			name: "Failure - Both file and files",
+			spec: Spec{
+				File:  "testdata/data.hcl",
+				Files: []string{"testdata/data.hcl"},
+				Key:   "resource.person.john.first_name",
+			},
+			wantErr:          true,
+			expectedErrorMsg: errors.New("wrong spec content"),
+		},
+	}
+
+	for _, tt := range testData {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.spec.Validate()
+
+			if tt.wantErr {
+				assert.Equal(t, tt.expectedErrorMsg.Error(), err.Error())
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/plugins/resources/hcl/target.go
+++ b/pkg/plugins/resources/hcl/target.go
@@ -71,16 +71,17 @@ func (h *Hcl) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarge
 
 		if !dryRun {
 
-			h.Apply(fileKey, valueToWrite)
-
-			h.contentRetriever.WriteToFile(
-				h.files[fileKey].content,
-				h.files[fileKey].filePath,
-			)
-
-			if err != nil {
+			if err := h.Apply(fileKey, valueToWrite); err != nil {
 				return err
 			}
+
+			if err := h.contentRetriever.WriteToFile(
+				h.files[fileKey].content,
+				h.files[fileKey].filePath,
+			); err != nil {
+				return err
+			}
+
 		}
 	}
 

--- a/pkg/plugins/resources/hcl/target.go
+++ b/pkg/plugins/resources/hcl/target.go
@@ -35,7 +35,7 @@ func (h *Hcl) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarge
 	valueToWrite := source
 	if h.spec.Value != "" {
 		valueToWrite = h.spec.Value
-		logrus.Info("INFO: Using spec.Value instead of source input value.")
+		logrus.Debug("Using spec.Value instead of source input value.")
 	}
 
 	resultTarget.NewInformation = valueToWrite

--- a/pkg/plugins/resources/hcl/target.go
+++ b/pkg/plugins/resources/hcl/target.go
@@ -30,7 +30,7 @@ func (h *Hcl) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarge
 		return fmt.Errorf("reading hcl file: %w", err)
 	}
 
-	query := h.spec.Key
+	query := h.spec.Path
 
 	valueToWrite := source
 	if h.spec.Value != "" {
@@ -53,7 +53,7 @@ func (h *Hcl) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarge
 		resultTarget.Information = currentValue
 
 		if currentValue == valueToWrite {
-			resultTarget.Description = fmt.Sprintf("key %q already set to %q, from file %q, ",
+			resultTarget.Description = fmt.Sprintf("path %q already set to %q, from file %q, ",
 				query,
 				valueToWrite,
 				resourceFile.originalFilePath)

--- a/pkg/plugins/resources/hcl/target.go
+++ b/pkg/plugins/resources/hcl/target.go
@@ -1,0 +1,90 @@
+package hcl
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/minamijoyo/hcledit/editor"
+	"github.com/sirupsen/logrus"
+	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
+	"github.com/updatecli/updatecli/pkg/core/result"
+)
+
+func (h *Hcl) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
+	if scm != nil {
+		h.UpdateAbsoluteFilePath(scm.GetDirectory())
+	}
+
+	for _, f := range h.files {
+		resourceFile := f
+
+		// Target doesn't support updating files on remote http location
+		if strings.HasPrefix(resourceFile.filePath, "https://") ||
+			strings.HasPrefix(resourceFile.filePath, "http://") {
+			return fmt.Errorf("%s URL scheme is not supported for HCL target: %q", result.FAILURE, h.spec.File)
+		}
+	}
+
+	if err := h.Read(); err != nil {
+		return fmt.Errorf("reading hcl file: %w", err)
+	}
+
+	query := h.spec.Key
+
+	valueToWrite := source
+	if h.spec.Value != "" {
+		valueToWrite = h.spec.Value
+		logrus.Info("INFO: Using spec.Value instead of source input value.")
+	}
+
+	resultTarget.NewInformation = valueToWrite
+
+	notChanged := 0
+
+	for _, f := range h.files {
+		resourceFile := f
+
+		currentValue, err := h.Query(resourceFile)
+		if err != nil {
+			return err
+		}
+
+		resultTarget.Information = currentValue
+
+		if currentValue == valueToWrite {
+			resultTarget.Description = fmt.Sprintf("key %q already set to %q, from file %q, ",
+				query,
+				valueToWrite,
+				resourceFile.originalFilePath)
+			notChanged++
+			continue
+		}
+
+		resultTarget.Changed = true
+		resultTarget.Files = append(resultTarget.Files, resourceFile.originalFilePath)
+		resultTarget.Result = result.ATTENTION
+		resultTarget.Description = fmt.Sprintf("path %q updated from %q to %q in file %q",
+			query,
+			currentValue,
+			valueToWrite,
+			resourceFile.originalFilePath)
+
+		if !dryRun {
+			filter := editor.NewAttributeSetFilter(query, valueToWrite)
+			err = editor.UpdateFile(resourceFile.filePath, filter)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	if notChanged == len(h.files) {
+		resultTarget.Result = result.SUCCESS
+		return nil
+	}
+
+	sort.Strings(resultTarget.Files)
+
+	return nil
+}

--- a/pkg/plugins/resources/hcl/target.go
+++ b/pkg/plugins/resources/hcl/target.go
@@ -5,7 +5,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/minamijoyo/hcledit/editor"
 	"github.com/sirupsen/logrus"
 	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
 	"github.com/updatecli/updatecli/pkg/core/result"
@@ -42,7 +41,7 @@ func (h *Hcl) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarge
 
 	notChanged := 0
 
-	for _, f := range h.files {
+	for fileKey, f := range h.files {
 		resourceFile := f
 
 		currentValue, err := h.Query(resourceFile)
@@ -71,8 +70,14 @@ func (h *Hcl) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarge
 			resourceFile.originalFilePath)
 
 		if !dryRun {
-			filter := editor.NewAttributeSetFilter(query, valueToWrite)
-			err = editor.UpdateFile(resourceFile.filePath, filter)
+
+			h.Apply(fileKey, valueToWrite)
+
+			h.contentRetriever.WriteToFile(
+				h.files[fileKey].content,
+				h.files[fileKey].filePath,
+			)
+
 			if err != nil {
 				return err
 			}

--- a/pkg/plugins/resources/hcl/target_test.go
+++ b/pkg/plugins/resources/hcl/target_test.go
@@ -1,0 +1,107 @@
+package hcl
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/updatecli/updatecli/pkg/core/result"
+)
+
+func TestTarget(t *testing.T) {
+	testData := []struct {
+		name             string
+		spec             Spec
+		sourceInput      string
+		expectedResult   bool
+		expectedErrorMsg error
+		wantErr          bool
+	}{
+		{
+			name: "Success - No change",
+			spec: Spec{
+				File: "testdata/data.hcl",
+				Key:  "resource.person.john.first_name",
+			},
+			sourceInput:    "John",
+			expectedResult: false,
+		},
+		{
+			name: "Success - Expected change",
+			spec: Spec{
+				File: "testdata/data.hcl",
+				Key:  "resource.person.john.first_name",
+			},
+			sourceInput:    "Jonathan",
+			expectedResult: true,
+		},
+		{
+			name: "Success - Expected change using Value",
+			spec: Spec{
+				File:  "testdata/data.hcl",
+				Key:   "resource.person.john.first_name",
+				Value: "Jonathan",
+			},
+			expectedResult: true,
+		},
+		{
+			name: "Success - Expected change replacing empty value",
+			spec: Spec{
+				File: "testdata/data.hcl",
+				Key:  "resource.person.john.middle_name",
+			},
+			sourceInput:    "Joe",
+			expectedResult: true,
+		},
+		{
+			name: "Failure - File does not exists",
+			spec: Spec{
+				File: "testdata/doNotExist.hcl",
+				Key:  "resource.person.john.first_name",
+			},
+			expectedResult:   false,
+			wantErr:          true,
+			expectedErrorMsg: errors.New("reading hcl file: ✗ The specified file \"testdata/doNotExist.hcl\" does not exist"),
+		},
+		{
+			name: "Failure - Path does not exists",
+			spec: Spec{
+				File: "testdata/data.hcl",
+				Key:  "resource.person.john.not_exist",
+			},
+			expectedResult:   false,
+			wantErr:          true,
+			expectedErrorMsg: errors.New("✗ cannot find value for path \"resource.person.john.not_exist\" from file \"testdata/data.hcl\""),
+		},
+		{
+			name: "Failure - HTTP Target",
+			spec: Spec{
+				File: "http://localhost/doNotExist.hcl",
+				Key:  "resource.person.john.first_name",
+			},
+			expectedResult:   false,
+			wantErr:          true,
+			expectedErrorMsg: errors.New("✗ URL scheme is not supported for HCL target: \"http://localhost/doNotExist.hcl\""),
+		},
+	}
+
+	for _, tt := range testData {
+		t.Run(tt.name, func(t *testing.T) {
+			j, err := New(tt.spec)
+
+			require.NoError(t, err)
+
+			gotResult := result.Target{}
+			err = j.Target(tt.sourceInput, nil, true, &gotResult)
+
+			if tt.wantErr {
+				assert.Equal(t, tt.expectedErrorMsg.Error(), err.Error())
+			} else {
+				require.NoError(t, err)
+			}
+
+			assert.Equal(t, tt.expectedResult, gotResult.Changed)
+		})
+	}
+}

--- a/pkg/plugins/resources/hcl/target_test.go
+++ b/pkg/plugins/resources/hcl/target_test.go
@@ -22,7 +22,7 @@ func TestTarget(t *testing.T) {
 			name: "Success - No change",
 			spec: Spec{
 				File: "testdata/data.hcl",
-				Key:  "resource.person.john.first_name",
+				Path: "resource.person.john.first_name",
 			},
 			sourceInput:    "John",
 			expectedResult: false,
@@ -31,7 +31,7 @@ func TestTarget(t *testing.T) {
 			name: "Success - Expected change",
 			spec: Spec{
 				File: "testdata/data.hcl",
-				Key:  "resource.person.john.first_name",
+				Path: "resource.person.john.first_name",
 			},
 			sourceInput:    "Jonathan",
 			expectedResult: true,
@@ -40,7 +40,7 @@ func TestTarget(t *testing.T) {
 			name: "Success - Expected change using Value",
 			spec: Spec{
 				File:  "testdata/data.hcl",
-				Key:   "resource.person.john.first_name",
+				Path:  "resource.person.john.first_name",
 				Value: "Jonathan",
 			},
 			expectedResult: true,
@@ -49,7 +49,7 @@ func TestTarget(t *testing.T) {
 			name: "Success - Expected change replacing empty value",
 			spec: Spec{
 				File: "testdata/data.hcl",
-				Key:  "resource.person.john.middle_name",
+				Path: "resource.person.john.middle_name",
 			},
 			sourceInput:    "Joe",
 			expectedResult: true,
@@ -58,7 +58,7 @@ func TestTarget(t *testing.T) {
 			name: "Failure - File does not exists",
 			spec: Spec{
 				File: "testdata/doNotExist.hcl",
-				Key:  "resource.person.john.first_name",
+				Path: "resource.person.john.first_name",
 			},
 			expectedResult:   false,
 			wantErr:          true,
@@ -68,7 +68,7 @@ func TestTarget(t *testing.T) {
 			name: "Failure - Path does not exists",
 			spec: Spec{
 				File: "testdata/data.hcl",
-				Key:  "resource.person.john.not_exist",
+				Path: "resource.person.john.not_exist",
 			},
 			expectedResult:   false,
 			wantErr:          true,
@@ -78,7 +78,7 @@ func TestTarget(t *testing.T) {
 			name: "Failure - HTTP Target",
 			spec: Spec{
 				File: "http://localhost/doNotExist.hcl",
-				Key:  "resource.person.john.first_name",
+				Path: "resource.person.john.first_name",
 			},
 			expectedResult:   false,
 			wantErr:          true,

--- a/pkg/plugins/resources/hcl/testdata/data.hcl
+++ b/pkg/plugins/resources/hcl/testdata/data.hcl
@@ -1,0 +1,10 @@
+resource "person" "john" {
+  first_name  = "John"
+  middle_name = ""
+  surname     = "Doe"
+  age         = 30
+
+  nested {
+    attr1 = "val1"
+  }
+}


### PR DESCRIPTION
Adds support for hcl updating uses [minamijoyo/hcledit](https://github.com/minamijoyo/hcledit).

## Test

To test this pull request, you can run the following commands:

```shell
cd ./pkg/plugins/resources/hcl
go test
```

```shell
go build -o bin/updatecli && ./bin/updatecli diff --config e2e/updatecli.d/success.d/hcl/noscm.yaml
```
