### PR TITLE
Remove unused target setting

### DIFF
--- a/pkg/core/pipeline/target/main.go
+++ b/pkg/core/pipeline/target/main.go
@@ -43,10 +43,6 @@ type Target struct {
 type Config struct {
 	// ResourceConfig defines target input parameters
 	resource.ResourceConfig `yaml:",inline"`
-	// ReportTitle contains the updatecli reports title for sources and conditions run
-	ReportTitle string `yaml:",omitempty"`
-	// ReportBody contains the updatecli reports body for sources and conditions run
-	ReportBody string `yaml:",omitempty"`
 	// ! Deprecated - please use all lowercase `sourceid`
 	DeprecatedSourceID string `yaml:"sourceID,omitempty" jsonschema:"-"`
 	// disablesourceinput disables the mechanism to retrieve a default value from a source. For example, if true, source information like changelog will not be accessible for a github/pullrequest action.


### PR DESCRIPTION
While fixing the target documentation this morning https://github.com/updatecli/website/pull/1161. 
I noticed two unused target setting and I don't remember when we used it 🤷🏾

I am removing them so they do not appear on https://www.updatecli.io/docs/core/target/