### PR TITLE
fix: sort terraform autodiscovery manifest during test

### DIFF
--- a/pkg/core/pipeline/target/main.go
+++ b/pkg/core/pipeline/target/main.go
@@ -43,10 +43,6 @@ type Target struct {
 type Config struct {
 	// ResourceConfig defines target input parameters
 	resource.ResourceConfig `yaml:",inline"`
-	// ReportTitle contains the updatecli reports title for sources and conditions run
-	ReportTitle string `yaml:",omitempty"`
-	// ReportBody contains the updatecli reports body for sources and conditions run
-	ReportBody string `yaml:",omitempty"`
 	// ! Deprecated - please use all lowercase `sourceid`
 	DeprecatedSourceID string `yaml:"sourceID,omitempty" jsonschema:"-"`
 	// disablesourceinput disables the mechanism to retrieve a default value from a source. For example, if true, source information like changelog will not be accessible for a github/pullrequest action.

--- a/pkg/plugins/autodiscovery/terraform/test/main_test.go
+++ b/pkg/plugins/autodiscovery/terraform/test/main_test.go
@@ -201,6 +201,10 @@ func TestDiscoverManifests(t *testing.T) {
 				return
 			}
 
+			// We sort both the pipelines and the expectedPipelines using the same algorithm
+			// to ensure the order is the same as map in Golang are unordered
+			test.SortConfigSpecArray(t, tt.expectedPipelines, pipelines)
+
 			for i := range pipelines {
 				test.AssertConfigSpecEqualByteArray(t, &tt.expectedPipelines[i], string(pipelines[i]))
 			}

--- a/pkg/plugins/utils/test/main.go
+++ b/pkg/plugins/utils/test/main.go
@@ -28,7 +28,7 @@ func AssertConfigSpecEqualByteArray(t *testing.T, spec *config.Spec, manifest st
 
 // SortConfigSpecArray allows to sort an array of config.Spec using the length of the name field as sorting
 // This function is used to sort a config.Spec array before comparing it to a manifest of type array of byte
-func SortConfigSpecArray(t *testing.T, configSpecs []config.Spec, byteSpecs [][]byte) error {
+func SortConfigSpecArray(t *testing.T, configSpecs []config.Spec, byteSpecs [][]byte) {
 
 	// We covert byteSpecs to an array of config.Spec so we can apply the same sort
 	// algorithm to both byteSpecs and configSpecs
@@ -55,8 +55,6 @@ func SortConfigSpecArray(t *testing.T, configSpecs []config.Spec, byteSpecs [][]
 		require.NoError(t, err)
 		byteSpecs[i] = buf.Bytes()
 	}
-
-	return nil
 }
 
 // yamlMarshalUnmarshal is used to parse a manifest to ensure it's a valid yaml one.

--- a/pkg/plugins/utils/test/main.go
+++ b/pkg/plugins/utils/test/main.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"bytes"
+	"sort"
 	"testing"
 
 	"gopkg.in/yaml.v3"
@@ -23,6 +24,39 @@ func AssertConfigSpecEqualByteArray(t *testing.T, spec *config.Spec, manifest st
 	return assert.Equal(t,
 		yamlMarshalUnmarshal(t, buf.String()),
 		yamlMarshalUnmarshal(t, manifest))
+}
+
+// SortConfigSpecArray allows to sort an array of config.Spec using the length of the name field as sorting
+// This function is used to sort a config.Spec array before comparing it to a manifest of type array of byte
+func SortConfigSpecArray(t *testing.T, configSpecs []config.Spec, byteSpecs [][]byte) error {
+
+	// We covert byteSpecs to an array of config.Spec so we can apply the same sort
+	// algorithm to both byteSpecs and configSpecs
+	tmpSpecs := make([]config.Spec, len(byteSpecs))
+	for i := range byteSpecs {
+		err := yaml.Unmarshal(byteSpecs[i], &tmpSpecs[i])
+		require.NoError(t, err)
+	}
+
+	sort.Slice(tmpSpecs, func(i, j int) bool {
+		return len(tmpSpecs[i].Name) < len(tmpSpecs[j].Name)
+	})
+
+	sort.Slice(configSpecs, func(i, j int) bool {
+		return configSpecs[i].Name < configSpecs[j].Name
+	})
+
+	// We convert back byteSpecs to an array of byte
+	for i := range byteSpecs {
+		buf := bytes.NewBufferString("")
+		yamlEncoder := yaml.NewEncoder(buf)
+		yamlEncoder.SetIndent(2)
+		err := yamlEncoder.Encode(tmpSpecs[i])
+		require.NoError(t, err)
+		byteSpecs[i] = buf.Bytes()
+	}
+
+	return nil
 }
 
 // yamlMarshalUnmarshal is used to parse a manifest to ensure it's a valid yaml one.


### PR DESCRIPTION
fix: https://github.com/updatecli/updatecli/actions/runs/6335541299/job/17208054420

When the tests for the Terraform autodiscovery plugins are executed, they don't necessarily generate manifests in the same order which leads to failing tests when we compare the result with expected results.

So this PR introduce a sort function that can be used during the test to ensure the expected manifest and generate manifests are sorted the same way.

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
pkg/plugins/autodiscovery/terraform/test/
while true; do GOFLAGS="-count=1" go test ./... && sleep 1; done;
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

This problem can also affects the other autodiscovery plugins so we may decided to update the expected result over there as well.
  