### PR TITLE
Show file plugin target diff by default

### DIFF
--- a/pkg/plugins/resources/file/target.go
+++ b/pkg/plugins/resources/file/target.go
@@ -120,8 +120,12 @@ func (f *File) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarg
 
 	sort.Strings(files)
 
+	descriptions := []string{}
+
 	// Otherwise write the new content to the file(s), or nothing but logs if dry run is enabled
+	changedFiles := []string{}
 	for filePath, file := range f.files {
+		changedFiles = append(changedFiles, filePath)
 		var contentType string
 		var err error
 
@@ -143,23 +147,22 @@ func (f *File) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarg
 			return err
 		}
 
-		resultTarget.Description = fmt.Sprintf("%s\nUpdated to %s %q in file %q\n",
-			resultTarget.Description,
-			contentType,
-			f.spec.Content,
-			file.originalPath)
-
-		logrus.Debugf("updated %s of file %q\n\n%s\n",
-			contentType,
-
+		description := fmt.Sprintf("%q updated with %s %q",
 			file.originalPath,
+			contentType,
+			inputContent)
+
+		logrus.Infof("%s\n\n```\n%s\n```\n\n",
+			description,
 			text.Diff(filePath, originalContents[filePath], file.content),
 		)
+
+		descriptions = append(descriptions, description)
 
 		f.files[filePath] = file
 	}
 
-	resultTarget.Description = strings.TrimPrefix(resultTarget.Description, "\n")
+	resultTarget.Description = fmt.Sprintf("%d file(s) updated with %q:\n\t* %s\n", len(descriptions), inputContent, strings.Join(changedFiles, "\n\t* "))
 
 	resultTarget.Result = result.ATTENTION
 	resultTarget.Changed = true


### PR DESCRIPTION
Related to #1472 
By default show file diff without requiring --debug 

<details><summary>New Console Output</summary>

```
TARGETS
========

download-url
------------
"docs/installation/other_inst_scenarios/install_epinio_on_rancher_desktop.md" updated with content "https://github.com/cert-manager/cert-manager/releases/download/v0.16.1/"

--- docs/installation/other_inst_scenarios/install_epinio_on_rancher_desktop.md
+++ docs/installation/other_inst_scenarios/install_epinio_on_rancher_desktop.md
@@ -47,7 +47,7 @@
 
 ```shell
 
-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.12.3/cert-manager.yaml
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v0.16.1/cert-manager.yaml
 
 # Wait for cert-manager to stabilize
 


"docs/tutorials/single-dev-workflow.md" updated with content "https://github.com/cert-manager/cert-manager/releases/download/v0.16.1/"

--- docs/tutorials/single-dev-workflow.md
+++ docs/tutorials/single-dev-workflow.md
@@ -69,7 +69,7 @@
 Here are the steps for Rancher Desktop:
 

-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.12.3/cert-manager.yaml
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v0.16.1/cert-manager.yaml
 
 # Wait for cert-manager to stabilize. This should take approximately
 # 30 seconds depending on your Internet connection.



⚠ - 2 file(s) updated with "https://github.com/cert-manager/cert-manager/releases/download/v0.16.1/":
	* docs/installation/other_inst_scenarios/install_epinio_on_rancher_desktop.md
	* docs/tutorials/single-dev-workflow.md


ACTIONS
========

[Dry Run] An action of kind "github/pullrequest" is expected.

=============================

REPORTS:

```

</details>

<details><summary> Old Console Output</summary>

```
TARGETS
========

download-url
------------
⚠ - Updated to content "" in file "docs/installation/other_inst_scenarios/install_epinio_on_rancher_desktop.md"

Updated to content "" in file "docs/tutorials/single-dev-workflow.md"


ACTIONS
========

[Dry Run] An action of kind "github/pullrequest" is expected.

=============================

REPORTS:

```

</details>

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
go build -o bin/updatecli
./bin/updatecli diff --config e2e/updatecli.d/success.d/file/noscm.yaml
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

We could do something similar for the other plugins