### PR TITLE
feat: add `skippackaging` option to helm target

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -44,3 +44,4 @@ Tanzu
 rawstring
 targetsystem
 temurin
+skippackaging

--- a/pkg/plugins/resources/helm/main.go
+++ b/pkg/plugins/resources/helm/main.go
@@ -74,6 +74,15 @@ type Spec struct {
 	*/
 	Name string `yaml:",omitempty"`
 	/*
+		skippackaging defines if a Chart should be packaged or not.
+
+		compatible:
+			* target
+
+		default: false
+	*/
+	SkipPackaging bool `yaml:",omitempty"`
+	/*
 		url defines the Chart location URL.
 
 		compatible:

--- a/pkg/plugins/resources/helm/target.go
+++ b/pkg/plugins/resources/helm/target.go
@@ -55,7 +55,7 @@ func (c *Chart) Target(source string, scm scm.ScmHandler, dryRun bool, resultTar
 		return fmt.Errorf("unable to update chart requirements: %s", err)
 	}
 
-	if !dryRun {
+	if !dryRun && !c.spec.SkipPackaging {
 		err = c.DependencyUpdate(&out, chartPath)
 
 		logrus.Debug(out.String())


### PR DESCRIPTION
On Helm chart updates, provide the option to skip the packaging phase of the update. This provides the end user with two main benefits:

1. Users will be able to leverage `updatecli` to update the metadata on their chart(s) while leveraging other mechanisms to handle the actual packaging and publishing, such as the [chart-releaser-action](https://github.com/helm/chart-releaser-action) action.
2. When using the `helmchart` target with an `scmid` defined, the compressed binary files for the chart dependencies will not be committed into the repository.

## Test

**Note:** I spent some time looking in the existing tests, but didn't see an obvious way to test if files had been created on disk within the current paradigm. I'm open to suggestions or thoughts about how to  handle this though. What I can offer however, are the tests I ran locally to validate both the new functionality and existing (default) behavior.

**Steps**
  1. Create a test Helm chart
  3. Update `Chart.yaml` to include at least one dependency, ensuring the version picked is outdated
  4. Adjust the `config.yaml` target spec to use `skippackaging: true` or `skippackaging: false` based on desired test
  5. Run `updatecli --config config.yaml apply`

<details>
<summary>Skip Packaging Test</summary>
  
**Create a test Helm chart**
```
?> helm create test-chart
?> cd test-chart
?> ls
charts  Chart.yaml  config.yaml  templates  values.yaml
?> ls charts/
?>
```
  
**Chart.yaml before running `updatecli`**
```
apiVersion: v2
name: test-chart
description: A Helm chart for Kubernetes
type: application
version: 0.5.0
appVersion: "1.16.0"
dependencies:
  - name: prometheus
    repository: https://prometheus-community.github.io/helm-charts
    version: 22.0.0
```

**config.yaml**
```
name: test

sources:
  getProm:
    name: "get prometheus chart version"
    kind: helmchart
    spec:
      url: https://prometheus-community.github.io/helm-charts
      name: prometheus

targets:
  prom:
    name: "bump prom"
    sourceid: getProm
    kind: helmchart
    spec:
      file: "Chart.yaml"
      key: "$.dependencies[0].version"
      name: "."
      skippackaging: true
      versionincrement: auto
```

**Chart.yaml after running `updatecli`**
```
apiVersion: v2
name: main
description: A Helm chart for Kubernetes
type: application
version: 1.0.0
appVersion: "1.16.0"
dependencies:
  - name: prometheus
    repository: https://prometheus-community.github.io/helm-charts
    version: 25.0.0
```

**Chart state after running `updatecli`**
```
  ?> ls
  charts  Chart.yaml  config.yaml  templates  values.yaml
  ?> ls charts/
  ?>
```
</details>
<details>
<summary>Don't Skip Packaging Test</summary>
  
**Create a test Helm chart**
```
?> helm create test-chart
?> cd test-chart
?> ls
charts  Chart.yaml  config.yaml  templates  values.yaml
?> ls charts/
?>
```
  
**Chart.yaml before running `updatecli`**
```
apiVersion: v2
name: test-chart
description: A Helm chart for Kubernetes
type: application
version: 0.5.0
appVersion: "1.16.0"
dependencies:
  - name: prometheus
    repository: https://prometheus-community.github.io/helm-charts
    version: 22.0.0
```

**config.yaml**
```
name: test

sources:
  getProm:
    name: "get prometheus chart version"
    kind: helmchart
    spec:
      url: https://prometheus-community.github.io/helm-charts
      name: prometheus

targets:
  prom:
    name: "bump prom"
    sourceid: getProm
    kind: helmchart
    spec:
      file: "Chart.yaml"
      key: "$.dependencies[0].version"
      name: "."
      versionincrement: auto
```

**Chart.yaml after running `updatecli`**
```
apiVersion: v2
name: main
description: A Helm chart for Kubernetes
type: application
version: 1.0.0
appVersion: "1.16.0"
dependencies:
  - name: prometheus
    repository: https://prometheus-community.github.io/helm-charts
    version: 25.0.0
```

**Chart state after running `updatecli`**
```
  ?> ls
Chart.lock  charts  Chart.yaml  config.yaml  templates  values.yaml
  ?> ls charts/
  ls charts/
prometheus-25.0.0.tgz
```
</details>

## Additional Information

### Tradeoff
- N/A

### Potential improvement

- Still bundle/package the chart dependencies, but do not commit them to the repository. Users would then only need to publish the new chart instead of package+publish.
