### PR TITLE
fix: do not exit on empty arguments

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,6 +4,7 @@ import (
 	"os"
 
 	"github.com/sirupsen/logrus"
+	"golang.org/x/exp/slices"
 
 	"github.com/updatecli/updatecli/pkg/core/cmdoptions"
 	"github.com/updatecli/updatecli/pkg/core/log"
@@ -220,7 +221,7 @@ func run(command string) error {
 
 func getPolicyFilesFromRegistry() error {
 
-	if len(policyReferences) == 0 {
+	if slices.Equal(policyReferences, []string{""}) || slices.Equal(policyReferences, []string{}) {
 		return nil
 	}
 


### PR DESCRIPTION
Fix #1706

Compare the slice of arguments with an empty slice and a slice with one empty string. (credit @olblak)

## Test

To test this pull request, you can run the following commands:

```shell
cat > test.yml << EOF
name: test
pipelineid: test

sources:
  one:
    name: 'Check {{ $updateChannel }} channel'
    kind: shell
    spec:
      command: echo 1
targets:
  one:
    name: 'Check {{ $updateChannel }} channel'
    kind: shell
    spec:
      command: echo 1
EOF
go run . apply "" --config test.yml
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
