### PR TITLE
Update for the release job

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,7 +9,7 @@ permissions:
   packages: write
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       DOCKER_CLI_EXPERIMENTAL: "enabled"
       DOCKER_BUILDKIT: 1

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -128,14 +128,12 @@ dockers:
 
 docker_signs:
   - cmd: cosign
-    env:
-    - COSIGN_EXPERIMENTAL=1
     artifacts: manifests
     output: true
     args:
-    - 'sign'
-    - '${artifact}@${digest}'
-    - '--yes'
+      - 'sign'
+      - '--yes'
+      - '${artifact}@${digest}'
 
 docker_manifests:
   - name_template: 'updatecli/updatecli:{{ .Tag }}'
@@ -203,14 +201,13 @@ sboms:
 
 signs:
   - cmd: cosign
-    env:
-    - COSIGN_EXPERIMENTAL=1
     certificate: '${artifact}.pem'
+    signature: "${artifact}.sig"
     output: true
     artifacts: checksum
     args:
       - sign-blob
+      - '--yes'
       - '--output-certificate=${certificate}'
       - '--output-signature=${signature}'
       - '${artifact}'
-      - '--yes'

--- a/Makefile
+++ b/Makefile
@@ -22,15 +22,15 @@ build: ## Build updatecli as a "dirty snapshot" (no tag, no release, but all OS/
 
 .PHONY: build.all
 build.all: ## Build updatecli for "release" (tag or release and all OS/arch combinations)
-	goreleaser --clean --skip-publish
+	goreleaser --clean --skip=publish,sign
 
 .PHONY: release ## Create a new updatecli release including packages
-release: ## release.snapshot generate a snapshot release but do not published it (no tag, but all OS/arch combinations)
-	goreleaser --clean
+release: ## release generate a release
+	goreleaser release --clean --timeout=2h
 
 .PHONY: release.snapshot ## Create a new snapshot release without publishing assets
 release.snapshot: ## release.snapshot generate a snapshot release but do not published it (no tag, but all OS/arch combinations)
-	goreleaser --snapshot --clean --skip-publish
+	goreleaser release --snapshot --clean --skip=publish,sign
 
 .PHONY: diff
 diff: ## Run the "diff" updatecli's subcommand for smoke test


### PR DESCRIPTION
- Update for the release job
some updates to have the signing part working again and update some deprecated goreleaser flags


rehearsal: https://github.com/cpanato/updatecli/actions/runs/6493608351/job/17634895938 / https://github.com/cpanato/updatecli/releases/tag/v99.99.00
