### PR TITLE
Deprecate pipeline title setting in favor of pipeline name

### DIFF
--- a/e2e/updatecli.d/success.d/command.yaml
+++ b/e2e/updatecli.d/success.d/command.yaml
@@ -1,8 +1,5 @@
-title: Test Various target scenario
-
-scms:
-  local:
-    disabled: true
+name: Test Various target scenario
+pipelineid: e2e/command
 
 sources:
   1:

--- a/e2e/updatecli.d/success.d/csv.yaml
+++ b/e2e/updatecli.d/success.d/csv.yaml
@@ -1,4 +1,5 @@
-title: CSV manipulation examples
+name: CSV manipulation examples
+pipelineid: "e2e/csv"
 
 sources:
   default:

--- a/e2e/updatecli.d/success.d/jenkins.yaml
+++ b/e2e/updatecli.d/success.d/jenkins.yaml
@@ -1,8 +1,5 @@
-title: "Bump Jenkins stable version"
-
-scms:
-  local:
-    disabled: true
+name: "Bump Jenkins stable version"
+pipelineid: "e2e/jenkins"
 
 sources:
   getLatestJenkinsStable:

--- a/e2e/updatecli.d/success.d/maven.yaml
+++ b/e2e/updatecli.d/success.d/maven.yaml
@@ -1,5 +1,6 @@
 ---
-title: Show a set of maven resources as a generic example
+name: Show a set of maven resources as a generic example
+pipelineid: "e2e/maven"
 
 scms:
   local:

--- a/e2e/updatecli.d/success.d/source/gitTag.yaml
+++ b/e2e/updatecli.d/success.d/source/gitTag.yaml
@@ -1,8 +1,7 @@
-title: "Test new gitTag resource"
+name: "Test new gitTag resource"
+pipelineid: "e2e/gitTag"
 
 scms:
-  local:
-    disabled: true
   updatecli:
     kind: git
     spec:
@@ -18,10 +17,7 @@ sources:
     name: Get latest updatecli test
     kind: gittag
     spec:
-      # comment following test until dockerimage and semver versionfilter move out from experimental
-      # more ctx on https://github.com/updatecli/updatecli/pull/816
-
-      #versionfilter:
-      #  kind: semver
-      #  pattern: "~0.1"
+      versionfilter:
+        kind: semver
+        pattern: "~0.1"
     scmid: updatecli

--- a/e2e/updatecli.d/success.d/source/githubRelease.2.yaml
+++ b/e2e/updatecli.d/success.d/source/githubRelease.2.yaml
@@ -1,9 +1,6 @@
 ---
-title: Test source githubRelease
-
-scms:
-  local:
-    disabled: true
+name: Test source githubRelease
+pipelineid: e2e/githubRelease
 
 sources:
   helm:

--- a/e2e/updatecli.d/success.d/source/githubRelease.yaml
+++ b/e2e/updatecli.d/success.d/source/githubRelease.yaml
@@ -1,9 +1,6 @@
 ---
-title: Test source githubRelease
-
-scms:
-  local:
-    disabled: true
+name: Test source githubRelease
+pipelineid: e2e/githubRelease
 
 sources:
   helm:

--- a/pkg/core/config/defaults.go
+++ b/pkg/core/config/defaults.go
@@ -10,9 +10,9 @@ import (
 // GetChangelogTitle try to guess a specific target based on various information available for
 // a specific job
 func (config *Config) GetChangelogTitle(ID string, fallback string) (title string) {
-	if len(config.Spec.Title) > 0 {
+	if len(config.Spec.Name) > 0 {
 		// If a pipeline title has been defined, then use it for action title
-		title = config.Spec.Title
+		title = config.Spec.Name
 
 	} else if len(config.Spec.Targets) == 1 && len(config.Spec.Targets[ID].Name) > 0 {
 		// If we only have one target then we can use it as fallback.
@@ -21,8 +21,8 @@ func (config *Config) GetChangelogTitle(ID string, fallback string) (title strin
 	} else {
 		// At the moment, we don't have an easy way to describe what changed
 		// I am still thinking to a better solution.
-		logrus.Warning("**Fallback** Please add a title to you configuration using the field 'title: <your pipeline>'")
-		title = fmt.Sprintf("[%s] Bump version to %s",
+		logrus.Warning("**Fallback** Please add a name to your configuration using the field 'name: <your pipeline>'")
+		title = fmt.Sprintf("deps: [%s] Bump version to %s",
 			config.Spec.Sources[config.Spec.Targets[ID].SourceID].Kind,
 			fallback)
 	}

--- a/pkg/core/config/main.go
+++ b/pkg/core/config/main.go
@@ -591,6 +591,10 @@ func (config *Config) Validate() error {
 			fmt.Errorf("updatecli version compatibility error:\n%s", err))
 	}
 
+	if config.Spec.Title != "" {
+		logrus.Warningf("title is deprecated, please use name instead")
+	}
+
 	err = config.validateConditions()
 	if err != nil {
 		errs = append(

--- a/pkg/core/config/main_test.go
+++ b/pkg/core/config/main_test.go
@@ -867,7 +867,7 @@ func TestNew(t *testing.T) {
 			expectedResult: []Config{
 				{
 					Spec: Spec{
-						Name: "Get latest Jenkins version",
+						Name: "Get lts Jenkins version",
 					},
 				},
 			},
@@ -917,7 +917,7 @@ func TestNew(t *testing.T) {
 			expectedResult: []Config{
 				{
 					Spec: Spec{
-						Name: "Get latest stable Jenkins version",
+						Name: "Get latest lts Jenkins version",
 					},
 				},
 				{
@@ -949,7 +949,7 @@ func TestNew(t *testing.T) {
 
 		require.EqualValues(t, len(data.expectedResult), len(got))
 		for i := range data.expectedResult {
-			require.Equal(t, data.expectedResult[i].Spec.Title, got[i].Spec.Title)
+			require.Equal(t, data.expectedResult[i].Spec.Name, got[i].Spec.Name)
 		}
 	}
 }

--- a/pkg/core/config/testdata/updatecli.d/jenkins.yaml
+++ b/pkg/core/config/testdata/updatecli.d/jenkins.yaml
@@ -1,1 +1,2 @@
-name: Get Latest Jenkins version
+name: Get latest Jenkins version
+pipelineid: jenkins/latest

--- a/pkg/core/config/testdata/updatecli.d/multiJenkins.yaml
+++ b/pkg/core/config/testdata/updatecli.d/multiJenkins.yaml
@@ -1,5 +1,7 @@
 ---
 name: Get latest stable Jenkins version
+pipelineid: jenkins/stable
 
 ---
 name: Get latest weekly Jenkins version
+pipelineid: jenkins/weekly

--- a/pkg/core/config/testdata/updatecli.d/multiTemplatedJenkins.tpl
+++ b/pkg/core/config/testdata/updatecli.d/multiTemplatedJenkins.tpl
@@ -1,4 +1,5 @@
 {{- range $release := .releases }}
 ---
 name: Get latest {{ $release.type }} Jenkins version
+pipelineid: jenkins/latest
 {{- end }}

--- a/pkg/core/engine/run.go
+++ b/pkg/core/engine/run.go
@@ -18,7 +18,7 @@ func (e *Engine) Run() (err error) {
 		e.Reports = append(e.Reports, pipeline.Report)
 
 		if err != nil {
-			logrus.Printf("Pipeline %q failed\n", pipeline.Title)
+			logrus.Printf("Pipeline %q failed\n", pipeline.Name)
 			logrus.Printf("Skipping due to:\n\t%s\n", err)
 			continue
 		}

--- a/pkg/core/pipeline/actions.go
+++ b/pkg/core/pipeline/actions.go
@@ -110,16 +110,16 @@ func (p *Pipeline) RunActions() error {
 			actionTitle = getActionTitle(action)
 		}
 
-		pipelineTitle := p.Config.Spec.Name
-		if pipelineTitle == "" && p.Config.Spec.Title != "" {
-			pipelineTitle = p.Config.Spec.Name
-		} else if pipelineTitle == "" && p.Name != "" {
-			pipelineTitle = p.Name
+		pipelineName := p.Config.Spec.Name
+		if pipelineName == "" && p.Config.Spec.Title != "" {
+			pipelineName = p.Config.Spec.Name
+		} else if pipelineName == "" && p.Name != "" {
+			pipelineName = p.Name
 		}
 
-		action.Report.ID = fmt.Sprintf("%x", sha256.Sum256([]byte(p.Title+actionTitle)))
+		action.Report.ID = fmt.Sprintf("%x", sha256.Sum256([]byte(p.Name)))
 		action.Report.Title = actionTitle
-		action.Report.PipelineTitle = pipelineTitle
+		action.Report.PipelineTitle = pipelineName
 
 		// Ignoring failed targets
 		if len(failedTargetIDs) > 0 {

--- a/pkg/core/pipeline/main.go
+++ b/pkg/core/pipeline/main.go
@@ -20,35 +20,38 @@ import (
 
 // Pipeline represent an updatecli run for a specific configuration
 type Pipeline struct {
-	Name  string // Name defines a pipeline name, used to improve human visualization
-	ID    string // ID allows to identify a full pipeline run, this value is propagated into each target if not defined at that level
-	Title string // Title is used for the full pipeline
-
-	Sources    map[string]source.Source
+	// Name defines a pipeline name, used to improve human visualization
+	Name string
+	// ID allows to identify a full pipeline run, this value is propagated into each target if not defined at that level
+	ID string
+	// Sources contains all sources defined in the configuration
+	Sources map[string]source.Source
+	// Conditions contains all conditions defined in the configuration
 	Conditions map[string]condition.Condition
-	Targets    map[string]target.Target
-	SCMs       map[string]scm.Scm
-	Actions    map[string]action.Action
-
+	// Targets contains all targets defined in the configuration
+	Targets map[string]target.Target
+	// SCMs contains all scms defined in the configuration
+	SCMs map[string]scm.Scm
+	// Actions contains all actions defined in the configuration
+	Actions map[string]action.Action
+	// Report contains the pipeline report
 	Report reports.Report
-
+	// Options contains all updatecli options for this specific pipeline
 	Options Options
-
+	// Config contains the pipeline configuration defined by the user
 	Config *config.Config
 }
 
 // Init initialize an updatecli context based on its configuration
 func (p *Pipeline) Init(config *config.Config, options Options) error {
 
-	if len(config.Spec.Title) > 0 {
-		p.Title = config.Spec.Title
-	} else {
-		p.Title = config.Spec.Name
+	p.Name = config.Spec.Name
+	if len(config.Spec.Title) > 0 && p.Name == "" {
+		p.Name = config.Spec.Title
 	}
 
 	p.Options = options
 
-	p.Name = config.Spec.Name
 	p.ID = config.Spec.PipelineID
 
 	p.Config = config
@@ -193,9 +196,9 @@ func (p *Pipeline) Init(config *config.Config, options Options) error {
 // Run execute an single pipeline
 func (p *Pipeline) Run() error {
 
-	logrus.Infof("\n\n%s\n", strings.Repeat("#", len(p.Title)+4))
-	logrus.Infof("# %s #\n", strings.ToTitle(p.Title))
-	logrus.Infof("%s\n", strings.Repeat("#", len(p.Title)+4))
+	logrus.Infof("\n\n%s\n", strings.Repeat("#", len(p.Name)+4))
+	logrus.Infof("# %s #\n", strings.ToTitle(p.Name))
+	logrus.Infof("%s\n", strings.Repeat("#", len(p.Name)+4))
 
 	if len(p.Sources) > 0 {
 		err := p.RunSources()
@@ -255,7 +258,6 @@ func (p *Pipeline) Run() error {
 func (p *Pipeline) String() string {
 
 	result := fmt.Sprintf("%q: %q\n", "Name", p.Name)
-	result = result + fmt.Sprintf("%q: %q\n", "Title", p.Title)
 	result = result + fmt.Sprintf("%q: %q\n", "ID", p.ID)
 
 	result = result + fmt.Sprintf("%q:\n", "Sources")


### PR DESCRIPTION
I don't fully remember why but at some point I introduce both the pipeline setting `name` and `title`.
In my opinion they both solves the same purpose, being able to specify  a small description for the pipeline such as 

`name: bump package version to XXX`

After looking at the code, I noticed that many time I default one of the two value based on the other one, such as set name based on title, etc... 

This increase even more the confusion :( 

This pullrequest consolidate on `name` and deprecated `title`. 
Since https://github.com/updatecli/updatecli/releases/tag/v0.63.0, jsonschema validation trigger an error if `title` is defined so I am planning to wait a bit before fully deprecating this setting.

Second change introduced in this pullrequest, is how actionid is generated. We now only use the pipeline title which shouldn't change over time. This fix improve pullrequest body

Please note that `name` and `title` are not related to `pipelineid` which solves a totally different problem.

## Test

This thing that we could test is to verify that a manifest using the setting `title` triggers a warning message. 
Everything else should be working as expected.

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
