### PR TITLE
feat: dockerimage support for setting os and variant

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -43,3 +43,4 @@ CIVO
 Tanzu
 rawstring
 targetsystem
+operatingsystem

--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -44,3 +44,6 @@ Tanzu
 rawstring
 targetsystem
 operatingsystem
+ltsc
+nanoserver
+temurin

--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -43,7 +43,4 @@ CIVO
 Tanzu
 rawstring
 targetsystem
-operatingsystem
-ltsc
-nanoserver
 temurin

--- a/pkg/plugins/resources/dockerimage/condition.go
+++ b/pkg/plugins/resources/dockerimage/condition.go
@@ -16,7 +16,12 @@ func (di *DockerImage) Condition(source string, scm scm.ScmHandler, resultCondit
 		logrus.Warningf("SCM configuration is not supported for condition of type dockerimage. Remove the `scm` directive from condition to remove this warning message")
 	}
 
-	ref, err := di.createRef(source)
+	version := source
+	if di.spec.Tag != "" {
+		version = di.spec.Tag
+	}
+
+	ref, err := di.createRef(version)
 	if err != nil {
 		return err
 	}
@@ -44,13 +49,13 @@ func (di *DockerImage) Condition(source string, scm scm.ScmHandler, resultCondit
 	if found {
 		resultCondition.Pass = true
 		resultCondition.Result = result.SUCCESS
-		resultCondition.Description = fmt.Sprintf("docker image %q:%q found", di.spec.Image, source)
+		resultCondition.Description = fmt.Sprintf("docker image %s:%s found", di.spec.Image, version)
 		return nil
 	}
 
 	resultCondition.Pass = false
 	resultCondition.Result = result.FAILURE
-	resultCondition.Description = fmt.Sprintf("docker image %q:%q not found", di.spec.Image, source)
+	resultCondition.Description = fmt.Sprintf("docker image %s:%s not found", di.spec.Image, version)
 
 	return nil
 }

--- a/pkg/plugins/resources/dockerimage/condition_test.go
+++ b/pkg/plugins/resources/dockerimage/condition_test.go
@@ -44,6 +44,15 @@ func TestCondition(t *testing.T) {
 			expectedResult: true,
 		},
 		{
+			name: "Success - architecture with variant",
+			spec: Spec{
+				Image:        "eclipse-temurin",
+				Architecture: "arm/v7",
+			},
+			source:         "11.0.20.1_1-jdk-focal",
+			expectedResult: true,
+		},
+		{
 			name: "Failure - missing architecture",
 			spec: Spec{
 				Image:         "ghcr.io/updatecli/updatecli",

--- a/pkg/plugins/resources/dockerimage/condition_test.go
+++ b/pkg/plugins/resources/dockerimage/condition_test.go
@@ -34,6 +34,16 @@ func TestCondition(t *testing.T) {
 			expectedResult: true,
 		},
 		{
+			name: "Success - operating system",
+			spec: Spec{
+				Image:           "eclipse-temurin",
+				Architecture:    "amd64",
+				OperatingSystem: "windows",
+			},
+			source:         "11.0.20.1_1-jdk-nanoserver-ltsc2022",
+			expectedResult: true,
+		},
+		{
 			name: "Failure - missing architecture",
 			spec: Spec{
 				Image:         "ghcr.io/updatecli/updatecli",

--- a/pkg/plugins/resources/dockerimage/condition_test.go
+++ b/pkg/plugins/resources/dockerimage/condition_test.go
@@ -26,6 +26,16 @@ func TestCondition(t *testing.T) {
 			expectedResult: true,
 		},
 		{
+			name: "Success - Tag",
+			spec: Spec{
+				Image:         "ghcr.io/updatecli/updatecli",
+				Architectures: []string{"amd64"},
+				Tag:           "v0.35.0",
+			},
+			source:         "",
+			expectedResult: true,
+		},
+		{
 			name: "Success - No architectures",
 			spec: Spec{
 				Image: "ghcr.io/updatecli/updatecli",
@@ -36,18 +46,17 @@ func TestCondition(t *testing.T) {
 		{
 			name: "Success - operating system",
 			spec: Spec{
-				Image:           "eclipse-temurin",
-				Architecture:    "amd64",
-				OperatingSystem: "windows",
+				Image:        "ghcr.io/updatecli/updatecli",
+				Architecture: "linux/amd64",
 			},
-			source:         "11.0.20.1_1-jdk-nanoserver-ltsc2022",
+			source:         "v0.35.0",
 			expectedResult: true,
 		},
 		{
 			name: "Success - architecture with variant",
 			spec: Spec{
 				Image:        "eclipse-temurin",
-				Architecture: "arm/v7",
+				Architecture: "linux/arm/v7",
 			},
 			source:         "11.0.20.1_1-jdk-focal",
 			expectedResult: true,

--- a/pkg/plugins/resources/dockerimage/main.go
+++ b/pkg/plugins/resources/dockerimage/main.go
@@ -104,7 +104,17 @@ func (di *DockerImage) checkImage(ref name.Reference, arch string) (bool, error)
 
 	var remoteOptions []remote.Option
 	if arch != "" {
-		remoteOptions = append(di.options, remote.WithPlatform(v1.Platform{Architecture: arch, OS: os}))
+
+		architecture := arch
+
+		splitArchitecture := strings.Split(arch, "/")
+		variant := ""
+		if len(splitArchitecture) > 1 {
+			architecture = splitArchitecture[0]
+			variant = splitArchitecture[1]
+		}
+
+		remoteOptions = append(di.options, remote.WithPlatform(v1.Platform{OS: os, Architecture: architecture, Variant: variant}))
 	}
 
 	descriptor, err := remote.Get(ref, remoteOptions...)

--- a/pkg/plugins/resources/dockerimage/spec.go
+++ b/pkg/plugins/resources/dockerimage/spec.go
@@ -18,8 +18,6 @@ type Spec struct {
 	Architectures []string `yaml:",omitempty"`
 	// [S][C] architecture specifies the container image architecture such as `amd64`
 	Architecture string `yaml:",omitempty"`
-	// [S][C] operatingsystem specifies the container image OS such as `linux`, defaults to `linux`
-	OperatingSystem string `yaml:",omitempty"`
 	// [S][C] image specifies the container image such as `updatecli/updatecli`
 	Image string `yaml:",omitempty"`
 	// [C] tag specifies the container image tag such as `latest`

--- a/pkg/plugins/resources/dockerimage/spec.go
+++ b/pkg/plugins/resources/dockerimage/spec.go
@@ -18,6 +18,8 @@ type Spec struct {
 	Architectures []string `yaml:",omitempty"`
 	// [S][C] architecture specifies the container image architecture such as `amd64`
 	Architecture string `yaml:",omitempty"`
+	// [S][C] operatingsystem specifies the container image OS such as `linux`, defaults to `linux`
+	OperatingSystem string `yaml:",omitempty"`
 	// [S][C] image specifies the container image such as `updatecli/updatecli`
 	Image string `yaml:",omitempty"`
 	// [C] tag specifies the container image tag such as `latest`
@@ -42,9 +44,7 @@ func sanitizeRegistryEndpoint(repository string) string {
 
 // NewDockerImageSpecFromImage return a new docker image specification using an image provided as parameter
 func NewDockerImageSpecFromImage(image, tag string, auths map[string]docker.InlineKeyChain) *Spec {
-
 	tagFilter, err := getTagFilterFromValue(tag)
-
 	if err != nil {
 		// We couldn't identify a good versionFilter so we do not return any dockerimage spec
 		// At the time of writing, semantic versioning is the only way to have reliable results
@@ -106,7 +106,6 @@ func NewDockerImageSpecFromImage(image, tag string, auths map[string]docker.Inli
 
 // getTagFilterFromValue tries to identify the closest tagFilter based on an existing tag
 func getTagFilterFromValue(tag string) (string, error) {
-
 	logrus.Debugf("Trying the identify the best versionFilter for %q", tag)
 
 	switch tag {


### PR DESCRIPTION
Fix #1606

Added support for setting OS and variant, leave default as linux:

* `architecture: amd64`
* `architecture: windows/amd64`
* `architecture: linux/arm/v7`

NOTE: It isn't possible to set variant without os

Also added and fixed some logging.

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
cd pkg/plugins/resources/dockerimage/
go test
```

<details><summary>Details</summary>
<p>

```yaml
sources:
  lastVersion:
    kind: githubrelease
    name: Get the latest Adoptium JDK11 version
    spec:
      owner: "adoptium"
      repository: "temurin11-binaries"
      token: '{{ requiredEnv "GITHUB_TOKEN" }}'
      versionfilter:
        kind: regex
        # jdk-11.0.12+7(https://github.com/adoptium/temurin11-binaries/releases/tag/jdk-11.0.12%2B7) is OK
        # jdk-11.0.16.1+1 (https://github.com/adoptium/temurin11-binaries/releases/tag/jdk-11.0.16.1%2B1) is OK
        pattern: "^jdk-11.(\\d*).(\\d*).(\\d*)(.(\\d*))+(\\d*)$"
    transformers:
      - trimprefix: "jdk-"
      - replacer:
          from: +
          to: _

conditions:
  checkTemurinAlpineDockerImage:
    kind: dockerimage
    name: Check if the container image "eclipse-temurin:<lastVersion>-jdk-alpine" is available
    disablesourceinput: true
    spec:
      architecture: amd64
      image: eclipse-temurin
      tag: '{{source "lastVersion" }}-jdk-alpine'

  checkTemurinDebianDockerImages:
    kind: dockerimage
    name: Check if the container image "eclipse-temurin:<lastVersion>-jdk-focal" is available
    disablesourceinput: true
    spec:
      architectures:
        - amd64
        - arm64
        - s390x
        - linux/arm/v7
      image: eclipse-temurin
      tag: '{{source "lastVersion" }}-jdk-focal'
  checkTemurinNanoserver2019DockerImage:
    kind: dockerimage
    name: Check if the container image "eclipse-temurin:<lastVersion>-jdk-nanoserver-1809" is available
    disablesourceinput: true
    spec:
      architecture: windows/amd64
      image: eclipse-temurin
      tag: '{{source "lastVersion" }}-jdk-nanoserver-1809'
  checkTemurinWindowsCore2019DockerImage:
    kind: dockerimage
    name: Check if the container image "eclipse-temurin:<lastVersion>-jdk-windowsservercore-1809" is available
    disablesourceinput: true
    spec:
      architecture: windows/amd64
      image: eclipse-temurin
      tag: '{{source "lastVersion" }}-jdk-windowsservercore-1809'
  checkTemurinNanoserver2022DockerImage:
    kind: dockerimage
    name: Check if the container image "eclipse-temurin:<lastVersion>-jdk-nanoserver-ltsc2022" is available
    disablesourceinput: true
    spec:
      architecture: windows/amd64
      image: eclipse-temurin
      tag: '{{source "lastVersion" }}-jdk-nanoserver-ltsc2022'
  checkTemurinWindowsCore2022DockerImage:
    kind: dockerimage
    name: Check if the container image "eclipse-temurin:<lastVersion>-jdk-windowsservercore-18ltsc202209" is available
    disablesourceinput: true
    spec:
      architecture: windows/amd64
      image: eclipse-temurin
      tag: '{{source "lastVersion" }}-jdk-windowsservercore-ltsc2022'
``` 

</p>
</details> 
