### PR TITLE
Specify golangci patch version

### DIFF
--- a/updatecli/updatecli.d/golangci-lint.yaml
+++ b/updatecli/updatecli.d/golangci-lint.yaml
@@ -48,10 +48,6 @@ targets:
     default:
         name: Update Golangci-lint version to {{ source "default" }}
         kind: yaml
-        transformers:
-            - findsubmatch:
-                pattern: v(\d*)\.(\d*)
-                captureindex: 0
         spec:
             file: .github/workflows/go.yaml
             key: $.jobs.build.steps[2].with.version


### PR DESCRIPTION
Related to https://github.com/updatecli/updatecli/actions/runs/5965128771/job/16181854535?pr=1532

If the pullrequest tests are passing than it automatically merge the version update.
The goal is to avoid breaking tests due to a regression in golangci-lint