### PR TITLE
fix: handle non-existing cargo packages

### DIFF
--- a/pkg/plugins/resources/cargopackage/condition_test.go
+++ b/pkg/plugins/resources/cargopackage/condition_test.go
@@ -41,7 +41,7 @@ func TestCondition(t *testing.T) {
 			expectedError:  false,
 		},
 		{
-			name: "Retrieving non-existing rand version from the default index api",
+			name: "Retrieving nonexistent rand version from the default index api",
 			spec: Spec{
 				Package: "rand",
 				Version: "99.99.99",
@@ -62,7 +62,7 @@ func TestCondition(t *testing.T) {
 			expectedError:  false,
 		},
 		{
-			name: "Retrieving none existing not-crate-test from the filesystem index",
+			name: "Retrieving nonexistent not-crate-test from the filesystem index",
 			spec: Spec{
 				Registry: cargo.Registry{
 					RootDir: dir,
@@ -86,7 +86,7 @@ func TestCondition(t *testing.T) {
 			expectedError:  false,
 		},
 		{
-			name: "Retrieving non-existing yanked crate-test version from the filesystem index",
+			name: "Retrieving nonexistent yanked crate-test version from the filesystem index",
 			spec: Spec{
 				Registry: cargo.Registry{
 					RootDir: dir,
@@ -120,7 +120,7 @@ func TestCondition(t *testing.T) {
 			mockedHTTPStatusCode: existingPackageStatus,
 		},
 		{
-			name: "Retrieving non-existing crate-test version from the mocked private registry",
+			name: "Retrieving nonexistent crate-test version from the mocked private registry",
 			spec: Spec{
 				Registry: cargo.Registry{
 					URL: "https://crates.io/api/v1/crates",
@@ -142,7 +142,7 @@ func TestCondition(t *testing.T) {
 			mockedHTTPStatusCode: existingPackageStatus,
 		},
 		{
-			name: "Retrieving none existing non-crate-test from the mocked private registry",
+			name: "Retrieving nonexistent non-crate-test from the mocked private registry",
 			spec: Spec{
 				Registry: cargo.Registry{
 					URL: "https://crates.io/api/v1/crates",

--- a/pkg/plugins/resources/cargopackage/condition_test.go
+++ b/pkg/plugins/resources/cargopackage/condition_test.go
@@ -62,7 +62,7 @@ func TestCondition(t *testing.T) {
 			expectedError:  false,
 		},
 		{
-			name: "Retrieving non existing not-crate-test from the filesystem index",
+			name: "Retrieving none existing not-crate-test from the filesystem index",
 			spec: Spec{
 				Registry: cargo.Registry{
 					RootDir: dir,

--- a/pkg/plugins/resources/cargopackage/condition_test.go
+++ b/pkg/plugins/resources/cargopackage/condition_test.go
@@ -62,6 +62,18 @@ func TestCondition(t *testing.T) {
 			expectedError:  false,
 		},
 		{
+			name: "Retrieving non existing not-crate-test from the filesystem index",
+			spec: Spec{
+				Registry: cargo.Registry{
+					RootDir: dir,
+				},
+				Package: "non-crate-test",
+				Version: "0.2.2",
+			},
+			expectedResult: false,
+			expectedError:  false,
+		},
+		{
 			name: "Retrieving existing yanked crate-test version from the filesystem index",
 			spec: Spec{
 				Registry: cargo.Registry{
@@ -128,6 +140,28 @@ func TestCondition(t *testing.T) {
 			mockedToken:          "mytoken",
 			mockedHeaderFormat:   "Bearer %s",
 			mockedHTTPStatusCode: existingPackageStatus,
+		},
+		{
+			name: "Retrieving non-existing non-crate-test from the mocked private registry",
+			spec: Spec{
+				Registry: cargo.Registry{
+					URL: "https://crates.io/api/v1/crates",
+					Auth: cargo.InlineKeyChain{
+						Token:        "mytoken",
+						HeaderFormat: "Bearer %s",
+					},
+				},
+				Package: "non-crate-test",
+				Version: "99.99.99",
+			},
+			expectedResult:       false,
+			expectedError:        false,
+			mockedResponse:       true,
+			mockedBody:           nonExistingPackageData,
+			mockedUrl:            "https://crates.io/api/v1/crates",
+			mockedToken:          "mytoken",
+			mockedHeaderFormat:   "Bearer %s",
+			mockedHTTPStatusCode: nonExistingPackageStatus,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/plugins/resources/cargopackage/condition_test.go
+++ b/pkg/plugins/resources/cargopackage/condition_test.go
@@ -142,7 +142,7 @@ func TestCondition(t *testing.T) {
 			mockedHTTPStatusCode: existingPackageStatus,
 		},
 		{
-			name: "Retrieving non-existing non-crate-test from the mocked private registry",
+			name: "Retrieving none existing non-crate-test from the mocked private registry",
 			spec: Spec{
 				Registry: cargo.Registry{
 					URL: "https://crates.io/api/v1/crates",

--- a/pkg/plugins/resources/cargopackage/main.go
+++ b/pkg/plugins/resources/cargopackage/main.go
@@ -121,6 +121,10 @@ func (cp *CargoPackage) getVersions() (v string, versions []string, err error) {
 		}
 	}
 
+	if len(versions) == 0 {
+		// No versions found
+		return "", versions, nil
+	}
 	sort.Strings(versions)
 	cp.foundVersion, err = cp.versionFilter.Search(versions)
 	if err != nil {
@@ -192,8 +196,7 @@ func (cp *CargoPackage) getPackageDataFromFS(name string, indexDir string) (Pack
 	packageFilePath := filepath.Join(indexDir, packageDir, name)
 	packageInfoFile, err := os.Open(packageFilePath)
 	if err != nil {
-		logrus.Errorf("something went wrong while opening the package file %q\n", err)
-		return pd, err
+		return pd, nil
 	}
 	defer func(packageInfoFile *os.File) {
 		err := packageInfoFile.Close()

--- a/pkg/plugins/resources/cargopackage/source_test.go
+++ b/pkg/plugins/resources/cargopackage/source_test.go
@@ -59,12 +59,12 @@ func TestSource(t *testing.T) {
 			expectedError:  false,
 		},
 		{
-			name: "Passing case of retrieving none existing crate-test from the filesystem index",
+			name: "Passing case of retrieving nonexistent crate-test from the filesystem index",
 			spec: Spec{
 				Registry: cargo.Registry{
 					RootDir: dir,
 				},
-				Package: "non-existing-crate-test",
+				Package: "nonexistent-crate-test",
 				VersionFilter: version.Filter{
 					Kind:    "semver",
 					Pattern: "~0.1",
@@ -107,7 +107,7 @@ func TestSource(t *testing.T) {
 						HeaderFormat: "Bearer %s",
 					},
 				},
-				Package: "crate-test-non-existing",
+				Package: "crate-test-nonexistent",
 				VersionFilter: version.Filter{
 					Kind:    "semver",
 					Pattern: "~0.1",

--- a/pkg/plugins/resources/cargopackage/source_test.go
+++ b/pkg/plugins/resources/cargopackage/source_test.go
@@ -59,7 +59,7 @@ func TestSource(t *testing.T) {
 			expectedError:  false,
 		},
 		{
-			name: "Passing case of retrieving non-existing crate-test from the filesystem index",
+			name: "Passing case of retrieving none existing crate-test from the filesystem index",
 			spec: Spec{
 				Registry: cargo.Registry{
 					RootDir: dir,

--- a/pkg/plugins/resources/cargopackage/source_test.go
+++ b/pkg/plugins/resources/cargopackage/source_test.go
@@ -59,6 +59,20 @@ func TestSource(t *testing.T) {
 			expectedError:  false,
 		},
 		{
+			name: "Passing case of retrieving non-existing crate-test from the filesystem index",
+			spec: Spec{
+				Registry: cargo.Registry{
+					RootDir: dir,
+				},
+				Package: "non-existing-crate-test",
+				VersionFilter: version.Filter{
+					Kind:    "semver",
+					Pattern: "~0.1",
+				},
+			},
+			expectedError: true,
+		},
+		{
 			name: "Passing case of retrieving crate-test version from a mocked private registry",
 			spec: Spec{
 				Registry: cargo.Registry{


### PR DESCRIPTION
Fix #1459

Make sure we can handle the cases when a package does not exists

## Test

To test this pull request, you can run check the following pipeline file
```yaml
name: Retrieve the latest Cargo Package Version

scms:
  private-registry:
    kind: git
    spec:
      url: "https://github.com/updatecli-test/fake-cargo-registry.git"
      branch: "main"

conditions:
  existing-package-private-reg:
    name: Test if test-crate-2 0.1.0 exists on private registry
    kind: cargopackage
    scmid: private-registry
    spec:
      package: test-crate-2
      version: 0.1.0
  existing-package-not-existing-version-private-reg:
    name: Test if test-crate-2 0.6.0 does not exists on private registry
    kind: cargopackage
    scmid: private-registry
    failwhen: true
    spec:
      package: test-crate-2
      version: 0.6.0
  non-existing-package-private-reg:
    name: Test if non-existing-test-crate 0.1.0 does not exists on private registry
    kind: cargopackage
    scmid: private-registry
    failwhen: true
    spec:
      package: non-existing-test-crate
      version: 0.1.0
  existing-package-public-reg:
    name: Test if rand version exists on public reg
    kind: cargopackage
    spec:
      package: rand
      version: 0.7.2
  existing-package-p-not-existing-version-public-reg:
    name: Test if rand version 99.99.99 does not exists on public reg
    kind: cargopackage
    failwhen: true
    spec:
      package: rand
      version: 99.99.99
  non-existing-package-public-reg:
    name: Test if non-existing-package-to-be-sure-123456 does exists on public reg
    kind: cargopackage
    failwhen: true
    spec:
      package: non-existing-package-to-be-sure-123456
      version: 0.7.2
```

