### PR TITLE
Clean up GitLab mergerquest plugin

### DIFF
--- a/pkg/plugins/resources/gitlab/client/spec.go
+++ b/pkg/plugins/resources/gitlab/client/spec.go
@@ -9,7 +9,7 @@ type Spec struct {
 		default:
 			url defaults to "gitlab.com"
 	*/
-	URL string `yaml:",omitempty" jsonschema:"required"`
+	URL string `yaml:",omitempty"`
 	/*
 		"username" defines the username used to authenticate with GitLab
 	*/

--- a/pkg/plugins/resources/gitlab/mergerequest/main.go
+++ b/pkg/plugins/resources/gitlab/mergerequest/main.go
@@ -72,10 +72,6 @@ func New(spec interface{}, scm *gitlabscm.Gitlab) (Gitlab, error) {
 
 	g.inheritFromScm()
 
-	if err != nil {
-		return Gitlab{}, nil
-	}
-
 	return g, nil
 
 }

--- a/pkg/plugins/resources/gitlab/mergerequest/spec.go
+++ b/pkg/plugins/resources/gitlab/mergerequest/spec.go
@@ -35,14 +35,14 @@ type Spec struct {
 		remark:
 			unless you know what you are doing, you shouldn't set this value and rely on the scmid to provide the sane default.
 	*/
-	Owner string `yaml:",omitempty" jsonschema:"required"`
+	Owner string `yaml:",omitempty"`
 	/*
 		"repository" defines the GitLab repository for a specific owner
 
 		remark:
 			unless you know what you are doing, you shouldn't set this value and rely on the scmid to provide the sane default.
 	*/
-	Repository string `yaml:",omitempty" jsonschema:"required"`
+	Repository string `yaml:",omitempty"`
 	/*
 		"title" defines the GitLab mergerequest title
 

--- a/pkg/plugins/resources/gitlab/mergerequest/utils.go
+++ b/pkg/plugins/resources/gitlab/mergerequest/utils.go
@@ -10,8 +10,8 @@ import (
 	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
-// isPullRequestExist queries a remote GitLab instance to know if a pullrequest already exists.
-func (g *Gitlab) isPullRequestExist() (bool, error) {
+// isMergeRequestExist queries a remote GitLab instance to know if a pullrequest already exists.
+func (g *Gitlab) isMergeRequestExist() (bool, error) {
 	ctx := context.Background()
 	// Timeout api query after 30sec
 	ctx, cancelList := context.WithTimeout(ctx, 30*time.Second)


### PR DESCRIPTION
While debugging #1531 I spotted a few issues

1. Several fields were considering required in the jsonschema which is not correct
2. I was missing more error message
3. I saw several mention of pullrequest even they are mergerequest on gitlab

<!-- Describe the changes introduced by this pull request -->

## Test

Changes from this pullrequest do not affect the gitlab plugin behavior

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

The same kind of cleanup should probably be done for gitea and stash
