### PR TITLE
by default disable Helm autodiscovery version increment

### DIFF
--- a/pkg/plugins/autodiscovery/helm/main.go
+++ b/pkg/plugins/autodiscovery/helm/main.go
@@ -87,6 +87,14 @@ func New(spec interface{}, rootDir, scmID string) (Helm, error) {
 		return Helm{}, err
 	}
 
+	/*
+		Due to https://github.com/updatecli/updatecli/issues/693
+		we don't want to increment the Chart version, each time a chart dependency is updated.
+	*/
+	if s.VersionIncrement == "" {
+		s.VersionIncrement = "none"
+	}
+
 	newFilter := s.VersionFilter
 	if s.VersionFilter.IsZero() {
 		// By default, helm versioning uses semantic versioning. Containers is not but...

--- a/pkg/plugins/autodiscovery/helm/test/main_test.go
+++ b/pkg/plugins/autodiscovery/helm/test/main_test.go
@@ -51,7 +51,7 @@ targets:
       file: 'Chart.yaml'
       key: '$.dependencies[0].version'
       name: 'epinio'
-      versionincrement: ''
+      versionincrement: 'none'
     sourceid: 'minio'
 `, `name: 'Bump dependency "kubed" for Helm chart "epinio"'
 sources:
@@ -81,7 +81,7 @@ targets:
       file: 'Chart.yaml'
       key: '$.dependencies[1].version'
       name: 'epinio'
-      versionincrement: ''
+      versionincrement: 'none'
     sourceid: 'kubed'
 `, `name: 'Bump dependency "epinio-ui" for Helm chart "epinio"'
 sources:
@@ -111,7 +111,7 @@ targets:
       file: 'Chart.yaml'
       key: '$.dependencies[2].version'
       name: 'epinio'
-      versionincrement: ''
+      versionincrement: 'none'
     sourceid: 'epinio-ui'
 `, `name: 'Bump Docker Image "epinioteam/epinio-ui-qa" for Helm chart "epinio"'
 sources:
@@ -140,7 +140,7 @@ targets:
       file: 'values.yaml'
       key: '$.images.ui.tag'
       name: 'epinio'
-      versionincrement: ''
+      versionincrement: 'none'
     sourceid: 'epinioteam/epinio-ui-qa'
 `, `name: 'Bump Docker Image "splatform/epinio-server" for Helm chart "epinio"'
 sources:
@@ -169,7 +169,7 @@ targets:
       file: 'values.yaml'
       key: '$.image.tag'
       name: 'epinio'
-      versionincrement: ''
+      versionincrement: 'none'
     sourceid: 'splatform/epinio-server'
 `},
 		},
@@ -204,7 +204,7 @@ targets:
       file: 'values.yaml'
       name: 'sample'
       key: '$.image.tag'
-      versionincrement: ''
+      versionincrement: 'none'
     sourceid: 'epinio_epinio-server'
 `,
 				`name: 'Bump Docker image "epinio/epinio-ui" for Helm chart "sample"'
@@ -235,7 +235,7 @@ targets:
       file: 'values.yaml'
       name: 'sample'
       key: '$.images.ui.tag'
-      versionincrement: ''
+      versionincrement: 'none'
     sourceid: 'epinio_epinio-ui'
 `},
 		},
@@ -278,7 +278,7 @@ targets:
       file: 'values.yaml'
       name: 'sample'
       key: '$.image.tag'
-      versionincrement: ''
+      versionincrement: 'none'
     sourceid: 'ghcr.io_epinio_epinio-server'
 `,
 				`name: 'Bump Docker image "ghcr.io/epinio/epinio-ui" for Helm chart "sample"'
@@ -317,7 +317,7 @@ targets:
       file: 'values.yaml'
       name: 'sample'
       key: '$.images.ui.tag'
-      versionincrement: ''
+      versionincrement: 'none'
     sourceid: 'ghcr.io_epinio_epinio-ui'
 `},
 		},


### PR DESCRIPTION
Related to https://github.com/updatecli/updatecli/issues/1475

I don't have an better workaround that disabling this behavior by default...

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
cd pkg/plugins/autodiscovery/helm/test/
go test
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
