### PR TITLE
Revert "Disable Helm autodiscovery version increment by default"

### DIFF
--- a/pkg/plugins/autodiscovery/helm/main.go
+++ b/pkg/plugins/autodiscovery/helm/main.go
@@ -87,14 +87,6 @@ func New(spec interface{}, rootDir, scmID string) (Helm, error) {
 		return Helm{}, err
 	}
 
-	/*
-		Due to https://github.com/updatecli/updatecli/issues/693
-		we don't want to increment the Chart version, each time a chart dependency is updated.
-	*/
-	if s.VersionIncrement == "" {
-		s.VersionIncrement = "none"
-	}
-
 	newFilter := s.VersionFilter
 	if s.VersionFilter.IsZero() {
 		// By default, helm versioning uses semantic versioning. Containers is not but...

--- a/pkg/plugins/autodiscovery/helm/test/main_test.go
+++ b/pkg/plugins/autodiscovery/helm/test/main_test.go
@@ -51,7 +51,7 @@ targets:
       file: 'Chart.yaml'
       key: '$.dependencies[0].version'
       name: 'epinio'
-      versionincrement: 'none'
+      versionincrement: ''
     sourceid: 'minio'
 `, `name: 'Bump dependency "kubed" for Helm chart "epinio"'
 sources:
@@ -81,7 +81,7 @@ targets:
       file: 'Chart.yaml'
       key: '$.dependencies[1].version'
       name: 'epinio'
-      versionincrement: 'none'
+      versionincrement: ''
     sourceid: 'kubed'
 `, `name: 'Bump dependency "epinio-ui" for Helm chart "epinio"'
 sources:
@@ -111,7 +111,7 @@ targets:
       file: 'Chart.yaml'
       key: '$.dependencies[2].version'
       name: 'epinio'
-      versionincrement: 'none'
+      versionincrement: ''
     sourceid: 'epinio-ui'
 `, `name: 'Bump Docker Image "epinioteam/epinio-ui-qa" for Helm chart "epinio"'
 sources:
@@ -140,7 +140,7 @@ targets:
       file: 'values.yaml'
       key: '$.images.ui.tag'
       name: 'epinio'
-      versionincrement: 'none'
+      versionincrement: ''
     sourceid: 'epinioteam/epinio-ui-qa'
 `, `name: 'Bump Docker Image "splatform/epinio-server" for Helm chart "epinio"'
 sources:
@@ -169,7 +169,7 @@ targets:
       file: 'values.yaml'
       key: '$.image.tag'
       name: 'epinio'
-      versionincrement: 'none'
+      versionincrement: ''
     sourceid: 'splatform/epinio-server'
 `},
 		},
@@ -204,7 +204,7 @@ targets:
       file: 'values.yaml'
       name: 'sample'
       key: '$.image.tag'
-      versionincrement: 'none'
+      versionincrement: ''
     sourceid: 'epinio_epinio-server'
 `,
 				`name: 'Bump Docker image "epinio/epinio-ui" for Helm chart "sample"'
@@ -235,7 +235,7 @@ targets:
       file: 'values.yaml'
       name: 'sample'
       key: '$.images.ui.tag'
-      versionincrement: 'none'
+      versionincrement: ''
     sourceid: 'epinio_epinio-ui'
 `},
 		},
@@ -278,7 +278,7 @@ targets:
       file: 'values.yaml'
       name: 'sample'
       key: '$.image.tag'
-      versionincrement: 'none'
+      versionincrement: ''
     sourceid: 'ghcr.io_epinio_epinio-server'
 `,
 				`name: 'Bump Docker image "ghcr.io/epinio/epinio-ui" for Helm chart "sample"'
@@ -317,7 +317,7 @@ targets:
       file: 'values.yaml'
       name: 'sample'
       key: '$.images.ui.tag'
-      versionincrement: 'none'
+      versionincrement: ''
     sourceid: 'ghcr.io_epinio_epinio-ui'
 `},
 		},


### PR DESCRIPTION
Reverts updatecli/updatecli#1526

The multiple version bump is now fixed with https://github.com/updatecli/updatecli/pull/1541 available in 0.59.0
Which seems to work as expected on my projects so I am now reverting https://github.com/updatecli/updatecli/pull/1572

To come back to the initial situation