### PR TITLE
fix: ensure docker image checks architecture

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -43,4 +43,3 @@ CIVO
 Tanzu
 rawstring
 targetsystem
-jenkinsciinfra

--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -43,3 +43,4 @@ CIVO
 Tanzu
 rawstring
 targetsystem
+jenkinsciinfra

--- a/pkg/plugins/resources/dockerimage/condition.go
+++ b/pkg/plugins/resources/dockerimage/condition.go
@@ -2,11 +2,7 @@ package dockerimage
 
 import (
 	"fmt"
-	"strings"
 
-	"github.com/google/go-containerregistry/pkg/name"
-	v1 "github.com/google/go-containerregistry/pkg/v1"
-	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/sirupsen/logrus"
 	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
 	"github.com/updatecli/updatecli/pkg/core/result"
@@ -16,44 +12,25 @@ import (
 // We assume that if we can't retrieve the docker image digest, then it means
 // it doesn't exist.
 func (di *DockerImage) Condition(source string, scm scm.ScmHandler, resultCondition *result.Condition) error {
-
 	if scm != nil {
 		logrus.Warningf("SCM configuration is not supported for condition of type dockerimage. Remove the `scm` directive from condition to remove this warning message")
 	}
 
-	refName := di.spec.Image
-	switch di.spec.Tag == "" {
-	case true:
-		refName += ":" + source
-	case false:
-		refName += ":" + di.spec.Tag
-	}
-
-	ref, err := name.ParseReference(refName)
+	ref, err := di.createRef(source)
 	if err != nil {
-		return fmt.Errorf("invalid image %s: %w", refName, err)
+		return err
 	}
 
-	found := false
-	switch len(di.spec.Architectures) {
-	case 0:
-		// If only one architecture is specified, then di.options are already set: let's proceed
-		found, err = checkImage(ref, di.spec.Architecture, di.options)
+	found := true
+
+	for _, arch := range di.spec.Architectures {
+		foundArchitecture, err := di.checkImage(ref, arch)
 		if err != nil {
 			return err
 		}
-
-	default:
-		for _, arch := range di.spec.Architectures {
-			remoteOptions := append(di.options, remote.WithPlatform(v1.Platform{Architecture: arch, OS: "linux"}))
-
-			found, err = checkImage(ref, arch, remoteOptions)
-			if err != nil {
-				return err
-			}
-			if found {
-				break
-			}
+		if !foundArchitecture {
+			found = false
+			break
 		}
 	}
 
@@ -69,29 +46,4 @@ func (di *DockerImage) Condition(source string, scm scm.ScmHandler, resultCondit
 	resultCondition.Description = fmt.Sprintf("docker image %q:%q not found", di.spec.Image, source)
 
 	return nil
-}
-
-// checkImage checks if a container reference exists on the "remote" registry with a given set of options
-func checkImage(ref name.Reference, arch string, remoteOpts []remote.Option) (bool, error) {
-	_, err := remote.Head(ref, remoteOpts...)
-
-	if err != nil {
-		if strings.Contains(err.Error(), "unexpected status code 404") {
-			logrus.Infof("%s The Docker image %s (%s) doesn't exist.",
-				result.FAILURE,
-				ref.Name(),
-				arch,
-			)
-			return false, nil
-		}
-		return false, err
-	}
-
-	logrus.Infof("%s The Docker image %s (%s) exists and is available.",
-		result.SUCCESS,
-		ref.Name(),
-		arch,
-	)
-
-	return true, nil
 }

--- a/pkg/plugins/resources/dockerimage/condition.go
+++ b/pkg/plugins/resources/dockerimage/condition.go
@@ -23,14 +23,21 @@ func (di *DockerImage) Condition(source string, scm scm.ScmHandler, resultCondit
 
 	found := true
 
-	for _, arch := range di.spec.Architectures {
-		foundArchitecture, err := di.checkImage(ref, arch)
+	if len(di.spec.Architectures) == 0 {
+		found, err = di.checkImage(ref, "")
 		if err != nil {
 			return err
 		}
-		if !foundArchitecture {
-			found = false
-			break
+	} else {
+		for _, arch := range di.spec.Architectures {
+			foundArchitecture, err := di.checkImage(ref, arch)
+			if err != nil {
+				return err
+			}
+			if !foundArchitecture {
+				found = false
+				break
+			}
 		}
 	}
 

--- a/pkg/plugins/resources/dockerimage/condition_test.go
+++ b/pkg/plugins/resources/dockerimage/condition_test.go
@@ -1,0 +1,64 @@
+package dockerimage
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/updatecli/updatecli/pkg/core/result"
+)
+
+func TestCondition(t *testing.T) {
+	tests := []struct {
+		name           string
+		spec           Spec
+		source         string
+		expectedError  bool
+		expectedResult bool
+	}{
+		{
+			name: "Success",
+			spec: Spec{
+				Image:         "jenkinsciinfra/wiki",
+				Architectures: []string{"amd64"},
+			},
+			source:         "0.1.6",
+			expectedResult: true,
+		},
+		{
+			name: "Failure - missing architecture",
+			spec: Spec{
+				Image:         "jenkinsciinfra/wiki",
+				Architectures: []string{"arm64"},
+			},
+			source:         "0.1.6",
+			expectedResult: false,
+		},
+		{
+			name: "Failure - one missing one not architecture",
+			spec: Spec{
+				Image:         "jenkinsciinfra/wiki",
+				Architectures: []string{"amd64", "arm64"},
+			},
+			source:         "0.1.6",
+			expectedResult: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := New(tt.spec)
+			require.NoError(t, err)
+
+			gotResult := result.Condition{}
+			err = got.Condition(tt.source, nil, &gotResult)
+
+			if tt.expectedError {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			assert.Equal(t, tt.expectedResult, gotResult.Pass)
+		})
+	}
+}

--- a/pkg/plugins/resources/dockerimage/condition_test.go
+++ b/pkg/plugins/resources/dockerimage/condition_test.go
@@ -19,28 +19,36 @@ func TestCondition(t *testing.T) {
 		{
 			name: "Success",
 			spec: Spec{
-				Image:         "jenkinsciinfra/wiki",
+				Image:         "ghcr.io/updatecli/updatecli",
 				Architectures: []string{"amd64"},
 			},
-			source:         "0.1.6",
+			source:         "v0.35.0",
+			expectedResult: true,
+		},
+		{
+			name: "Success - No architectures",
+			spec: Spec{
+				Image: "ghcr.io/updatecli/updatecli",
+			},
+			source:         "v0.35.0",
 			expectedResult: true,
 		},
 		{
 			name: "Failure - missing architecture",
 			spec: Spec{
-				Image:         "jenkinsciinfra/wiki",
-				Architectures: []string{"arm64"},
+				Image:         "ghcr.io/updatecli/updatecli",
+				Architectures: []string{"i386"},
 			},
-			source:         "0.1.6",
+			source:         "v0.35.0",
 			expectedResult: false,
 		},
 		{
 			name: "Failure - one missing one not architecture",
 			spec: Spec{
-				Image:         "jenkinsciinfra/wiki",
-				Architectures: []string{"amd64", "arm64"},
+				Image:         "ghcr.io/updatecli/updatecli",
+				Architectures: []string{"amd64", "i386"},
 			},
-			source:         "0.1.6",
+			source:         "v0.35.0",
 			expectedResult: false,
 		},
 	}

--- a/pkg/plugins/resources/dockerimage/main.go
+++ b/pkg/plugins/resources/dockerimage/main.go
@@ -2,11 +2,15 @@ package dockerimage
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/mitchellh/mapstructure"
+	"github.com/sirupsen/logrus"
+	"github.com/updatecli/updatecli/pkg/core/result"
 	"github.com/updatecli/updatecli/pkg/plugins/utils/version"
 )
 
@@ -22,7 +26,6 @@ type DockerImage struct {
 // New returns a reference to a newly initialized DockerImage object from a dockerimage.Spec
 // or an error if the provided Spec triggers a validation error.
 func New(spec interface{}) (*DockerImage, error) {
-
 	newSpec := Spec{}
 
 	err := mapstructure.Decode(spec, &newSpec)
@@ -34,7 +37,6 @@ func New(spec interface{}) (*DockerImage, error) {
 		if newSpec.Architecture != "" {
 			return nil, fmt.Errorf("validation error in the resource of type 'dockerimage': the attributes `spec.architecture` and `spec.architecture` are mutually exclusive")
 		}
-
 	} else {
 		if newSpec.Architecture == "" {
 			newSpec.Architecture = "amd64"
@@ -70,14 +72,64 @@ func New(spec interface{}) (*DockerImage, error) {
 
 	newResource.options = append(newResource.options, remote.WithAuthFromKeychain(authn.NewMultiKeychain(keychains...)))
 
-	if len(newSpec.Architectures) == 1 {
-		newResource.options = append(newResource.options, remote.WithPlatform(v1.Platform{Architecture: newSpec.Architectures[0], OS: "linux"}))
-	}
-
 	return newResource, nil
 }
 
 // Changelog returns the changelog for this resource, or an empty string if not supported
 func (di *DockerImage) Changelog() string {
 	return ""
+}
+
+func (di *DockerImage) createRef(source string) (name.Reference, error) {
+	refName := di.spec.Image
+	switch di.spec.Tag == "" {
+	case true:
+		refName += ":" + source
+	case false:
+		refName += ":" + di.spec.Tag
+	}
+
+	ref, err := name.ParseReference(refName)
+	if err != nil {
+		return nil, fmt.Errorf("invalid image %s: %w", refName, err)
+	}
+
+	return ref, nil
+}
+
+// checkImage checks if a container reference exists on the "remote" registry with a given set of options
+func (di *DockerImage) checkImage(ref name.Reference, arch string) (bool, error) {
+	remoteOptions := append(di.options, remote.WithPlatform(v1.Platform{Architecture: arch, OS: "linux"}))
+	descriptor, err := remote.Get(ref, remoteOptions...)
+	if err != nil {
+		if strings.Contains(err.Error(), "unexpected status code 404") {
+			logrus.Infof("%s The Docker image %s doesn't exist.",
+				result.FAILURE,
+				ref.Name(),
+			)
+			return false, nil
+		}
+		return false, err
+	}
+
+	_, err = descriptor.Image()
+	if err != nil {
+		if strings.Contains(err.Error(), "no child with platform") {
+			logrus.Infof("%s The Docker image %s (%s) doesn't exist.",
+				result.FAILURE,
+				ref.Name(),
+				arch,
+			)
+			return false, nil
+		}
+		return false, err
+	}
+
+	logrus.Infof("%s The Docker image %s (%s) exists and is available.",
+		result.SUCCESS,
+		ref.Name(),
+		arch,
+	)
+
+	return true, nil
 }

--- a/pkg/plugins/resources/dockerimage/main.go
+++ b/pkg/plugins/resources/dockerimage/main.go
@@ -10,8 +10,6 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/mitchellh/mapstructure"
-	"github.com/sirupsen/logrus"
-	"github.com/updatecli/updatecli/pkg/core/result"
 	"github.com/updatecli/updatecli/pkg/plugins/utils/version"
 )
 
@@ -106,10 +104,6 @@ func (di *DockerImage) checkImage(ref name.Reference, arch string) (bool, error)
 	descriptor, err := remote.Get(ref, remoteOptions...)
 	if err != nil {
 		if strings.Contains(err.Error(), "unexpected status code 404") {
-			logrus.Infof("%s The Docker image %s doesn't exist.",
-				result.FAILURE,
-				ref.Name(),
-			)
 			return false, nil
 		}
 		return false, err
@@ -124,22 +118,11 @@ func (di *DockerImage) checkImage(ref name.Reference, arch string) (bool, error)
 		_, err = descriptor.Image()
 		if err != nil {
 			if strings.Contains(err.Error(), "no child with platform") {
-				logrus.Infof("%s The Docker image %s (%s) doesn't exist.",
-					result.FAILURE,
-					ref.Name(),
-					arch,
-				)
 				return false, nil
 			}
 			return false, err
 		}
 	}
-
-	logrus.Infof("%s The Docker image %s (%s) exists and is available.",
-		result.SUCCESS,
-		ref.Name(),
-		arch,
-	)
 
 	return true, nil
 }

--- a/pkg/plugins/resources/dockerimage/main_test.go
+++ b/pkg/plugins/resources/dockerimage/main_test.go
@@ -42,8 +42,7 @@ func TestNew(t *testing.T) {
 				Kind:    "latest",
 				Pattern: "latest",
 			},
-			// Only 1 architecture: there is an option for the platform
-			wantRemoteOptionsSize: 2,
+			wantRemoteOptionsSize: 1,
 		},
 		{
 			name: "Normal case with default (implicit) architecture",
@@ -68,8 +67,7 @@ func TestNew(t *testing.T) {
 				Kind:    "latest",
 				Pattern: "latest",
 			},
-			// Only 1 architecture: there is an option for the platform
-			wantRemoteOptionsSize: 2,
+			wantRemoteOptionsSize: 1,
 		},
 		{
 			name: "Normal case with multiple architectures",
@@ -95,7 +93,6 @@ func TestNew(t *testing.T) {
 				Kind:    "latest",
 				Pattern: "latest",
 			},
-			// Multiple architectures: there is NO option for the platform
 			wantRemoteOptionsSize: 1,
 		},
 		{
@@ -122,8 +119,7 @@ func TestNew(t *testing.T) {
 				Kind:    "latest",
 				Pattern: "latest",
 			},
-			// Only 1 architecture: there is an option for the platform
-			wantRemoteOptionsSize: 2,
+			wantRemoteOptionsSize: 1,
 		},
 		{
 			name: "Invalid Spec provided (no password but username)",

--- a/pkg/plugins/resources/dockerimage/main_test.go
+++ b/pkg/plugins/resources/dockerimage/main_test.go
@@ -55,7 +55,7 @@ func TestNew(t *testing.T) {
 				},
 			},
 			wantSpec: Spec{
-				Architectures: []string{"amd64"},
+				Architectures: nil,
 				Image:         "ghcr.io/updatecli/updatecli",
 				Tag:           "0.15.0",
 				InlineKeyChain: docker.InlineKeyChain{

--- a/pkg/plugins/resources/dockerimage/source.go
+++ b/pkg/plugins/resources/dockerimage/source.go
@@ -11,7 +11,6 @@ import (
 )
 
 func (di *DockerImage) Source(workingDir string, resultSource *result.Source) error {
-
 	repo, err := name.NewRepository(di.spec.Image)
 	if err != nil {
 		return fmt.Errorf("invalid repository %s: %w", di.spec.Image, err)
@@ -42,6 +41,20 @@ func (di *DockerImage) Source(workingDir string, resultSource *result.Source) er
 
 	if len(tag) == 0 {
 		return fmt.Errorf("no Docker Image Tag tag found matching pattern %q", di.versionFilter.Pattern)
+	}
+
+	ref, err := di.createRef(tag)
+	if err != nil {
+		return err
+	}
+
+	found, err := di.checkImage(ref, di.spec.Architectures[0])
+	if err != nil {
+		return err
+	}
+
+	if !found {
+		return fmt.Errorf("no Docker Image for architecture %s", di.spec.Architectures[0])
 	}
 
 	resultSource.Result = result.SUCCESS

--- a/pkg/plugins/resources/dockerimage/source.go
+++ b/pkg/plugins/resources/dockerimage/source.go
@@ -48,7 +48,13 @@ func (di *DockerImage) Source(workingDir string, resultSource *result.Source) er
 		return err
 	}
 
-	found, err := di.checkImage(ref, di.spec.Architectures[0])
+	architecture := ""
+
+	if len(di.spec.Architectures) > 0 {
+		architecture = di.spec.Architectures[0]
+	}
+
+	found, err := di.checkImage(ref, architecture)
 	if err != nil {
 		return err
 	}

--- a/pkg/plugins/resources/dockerimage/source_test.go
+++ b/pkg/plugins/resources/dockerimage/source_test.go
@@ -19,25 +19,37 @@ func TestSource(t *testing.T) {
 		{
 			name: "Success",
 			spec: Spec{
-				Image: "jenkinsciinfra/wiki",
+				Image: "ghcr.io/updatecli/updatecli",
 				VersionFilter: version.Filter{
 					Kind:    "semver",
-					Pattern: "0.1.6",
+					Pattern: "v0.35.0",
 				},
 				Architectures: []string{"amd64"},
 			},
-			expectedResult: "0.1.6",
+			expectedResult: "v0.35.0",
+			expectedError:  false,
+		},
+		{
+			name: "Success - no architecture",
+			spec: Spec{
+				Image: "ghcr.io/updatecli/updatecli",
+				VersionFilter: version.Filter{
+					Kind:    "semver",
+					Pattern: "v0.35.0",
+				},
+			},
+			expectedResult: "v0.35.0",
 			expectedError:  false,
 		},
 		{
 			name: "Failure - missing architecture",
 			spec: Spec{
-				Image: "jenkinsciinfra/wiki",
+				Image: "ghcr.io/updatecli/updatecli",
 				VersionFilter: version.Filter{
 					Kind:    "semver",
-					Pattern: "0.1.6",
+					Pattern: "v0.35.0",
 				},
-				Architectures: []string{"arm64"},
+				Architectures: []string{"i386"},
 			},
 			expectedError: true,
 		},

--- a/pkg/plugins/resources/dockerimage/source_test.go
+++ b/pkg/plugins/resources/dockerimage/source_test.go
@@ -1,0 +1,62 @@
+package dockerimage
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/updatecli/updatecli/pkg/core/result"
+	"github.com/updatecli/updatecli/pkg/plugins/utils/version"
+)
+
+func TestSource(t *testing.T) {
+	tests := []struct {
+		name           string
+		spec           Spec
+		expectedError  bool
+		expectedResult string
+	}{
+		{
+			name: "Success",
+			spec: Spec{
+				Image: "jenkinsciinfra/wiki",
+				VersionFilter: version.Filter{
+					Kind:    "semver",
+					Pattern: "0.1.6",
+				},
+				Architectures: []string{"amd64"},
+			},
+			expectedResult: "0.1.6",
+			expectedError:  false,
+		},
+		{
+			name: "Failure - missing architecture",
+			spec: Spec{
+				Image: "jenkinsciinfra/wiki",
+				VersionFilter: version.Filter{
+					Kind:    "semver",
+					Pattern: "0.1.6",
+				},
+				Architectures: []string{"arm64"},
+			},
+			expectedError: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := New(tt.spec)
+			require.NoError(t, err)
+
+			gotResult := result.Source{}
+			err = got.Source("", &gotResult)
+
+			if tt.expectedError {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			assert.Equal(t, tt.expectedResult, gotResult.Information)
+		})
+	}
+}


### PR DESCRIPTION
Fix #1582

Moved away from setting remoteOptions for single architecture, as this was causing the multi conditions case to fail.

I can remove the tests if we don't want it to look up those images.

## Test

To test this pull request, you can run the following commands:

```shell
cd pkg/plugins/resources/dockerimage
go test
```

## Additional Information

### Potential improvement

Mock the tests
