### PR TITLE
chore: remove time from generated markdown man pages

### DIFF
--- a/cmd/docs.go
+++ b/cmd/docs.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
@@ -16,7 +15,6 @@ var (
 	docPrepender = func(s string) string {
 
 		header := "---\n"
-		date := time.Now()
 
 		name := filepath.Base(s)
 		name = strings.ReplaceAll(name, "_", " ")
@@ -25,8 +23,6 @@ var (
 		header = header + fmt.Sprintf("title: %v\n", name)
 		header = header + fmt.Sprintf("description: Documentation for the command `%v`\n", name)
 		header = header + fmt.Sprintf("lead: Documentation for the command `%v`\n", name)
-		header = header + fmt.Sprintf("date: %v\n", date.Format(time.RFC3339))
-		header = header + fmt.Sprintf("lastmod: %v\n", date.Format(time.RFC3339))
 		header = header + "draft: false\n"
 		header = header + "images: []\n"
 		header = header + "menu:\n  docs:\n    parent: \"commands\"\n"


### PR DESCRIPTION
Removing the time from the man page makes it easier to automate those page update.

When running `updatecli docs -d ./content/en/docs/commands` on github.com/updatecli/website, we can't easily differentiate if the man pages changed or if it's just the time without them.  