### PR TITLE
Update golangci-lint installation method

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -30,7 +30,8 @@ jobs:
           # Required: the version of golangci-lint is required
           # and must be specified without patch version:
           # we always use the latest patch version.
-          version: v1.54.0
+          version: v1.54.1
+          install-mode: "binary"
       - name: Install GoReleaser
         uses: goreleaser/goreleaser-action@v4
         with:


### PR DESCRIPTION
At the moment golangci-lint is failing on all new PR, 
I can't reproduce the typecheck error locally, so I am switching the installation method to the binary one
