### PR TITLE
temporary disable go mod update for github.com/opencontainers/image-spec

### DIFF
--- a/updatecli/updatecli.d/golang/major.yaml
+++ b/updatecli/updatecli.d/golang/major.yaml
@@ -46,6 +46,9 @@ autodiscovery:
             # Same for https://pkg.go.dev/golang.org/x/time?tab=versions
             github.com/skratchdot/open-golang:
             k8s.io/utils:
+            # We currently requires a RC version which is not handle by versionfilter
+            # To remove once https://github.com/updatecli/updatecli/issues/1661 is done
+            github.com/opencontainers/image-spec:
       only:
         # This repository contains other go.sum file used for testing.
         # So we want to be sure that we only update the one at the root of the repository

--- a/updatecli/updatecli.d/golang/minor.yaml
+++ b/updatecli/updatecli.d/golang/minor.yaml
@@ -48,6 +48,9 @@ autodiscovery:
             # Same for https://pkg.go.dev/golang.org/x/time?tab=versions
             github.com/skratchdot/open-golang:
             k8s.io/utils:
+            # We currently requires a RC version which is not handle by versionfilter
+            # To remove once https://github.com/updatecli/updatecli/issues/1661 is done
+            github.com/opencontainers/image-spec:
 
       only:
         # This repository contains other go.sum file used for testing.

--- a/updatecli/updatecli.d/golang/patch.yaml
+++ b/updatecli/updatecli.d/golang/patch.yaml
@@ -46,6 +46,9 @@ autodiscovery:
             # Same for https://pkg.go.dev/golang.org/x/time?tab=versions
             github.com/skratchdot/open-golang:
             k8s.io/utils:
+            # We currently requires a RC version which is not handle by versionfilter
+            # # To remove once https://github.com/updatecli/updatecli/issues/1661 is done
+            github.com/opencontainers/image-spec:
 
       only:
         # This repository contains other go.sum file used for testing.


### PR DESCRIPTION
Updatecli pipelines are currently broken due to https://github.com/updatecli/updatecli/issues/1661
Until solves I am disabling this dependency update