### PR TITLE
Support multiple manifest into one single file

### DIFF
--- a/e2e/updatecli.d/success.d/multiManifest.yaml
+++ b/e2e/updatecli.d/success.d/multiManifest.yaml
@@ -1,0 +1,18 @@
+--- 
+name: First manifest
+sources:
+  default:
+    name: Show true
+    kind: shell
+    spec:
+      command: "echo 'Welcome to Updatecli'"
+
+--- 
+name: Second manifest
+sources:
+  default:
+    name: Show true
+    kind: shell
+    spec:
+      command: "echo 'Welcome to Updatecli'"
+

--- a/pkg/core/config/helper.go
+++ b/pkg/core/config/helper.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"fmt"
 	"io"
@@ -11,6 +12,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
+	"gopkg.in/yaml.v3"
 )
 
 // FileChecksum returns sha256 checksum based on a file content.
@@ -125,4 +127,25 @@ func getFieldValueByQuery(conf interface{}, query []string) (value string, err e
 
 	return value, nil
 
+}
+
+// unmarshalConfigSpec unmarshal an Updatecli config spec
+func unmarshalConfigSpec(in []byte, out *[]Spec) error {
+
+	r := bytes.NewReader(in)
+	dec := yaml.NewDecoder(r)
+
+	for {
+		var s Spec
+		if err := dec.Decode(&s); err != nil {
+			if err == io.EOF {
+				break
+			}
+			return err
+		}
+
+		*out = append(*out, s)
+	}
+
+	return nil
 }

--- a/pkg/core/config/testdata/updatecli.d/badJenkins.yaml
+++ b/pkg/core/config/testdata/updatecli.d/badJenkins.yaml
@@ -1,0 +1,9 @@
+name: Bad manifestg
+sources:
+  - name: Get latest stable Jenkins version
+    url: https://updates.jenkins.io/stable/latestCore.txt
+    type: file
+    version:
+      kind: regex
+      regex: "(\\d+\\.\\d+)"
+      group: 1

--- a/pkg/core/config/testdata/updatecli.d/badJenkins.yaml
+++ b/pkg/core/config/testdata/updatecli.d/badJenkins.yaml
@@ -1,4 +1,4 @@
-name: Bad manifestg
+name: Bad manifest
 sources:
   - name: Get latest stable Jenkins version
     url: https://updates.jenkins.io/stable/latestCore.txt
@@ -7,3 +7,4 @@ sources:
       kind: regex
       regex: "(\\d+\\.\\d+)"
       group: 1
+

--- a/pkg/core/config/testdata/updatecli.d/jenkins.yaml
+++ b/pkg/core/config/testdata/updatecli.d/jenkins.yaml
@@ -1,0 +1,1 @@
+name: Get Latest Jenkins version

--- a/pkg/core/config/testdata/updatecli.d/multiJenkins.yaml
+++ b/pkg/core/config/testdata/updatecli.d/multiJenkins.yaml
@@ -1,0 +1,5 @@
+---
+name: Get latest stable Jenkins version
+
+---
+name: Get latest weekly Jenkins version

--- a/pkg/core/config/testdata/updatecli.d/multiTemplatedJenkins.tpl
+++ b/pkg/core/config/testdata/updatecli.d/multiTemplatedJenkins.tpl
@@ -1,0 +1,4 @@
+{{- range $release := .releases }}
+---
+name: Get latest {{ $release.type }} Jenkins version
+{{- end }}

--- a/pkg/core/config/testdata/values.yaml
+++ b/pkg/core/config/testdata/values.yaml
@@ -1,0 +1,3 @@
+releases:
+  - type: lts
+  - type: weekly

--- a/pkg/core/engine/main.go
+++ b/pkg/core/engine/main.go
@@ -208,7 +208,7 @@ func (e *Engine) LoadConfigurations() error {
 
 	for _, manifestFile := range manifestFiles {
 
-		loadedConfiguration, err := config.New(
+		loadedConfigurations, err := config.New(
 			config.Option{
 				ManifestFile:      manifestFile,
 				SecretsFiles:      e.Options.Config.SecretsFiles,
@@ -229,18 +229,22 @@ func (e *Engine) LoadConfigurations() error {
 			continue
 		}
 
-		newPipeline := pipeline.Pipeline{}
-		err = newPipeline.Init(
-			&loadedConfiguration,
-			e.Options.Pipeline)
+		for id := range loadedConfigurations {
+			newPipeline := pipeline.Pipeline{}
+			loadedConfiguration := loadedConfigurations[id]
 
-		if err == nil {
-			e.Pipelines = append(e.Pipelines, newPipeline)
-			e.configurations = append(e.configurations, loadedConfiguration)
-		} else {
-			// don't initially fail as init. of the pipeline still fails even with a successful validation
-			err := fmt.Errorf("%q - %s", manifestFile, err)
-			errs = append(errs, err)
+			err = newPipeline.Init(
+				&loadedConfiguration,
+				e.Options.Pipeline)
+
+			if err == nil {
+				e.Pipelines = append(e.Pipelines, newPipeline)
+				e.configurations = append(e.configurations, loadedConfiguration)
+			} else {
+				// don't initially fail as init. of the pipeline still fails even with a successful validation
+				err := fmt.Errorf("%q - %s", manifestFile, err)
+				errs = append(errs, err)
+			}
 		}
 	}
 


### PR DESCRIPTION
This pullrequest adds support for multiple Updatecli manifest into one YAML file.
Combined with the templating engine, this open the door to very advanced scenario **but** this also means **complex** manifest without jsonschema validation...

ps: worth mentioning by default if no pipelineid are defined, then they all share the same one 

Fix #961 

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
cd pkg/core/config/
go test
```

## Additional Information

### Tradeoff

This feature allows to leverage the Golang templating with things like `range` such as in the following example

<details><summary>Simple manifest</summary>

values.yaml
```
names:
  - "Manifest 1"
  - "Manifest 2"
```

updatecli.yaml
```
{{- range $name := .names }}
---
name: {{ $name }}

sources:
  default:
    kind: shell
    spec:
      command: "echo 'Executing manifest {{ $name }}'"
{{- end }}
```
</details>

which shows

<details><summary>output</summary>

```
++++++++++++++++++
+ AUTO DISCOVERY +
++++++++++++++++++



++++++++++++
+ PIPELINE +
++++++++++++



##############
# MANIFEST 1 #
##############


SOURCES
=======

default
-------
The shell 🐚 command "/bin/sh /tmp/updatecli/bin/99aa0860859530c73d7b46e96b6a743321479b6f704e5ab92d961359e87fb0dd.sh" ran successfully with the following output:
----
Executing manifest Manifest 1
----
✔ shell command executed successfully


##############
# MANIFEST 2 #
##############


SOURCES
=======

default
-------
The shell 🐚 command "/bin/sh /tmp/updatecli/bin/2e064305c4cb4d9e1c4752a51558e7ff6338057f693aaf58b8bbc760e7050cfd.sh" ran successfully with the following output:
----
Executing manifest Manifest 2
----
✔ shell command executed successfully

=============================

REPORTS:



- Manifest 1:
	Source:
		✔ [default] 

- Manifest 2:
	Source:
		✔ [default] 

Run Summary
===========
Pipeline(s) run:
  * Changed:	0
  * Failed:	0
  * Skipped:	2
  * Succeeded:	0
  * Total:	2

```

</details>

### Potential improvement

While looking into this I spotted the following improvement which would be useful:

* Allowing to load manifest from http/https endpoint, we already have the code in Updatecli...
  * After having a quick look this would slightly complicate the code while bringing little benefits so I am going to skip on this one 
* Allowing to use json syntax, considering json is a subset of YAML. I did some early tests and everything seems to work as expected
- [ ] https://github.com/updatecli/updatecli/pull/1463
* Adding to the go template the function `toYaml` from the sprig library https://github.com/Masterminds/sprig/pull/360. I am considering adding the same function than the one used in helm as it will be exactly the same one that should be in the sprig library. This function would be the missing component to fix #961
- [ ] https://github.com/updatecli/updatecli/pull/1458 
* the command `updatecli manifest upgrade` don't work with multiple manifest into the same file. I am not considering add the support in this pullrequest because I think this command should be rework anyway.