### PR TITLE
Add update compose command

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -53,3 +53,5 @@ testcontainers
 pullpush
 fileStore
 skippackaging
+joho
+godotenv

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -4,7 +4,7 @@ import (
 	"os"
 
 	"github.com/sirupsen/logrus"
-	"github.com/updatecli/updatecli/pkg/core/engine"
+	"github.com/updatecli/updatecli/pkg/core/engine/manifest"
 
 	"github.com/spf13/cobra"
 )
@@ -33,7 +33,7 @@ var (
 				os.Exit(1)
 			}
 
-			e.Options.Manifests = append(e.Options.Manifests, engine.Manifest{
+			e.Options.Manifests = append(e.Options.Manifests, manifest.Manifest{
 				Manifests: manifestFiles,
 				Values:    valuesFiles,
 				Secrets:   secretsFiles,

--- a/cmd/compose.go
+++ b/cmd/compose.go
@@ -1,0 +1,21 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var (
+	// composeCmdClean represents the compose clean flag to enable or disable the clean stage
+	composeCmdClean bool
+	// composeCmdDisablePrepare represents the compose disable prepare flag to enable or disable the prepare stage
+	composeCmdDisablePrepare bool
+	// composeCmdDisableTemplating represents the compose disable templating flag to enable or disable the templating stage
+	composeCmdDisableTemplating bool
+	// composeCmdFile represents the compose filename
+	composeCmdFile string
+	// composeCmd represents the compose command
+	composeCmd = &cobra.Command{
+		Use:   "compose",
+		Short: "compose executes specific Updatecli compose tasks such as diff or apply",
+	}
+)

--- a/cmd/compose_apply.go
+++ b/cmd/compose_apply.go
@@ -18,6 +18,12 @@ var (
 		Short: "apply checks and apply changes defined by the compose file",
 		Run: func(cmd *cobra.Command, args []string) {
 
+			// TODO: To be removed once not experimental anymore
+			if !experimental {
+				logrus.Warningf("The 'compose' subcommand requires the flag experimental to work, such as:\n\t`updatecli compose apply --experimental`")
+				os.Exit(1)
+			}
+
 			c, err := compose.New(composeCmdFile)
 			if err != nil {
 				logrus.Errorf("command failed: %s", err)

--- a/cmd/compose_apply.go
+++ b/cmd/compose_apply.go
@@ -1,0 +1,58 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/updatecli/updatecli/pkg/core/compose"
+)
+
+var (
+	composeApplyCommit bool
+	composeApplyClean  bool
+	composeApplyPush   bool
+
+	composeApplyCmd = &cobra.Command{
+		Use:   "apply",
+		Short: "apply checks and apply changes defined by the compose file",
+		Run: func(cmd *cobra.Command, args []string) {
+
+			c, err := compose.New(composeCmdFile)
+			if err != nil {
+				logrus.Errorf("command failed: %s", err)
+				os.Exit(1)
+			}
+
+			policies, err := c.GetPolicies(disableTLS)
+			if err != nil {
+				logrus.Errorf("command failed: %s", err)
+				os.Exit(1)
+			}
+
+			e.Options.Manifests = append(e.Options.Manifests, policies...)
+
+			e.Options.Pipeline.Target.Commit = composeApplyCommit
+			e.Options.Pipeline.Target.Push = composeApplyPush
+			e.Options.Pipeline.Target.Clean = composeApplyClean
+			e.Options.Pipeline.Target.DryRun = false
+
+			err = run("compose/apply")
+			if err != nil {
+				logrus.Errorf("command failed: %s", err)
+				os.Exit(1)
+			}
+		},
+	}
+)
+
+func init() {
+	composeApplyCmd.Flags().StringVarP(&composeCmdFile, "file", "f", "update-compose.yaml", "Define the update-compose file")
+
+	composeApplyCmd.Flags().BoolVarP(&composeApplyCommit, "commit", "", true, "Record changes to the repository, '--commit=false'")
+	composeApplyCmd.Flags().BoolVarP(&composeApplyPush, "push", "", true, "Update remote refs '--push=false'")
+	composeApplyCmd.Flags().BoolVar(&disableTLS, "disable-tls", false, "Disable TLS verification like '--disable-tls=true'")
+	composeApplyCmd.Flags().BoolVar(&composeApplyClean, "clean", false, "Remove updatecli working directory like '--clean=true'")
+
+	composeCmd.AddCommand(composeApplyCmd)
+}

--- a/cmd/compose_diff.go
+++ b/cmd/compose_diff.go
@@ -1,0 +1,51 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/updatecli/updatecli/pkg/core/compose"
+)
+
+var (
+	composeDiffCmd = &cobra.Command{
+		Use:   "diff",
+		Short: "diff show changes defined by the compose file",
+		Run: func(cmd *cobra.Command, args []string) {
+
+			c, err := compose.New(composeCmdFile)
+			if err != nil {
+				logrus.Errorf("command failed: %s", err)
+				os.Exit(1)
+			}
+
+			policies, err := c.GetPolicies(disableTLS)
+			if err != nil {
+				logrus.Errorf("command failed: %s", err)
+				os.Exit(1)
+			}
+
+			e.Options.Manifests = append(e.Options.Manifests, policies...)
+
+			e.Options.Pipeline.Target.Commit = false
+			e.Options.Pipeline.Target.Push = false
+			e.Options.Pipeline.Target.Clean = composeCmdClean
+			e.Options.Pipeline.Target.DryRun = true
+
+			err = run("compose/diff")
+			if err != nil {
+				logrus.Errorf("command failed: %s", err)
+				os.Exit(1)
+			}
+		},
+	}
+)
+
+func init() {
+	composeDiffCmd.Flags().StringVarP(&composeCmdFile, "file", "f", "update-compose.yaml", "Define the update-compose file")
+	composeDiffCmd.Flags().BoolVar(&composeCmdClean, "clean", false, "Remove updatecli working directory like '--clean=true'")
+	composeDiffCmd.Flags().BoolVar(&disableTLS, "disable-tls", false, "Disable TLS verification like '--disable-tls=true'")
+
+	composeCmd.AddCommand(composeDiffCmd)
+}

--- a/cmd/compose_diff.go
+++ b/cmd/compose_diff.go
@@ -14,6 +14,12 @@ var (
 		Short: "diff show changes defined by the compose file",
 		Run: func(cmd *cobra.Command, args []string) {
 
+			// TODO: To be removed once not experimental anymore
+			if !experimental {
+				logrus.Warningf("The 'compose' subcommand requires the flag experimental to work, such as:\n\t`updatecli compose diff --experimental`")
+				os.Exit(1)
+			}
+
 			c, err := compose.New(composeCmdFile)
 			if err != nil {
 				logrus.Errorf("command failed: %s", err)

--- a/cmd/compose_show.go
+++ b/cmd/compose_show.go
@@ -15,6 +15,12 @@ var (
 		Short: "show manifest(s) defined by the compose file that should be executed",
 		Run: func(cmd *cobra.Command, args []string) {
 
+			// TODO: To be removed once not experimental anymore
+			if !experimental {
+				logrus.Warningf("The 'compose' subcommand requires the flag experimental to work, such as:\n\t`updatecli compose show --experimental`")
+				os.Exit(1)
+			}
+
 			c, err := compose.New(composeCmdFile)
 			if err != nil {
 				logrus.Errorf("command failed: %s", err)

--- a/cmd/compose_show.go
+++ b/cmd/compose_show.go
@@ -1,0 +1,55 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/updatecli/updatecli/pkg/core/compose"
+	"github.com/updatecli/updatecli/pkg/core/config"
+)
+
+var (
+	composeShowCmd = &cobra.Command{
+		Use:   "show",
+		Short: "show manifest(s) defined by the compose file that should be executed",
+		Run: func(cmd *cobra.Command, args []string) {
+
+			c, err := compose.New(composeCmdFile)
+			if err != nil {
+				logrus.Errorf("command failed: %s", err)
+				os.Exit(1)
+			}
+
+			policies, err := c.GetPolicies(disableTLS)
+			if err != nil {
+				logrus.Errorf("command failed: %s", err)
+				os.Exit(1)
+			}
+
+			e.Options.Manifests = append(e.Options.Manifests, policies...)
+
+			e.Options.Pipeline.Target.Clean = composeCmdClean
+			e.Options.Config.DisableTemplating = composeCmdDisableTemplating
+
+			// Showing templating diff may leak sensitive information such as credentials
+			config.GolangTemplatingDiff = true
+
+			err = run("compose/show")
+			if err != nil {
+				logrus.Errorf("command failed: %s", err)
+				os.Exit(1)
+			}
+		},
+	}
+)
+
+func init() {
+	composeShowCmd.Flags().StringVarP(&composeCmdFile, "file", "f", "update-compose.yaml", "Define the update-compose file")
+	composeShowCmd.Flags().BoolVar(&composeCmdClean, "clean", false, "Remove updatecli working directory like '--clean=true'")
+	composeShowCmd.Flags().BoolVar(&composeCmdDisablePrepare, "disable-prepare", false, "--disable-prepare skip the Updatecli 'prepare' stage")
+	composeShowCmd.Flags().BoolVar(&composeCmdDisableTemplating, "disable-templating", false, "Disable manifest templating")
+	composeShowCmd.Flags().BoolVar(&disableTLS, "disable-tls", false, "Disable TLS verification like '--disable-tls=true'")
+
+	composeCmd.AddCommand(composeShowCmd)
+}

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -4,7 +4,7 @@ import (
 	"os"
 
 	"github.com/sirupsen/logrus"
-	"github.com/updatecli/updatecli/pkg/core/engine"
+	"github.com/updatecli/updatecli/pkg/core/engine/manifest"
 
 	"github.com/spf13/cobra"
 )
@@ -24,7 +24,7 @@ var (
 				os.Exit(1)
 			}
 
-			e.Options.Manifests = append(e.Options.Manifests, engine.Manifest{
+			e.Options.Manifests = append(e.Options.Manifests, manifest.Manifest{
 				Manifests: manifestFiles,
 				Values:    valuesFiles,
 				Secrets:   secretsFiles,

--- a/cmd/jsonschema.go
+++ b/cmd/jsonschema.go
@@ -27,5 +27,5 @@ var (
 
 func init() {
 	jsonschemaCmd.Flags().StringVarP(&jsonschemaDirectory, "directory", "d", "./", "Export schema to directory")
-	jsonschemaCmd.Flags().StringVarP(&jsonschemaBaseID, "baseid", "b", "https://www.updatecli.io/latest/schema", "Define schema baseid")
+	jsonschemaCmd.Flags().StringVarP(&jsonschemaBaseID, "baseid", "b", "https://www.updatecli.io/schema/latest", "Define schema baseid")
 }

--- a/cmd/manifest_show.go
+++ b/cmd/manifest_show.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/updatecli/updatecli/pkg/core/config"
-	"github.com/updatecli/updatecli/pkg/core/engine"
+	"github.com/updatecli/updatecli/pkg/core/engine/manifest"
 )
 
 var (
@@ -28,7 +28,7 @@ var (
 				os.Exit(1)
 			}
 
-			e.Options.Manifests = append(e.Options.Manifests, engine.Manifest{
+			e.Options.Manifests = append(e.Options.Manifests, manifest.Manifest{
 				Manifests: manifestFiles,
 				Values:    valuesFiles,
 				Secrets:   secretsFiles,

--- a/cmd/manifest_upgrade.go
+++ b/cmd/manifest_upgrade.go
@@ -4,7 +4,7 @@ import (
 	"os"
 
 	"github.com/sirupsen/logrus"
-	"github.com/updatecli/updatecli/pkg/core/engine"
+	"github.com/updatecli/updatecli/pkg/core/engine/manifest"
 
 	"github.com/spf13/cobra"
 )
@@ -17,7 +17,7 @@ var (
 		Short: "upgrade executes manifest upgrade task",
 		Run: func(cmd *cobra.Command, args []string) {
 
-			e.Options.Manifests = append(e.Options.Manifests, engine.Manifest{
+			e.Options.Manifests = append(e.Options.Manifests, manifest.Manifest{
 				Manifests: manifestFiles,
 			})
 

--- a/cmd/prepare.go
+++ b/cmd/prepare.go
@@ -4,7 +4,7 @@ import (
 	"os"
 
 	"github.com/sirupsen/logrus"
-	"github.com/updatecli/updatecli/pkg/core/engine"
+	"github.com/updatecli/updatecli/pkg/core/engine/manifest"
 
 	"github.com/spf13/cobra"
 )
@@ -24,7 +24,7 @@ var (
 				os.Exit(1)
 			}
 
-			e.Options.Manifests = append(e.Options.Manifests, engine.Manifest{
+			e.Options.Manifests = append(e.Options.Manifests, manifest.Manifest{
 				Manifests: manifestFiles,
 				Values:    valuesFiles,
 				Secrets:   secretsFiles,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -70,6 +70,7 @@ func init() {
 		manifestCmd,
 		udashCmd,
 		showCmd,
+		composeCmd,
 		versionCmd,
 		docsCmd,
 		manCmd,
@@ -79,7 +80,7 @@ func init() {
 func run(command string) error {
 
 	switch command {
-	case "apply":
+	case "apply", "compose/apply":
 		udash.Audience = udashOAuthAudience
 
 		if applyClean {
@@ -101,7 +102,7 @@ func run(command string) error {
 			logrus.Errorf("%s %s", result.FAILURE, err)
 			return err
 		}
-	case "diff":
+	case "diff", "compose/diff":
 		udash.Audience = udashOAuthAudience
 		if diffClean {
 			defer func() {
@@ -159,7 +160,7 @@ func run(command string) error {
 		}
 
 	// Show is deprecated
-	case "manifest/show", "show":
+	case "manifest/show", "show", "compose/show":
 		if showClean {
 			defer func() {
 				if err := e.Clean(); err != nil {

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -4,7 +4,7 @@ import (
 	"os"
 
 	"github.com/sirupsen/logrus"
-	"github.com/updatecli/updatecli/pkg/core/engine"
+	"github.com/updatecli/updatecli/pkg/core/engine/manifest"
 
 	"github.com/spf13/cobra"
 )
@@ -26,7 +26,7 @@ var (
 				os.Exit(1)
 			}
 
-			e.Options.Manifests = append(e.Options.Manifests, engine.Manifest{
+			e.Options.Manifests = append(e.Options.Manifests, manifest.Manifest{
 				Manifests: manifestFiles,
 				Values:    valuesFiles,
 				Secrets:   secretsFiles,

--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	github.com/hashicorp/hcl/v2 v2.18.1
 	github.com/hashicorp/terraform-registry-address v0.2.0
 	github.com/invopop/jsonschema v0.8.0
+	github.com/joho/godotenv v1.5.1
 	github.com/minamijoyo/hcledit v0.2.10
 	github.com/minamijoyo/tfupdate v0.7.2
 	github.com/muesli/mango-cobra v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -559,6 +559,8 @@ github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGw
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/jmoiron/sqlx v1.3.5 h1:vFFPA71p1o5gAeqtEAwLU4dnX2napprKtHr7PYIcN3g=
 github.com/jmoiron/sqlx v1.3.5/go.mod h1:nRVWtLre0KfCLJvgxzCsLVMogSvQ1zNJtpYr2Ccp0mQ=
+github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
+github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=

--- a/pkg/core/compose/env_files.go
+++ b/pkg/core/compose/env_files.go
@@ -1,0 +1,28 @@
+package compose
+
+import (
+	"fmt"
+
+	"github.com/joho/godotenv"
+)
+
+/*
+	It's important to note that it WILL NOT OVERRIDE an env variable that already exists - consider the .env file to set dev vars or sensible defaults.
+*/
+
+// EnvFiles is a list of environment files
+
+type EnvFiles []string
+
+// SetEnv sets the environment variables
+func (e EnvFiles) SetEnv() error {
+	if len(e) == 0 {
+		return nil
+	}
+	err := godotenv.Load(e...)
+	if err != nil {
+		return fmt.Errorf("error setting environment variables: %s", err)
+	}
+
+	return nil
+}

--- a/pkg/core/compose/environment.go
+++ b/pkg/core/compose/environment.go
@@ -1,0 +1,25 @@
+package compose
+
+import (
+	"fmt"
+	"os"
+)
+
+// Environments is a map of environment variables
+type Environments map[string]string
+
+// SetEnv sets the environment variables
+func (e Environments) SetEnv() error {
+	var errs []error
+	for key, value := range e {
+		if err := os.Setenv(key, value); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("error setting environment variables: %s", errs)
+	}
+
+	return nil
+}

--- a/pkg/core/compose/file.go
+++ b/pkg/core/compose/file.go
@@ -1,0 +1,33 @@
+package compose
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+// LoadFile loads an Updatecli compose file into a compose Spec
+func LoadFile(filename string) (*Spec, error) {
+
+	var composeSpec Spec
+
+	f, err := os.Open(filename)
+	if err != nil {
+		return nil, fmt.Errorf("opening Updatecli compose file %q: %s", filename, err)
+	}
+	defer f.Close()
+
+	composeFileByte, err := io.ReadAll(f)
+	if err != nil {
+		return nil, fmt.Errorf("reading Updatecli compose file %q: %s", filename, err)
+	}
+
+	err = yaml.Unmarshal(composeFileByte, &composeSpec)
+	if err != nil {
+		return nil, fmt.Errorf("parsing Updatecli compose file %q: %s", filename, err)
+	}
+
+	return &composeSpec, nil
+}

--- a/pkg/core/compose/main.go
+++ b/pkg/core/compose/main.go
@@ -3,7 +3,7 @@ package compose
 import (
 	"fmt"
 
-	"github.com/updatecli/updatecli/pkg/core/engine"
+	"github.com/updatecli/updatecli/pkg/core/engine/manifest"
 	"github.com/updatecli/updatecli/pkg/core/registry"
 )
 
@@ -28,8 +28,8 @@ func New(filename string) (Compose, error) {
 }
 
 // GetPolicies returns a list of policies defined in the compose file
-func (c *Compose) GetPolicies(disableTLS bool) ([]engine.Manifest, error) {
-	var manifests []engine.Manifest
+func (c *Compose) GetPolicies(disableTLS bool) ([]manifest.Manifest, error) {
+	var manifests []manifest.Manifest
 	var errs []error
 
 	if err := c.spec.Environments.SetEnv(); err != nil {
@@ -52,7 +52,7 @@ func (c *Compose) GetPolicies(disableTLS bool) ([]engine.Manifest, error) {
 			policyValues = append(policyValues, c.spec.Policies[i].Values...)
 			policySecrets = append(policySecrets, c.spec.Policies[i].Secrets...)
 
-			manifests = append(manifests, engine.Manifest{
+			manifests = append(manifests, manifest.Manifest{
 				Manifests: policyManifest,
 				Values:    policyValues,
 				Secrets:   policySecrets,

--- a/pkg/core/compose/main.go
+++ b/pkg/core/compose/main.go
@@ -1,0 +1,68 @@
+package compose
+
+import (
+	"fmt"
+
+	"github.com/updatecli/updatecli/pkg/core/engine"
+	"github.com/updatecli/updatecli/pkg/core/registry"
+)
+
+// Compose is a struct that contains a compose object
+type Compose struct {
+	// spec contains the compose spec
+	spec Spec
+}
+
+// New creates a new Compose object
+func New(filename string) (Compose, error) {
+	var c Compose
+
+	spec, err := LoadFile(filename)
+	if err != nil {
+		return c, err
+	}
+
+	c.spec = *spec
+
+	return c, nil
+}
+
+// GetPolicies returns a list of policies defined in the compose file
+func (c *Compose) GetPolicies(disableTLS bool) ([]engine.Manifest, error) {
+	var manifests []engine.Manifest
+	var errs []error
+
+	if err := c.spec.Environments.SetEnv(); err != nil {
+		errs = append(errs, err)
+	}
+
+	if err := c.spec.Env_files.SetEnv(); err != nil {
+		errs = append(errs, err)
+	}
+
+	for i := range c.spec.Policies {
+		if c.spec.Policies[i].Policy != "" {
+			policyManifest, policyValues, policySecrets, err := registry.Pull(c.spec.Policies[i].Policy, disableTLS)
+			if err != nil {
+				errs = append(errs, fmt.Errorf("pulling policy %q: %s", c.spec.Policies[i].Policy, err))
+				continue
+			}
+
+			policyManifest = append(policyManifest, c.spec.Policies[i].Config...)
+			policyValues = append(policyValues, c.spec.Policies[i].Values...)
+			policySecrets = append(policySecrets, c.spec.Policies[i].Secrets...)
+
+			manifests = append(manifests, engine.Manifest{
+				Manifests: policyManifest,
+				Values:    policyValues,
+				Secrets:   policySecrets,
+			})
+		}
+	}
+
+	if len(errs) > 0 {
+		return manifests, fmt.Errorf("policies errors: %s", errs)
+	}
+
+	return manifests, nil
+}

--- a/pkg/core/compose/main_test.go
+++ b/pkg/core/compose/main_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/updatecli/updatecli/pkg/core/engine"
+	"github.com/updatecli/updatecli/pkg/core/engine/manifest"
 )
 
 func TestGetPolicies(t *testing.T) {
@@ -15,13 +15,13 @@ func TestGetPolicies(t *testing.T) {
 	testdata := []struct {
 		name              string
 		file              string
-		expectedManifests []engine.Manifest
+		expectedManifests []manifest.Manifest
 		expectedEnv       map[string]string
 	}{
 		{
 			name: "Test getPolicies with environment variables",
 			file: "testdata/update-compose.yaml",
-			expectedManifests: []engine.Manifest{
+			expectedManifests: []manifest.Manifest{
 				{
 					Manifests: []string{
 						filepath.Join("/", "tmp", "updatecli", "store", "7aaff2727eef42f7d0add2d5ed3fd83f74a125420682bec7e4bc8835bb28e833", "updatecli.d", "default.tpl"),

--- a/pkg/core/compose/main_test.go
+++ b/pkg/core/compose/main_test.go
@@ -8,12 +8,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/updatecli/updatecli/pkg/core/engine"
-	"github.com/updatecli/updatecli/pkg/core/tmp"
 )
 
 func TestGetPolicies(t *testing.T) {
-
-	tmpDir := tmp.Directory
 
 	testdata := []struct {
 		name              string
@@ -27,7 +24,10 @@ func TestGetPolicies(t *testing.T) {
 			expectedManifests: []engine.Manifest{
 				{
 					Manifests: []string{
-						filepath.Join(tmpDir, "store", "ghcr", "io", "olblak", "policies", "updatecli", "latest", "updatecli", "updatecli.d", "updatecli.yaml"),
+						filepath.Join("/", "tmp", "updatecli", "store", "7aaff2727eef42f7d0add2d5ed3fd83f74a125420682bec7e4bc8835bb28e833", "updatecli.d", "default.tpl"),
+					},
+					Values: []string{
+						filepath.Join("/", "tmp", "updatecli", "store", "7aaff2727eef42f7d0add2d5ed3fd83f74a125420682bec7e4bc8835bb28e833", "values.yaml"),
 					},
 				},
 			},
@@ -38,18 +38,20 @@ func TestGetPolicies(t *testing.T) {
 		},
 	}
 
-	for i := range testdata {
-		updateCompose, err := New(testdata[i].file)
-		require.NoError(t, err)
+	for _, data := range testdata {
+		t.Run(data.name, func(t *testing.T) {
+			updateCompose, err := New(data.file)
+			require.NoError(t, err)
 
-		gotManifests, err := updateCompose.GetPolicies(false)
-		require.NoError(t, err)
+			gotManifests, err := updateCompose.GetPolicies(false)
+			require.NoError(t, err)
 
-		assert.Equal(t, testdata[i].expectedManifests, gotManifests)
+			assert.Equal(t, data.expectedManifests, gotManifests)
 
-		for key, expectedValue := range testdata[i].expectedEnv {
-			gotValue := os.Getenv(key)
-			assert.Equal(t, expectedValue, gotValue)
-		}
+			for key, expectedValue := range data.expectedEnv {
+				gotValue := os.Getenv(key)
+				assert.Equal(t, expectedValue, gotValue)
+			}
+		})
 	}
 }

--- a/pkg/core/compose/main_test.go
+++ b/pkg/core/compose/main_test.go
@@ -1,0 +1,55 @@
+package compose
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/updatecli/updatecli/pkg/core/engine"
+	"github.com/updatecli/updatecli/pkg/core/tmp"
+)
+
+func TestGetPolicies(t *testing.T) {
+
+	tmpDir := tmp.Directory
+
+	testdata := []struct {
+		name              string
+		file              string
+		expectedManifests []engine.Manifest
+		expectedEnv       map[string]string
+	}{
+		{
+			name: "Test getPolicies with environment variables",
+			file: "testdata/update-compose.yaml",
+			expectedManifests: []engine.Manifest{
+				{
+					Manifests: []string{
+						filepath.Join(tmpDir, "store", "ghcr", "io", "olblak", "policies", "updatecli", "latest", "updatecli", "updatecli.d", "updatecli.yaml"),
+					},
+				},
+			},
+			expectedEnv: map[string]string{
+				"UPDATECLI_TEST_GITHUB_TOKEN": "my super secret token",
+				"UPDATECLI_TEST_GITHUB_ACTOR": "me",
+			},
+		},
+	}
+
+	for i := range testdata {
+		updateCompose, err := New(testdata[i].file)
+		require.NoError(t, err)
+
+		gotManifests, err := updateCompose.GetPolicies(false)
+		require.NoError(t, err)
+
+		assert.Equal(t, testdata[i].expectedManifests, gotManifests)
+
+		for key, expectedValue := range testdata[i].expectedEnv {
+			gotValue := os.Getenv(key)
+			assert.Equal(t, expectedValue, gotValue)
+		}
+	}
+}

--- a/pkg/core/compose/spec.go
+++ b/pkg/core/compose/spec.go
@@ -1,0 +1,23 @@
+package compose
+
+type Spec struct {
+	// Policies contains a list of policies
+	Policies []Policy
+	// Environment contains a list of environment variables
+	Environments Environments `yaml:",omitempty"`
+	// Env_files contains a list of environment files
+	Env_files EnvFiles `yaml:"env_files,omitempty"`
+}
+
+type Policy struct {
+	// Config contains a list of config ids to be used for the policy
+	Configs []string `yaml:",omitempty"`
+	// Policy contains the policy OCI name
+	Policy string `yaml:",omitempty"`
+	// Config contains a list of Updatecli config file path
+	Config []string `yaml:",omitempty"`
+	// Values contains a list of Updatecli config file path
+	Values []string `yaml:",omitempty"`
+	// Secrets contains a list of Updatecli secret file path
+	Secrets []string `yaml:",omitempty"`
+}

--- a/pkg/core/compose/testdata/credentials.yaml
+++ b/pkg/core/compose/testdata/credentials.yaml
@@ -1,0 +1,1 @@
+UPDATECLI_TEST_GITHUB_TOKEN="my super secret token"

--- a/pkg/core/compose/testdata/update-compose.yaml
+++ b/pkg/core/compose/testdata/update-compose.yaml
@@ -1,0 +1,8 @@
+environments:
+  UPDATECLI_TEST_GITHUB_ACTOR: 'me'
+
+env_files:
+  - testdata/credentials.yaml
+
+policies: 
+  - policy: ghcr.io/olblak/policies/updatecli:latest

--- a/pkg/core/compose/testdata/update-compose.yaml
+++ b/pkg/core/compose/testdata/update-compose.yaml
@@ -5,4 +5,5 @@ env_files:
   - testdata/credentials.yaml
 
 policies: 
-  - policy: ghcr.io/olblak/policies/updatecli:latest
+  - policy: ghcr.io/updatecli/policies/autodiscovery:0.0.1-alpha
+  - policy: ghcr.io/updatecli/policies/autodiscovery:latest

--- a/pkg/core/compose/testdata/update-compose.yaml
+++ b/pkg/core/compose/testdata/update-compose.yaml
@@ -2,7 +2,7 @@ environments:
   UPDATECLI_TEST_GITHUB_ACTOR: 'me'
 
 env_files:
-  - testdata/credentials.yaml
+  - credentials.yaml
 
 policies: 
   - policy: ghcr.io/updatecli-test/policies/autodiscovery:0.0.1-alpha

--- a/pkg/core/compose/testdata/update-compose.yaml
+++ b/pkg/core/compose/testdata/update-compose.yaml
@@ -5,5 +5,4 @@ env_files:
   - testdata/credentials.yaml
 
 policies: 
-  - policy: ghcr.io/updatecli/policies/autodiscovery:0.0.1-alpha
-  - policy: ghcr.io/updatecli/policies/autodiscovery:latest
+  - policy: ghcr.io/updatecli-test/policies/autodiscovery:0.0.1-alpha

--- a/pkg/core/engine/manifest/main.go
+++ b/pkg/core/engine/manifest/main.go
@@ -1,0 +1,19 @@
+package manifest
+
+type Manifest struct {
+	// Manifests is a list of Updatecli manifest file
+	Manifests []string
+	// Values is a list of Updatecli value file
+	Values []string
+	// Secrets is a list of Updatecli secret file
+	Secrets []string
+}
+
+func (m Manifest) IsZero() bool {
+	if len(m.Manifests) == 0 &&
+		len(m.Values) == 0 &&
+		len(m.Secrets) == 0 {
+		return true
+	}
+	return false
+}

--- a/pkg/core/engine/options.go
+++ b/pkg/core/engine/options.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"github.com/updatecli/updatecli/pkg/core/config"
+	"github.com/updatecli/updatecli/pkg/core/engine/manifest"
 	"github.com/updatecli/updatecli/pkg/core/pipeline"
 )
 
@@ -9,23 +10,5 @@ import (
 type Options struct {
 	Config    config.Option
 	Pipeline  pipeline.Options
-	Manifests []Manifest
-}
-
-type Manifest struct {
-	// Manifests is a list of Updatecli manifest file
-	Manifests []string
-	// Values is a list of Updatecli value file
-	Values []string
-	// Secrets is a list of Updatecli secret file
-	Secrets []string
-}
-
-func (m Manifest) IsZero() bool {
-	if len(m.Manifests) == 0 &&
-		len(m.Values) == 0 &&
-		len(m.Secrets) == 0 {
-		return true
-	}
-	return false
+	Manifests []manifest.Manifest
 }

--- a/pkg/core/engine/schema.go
+++ b/pkg/core/engine/schema.go
@@ -2,10 +2,15 @@ package engine
 
 import (
 	"fmt"
+	"path/filepath"
+
+	"net/url"
 
 	"github.com/sirupsen/logrus"
+	"github.com/updatecli/updatecli/pkg/core/compose"
 	"github.com/updatecli/updatecli/pkg/core/config"
 	"github.com/updatecli/updatecli/pkg/core/jsonschema"
+	"github.com/updatecli/updatecli/pkg/core/registry"
 )
 
 func GenerateSchema(baseSchemaID, schemaDir string) error {
@@ -25,18 +30,52 @@ func GenerateSchema(baseSchemaID, schemaDir string) error {
 		}
 	}()
 
-	s := jsonschema.New(baseSchemaID, schemaDir)
-	err = s.GenerateSchema(&config.Spec{})
-	if err != nil {
-		return err
+	generateSchema := func(baseSchemaID, schemaDir, subSchemaDir string, spec interface{}) error {
+
+		if subSchemaDir != "" {
+			schemaDir = filepath.Join(schemaDir, subSchemaDir)
+
+			u, err := url.Parse(baseSchemaID)
+			if err != nil {
+				return err
+			}
+
+			u.Path = filepath.Join(u.Path, subSchemaDir)
+
+			baseSchemaID = u.String()
+		}
+
+		s := jsonschema.New(baseSchemaID, schemaDir)
+		err = s.GenerateSchema(spec)
+		if err != nil {
+			return err
+		}
+
+		logrus.Infof("```\n%s\n```\n", s)
+
+		err = s.Save()
+		if err != nil {
+			return fmt.Errorf("unable to save schema - %s", err)
+		}
+
+		return s.GenerateSchema(spec)
 	}
 
-	logrus.Infof("```\n%s\n```\n", s)
-
-	err = s.Save()
-	if err != nil {
-		return err
+	if err = generateSchema(baseSchemaID, schemaDir, "", config.Spec{}); err != nil {
+		return fmt.Errorf("unable to generate schema - %s", err)
 	}
 
-	return s.GenerateSchema(&config.Spec{})
+	if err = generateSchema(baseSchemaID, schemaDir, "policy/manifest", config.Spec{}); err != nil {
+		return fmt.Errorf("unable to generate schema - %s", err)
+	}
+
+	if err = generateSchema(baseSchemaID, schemaDir, "policy/metadata", registry.PolicySpec{}); err != nil {
+		return fmt.Errorf("unable to generate schema - %s", err)
+	}
+
+	if err = generateSchema(baseSchemaID, schemaDir, "compose", compose.Spec{}); err != nil {
+		return fmt.Errorf("unable to generate schema - %s", err)
+	}
+
+	return nil
 }

--- a/pkg/core/registry/pull.go
+++ b/pkg/core/registry/pull.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	spec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/sirupsen/logrus"
 
 	oras "oras.land/oras-go/v2"
@@ -15,8 +16,6 @@ import (
 	"oras.land/oras-go/v2/content/file"
 	"oras.land/oras-go/v2/registry"
 	"oras.land/oras-go/v2/registry/remote"
-
-	spec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // Pull pulls an OCI image from a registry.


### PR DESCRIPTION
Fix #1622 
Doc https://github.com/updatecli/website/pull/1173

Requirements:
- [x] https://github.com/updatecli/updatecli/pull/1605

This pullrquest add the support for a new configuration that allows to "compose" multiple policies. 
A compose file looks like 

<details><summary>update-compose.yaml</summary>

```
# Policies defines a list policies to enforce when running 
# `updatecli compose apply`
# `updatecli compose diff`
# `updatelci compose show`
#
configs:
  default:
    config:
      - updatecli.d
    values: 
      - values.yaml
    secrets:
      - secrets.yaml

policies: 
  - policy: ghcr.io/olblak/policies/updatecli:latest
  
    # The following policies are just examples and won't work as is
  - policy: ghcr.io/olblak/policies/golang:v2.1.1
  - policy: ghcr.io/olblak/policies/readme:v0.1.3
```

</details>

This file can be used using one of the three following commands

* `updatecli compose diff` : similar to `updatecli diff` but for multiple policies at once
* `updatecli compose apply`: similar to `updatecli apply` but for multiple policies at once
* `updatecli compose show` : similar to `updatecli show` but for multiple policies at once

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
go build -o bin/updatecli
./bin/updatecli compose diff -f update-compose.yaml
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

* Generating a jsonschema and publish on the jsonschema store