### PR TITLE
Fix Udash login flow with access_token

### DIFF
--- a/pkg/core/udash/config_spec.go
+++ b/pkg/core/udash/config_spec.go
@@ -72,6 +72,39 @@ func writeConfigFile(configFileName string, data *spec) error {
 	return nil
 }
 
+// updateConfigFile updates the config file
+func updateConfigFile(data authData) error {
+
+	updatecliConfigPath, err := initConfigFile()
+	if err != nil {
+		return err
+	}
+
+	d, err := readConfigFile()
+	if err != nil {
+		return err
+	}
+
+	if d == nil {
+		d = &spec{}
+		d.Auths = make(map[string]authData)
+	}
+
+	d.Auths[sanitizeTokenID(data.Api)] = authData{
+		Token: data.Token,
+		Api:   data.Api,
+		URL:   data.URL,
+	}
+	d.Default = sanitizeTokenID(data.Api)
+
+	err = writeConfigFile(updatecliConfigPath, d)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // ConfigFilePath returns the path of the config file
 func ConfigFilePath() (string, error) {
 	configFile, err := initConfigFile()

--- a/pkg/core/udash/main.go
+++ b/pkg/core/udash/main.go
@@ -46,7 +46,7 @@ func authorizeUser(frontURL, clientID, authDomain, audience, redirectURL, access
 
 	// If accessToken is provided, we skip the oauth flow
 	if accessToken != "" {
-		logrus.Infof("Token detected via flag --token, skipping the oauth PKCE flow")
+		logrus.Infof("Token detected via flag --oauth-access-token, skipping the oauth PKCE flow")
 		err = updateConfigFile(authData{
 			Token: accessToken,
 			Api:   audience,

--- a/pkg/core/udash/main.go
+++ b/pkg/core/udash/main.go
@@ -44,6 +44,23 @@ func authorizeUser(frontURL, clientID, authDomain, audience, redirectURL, access
 	authDomain = setDefaultHTTPSScheme(authDomain)
 	audience = setDefaultHTTPSScheme(audience)
 
+	// If accessToken is provided, we skip the oauth flow
+	if accessToken != "" {
+		logrus.Infof("Token detected via flag --token, skipping the oauth PKCE flow")
+		err = updateConfigFile(authData{
+			Token: accessToken,
+			Api:   audience,
+			URL:   frontURL,
+		})
+		if err != nil {
+			logrus.Errorln(err)
+			return nil
+		}
+		logrus.Println("Successfully logged into updatecli service.")
+
+		return nil
+	}
+
 	authorizationURL, err := url.Parse(authDomain)
 	if err != nil {
 		logrus.Errorln(err)
@@ -102,34 +119,27 @@ func authorizeUser(frontURL, clientID, authDomain, audience, redirectURL, access
 
 		// trade the authorization code and the code verifier for an access token
 		codeVerifier := CodeVerifier.String()
-		token := accessToken
-		if accessToken == "" {
-			token, err = getAccessToken(authDomain, clientID, codeVerifier, code, redirectURL)
+		accessToken, err = getAccessToken(authDomain, clientID, codeVerifier, code, redirectURL)
+		if err != nil {
+
+			errmsg := "could not retrieve access token\n"
+			_, err := io.WriteString(w, fmt.Sprintf("Error: %s", errmsg))
 			if err != nil {
-
-				errmsg := "could not retrieve access token\n"
-				_, err := io.WriteString(w, fmt.Sprintf("Error: %s", errmsg))
-				if err != nil {
-					logrus.Errorln(err)
-					return
-				}
-
-				logrus.Debugln(errmsg)
-				// close the HTTP server and return
-				cleanup(server)
+				logrus.Errorln(err)
 				return
 			}
-		}
 
-		updatecliConfigPath, err := initConfigFile()
-		if err != nil {
-			logrus.Errorln(err)
+			logrus.Debugln(errmsg)
+			// close the HTTP server and return
+			cleanup(server)
 			return
 		}
 
-		logrus.Debugf("Updatecli configuration located at %q", updatecliConfigPath)
-
-		data, err := readConfigFile()
+		err = updateConfigFile(authData{
+			Token: accessToken,
+			Api:   audience,
+			URL:   frontURL,
+		})
 		if err != nil {
 			if !os.IsNotExist(err) {
 				logrus.Errorln(err)
@@ -137,26 +147,6 @@ func authorizeUser(frontURL, clientID, authDomain, audience, redirectURL, access
 				cleanup(server)
 				return
 			}
-		}
-
-		if data == nil {
-			data = &spec{}
-			data.Auths = make(map[string]authData)
-		}
-
-		data.Auths[sanitizeTokenID(audience)] = authData{
-			Token: token,
-			Api:   audience,
-			URL:   frontURL,
-		}
-		data.Default = sanitizeTokenID(audience)
-
-		err = writeConfigFile(updatecliConfigPath, data)
-		if err != nil {
-			logrus.Errorln(err)
-			// close the HTTP server and return
-			cleanup(server)
-			return
 		}
 
 		// return an indication of success to the caller


### PR DESCRIPTION
PKCE flow doesn't work from none interactive environment such as CI
This commit allows to skip the PKCE flow if an access token is provided via parameter

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
cp <to_package_directory>
go test
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
