### PR TITLE
Group all go mod update

### DIFF
--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -1,12 +1,13 @@
 name: updatecli
 on:
+  release:
   workflow_dispatch:
   push:
   pull_request:
   schedule:
     # * is a special character in YAML so you have to quote this string
-    # Run every hour
-    - cron: '0 * * * *'
+    # Run at 12:00 on Friday.”
+    - cron: '0 12 * * 5'
 jobs:
   updatecli:
     runs-on: ubuntu-latest

--- a/updatecli/updatecli.d/golang/minor.yaml
+++ b/updatecli/updatecli.d/golang/minor.yaml
@@ -18,13 +18,14 @@ actions:
         kind: github/pullrequest
         scmid: default
         spec:
+          title: "Bump minor version for Golang module"
           labels:
             - "dependencies"
 
 autodiscovery:
   scmid: default
   actionid:  default
-  groupby: individual
+  groupby: all
   crawlers:
     golang/gomod:
       versionfilter:

--- a/updatecli/updatecli.d/golang/patch.yaml
+++ b/updatecli/updatecli.d/golang/patch.yaml
@@ -15,14 +15,15 @@ actions:
         kind: github/pullrequest
         scmid: default
         spec:
-          automerge: true
+          title: "Bump patch version for Golang module"
+          automerge: false
           labels:
             - "dependencies"
 
 autodiscovery:
   scmid: default
   actionid:  default
-  groupby: individual
+  groupby: all
   crawlers:
     golang/gomod:
       versionfilter:


### PR DESCRIPTION
Change Updatecli cronjob trigger from every 15min to every Friday at 12AM.
The current situation, increase notification, and exhaust our API limit very quickly

Trigger Updatecli on release event

Group All go mod update until https://github.com/updatecli/updatecli/issues is fixed
