### PR TITLE
Show templating diff from `updatecli manifest show --debug`

### DIFF
--- a/cmd/manifest_show.go
+++ b/cmd/manifest_show.go
@@ -6,6 +6,8 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/spf13/cobra"
+
+	"github.com/updatecli/updatecli/pkg/core/config"
 )
 
 var (
@@ -23,6 +25,9 @@ var (
 			e.Options.Pipeline.Target.Clean = manifestShowClean
 
 			e.Options.Config.DisableTemplating = manifestShowDisableTemplating
+
+			// Showing templating diff may leak sensitive information such as credentials
+			config.GolangTemplatingDiff = true
 
 			err := run("manifest/show")
 			if err != nil {

--- a/pkg/core/config/main.go
+++ b/pkg/core/config/main.go
@@ -147,12 +147,12 @@ func New(option Option) (configs []Config, err error) {
 		}
 
 		if GolangTemplatingDiff {
-			diff := text.Diff(option.ManifestFile, string(rawcontent), string(content))
+			diff := text.Diff("raw manifest", "templated manifest", string(rawcontent), string(content))
 			switch diff {
 			case "":
 				logrus.Debugf("no Golang templating detected\n", diff)
 			default:
-				logrus.Debugf("Golang templating change detected:\n---raw file content\n+++post Golang templating\n%v\n\n---\n", diff)
+				logrus.Debugf("Golang templating change detected:\n%s\n\n---\n", diff)
 			}
 		}
 	}

--- a/pkg/core/config/main.go
+++ b/pkg/core/config/main.go
@@ -115,8 +115,8 @@ func New(option Option) (configs []Config, err error) {
 
 	defer c.Close()
 
-	var content []byte
-	rawcontent, err := io.ReadAll(c)
+	var templatedManifestContent []byte
+	rawManifestContent, err := io.ReadAll(c)
 	if err != nil {
 		return configs, err
 	}
@@ -140,14 +140,14 @@ func New(option Option) (configs []Config, err error) {
 			fs:           fs,
 		}
 
-		content, err = t.New(rawcontent)
+		templatedManifestContent, err = t.New(rawManifestContent)
 		if err != nil {
-			logrus.Errorf("Error while templating %q:\n---\n%s\n---\n\t%s\n", option.ManifestFile, string(rawcontent), err.Error())
+			logrus.Errorf("Error while templating %q:\n---\n%s\n---\n\t%s\n", option.ManifestFile, string(rawManifestContent), err.Error())
 			return configs, err
 		}
 
 		if GolangTemplatingDiff {
-			diff := text.Diff("raw manifest", "templated manifest", string(rawcontent), string(content))
+			diff := text.Diff("raw manifest", "templated manifest", string(rawManifestContent), string(templatedManifestContent))
 			switch diff {
 			case "":
 				logrus.Debugf("no Golang templating detected\n", diff)
@@ -160,7 +160,7 @@ func New(option Option) (configs []Config, err error) {
 	switch extension := filepath.Ext(basename); extension {
 	case ".tpl", ".tmpl", ".yaml", ".yml", ".json":
 
-		err = unmarshalConfigSpec(content, &specs)
+		err = unmarshalConfigSpec(templatedManifestContent, &specs)
 		if err != nil {
 			return configs, err
 		}

--- a/pkg/core/config/main.go
+++ b/pkg/core/config/main.go
@@ -150,7 +150,7 @@ func New(option Option) (configs []Config, err error) {
 			diff := text.Diff("raw manifest", "templated manifest", string(rawManifestContent), string(templatedManifestContent))
 			switch diff {
 			case "":
-				logrus.Debugf("no Golang templating detected\n", diff)
+				logrus.Debugln("no Golang templating detected")
 			default:
 				logrus.Debugf("Golang templating change detected:\n%s\n\n---\n", diff)
 			}

--- a/pkg/core/config/variables.go
+++ b/pkg/core/config/variables.go
@@ -3,4 +3,10 @@ package config
 var (
 	// Define indentation used to encode yaml data
 	YAMLSetIdent int = 4
+
+	/*
+		GolangTemplatingDiff is used to enable or disable the diff feature.
+		Showing the diff may leak sensitive information like credentials.
+	*/
+	GolangTemplatingDiff bool
 )

--- a/pkg/core/text/main.go
+++ b/pkg/core/text/main.go
@@ -155,9 +155,9 @@ func (t *Text) ReadLine(location string, line int) (string, error) {
 }
 
 // Diff return a diff like string, comparing string A and string B
-func Diff(filename, originalFileContent, newFileContent string) string {
-	edits := myers.ComputeEdits(span.URIFromPath(filename), originalFileContent, newFileContent)
-	diff := fmt.Sprint(gotextdiff.ToUnified(filename, filename, originalFileContent, edits))
+func Diff(from, to, originalFileContent, newFileContent string) string {
+	edits := myers.ComputeEdits(span.URIFromPath(to), originalFileContent, newFileContent)
+	diff := fmt.Sprint(gotextdiff.ToUnified(from, to, originalFileContent, edits))
 	return diff
 }
 

--- a/pkg/plugins/resources/file/condition.go
+++ b/pkg/plugins/resources/file/condition.go
@@ -105,7 +105,7 @@ func (f *File) condition(source string) (bool, error) {
 					"%s %s is different than the input source value:\n%s",
 					result.FAILURE,
 					logMessage,
-					text.Diff(filePath, file.content, source),
+					text.Diff(filePath, filePath, file.content, source),
 				)
 
 				return false, nil
@@ -136,7 +136,7 @@ func (f *File) condition(source string) (bool, error) {
 			logrus.Infof("%s %s is different than the specified content: \n%s",
 				result.FAILURE,
 				logMessage,
-				text.Diff(filePath, file.content, f.spec.Content),
+				text.Diff(filePath, filePath, file.content, f.spec.Content),
 			)
 			return false, nil
 		}

--- a/pkg/plugins/resources/file/target.go
+++ b/pkg/plugins/resources/file/target.go
@@ -153,7 +153,7 @@ func (f *File) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarg
 			contentType,
 
 			file.originalPath,
-			text.Diff(filePath, originalContents[filePath], file.content),
+			text.Diff(filePath, filePath, originalContents[filePath], file.content),
 		)
 
 		f.files[filePath] = file


### PR DESCRIPTION
Fix #954 

This pullrequest shows a diff between the raw manifest and the templated manifest when running 

```
updatecli manifest show --debug
```

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
go build -o bin/updatecli
./bin/updatecli manifest show --debug
```

<details><summary>Successful templating</summary>

```
 ~/Pr/Updatecli/updatecli │ on @a20269f7 *141 !3  ./bin/updatecli manifest show --config /tmp/updatecli.yaml --values /tmp/scm.yaml --debug


+++++++++++
+ PREPARE +
+++++++++++

Loading Pipeline "/tmp/updatecli.yaml"
DEBUG: Golang templating change detected:
- - - raw manifest
+++ templated manifest

@@ -1,3 +1,8 @@
 scms:
   default:
-{{ .scms.default | toYaml | indent 4}}
+    kind: github
+    spec:
+        owner: updatecli
+        repository: updatecli
+        token: xxx
+        username: yyy


---

SCM repository retrieved: 1
DEBUG: stage: git-clone
...
```

</details>

<details><summary>On purpose failing templating</summary>

```
+++++++++++
+ PREPARE +
+++++++++++

Loading Pipeline "/tmp/updatecli.yaml"
DEBUG: Golang templating change detected:
--- raw manifest
+++ templated manifest
@@ -1,3 +1,8 @@
 scms:
   default:
-    {{ .scms.default | toYaml | indent 4}}
+        kind: github
+    spec:
+        owner: updatecli
+        repository: updatecli
+        token: xxx
+        username: yyy


---
ERROR: failed loading pipeline(s)
	* "/tmp/updatecli.yaml" - yaml: line 1: did not find expected key

0 pipeline(s) successfully loaded

```

</details>

## Additional Information

### Tradeoff

While thinking about this issue, I was concerned showing too much information like:

1. Raw manifest content
2. Post templating
3. Post YAML parser

The purpose of the command `updatecli manifest show` sounds the perfect fit to debug the manifest

My second concern was leaking credentials from a CI environment, and it is unlikely that we run `updatecli manifest show` from a CI

### Potential improvement

Maybe the `debug` flag shouldn't be needed when running `updatecli manifest show`
