### PR TITLE
Revert "chore(deps): Bump check-spelling/check-spelling from 0.0.21 to 0.0.22"

### DIFF
--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -89,7 +89,7 @@ jobs:
     steps:
     - name: check-spelling
       id: spelling
-      uses: check-spelling/check-spelling@v0.0.22
+      uses: check-spelling/check-spelling@v0.0.21
       with:
         suppress_push_for_open_pull_request: 1
         checkout: true


### PR DESCRIPTION
Reverts updatecli/updatecli#1640

It appears that [github.com/check-spelling/check-spelling@0.0.22](https://github.com/check-spelling/check-spelling/releases) is a pretty major release which I need to look into #988 