### PR TITLE
fix: dockerimage correctly set auth if arch unspecified

### DIFF
--- a/pkg/plugins/resources/dockerimage/main.go
+++ b/pkg/plugins/resources/dockerimage/main.go
@@ -92,7 +92,7 @@ func (di *DockerImage) createRef(source string) (name.Reference, error) {
 
 // checkImage checks if a container reference exists on the "remote" registry with a given set of options
 func (di *DockerImage) checkImage(ref name.Reference, arch string) (bool, error) {
-	var remoteOptions []remote.Option
+	var remoteOptions []remote.Option = di.options
 	var queriedPlatform string
 
 	if arch != "" {
@@ -115,7 +115,7 @@ func (di *DockerImage) checkImage(ref name.Reference, arch string) (bool, error)
 
 		queriedPlatform = platform.String()
 
-		remoteOptions = append(di.options, remote.WithPlatform(platform))
+		remoteOptions = append(remoteOptions, remote.WithPlatform(platform))
 
 		logrus.Debugf("Querying docker image %q, os: %q, arch: %q, variant %q", ref.Name(), platform.OS, platform.Architecture, platform.Variant)
 	}


### PR DESCRIPTION
Fix #1613 

The authentication options weren't defined if the plugin was used without specifying the architecture in the setting which is solved with the current pullrequest.

I tested this PR using 

```
sources:
  default:
    kind: dockerimage
    spec:
      image: ghcr.io/olblak/charts/upgrade-responder

conditions:
  default:
    kind: dockerimage
    spec:
      image: ghcr.io/olblak/charts/upgrade-responder
      tag: v0.1.5
```

which is a private docker image

## Test

To test this pull request, you can run the following commands:

```shell
cd pkg/plugins/resources/dockerimage/
go test
```

## Additional Information

### Tradeoff

/

### Potential improvement
/