### PR TITLE
Run helm chart metadata update only on a changed target

### DIFF
--- a/pkg/plugins/resources/helm/target.go
+++ b/pkg/plugins/resources/helm/target.go
@@ -45,9 +45,17 @@ func (c *Chart) Target(source string, scm scm.ScmHandler, dryRun bool, resultTar
 		chartPath = filepath.Join(scm.GetDirectory(), c.spec.Name)
 	}
 
-	err = c.MetadataUpdate(resultTarget.NewInformation, scm, dryRun, resultTarget)
-	if err != nil {
-		return fmt.Errorf("unable to update chart metadata: %s", err)
+	/*
+	  We only want to update the Chart metadata if the chart has been modified during the current target execution.
+	  To make this process more idempotent in the context of a scm, we could also check if the helm chart
+	  has been modified during one of the previous target execution by comparing the current chart versus the one defined
+	  on the source branch. But the code complexity induced by this check is probably not worth the effort today.
+	*/
+	if resultTarget.Changed {
+		err = c.MetadataUpdate(resultTarget.NewInformation, scm, dryRun, resultTarget)
+		if err != nil {
+			return fmt.Errorf("unable to update chart metadata: %s", err)
+		}
 	}
 
 	err = c.RequirementsUpdate(chartPath)

--- a/pkg/plugins/resources/helm/target.go
+++ b/pkg/plugins/resources/helm/target.go
@@ -45,17 +45,9 @@ func (c *Chart) Target(source string, scm scm.ScmHandler, dryRun bool, resultTar
 		chartPath = filepath.Join(scm.GetDirectory(), c.spec.Name)
 	}
 
-	/*
-	  We only want to update the Chart metadata if the chart has been modified during the current target execution.
-	  To make this process more idempotent in the context of a scm, we could also check if the helm chart
-	  has been modified during one of the previous target execution by comparing the current chart versus the one defined
-	  on the source branch. But the code complexity induced by this check is probably not worth the effort today.
-	*/
-	if resultTarget.Changed {
-		err = c.MetadataUpdate(resultTarget.NewInformation, scm, dryRun, resultTarget)
-		if err != nil {
-			return fmt.Errorf("unable to update chart metadata: %s", err)
-		}
+	err = c.MetadataUpdate(resultTarget.NewInformation, scm, dryRun, resultTarget)
+	if err != nil {
+		return fmt.Errorf("unable to update chart metadata: %s", err)
 	}
 
 	err = c.RequirementsUpdate(chartPath)

--- a/pkg/plugins/resources/helm/utils.go
+++ b/pkg/plugins/resources/helm/utils.go
@@ -214,6 +214,16 @@ func (c *Chart) MetadataUpdate(source string, scm scm.ScmHandler, dryRun bool, r
 		}
 	}
 
+	/*
+	  We only want to update the Chart metadata if the chart has been modified during the current target execution.
+	  To make this process more idempotent in the context of a scm, we could also check if the helm chart
+	  has been modified during one of the previous target execution by comparing the current chart versus the one defined
+	  on the source branch. But the code complexity induced by this check is probably not worth the effort today.
+	*/
+	if !resultTarget.Changed {
+		return nil
+	}
+
 	// Handle the situation where the version is not set yet
 	if currentChartMetadata.Version == "" {
 		currentChartMetadata.Version = "0.0.1"


### PR DESCRIPTION
Fix #1614 

We only want to update the Chart metadata if the chart has been modified during the current target execution.
To make this process more idempotent in the context of a SCM, we could also check if the helm chart
has been modified during one of the previous target execution by comparing the current chart versus the one defined
on the source branch. But the code complexity induced by this check is probably not worth the effort today.

## Test

To test this pull request, you can run the following commands:

```shell
cd pkg/plugins/resources/helm/ 
go test
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
