### PR TITLE
various updatecli compose fixes

### DIFF
--- a/cmd/manifest_push.go
+++ b/cmd/manifest_push.go
@@ -24,6 +24,23 @@ var (
 		Run: func(cmd *cobra.Command, args []string) {
 			manifestPushFileStore = args[0]
 
+			// Check if the user has specified at least one tag
+			if len(manifestPushPolicyReference) == 0 {
+				logrus.Errorf("At least one tag must be specified")
+				os.Exit(1)
+			}
+
+			// Default store to current working directory
+			if manifestPushFileStore == "" {
+				manifestPushFileStore, _ = os.Getwd()
+			}
+
+			// For some reason the StringArrayVarP does not work as expected
+			// so I have to manually check if the user has specified a manifest directory
+			if len(manifestFiles) == 0 {
+				manifestFiles = []string{"updatecli.d"}
+			}
+
 			err := run("manifest/push")
 			if err != nil {
 				logrus.Errorf("command failed: %s", err)

--- a/pkg/core/compose/spec.go
+++ b/pkg/core/compose/spec.go
@@ -10,8 +10,8 @@ type Spec struct {
 }
 
 type Policy struct {
-	// Config contains a list of config ids to be used for the policy
-	Configs []string `yaml:",omitempty"`
+	// Name contains the policy name
+	Name string `yaml:",omitempty"`
 	// Policy contains the policy OCI name
 	Policy string `yaml:",omitempty"`
 	// Config contains a list of Updatecli config file path
@@ -20,4 +20,25 @@ type Policy struct {
 	Values []string `yaml:",omitempty"`
 	// Secrets contains a list of Updatecli secret file path
 	Secrets []string `yaml:",omitempty"`
+}
+
+func (p Policy) IsZero() bool {
+
+	if len(p.Config) > 0 {
+		return false
+	}
+
+	if len(p.Values) > 0 {
+		return false
+	}
+
+	if len(p.Secrets) > 0 {
+		return false
+	}
+
+	if p.Policy != "" {
+		return false
+	}
+
+	return true
 }

--- a/pkg/core/engine/configuration.go
+++ b/pkg/core/engine/configuration.go
@@ -47,7 +47,7 @@ func (e *Engine) LoadConfigurations() error {
 			}
 		}
 
-		for _, manifestFile := range sanitizeUpdatecliManifestFilePath(e.Options.Manifests[i].Manifests, "") {
+		for _, manifestFile := range sanitizeUpdatecliManifestFilePath(e.Options.Manifests[i].Manifests) {
 
 			loadedConfigurations, err := config.New(
 				config.Option{

--- a/pkg/core/engine/registry.go
+++ b/pkg/core/engine/registry.go
@@ -1,6 +1,9 @@
 package engine
 
 import (
+	"path/filepath"
+
+	"github.com/sirupsen/logrus"
 	"github.com/updatecli/updatecli/pkg/core/registry"
 )
 
@@ -23,7 +26,38 @@ func (e *Engine) PushToRegistry(manifests, valuesFiles, secretsFiles, policyRefe
 
 	PrintTitle("Registry")
 
-	manifests = sanitizeUpdatecliManifestFilePath(manifests, fileStore)
+	joinWithFileStore := func(files []string) []string {
+		for i, file := range files {
+			if !filepath.IsAbs(file) {
+				files[i] = filepath.Join(fileStore, file)
+			}
+		}
+		return files
+	}
+
+	relativeFromFileStore := func(files []string) []string {
+		for i, file := range files {
+			relPath, err := filepath.Rel(fileStore, file)
+			if err != nil {
+				logrus.Errorf("Unable to get relative path from %s to %s", fileStore, file)
+				continue
+			}
+			files[i] = relPath
+		}
+		return files
+	}
+
+	// If policyMetadataFile is not an absolute path then we assume it is relative to fileStore
+	if !filepath.IsAbs(policyMetadataFile) {
+		policyMetadataFile = filepath.Join(fileStore, policyMetadataFile)
+	}
+
+	joinWithFileStore(manifests)
+
+	manifests = sanitizeUpdatecliManifestFilePath(manifests)
+
+	relativeFromFileStore(manifests)
+
 	err := registry.Push(policyMetadataFile, manifests, valuesFiles, secretsFiles, policyReference, disableTLS, fileStore)
 	if err != nil {
 		return err

--- a/pkg/core/engine/utils.go
+++ b/pkg/core/engine/utils.go
@@ -13,22 +13,14 @@ import (
 /*
 sanitizeUpdatecliManifestFilePath receives a list of files (directory or file) and returns a list of files that could be accepted by Updatecli.
 */
-func sanitizeUpdatecliManifestFilePath(rawFilePaths []string, rootDirPath string) (sanitizedFilePaths []string) {
+func sanitizeUpdatecliManifestFilePath(rawFilePaths []string) (sanitizedFilePaths []string) {
 	for _, r := range rawFilePaths {
-		r = filepath.Join(rootDirPath, r)
 		err := filepath.Walk(r, func(path string, info os.FileInfo, err error) error {
 			if err != nil {
 				logrus.Errorf("\n%s File %s: %s\n", result.FAILURE, path, err)
 				return fmt.Errorf("unable to walk %q: %s", path, err)
 			}
 			if info.Mode().IsRegular() {
-				if rootDirPath != "" {
-					tmpPath := path
-					path, err = filepath.Rel(rootDirPath, path)
-					if err != nil {
-						return fmt.Errorf("unable to get relative path for %q: %s", tmpPath, err)
-					}
-				}
 				sanitizedFilePaths = append(sanitizedFilePaths, path)
 			}
 			return nil

--- a/pkg/core/registry/metadata.go
+++ b/pkg/core/registry/metadata.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 
 	"github.com/Masterminds/semver/v3"
 	"gopkg.in/yaml.v3"
@@ -34,11 +33,11 @@ type PolicySpec struct {
 }
 
 // LoadPolicyFile loads an Updatecli compose file into a compose Spec
-func LoadPolicyFile(filename, store string) (*PolicySpec, error) {
+func LoadPolicyFile(filename string) (*PolicySpec, error) {
 
 	var policySpec PolicySpec
 
-	f, err := os.Open(filepath.Join(store, filename))
+	f, err := os.Open(filename)
 	if err != nil {
 		return nil, fmt.Errorf("opening Updatecli policy file %q: %s", filename, err)
 	}

--- a/pkg/core/registry/metadata.go
+++ b/pkg/core/registry/metadata.go
@@ -19,7 +19,7 @@ type PolicySpec struct {
 	Documentation string `yaml:",omitempty"`
 	// Source is the URL of the policy source code
 	Source string `yaml:",omitempty"`
-	// Version is the policy version
+	// Version is the policy version, it must be semantic versioning compliant without the leading v
 	Version string `yaml:",omitempty"`
 	// Vendor is the policy vendor
 	Vendor string `yaml:",omitempty"`
@@ -66,9 +66,13 @@ func (s *PolicySpec) Sanitize() error {
 		s.Version = "0.0.1"
 	}
 
-	_, err := semver.NewVersion(s.Version)
+	v, err := semver.NewVersion(s.Version)
 	if err != nil {
 		return fmt.Errorf("invalid policy version %q: %s", s.Version, err)
 	}
+
+	// Trim leading v
+	s.Version = v.String()
+
 	return nil
 }

--- a/pkg/core/registry/pull.go
+++ b/pkg/core/registry/pull.go
@@ -33,7 +33,6 @@ func Pull(ociName string, disableTLS bool) (manifests []string, values []string,
 		if err != nil {
 			return nil, nil, nil, fmt.Errorf("get latest tag sorted by semver: %w", err)
 		}
-		logrus.Debugf("Latest tag founded %s", ref.String())
 	}
 
 	// 1. Connect to a remote repository
@@ -55,7 +54,6 @@ func Pull(ociName string, disableTLS bool) (manifests []string, values []string,
 	}
 
 	// 2.5 Get remote manifest digest
-
 	remoteManifestSpec, _, err := oras.Fetch(ctx, repo, ref.String(), oras.DefaultFetchOptions)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("fetch: %w", err)

--- a/pkg/core/registry/pullpush_test.go
+++ b/pkg/core/registry/pullpush_test.go
@@ -60,7 +60,7 @@ func TestPushPullPolicy(t *testing.T) {
 		disableTLS                bool
 	}{
 		{
-			name:                      "Validate that we can push and pull a policy using the latest tag",
+			name:                      "Validate that we can push and pull a policy using the latest tag, even thought the tag is ignored",
 			toPushPolicyName:          []string{fmt.Sprintf("localhost:%d/myrepo:latest", port.Int())},
 			disableTLS:                true,
 			toPushPolicyFile:          "testdata/Policy.yaml",
@@ -87,14 +87,14 @@ func TestPushPullPolicy(t *testing.T) {
 			name:                      "Validate that we can push and pull a policy without tag from a different file store",
 			toPushPolicyName:          []string{fmt.Sprintf("localhost:%d/myrepo", port.Int())},
 			disableTLS:                true,
-			toPushPolicyFile:          "Policy.yaml",
-			toPushManifestFiles:       []string{"venom.yaml"},
-			toPushValueFiles:          []string{"values.yaml"},
-			toPushSecretFiles:         []string{"secrets.yaml"},
-			expectedPullManifestFiles: []string{"venom.yaml"},
-			expectedPullValuesFiles:   []string{"values.yaml"},
-			expectedPullSecretsFiles:  []string{"secrets.yaml"},
-			toPushFileStore:           "testdata",
+			toPushPolicyFile:          "testdata/Policy.yaml",
+			toPushManifestFiles:       []string{"testdata/venom.yaml"},
+			toPushValueFiles:          []string{"testdata/values.yaml"},
+			toPushSecretFiles:         []string{"testdata/secrets.yaml"},
+			expectedPullManifestFiles: []string{"testdata/venom.yaml"},
+			expectedPullValuesFiles:   []string{"testdata/values.yaml"},
+			expectedPullSecretsFiles:  []string{"testdata/secrets.yaml"},
+			toPushFileStore:           ".",
 		},
 	}
 

--- a/pkg/core/registry/utils.go
+++ b/pkg/core/registry/utils.go
@@ -33,6 +33,7 @@ func getLatestTagSortedBySemver(refName string, disableTLS bool) (string, error)
 	ctx := context.Background()
 
 	tags, err := registry.Tags(ctx, repo)
+
 	if err != nil {
 		return "", fmt.Errorf("get tags: %w", err)
 	}
@@ -51,9 +52,14 @@ func getLatestTagSortedBySemver(refName string, disableTLS bool) (string, error)
 	if len(result) == 0 {
 		return "", fmt.Errorf("no valid semver tags found")
 	}
-	sort.Sort(semver.Collection(result))
 
-	return result[0].Original(), nil
+	sort.Sort(semver.Collection(result))
+	sort.Sort(sort.Reverse(semver.Collection(result)))
+
+	latestTag := result[0].Original()
+	logrus.Debugf("latest tag identified %q", latestTag)
+
+	return latestTag, nil
 }
 
 // getCredentialsFromDockerStore get the credentials from the docker credential store


### PR DESCRIPTION
While working on https://github.com/olblak/updatecli-policy-docusaurus
I spotted a few issues which I am collecting and fixing in this pullrequest

* fix: compose file should work without oci policies
* fix: latest tag shouldn't return the oldest tag 
* fix: used sanitize policy version for before push to ensure that v prefix are removed
* fix: various path scenarios when publishing policies

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
cd <to_package_directory>
go test
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
