### PR TITLE
Fix condition report by using the correct variable

### DIFF
--- a/pkg/core/pipeline/conditions.go
+++ b/pkg/core/pipeline/conditions.go
@@ -32,10 +32,6 @@ func (p *Pipeline) RunConditions() (globalResult bool, err error) {
 		condition := p.Conditions[id]
 		condition.Config = p.Config.Spec.Conditions[id]
 
-		rpt := p.Report.Conditions[id]
-		// Update report name as the condition configuration might has been updated (templated values)
-		rpt.Name = condition.Config.Name
-
 		logrus.Infof("\n%s\n", id)
 		logrus.Infof("%s\n", strings.Repeat("-", len(id)))
 
@@ -45,16 +41,13 @@ func (p *Pipeline) RunConditions() (globalResult bool, err error) {
 			logrus.Error(err)
 		}
 
-		// Reports the result of the execution of this condition
-		rpt.Result = condition.Result.Result
-
 		// If there was an error OR if the condition is not successful then defines the global result as false
 		if err != nil || condition.Result.Result != result.SUCCESS {
 			globalResult = false
 		}
 
 		p.Conditions[id] = condition
-		p.Report.Conditions[id] = rpt
+		p.Report.Conditions[id] = &condition.Result
 
 	}
 

--- a/pkg/core/pipeline/sources.go
+++ b/pkg/core/pipeline/sources.go
@@ -28,10 +28,6 @@ func (p *Pipeline) RunSources() error {
 		source := p.Sources[id]
 		source.Config = p.Config.Spec.Sources[id]
 
-		rpt := p.Report.Sources[id]
-		// Update report name as the source configuration might has been updated (templated values)
-		rpt.Name = source.Config.Name
-
 		logrus.Infof("\n%s\n", id)
 		logrus.Infof("%s\n", strings.Repeat("-", len(id)))
 

--- a/pkg/core/pipeline/targets.go
+++ b/pkg/core/pipeline/targets.go
@@ -54,20 +54,14 @@ func (p *Pipeline) RunTargets() error {
 			}
 		}
 
-		report := p.Report.Targets[id]
 		// No need to run this target as one of its dependency failed
 		if shouldSkipTarget {
 			p.Targets[id] = target
-			p.Report.Targets[id] = report
+			p.Report.Targets[id] = &target.Result
 			continue
 		}
 
 		err = target.Run(p.Sources[target.Config.SourceID].Output, &p.Options.Target)
-
-		report = &target.Result
-
-		// Update report name as the target configuration might has been updated (templated values)
-		report.Name = target.Config.Name
 
 		if err != nil {
 			p.Report.Result = result.FAILURE
@@ -76,10 +70,8 @@ func (p *Pipeline) RunTargets() error {
 			errs = append(errs, fmt.Errorf("something went wrong in target %q : %q", id, err))
 		}
 
-		report.Result = target.Result.Result
-
 		p.Targets[id] = target
-		p.Report.Targets[id] = report
+		p.Report.Targets[id] = &target.Result
 
 		if target.Result.Changed {
 			isResultChanged = target.Result.Changed


### PR DESCRIPTION
While working on Udash, I noticed the condition report data were incomplete.

![image](https://github.com/updatecli/updatecli/assets/2360224/6e1bd847-fc68-41d4-9078-4cc741a5adea)

This commit also removes declared but unused variable which were probably left over from another iteration

<!-- Describe the changes introduced by this pull request -->

## Test

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
