### PR TITLE
chore: clean up Updatecli manifest

### DIFF
--- a/updatecli/updatecli.d/golang/golang.yaml
+++ b/updatecli/updatecli.d/golang/golang.yaml
@@ -55,13 +55,13 @@ conditions:
 
 targets:
     go.mod:
-        name: 'Update Golang version to {{ source "golang" }}'
+        name: 'deps: update Golang version to {{ source "golang" }}'
         kind: golang/gomod
         scmid: default
         sourceid: golang
 
     release:
-        name: '[release.yaml] Update Golang version to {{ source "golang" }}'
+        name: 'deps: update release workflow with Golang version to {{ source "golang" }}'
         kind: yaml
         spec:
             file: .github/workflows/release.yaml
@@ -70,7 +70,7 @@ targets:
         sourceid: golang
 
     workflowgo:
-        name: '[release.yaml] Update Golang version to {{ source "golang" }}'
+        name: 'deps: update build workflow with Golang version to {{ source "golang" }}'
         kind: yaml
         spec:
             file: .github/workflows/go.yaml

--- a/updatecli/updatecli.d/golang/major.yaml
+++ b/updatecli/updatecli.d/golang/major.yaml
@@ -46,9 +46,6 @@ autodiscovery:
             # Same for https://pkg.go.dev/golang.org/x/time?tab=versions
             github.com/skratchdot/open-golang:
             k8s.io/utils:
-            # We currently requires a RC version which is not handle by versionfilter
-            # To remove once https://github.com/updatecli/updatecli/issues/1661 is done
-            github.com/opencontainers/image-spec:
       only:
         # This repository contains other go.sum file used for testing.
         # So we want to be sure that we only update the one at the root of the repository

--- a/updatecli/updatecli.d/golang/minor.yaml
+++ b/updatecli/updatecli.d/golang/minor.yaml
@@ -49,9 +49,6 @@ autodiscovery:
             # Same for https://pkg.go.dev/golang.org/x/time?tab=versions
             github.com/skratchdot/open-golang:
             k8s.io/utils:
-            # We currently requires a RC version which is not handle by versionfilter
-            # To remove once https://github.com/updatecli/updatecli/issues/1661 is done
-            github.com/opencontainers/image-spec:
 
       only:
         # This repository contains other go.sum file used for testing.

--- a/updatecli/updatecli.d/golang/patch.yaml
+++ b/updatecli/updatecli.d/golang/patch.yaml
@@ -47,9 +47,6 @@ autodiscovery:
             # Same for https://pkg.go.dev/golang.org/x/time?tab=versions
             github.com/skratchdot/open-golang:
             k8s.io/utils:
-            # We currently requires a RC version which is not handle by versionfilter
-            # # To remove once https://github.com/updatecli/updatecli/issues/1661 is done
-            github.com/opencontainers/image-spec:
 
       only:
         # This repository contains other go.sum file used for testing.

--- a/updatecli/updatecli.d/golangci-lint.yaml
+++ b/updatecli/updatecli.d/golangci-lint.yaml
@@ -46,7 +46,7 @@ conditions:
         disablesourceinput: true
 targets:
     default:
-        name: Update Golangci-lint version to {{ source "default" }}
+        name: 'ci: update Golangci-lint version to {{ source "default" }}'
         kind: yaml
         spec:
             file: .github/workflows/go.yaml

--- a/updatecli/updatecli.d/updatecli.yaml
+++ b/updatecli/updatecli.d/updatecli.yaml
@@ -23,8 +23,6 @@ scms:
             token: '{{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}'
             user: updatecli
             username: '{{ requiredEnv "UPDATECLI_GITHUB_ACTOR" }}'
-            commitmessage:
-                title: 'Bump updatecli version to {{ source "latestVersion" }}'
 
 sources:
     latestVersion:
@@ -35,6 +33,8 @@ sources:
             repository: updatecli
             token: '{{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}'
             username: '{{ requiredEnv "UPDATECLI_GITHUB_ACTOR" }}'
+            versionfilter:
+              kind: semver
 
 conditions:
     container:
@@ -45,7 +45,7 @@ conditions:
 
 targets:
     bugReport:
-        name: 'Update updatecli version to {{ source "latestVersion" }}'
+        name: 'docs: update updatecli version to {{ source "latestVersion" }}'
         kind: file
         spec:
             content: '**updatecli**: {{ source `latestVersion` }}'
@@ -54,12 +54,32 @@ targets:
         scmid: default
         sourceid: latestVersion
 
-    cosign:
-        name: 'Update updatecli version to {{ source "latestVersion" }}'
+    cosign-container:
+        name: 'docs: update issue template with Updatecli version to {{ source "latestVersion" }}'
         kind: file
         spec:
-            content: 'ghcr.io/updatecli/updatecli:{{ source `latestVersion` }}'
             file: README.adoc
-            matchpattern: 'ghcr.io/updatecli/updatecli:.*'
+            matchpattern: 'ghcr.io/updatecli/updatecli:(.*)'
+            replacepattern: 'ghcr.io/updatecli/updatecli:{{ source "latestVersion" }}'
+        scmid: default
+        sourceid: latestVersion
+
+    cosign-checksums-txt-sig:
+        name: 'docs: update checksums.txt.sig url with Updatecli version to {{ source "latestVersion" }}'
+        kind: file
+        spec:
+            file: README.adoc
+            matchpattern: '(.*)https://github.com/updatecli/updatecli/releases/download/(.*)/checksums.txt.sig(.*)'
+            replacepattern: '${1}https://github.com/updatecli/updatecli/releases/download/{{ source "latestVersion" }}/checksums.txt.sig${3}'
+        scmid: default
+        sourceid: latestVersion
+
+    cosign-checksums-txt-pem:
+        name: 'docs: update checksums.txt.pem url with Updatecli version to {{ source "latestVersion" }}'
+        kind: file
+        spec:
+            file: README.adoc
+            matchpattern: '(.*)https://github.com/updatecli/updatecli/releases/download/(.*)/checksums.txt.pem(.*)'
+            replacepattern: '${1}https://github.com/updatecli/updatecli/releases/download/{{ source "latestVersion" }}/checksums.txt.pem${3}'
         scmid: default
         sourceid: latestVersion

--- a/updatecli/updatecli.d/venom.yaml
+++ b/updatecli/updatecli.d/venom.yaml
@@ -37,7 +37,7 @@ sources:
                 kind: semver
 targets:
     goWorkflow:
-        name: Bump Venom version to {{ source "latestVersion" }}
+        name: 'ci: update Venom version to {{ source "latestVersion" }}'
         kind: file
         spec:
             content: 'VENOM_VERSION: {{ source `latestVersion` }}'


### PR DESCRIPTION
This pullrequest introduces various cleanup in Updatecli manifests

* Update Updatecli target title using conventional commit scope which are used for git commit title
* Remove go mod ignore rule now that Updatecli 0.63.0 correctly handle prerelease version for go dependencies autodiscovery
* Automate documentation update for cosign instruction suggested by @cpanato in https://github.com/updatecli/updatecli/pull/1686