### PR TITLE
Add Docker Image Tag to Docker Image Digest

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -23,3 +23,4 @@ CLIENTID
 minamijoyo
 hcledit
 work-around
+hidetag

--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -23,4 +23,3 @@ CLIENTID
 minamijoyo
 hcledit
 work-around
-hidetag

--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -23,3 +23,4 @@ CLIENTID
 minamijoyo
 hcledit
 work-around
+hiddentag

--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -23,4 +23,4 @@ CLIENTID
 minamijoyo
 hcledit
 work-around
-hiddentag
+hidetag

--- a/e2e/updatecli.d/success.d/dockerdigest.yaml
+++ b/e2e/updatecli.d/success.d/dockerdigest.yaml
@@ -56,6 +56,21 @@ conditions:
       image: "updatecli/updatecli"
       digest: "@sha256:5d86b9249e62a10655a207359cf8480e113284d4bcfd68cd088de5879e293408"
 
+  dockerhub2:
+    name: "Test if  Digest for docker image updatecli/updatecli:v0.35.1 exist"
+    kind: "dockerdigest"
+    sourceid: dockerhub
+    spec:
+      image: "updatecli/updatecli"
+
+  dockerhubWithTag:
+    name: "Test if  Digest for docker image updatecli/updatecli:v0.35.1 exist using both tag and digest"
+    kind: "dockerdigest"
+    disablesourceinput: true
+    spec:
+      image: "updatecli/updatecli"
+      digest: "v0.35.1@sha256:5d86b9249e62a10655a207359cf8480e113284d4bcfd68cd088de5879e293408"
+
   # Ghcr return an created time ordered list of container image tag
   ghcr.io:
     name: "Test if  Latest Tag  ghcr.io/updatecli/updatecli exist"

--- a/e2e/updatecli.d/success.d/dockerdigest.yaml
+++ b/e2e/updatecli.d/success.d/dockerdigest.yaml
@@ -26,7 +26,7 @@ sources:
       image: "ghcr.io/updatecli/updatecli"
       architecture: "amd64"
       tag: "v0.35.1"
-      hidetag: true
+      hiddentag: true
 
 
 conditions:

--- a/e2e/updatecli.d/success.d/dockerdigest.yaml
+++ b/e2e/updatecli.d/success.d/dockerdigest.yaml
@@ -26,6 +26,7 @@ sources:
       image: "ghcr.io/updatecli/updatecli"
       architecture: "amd64"
       tag: "v0.35.1"
+      hidetag: true
 
 
 conditions:

--- a/e2e/updatecli.d/success.d/dockerdigest.yaml
+++ b/e2e/updatecli.d/success.d/dockerdigest.yaml
@@ -26,7 +26,7 @@ sources:
       image: "ghcr.io/updatecli/updatecli"
       architecture: "amd64"
       tag: "v0.35.1"
-      hiddentag: true
+      hidetag: true
 
 
 conditions:

--- a/pkg/plugins/resources/dockerdigest/condition.go
+++ b/pkg/plugins/resources/dockerdigest/condition.go
@@ -11,6 +11,7 @@ import (
 	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
+// Condition checks if a Docker image tag digest exists in a registry
 func (ds *DockerDigest) Condition(source string, scm scm.ScmHandler, resultCondition *result.Condition) error {
 	if scm != nil {
 		logrus.Warningln("scm is not supported, ignoring")
@@ -19,9 +20,9 @@ func (ds *DockerDigest) Condition(source string, scm scm.ScmHandler, resultCondi
 	refName := ds.spec.Image
 	switch ds.spec.Digest == "" {
 	case true:
-		refName += "@" + source
+		refName = joinImageTagWithName(refName, source)
 	case false:
-		refName += ds.spec.Digest
+		refName = joinImageTagWithName(refName, ds.spec.Digest)
 	}
 
 	ref, err := name.ParseReference(refName)
@@ -50,4 +51,22 @@ func (ds *DockerDigest) Condition(source string, scm scm.ScmHandler, resultCondi
 	)
 
 	return nil
+}
+
+// joinImageTagWithName handles the different kind of join tag
+func joinImageTagWithName(image, tag string) string {
+	/*
+		if tag start with @sha256, we assume that the tag is a digest
+		if tag start with ':', we assume that the tag is a tag and not a digest
+	*/
+	if strings.HasPrefix(tag, ":") || strings.HasPrefix(tag, "@sha256") {
+		return image + tag
+	}
+
+	// if the tag doesnt' start with @sha256 then we assume the first part is a tag
+	if strings.Contains(tag, "@sha256") && !strings.HasPrefix(tag, "@sha256") {
+		return image + ":" + strings.TrimPrefix(tag, ":")
+	}
+
+	return image + "@" + tag
 }

--- a/pkg/plugins/resources/dockerdigest/condition_test.go
+++ b/pkg/plugins/resources/dockerdigest/condition_test.go
@@ -71,7 +71,8 @@ func TestCondition(t *testing.T) {
 
 			gotResult := result.Condition{}
 
-			DockerDigest.Condition(TestCases[i].sourceOutput, nil, &gotResult)
+			err = DockerDigest.Condition(TestCases[i].sourceOutput, nil, &gotResult)
+			require.NoError(t, err)
 
 			assert.Equal(t, TestCases[i].expectedResult.Pass, gotResult.Pass)
 		})

--- a/pkg/plugins/resources/dockerdigest/condition_test.go
+++ b/pkg/plugins/resources/dockerdigest/condition_test.go
@@ -1,0 +1,79 @@
+package dockerdigest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/updatecli/updatecli/pkg/core/result"
+)
+
+func TestCondition(t *testing.T) {
+	TestCases := []struct {
+		name           string
+		spec           Spec
+		sourceOutput   string
+		expectedResult result.Condition
+	}{
+		{
+			name: "Test condition with a digest specified via the manifest",
+			spec: Spec{
+				Image:  "ghcr.io/updatecli/updatecli",
+				Digest: "v0.35.0@sha256:6e1833e5240ac52ecf7609623f18ec4536151e0f58b7243b92fd71ecdf3b94df",
+			},
+			expectedResult: result.Condition{
+				Result: "SUCCESS",
+				Pass:   true,
+			},
+		},
+		{
+			name:         "Test condition with a digest specified via the source output",
+			sourceOutput: "v0.35.0@sha256:6e1833e5240ac52ecf7609623f18ec4536151e0f58b7243b92fd71ecdf3b94df",
+			spec: Spec{
+				Image:  "ghcr.io/updatecli/updatecli",
+				Digest: "v0.35.0@sha256:6e1833e5240ac52ecf7609623f18ec4536151e0f58b7243b92fd71ecdf3b94df",
+			},
+			expectedResult: result.Condition{
+				Result: "SUCCESS",
+				Pass:   true,
+			},
+		},
+		{
+			name: "Test condition with a digest specified via the manifest without tag",
+			spec: Spec{
+				Image:  "ghcr.io/updatecli/updatecli",
+				Digest: "@sha256:6e1833e5240ac52ecf7609623f18ec4536151e0f58b7243b92fd71ecdf3b94df",
+			},
+			expectedResult: result.Condition{
+				Result: "SUCCESS",
+				Pass:   true,
+			},
+		},
+		{
+			name:         "Test condition with a digest specified via the source output",
+			sourceOutput: "v0.35.0@sha256:6e1833e5240ac52ecf7609623f18ec4536151e0f58b7243b92fd71ecdf3b94df",
+			spec: Spec{
+				Image:  "ghcr.io/updatecli/updatecli",
+				Digest: "@sha256:6e1833e5240ac52ecf7609623f18ec4536151e0f58b7243b92fd71ecdf3b94df",
+			},
+			expectedResult: result.Condition{
+				Result: "SUCCESS",
+				Pass:   true,
+			},
+		},
+	}
+
+	for i := range TestCases {
+
+		t.Run(t.Name(), func(t *testing.T) {
+			DockerDigest, err := New(TestCases[i].spec)
+			require.NoError(t, err)
+
+			gotResult := result.Condition{}
+
+			DockerDigest.Condition(TestCases[i].sourceOutput, nil, &gotResult)
+
+			assert.Equal(t, TestCases[i].expectedResult.Pass, gotResult.Pass)
+		})
+	}
+}

--- a/pkg/plugins/resources/dockerdigest/main.go
+++ b/pkg/plugins/resources/dockerdigest/main.go
@@ -49,7 +49,7 @@ type Spec struct {
 	Digest                string `yaml:",omitempty"`
 	docker.InlineKeyChain `yaml:",inline" mapstructure:",squash"`
 	/*
-		hiddenTag specifies if the tag should be hidden from the digest
+		hideTag specifies if the tag should be hidden from the digest
 
 		compatible:
 			* source
@@ -57,7 +57,7 @@ type Spec struct {
 		default:
 			false
 	*/
-	HiddenTag bool `yaml:",omitempty"`
+	HideTag bool `yaml:",omitempty"`
 }
 
 // DockerDigest defines a resource of kind "dockerDigest" to interact with a docker registry

--- a/pkg/plugins/resources/dockerdigest/main.go
+++ b/pkg/plugins/resources/dockerdigest/main.go
@@ -10,13 +10,39 @@ import (
 
 // Spec defines a specification for a "dockerdigest" resource parsed from an updatecli manifest file
 type Spec struct {
-	// [s][c] Architecture specifies the container image architecture such as `amd64`
+	/*
+		architecture specifies the container image architecture such as `amd64`
+
+		compatible:
+			* source
+			* condition
+	*/
 	Architecture string `yaml:",omitempty"`
-	// [s][c] Image specifies the container image such as `updatecli/updatecli`
+	/*
+		image specifies the container image such as `updatecli/updatecli`
+
+		compatible:
+			* source
+			* condition
+	*/
 	Image string `yaml:",omitempty"`
-	// [s] Tag specifies the container image tag such as `latest`
+	/*
+		tag specifies the container image tag such as `latest`
+
+		compatible:
+			* source
+			* condition
+	*/
 	Tag string `yaml:",omitempty"`
-	// [c] Digest specifies the container image digest such as `@sha256:ce782db15ab5491c6c6178da8431b3db66988ccd11512034946a9667846952a6`
+	/*
+		digest specifies the container image digest such as `sha256:ce782db15ab5491c6c6178da8431b3db66988ccd11512034946a9667846952a6`
+
+		compatible:
+			* condition
+
+		default:
+			When used from a condition, the default value is set to the linked source output.
+	*/
 	Digest                string `yaml:",omitempty"`
 	docker.InlineKeyChain `yaml:",inline" mapstructure:",squash"`
 }

--- a/pkg/plugins/resources/dockerdigest/main.go
+++ b/pkg/plugins/resources/dockerdigest/main.go
@@ -16,6 +16,9 @@ type Spec struct {
 		compatible:
 			* source
 			* condition
+
+		default:
+			amd64
 	*/
 	Architecture string `yaml:",omitempty"`
 	/*
@@ -45,6 +48,16 @@ type Spec struct {
 	*/
 	Digest                string `yaml:",omitempty"`
 	docker.InlineKeyChain `yaml:",inline" mapstructure:",squash"`
+	/*
+		hideTag specifies if the tag should be hidden from the digest
+
+		compatible:
+			* source
+
+		default:
+			false
+	*/
+	HideTag bool `yaml:",omitempty"`
 }
 
 // DockerDigest defines a resource of kind "dockerDigest" to interact with a docker registry

--- a/pkg/plugins/resources/dockerdigest/main.go
+++ b/pkg/plugins/resources/dockerdigest/main.go
@@ -49,7 +49,7 @@ type Spec struct {
 	Digest                string `yaml:",omitempty"`
 	docker.InlineKeyChain `yaml:",inline" mapstructure:",squash"`
 	/*
-		hideTag specifies if the tag should be hidden from the digest
+		hiddenTag specifies if the tag should be hidden from the digest
 
 		compatible:
 			* source
@@ -57,7 +57,7 @@ type Spec struct {
 		default:
 			false
 	*/
-	HideTag bool `yaml:",omitempty"`
+	HiddenTag bool `yaml:",omitempty"`
 }
 
 // DockerDigest defines a resource of kind "dockerDigest" to interact with a docker registry

--- a/pkg/plugins/resources/dockerdigest/source.go
+++ b/pkg/plugins/resources/dockerdigest/source.go
@@ -43,7 +43,7 @@ func (ds *DockerDigest) Source(workingDir string, resultSource *result.Source) e
 	finalDigest := refTag + "@" + digest.String()
 	imageDigest := ref.Context().Name() + ":" + finalDigest
 
-	if ds.spec.HideTag {
+	if ds.spec.HiddenTag {
 		imageDigest = ref.Context().Name() + "@" + digest.String()
 		finalDigest = "@" + digest.String()
 	}

--- a/pkg/plugins/resources/dockerdigest/source.go
+++ b/pkg/plugins/resources/dockerdigest/source.go
@@ -8,7 +8,7 @@ import (
 	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
-// Source retrieve docker image tag digest from a registry
+// Source retrieves Docker image tag digest from a registry
 func (ds *DockerDigest) Source(workingDir string, resultSource *result.Source) error {
 	refName := ds.spec.Image
 	if ds.spec.Tag != "" {
@@ -26,10 +26,12 @@ func (ds *DockerDigest) Source(workingDir string, resultSource *result.Source) e
 	if err != nil {
 		return fmt.Errorf("unable to retrieve image digest %s: %w", refName, err)
 	}
-	imageDigest := ref.Context().Name() + "@" + digest.String()
+
+	digestWithTag := ds.spec.Tag + "@" + digest.String()
+	imageDigest := ref.Context().Name() + ":" + digestWithTag
 
 	resultSource.Result = result.SUCCESS
-	resultSource.Information = digest.String()
+	resultSource.Information = digestWithTag
 	resultSource.Description = fmt.Sprintf("Docker Image Tag %s resolved to digest %s",
 		ref.String(), imageDigest)
 

--- a/pkg/plugins/resources/dockerdigest/source.go
+++ b/pkg/plugins/resources/dockerdigest/source.go
@@ -2,6 +2,7 @@ package dockerdigest
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
@@ -10,24 +11,36 @@ import (
 
 // Source retrieves Docker image tag digest from a registry
 func (ds *DockerDigest) Source(workingDir string, resultSource *result.Source) error {
+	refTag := ""
 	refName := ds.spec.Image
+
 	if ds.spec.Tag != "" {
-		refName += ":" + ds.spec.Tag
+		if strings.HasPrefix(ds.spec.Tag, "@") {
+			return fmt.Errorf("invalid tag %s: only contain a digest", ds.spec.Image)
+		}
+
+		refTagArray := strings.Split(ds.spec.Tag, "@")
+		refTag = strings.TrimPrefix(refTagArray[0], ":")
+
+		refName += ":" + refTag
 	}
+
 	ref, err := name.ParseReference(refName)
 	if err != nil {
 		return fmt.Errorf("invalid image %s: %w", refName, err)
 	}
+
 	image, err := remote.Image(ref, ds.options...)
 	if err != nil {
 		return fmt.Errorf("unable to retrieve image %s: %w", refName, err)
 	}
+
 	digest, err := image.Digest()
 	if err != nil {
 		return fmt.Errorf("unable to retrieve image digest %s: %w", refName, err)
 	}
 
-	finalDigest := ds.spec.Tag + "@" + digest.String()
+	finalDigest := refTag + "@" + digest.String()
 	imageDigest := ref.Context().Name() + ":" + finalDigest
 
 	if ds.spec.HideTag {

--- a/pkg/plugins/resources/dockerdigest/source.go
+++ b/pkg/plugins/resources/dockerdigest/source.go
@@ -27,11 +27,16 @@ func (ds *DockerDigest) Source(workingDir string, resultSource *result.Source) e
 		return fmt.Errorf("unable to retrieve image digest %s: %w", refName, err)
 	}
 
-	digestWithTag := ds.spec.Tag + "@" + digest.String()
-	imageDigest := ref.Context().Name() + ":" + digestWithTag
+	finalDigest := ds.spec.Tag + "@" + digest.String()
+	imageDigest := ref.Context().Name() + ":" + finalDigest
+
+	if ds.spec.HideTag {
+		imageDigest = ref.Context().Name() + "@" + digest.String()
+		finalDigest = "@" + digest.String()
+	}
 
 	resultSource.Result = result.SUCCESS
-	resultSource.Information = digestWithTag
+	resultSource.Information = finalDigest
 	resultSource.Description = fmt.Sprintf("Docker Image Tag %s resolved to digest %s",
 		ref.String(), imageDigest)
 

--- a/pkg/plugins/resources/dockerdigest/source.go
+++ b/pkg/plugins/resources/dockerdigest/source.go
@@ -43,7 +43,7 @@ func (ds *DockerDigest) Source(workingDir string, resultSource *result.Source) e
 	finalDigest := refTag + "@" + digest.String()
 	imageDigest := ref.Context().Name() + ":" + finalDigest
 
-	if ds.spec.HiddenTag {
+	if ds.spec.HideTag {
 		imageDigest = ref.Context().Name() + "@" + digest.String()
 		finalDigest = "@" + digest.String()
 	}

--- a/pkg/plugins/resources/dockerdigest/source_test.go
+++ b/pkg/plugins/resources/dockerdigest/source_test.go
@@ -28,9 +28,9 @@ func TestSource(t *testing.T) {
 		{
 			name: "Nominal case with hidden tag from digest",
 			spec: Spec{
-				Image:   "ghcr.io/updatecli/updatecli",
-				Tag:     "v0.35.0",
-				HideTag: true,
+				Image:     "ghcr.io/updatecli/updatecli",
+				Tag:       "v0.35.0",
+				HiddenTag: true,
 			},
 			expectedResult: result.Source{
 				Information: "@sha256:6e1833e5240ac52ecf7609623f18ec4536151e0f58b7243b92fd71ecdf3b94df",

--- a/pkg/plugins/resources/dockerdigest/source_test.go
+++ b/pkg/plugins/resources/dockerdigest/source_test.go
@@ -25,6 +25,17 @@ func TestSource(t *testing.T) {
 				Information: "v0.35.0@sha256:6e1833e5240ac52ecf7609623f18ec4536151e0f58b7243b92fd71ecdf3b94df",
 			},
 		},
+		{
+			name: "Nominal case",
+			spec: Spec{
+				Image:   "ghcr.io/updatecli/updatecli",
+				Tag:     "v0.35.0",
+				HideTag: true,
+			},
+			expectedResult: result.Source{
+				Information: "@sha256:6e1833e5240ac52ecf7609623f18ec4536151e0f58b7243b92fd71ecdf3b94df",
+			},
+		},
 	}
 
 	for i := range TestCases {
@@ -35,7 +46,8 @@ func TestSource(t *testing.T) {
 
 			gotResult := result.Source{}
 
-			DockerDigest.Source("", &gotResult)
+			err = DockerDigest.Source("", &gotResult)
+			require.NoError(t, err)
 
 			assert.Equal(t, TestCases[i].expectedResult.Information, gotResult.Information)
 		})

--- a/pkg/plugins/resources/dockerdigest/source_test.go
+++ b/pkg/plugins/resources/dockerdigest/source_test.go
@@ -28,9 +28,9 @@ func TestSource(t *testing.T) {
 		{
 			name: "Nominal case with hidden tag from digest",
 			spec: Spec{
-				Image:     "ghcr.io/updatecli/updatecli",
-				Tag:       "v0.35.0",
-				HiddenTag: true,
+				Image:   "ghcr.io/updatecli/updatecli",
+				Tag:     "v0.35.0",
+				HideTag: true,
 			},
 			expectedResult: result.Source{
 				Information: "@sha256:6e1833e5240ac52ecf7609623f18ec4536151e0f58b7243b92fd71ecdf3b94df",

--- a/pkg/plugins/resources/dockerdigest/source_test.go
+++ b/pkg/plugins/resources/dockerdigest/source_test.go
@@ -1,0 +1,43 @@
+package dockerdigest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/updatecli/updatecli/pkg/core/result"
+)
+
+// TestSource tests the Source method using integration tests
+func TestSource(t *testing.T) {
+	TestCases := []struct {
+		name           string
+		spec           Spec
+		expectedResult result.Source
+	}{
+		{
+			name: "Nominal case",
+			spec: Spec{
+				Image: "ghcr.io/updatecli/updatecli",
+				Tag:   "v0.35.0",
+			},
+			expectedResult: result.Source{
+				Information: "v0.35.0@sha256:6e1833e5240ac52ecf7609623f18ec4536151e0f58b7243b92fd71ecdf3b94df",
+			},
+		},
+	}
+
+	for i := range TestCases {
+
+		t.Run(t.Name(), func(t *testing.T) {
+			DockerDigest, err := New(TestCases[i].spec)
+			require.NoError(t, err)
+
+			gotResult := result.Source{}
+
+			DockerDigest.Source("", &gotResult)
+
+			assert.Equal(t, TestCases[i].expectedResult.Information, gotResult.Information)
+		})
+	}
+}

--- a/pkg/plugins/resources/dockerdigest/source_test.go
+++ b/pkg/plugins/resources/dockerdigest/source_test.go
@@ -26,7 +26,7 @@ func TestSource(t *testing.T) {
 			},
 		},
 		{
-			name: "Nominal case",
+			name: "Nominal case with hidden tag from digest",
 			spec: Spec{
 				Image:   "ghcr.io/updatecli/updatecli",
 				Tag:     "v0.35.0",
@@ -34,6 +34,16 @@ func TestSource(t *testing.T) {
 			},
 			expectedResult: result.Source{
 				Information: "@sha256:6e1833e5240ac52ecf7609623f18ec4536151e0f58b7243b92fd71ecdf3b94df",
+			},
+		},
+		{
+			name: "Get latest digest reusing the tag prefix",
+			spec: Spec{
+				Image: "ghcr.io/updatecli/updatecli",
+				Tag:   "v0.35.0@sha256:6e1833e5240ac52ecf7609623f18ec4536151e0f58b7243b92fd71ecdf3b94df",
+			},
+			expectedResult: result.Source{
+				Information: "v0.35.0@sha256:6e1833e5240ac52ecf7609623f18ec4536151e0f58b7243b92fd71ecdf3b94df",
 			},
 		},
 	}

--- a/pkg/plugins/resources/dockerdigest/target.go
+++ b/pkg/plugins/resources/dockerdigest/target.go
@@ -7,6 +7,7 @@ import (
 	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
+// Target is not supported for the plugin Docker Digest
 func (ds *DockerDigest) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
 	return fmt.Errorf("Target not supported for the plugin Docker Digest")
 }

--- a/pkg/plugins/utils/docker/main.go
+++ b/pkg/plugins/utils/docker/main.go
@@ -7,12 +7,43 @@ import (
 	"github.com/google/go-containerregistry/pkg/authn"
 )
 
+// InlineKeyChain defines a keychain with OCI registry credentials
 type InlineKeyChain struct {
-	// [S][C][T] Username specifies the container registry username to use for authentication. Not compatible with token
+	/*
+		username specifies the container registry username to use for authentication.
+
+		compatible:
+			* source
+			* condition
+			* target
+
+		remark:
+			Not compatible with token
+	*/
 	Username string `yaml:",omitempty"`
-	// [S][C][T] Password specifies the container registry password to use for authentication. Not compatible with token
+	/*
+		password specifies the container registry password to use for authentication. Not compatible with token
+
+		compatible:
+			* source
+			* condition
+			* target
+
+		remark:
+			Not compatible with token
+	*/
 	Password string `yaml:",omitempty"`
-	// [S][C][T] Token specifies the container registry token to use for authentication. Not compatible with username/password
+	/*
+		token specifies the container registry token to use for authentication.
+
+		compatible:
+			* source
+			* condition
+			* target
+
+		remark:
+			Not compatible with username/password
+	*/
 	Token string `yaml:",omitempty"`
 }
 
@@ -25,6 +56,7 @@ func (kc InlineKeyChain) Resolve(authn.Resource) (authn.Authenticator, error) {
 	}), nil
 }
 
+// Empty returns true if the keychain is empty
 func (kc InlineKeyChain) Empty() bool {
 	return kc.Username == "" && kc.Password == "" && kc.Token == ""
 }


### PR DESCRIPTION
Fix #999 

I had the param `hidetag` to hide the tag from the final digest such as 

```
sources:
  ghcr.io:
    name: "Get Latest Tag from ghcr"
    kind: "dockerdigest"
    spec:
      image: "ghcr.io/updatecli/updatecli"
      architecture: "amd64"
      tag: "v0.35.1"
      hidetag: true

```

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
cd pkg/plugins/resources/dockerdigest/
go test
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

