### PR TITLE
feat: support for pinning docker digests by image config

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -54,6 +54,7 @@ require (
 	github.com/testcontainers/testcontainers-go v0.24.1
 	github.com/tomwright/dasel v1.27.3
 	github.com/zclconf/go-cty v1.14.1
+	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1
 	golang.org/x/text v0.13.0
 	golang.org/x/time v0.3.0
 	gopkg.in/ini.v1 v1.67.0
@@ -91,7 +92,6 @@ require (
 	github.com/yusufpapurcu/wmi v1.2.3 // indirect
 	go.opentelemetry.io/otel v1.14.0 // indirect
 	go.opentelemetry.io/otel/trace v1.14.0 // indirect
-	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1 // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230530153820-e85fd2cbaebc // indirect
 )

--- a/pkg/plugins/resources/dockerdigest/condition_test.go
+++ b/pkg/plugins/resources/dockerdigest/condition_test.go
@@ -16,10 +16,34 @@ func TestCondition(t *testing.T) {
 		expectedResult result.Condition
 	}{
 		{
-			name: "Test condition with a digest specified via the manifest",
+			name: "Test condition with a digest specified via the manifest without architecture",
 			spec: Spec{
 				Image:  "ghcr.io/updatecli/updatecli",
-				Digest: "v0.35.0@sha256:6e1833e5240ac52ecf7609623f18ec4536151e0f58b7243b92fd71ecdf3b94df",
+				Digest: "v0.64.1@sha256:0c7a19c9607b349cb90af92cb0ec98a70074192eb1a3463c3883f10663024ce5",
+			},
+			expectedResult: result.Condition{
+				Result: "SUCCESS",
+				Pass:   true,
+			},
+		},
+		{
+			name: "Test condition with a digest specified via the manifest for arm64 architecture",
+			spec: Spec{
+				Image:        "ghcr.io/updatecli/updatecli",
+				Architecture: "arm64",
+				Digest:       "v0.64.1@sha256:80c8393095062a96e74ac7e23aab35c8b639b890d94f2fe8fbcbbc983993e1de",
+			},
+			expectedResult: result.Condition{
+				Result: "SUCCESS",
+				Pass:   true,
+			},
+		},
+		{
+			name: "Test condition with a digest specified via the manifest for amd64 architecture",
+			spec: Spec{
+				Image:        "ghcr.io/updatecli/updatecli",
+				Architecture: "amd64",
+				Digest:       "v0.64.1@sha256:4eb444331ca649b24fa8905a98cc1bf922111b7b07292b86a30d3977e5e8f56d",
 			},
 			expectedResult: result.Condition{
 				Result: "SUCCESS",
@@ -30,8 +54,9 @@ func TestCondition(t *testing.T) {
 			name:         "Test condition with a digest specified via the source output",
 			sourceOutput: "v0.35.0@sha256:6e1833e5240ac52ecf7609623f18ec4536151e0f58b7243b92fd71ecdf3b94df",
 			spec: Spec{
-				Image:  "ghcr.io/updatecli/updatecli",
-				Digest: "v0.35.0@sha256:6e1833e5240ac52ecf7609623f18ec4536151e0f58b7243b92fd71ecdf3b94df",
+				Image:        "ghcr.io/updatecli/updatecli",
+				Digest:       "v0.35.0@sha256:6e1833e5240ac52ecf7609623f18ec4536151e0f58b7243b92fd71ecdf3b94df",
+				Architecture: "amd64",
 			},
 			expectedResult: result.Condition{
 				Result: "SUCCESS",
@@ -41,8 +66,9 @@ func TestCondition(t *testing.T) {
 		{
 			name: "Test condition with a digest specified via the manifest without tag",
 			spec: Spec{
-				Image:  "ghcr.io/updatecli/updatecli",
-				Digest: "@sha256:6e1833e5240ac52ecf7609623f18ec4536151e0f58b7243b92fd71ecdf3b94df",
+				Image:        "ghcr.io/updatecli/updatecli",
+				Digest:       "@sha256:6e1833e5240ac52ecf7609623f18ec4536151e0f58b7243b92fd71ecdf3b94df",
+				Architecture: "amd64",
 			},
 			expectedResult: result.Condition{
 				Result: "SUCCESS",
@@ -53,8 +79,9 @@ func TestCondition(t *testing.T) {
 			name:         "Test condition with a digest specified via the source output",
 			sourceOutput: "v0.35.0@sha256:6e1833e5240ac52ecf7609623f18ec4536151e0f58b7243b92fd71ecdf3b94df",
 			spec: Spec{
-				Image:  "ghcr.io/updatecli/updatecli",
-				Digest: "@sha256:6e1833e5240ac52ecf7609623f18ec4536151e0f58b7243b92fd71ecdf3b94df",
+				Image:        "ghcr.io/updatecli/updatecli",
+				Digest:       "@sha256:6e1833e5240ac52ecf7609623f18ec4536151e0f58b7243b92fd71ecdf3b94df",
+				Architecture: "amd64",
 			},
 			expectedResult: result.Condition{
 				Result: "SUCCESS",

--- a/pkg/plugins/resources/dockerdigest/source.go
+++ b/pkg/plugins/resources/dockerdigest/source.go
@@ -30,14 +30,22 @@ func (ds *DockerDigest) Source(workingDir string, resultSource *result.Source) e
 		return fmt.Errorf("invalid image %s: %w", refName, err)
 	}
 
-	image, err := remote.Image(ref, ds.options...)
+	remoteDescriptor, err := remote.Get(ref, ds.options...)
 	if err != nil {
 		return fmt.Errorf("unable to retrieve image %s: %w", refName, err)
 	}
 
-	digest, err := image.Digest()
-	if err != nil {
-		return fmt.Errorf("unable to retrieve image digest %s: %w", refName, err)
+	digest := remoteDescriptor.Digest
+	if ds.spec.Architecture != "" {
+		image, err := remote.Image(ref, ds.options...)
+		if err != nil {
+			return fmt.Errorf("unable to retrieve image %s: %w", refName, err)
+		}
+
+		digest, err = image.Digest()
+		if err != nil {
+			return fmt.Errorf("unable to retrieve image digest %s: %w", refName, err)
+		}
 	}
 
 	finalDigest := refTag + "@" + digest.String()

--- a/pkg/plugins/resources/dockerdigest/source_test.go
+++ b/pkg/plugins/resources/dockerdigest/source_test.go
@@ -17,24 +17,35 @@ func TestSource(t *testing.T) {
 		expectedError  bool
 	}{
 		{
-			name: "Nominal case",
 			spec: Spec{
+
 				Image: "ghcr.io/updatecli/updatecli",
-				Tag:   "v0.35.0",
+				Tag:   "v0.64.1",
 			},
 			expectedResult: result.Source{
-				Information: "v0.35.0@sha256:6e1833e5240ac52ecf7609623f18ec4536151e0f58b7243b92fd71ecdf3b94df",
+				Information: "v0.64.1@sha256:0c7a19c9607b349cb90af92cb0ec98a70074192eb1a3463c3883f10663024ce5",
 			},
 		},
 		{
-			name: "Nominal case with architecture",
+			name: "Nominal case with arm64 architecture",
 			spec: Spec{
 				Image:        "ghcr.io/updatecli/updatecli",
-				Tag:          "v0.35.0",
+				Tag:          "v0.64.1",
 				Architecture: "arm64",
 			},
 			expectedResult: result.Source{
-				Information: "v0.35.0@sha256:5fa1ad470832ab88c5e94f942fe15b3298fa7f54a660dbe023b937fec1ad2128",
+				Information: "v0.64.1@sha256:80c8393095062a96e74ac7e23aab35c8b639b890d94f2fe8fbcbbc983993e1de",
+			},
+		},
+		{
+			name: "Nominal case with amd64 architecture",
+			spec: Spec{
+				Image:        "ghcr.io/updatecli/updatecli",
+				Tag:          "v0.64.1",
+				Architecture: "amd64",
+			},
+			expectedResult: result.Source{
+				Information: "v0.64.1@sha256:4eb444331ca649b24fa8905a98cc1bf922111b7b07292b86a30d3977e5e8f56d",
 			},
 		},
 		{
@@ -49,9 +60,10 @@ func TestSource(t *testing.T) {
 		{
 			name: "Nominal case with hidden tag from digest",
 			spec: Spec{
-				Image:   "ghcr.io/updatecli/updatecli",
-				Tag:     "v0.35.0",
-				HideTag: true,
+				Image:        "ghcr.io/updatecli/updatecli",
+				Tag:          "v0.35.0",
+				Architecture: "amd64",
+				HideTag:      true,
 			},
 			expectedResult: result.Source{
 				Information: "@sha256:6e1833e5240ac52ecf7609623f18ec4536151e0f58b7243b92fd71ecdf3b94df",
@@ -60,8 +72,9 @@ func TestSource(t *testing.T) {
 		{
 			name: "Get latest digest reusing the tag prefix",
 			spec: Spec{
-				Image: "ghcr.io/updatecli/updatecli",
-				Tag:   "v0.35.0@sha256:6e1833e5240ac52ecf7609623f18ec4536151e0f58b7243b92fd71ecdf3b94df",
+				Image:        "ghcr.io/updatecli/updatecli",
+				Tag:          "v0.35.0@sha256:6e1833e5240ac52ecf7609623f18ec4536151e0f58b7243b92fd71ecdf3b94df",
+				Architecture: "amd64",
 			},
 			expectedResult: result.Source{
 				Information: "v0.35.0@sha256:6e1833e5240ac52ecf7609623f18ec4536151e0f58b7243b92fd71ecdf3b94df",

--- a/updatecli/updatecli.d/golang/major.yaml
+++ b/updatecli/updatecli.d/golang/major.yaml
@@ -47,6 +47,8 @@ autodiscovery:
             # Same for https://pkg.go.dev/golang.org/x/time?tab=versions
             github.com/skratchdot/open-golang: ""
             k8s.io/utils: ""
+            # https://pkg.go.dev/golang.org/x/exp?tab=versions
+            golang.org/x/exp:
       only:
         # This repository contains other go.sum file used for testing.
         # So we want to be sure that we only update the one at the root of the repository

--- a/updatecli/updatecli.d/golang/minor.yaml
+++ b/updatecli/updatecli.d/golang/minor.yaml
@@ -49,6 +49,8 @@ autodiscovery:
             # Same for https://pkg.go.dev/golang.org/x/time?tab=versions
             github.com/skratchdot/open-golang: ""
             k8s.io/utils: ""
+            # https://pkg.go.dev/golang.org/x/exp?tab=versions
+            golang.org/x/exp:
 
       only:
         # This repository contains other go.sum file used for testing.

--- a/updatecli/updatecli.d/golang/patch.yaml
+++ b/updatecli/updatecli.d/golang/patch.yaml
@@ -47,6 +47,8 @@ autodiscovery:
             # Same for https://pkg.go.dev/golang.org/x/time?tab=versions
             github.com/skratchdot/open-golang: ""
             k8s.io/utils: ""
+            # https://pkg.go.dev/golang.org/x/exp?tab=versions
+            golang.org/x/exp:
 
       only:
         # This repository contains other go.sum file used for testing.


### PR DESCRIPTION
Fix #1603

<details><summary>updatecli.yaml</summary>

```
# To compare the following digests with 
# https://github.com/updatecli/updatecli/pkgs/container/updatecli/139180422?tag=v0.64.1

sources:
  noarch:
    name: "Get Digest for docker image updatecli/updatecli:v0.64.1"
    kind: "dockerdigest"
    spec:
      image: "ghcr.io/updatecli/updatecli"
      tag: "v0.64.1"

  amd64:
    name: "Get Digest for docker image updatecli/updatecli:v0.64.1"
    kind: "dockerdigest"
    spec:
      image: "ghcr.io/updatecli/updatecli"
      tag: "v0.64.1"
      architecture: amd64

  arm64:
    name: "Get Digest for docker image updatecli/updatecli:v0.64.1"
    kind: "dockerdigest"
    spec:
      image: "ghcr.io/updatecli/updatecli"
      tag: "v0.64.1"
      architecture: arm64
```

</details>

## Test

To test this pull request, you can run the following commands:

```shell
cd pkg/plugins/resources/dockerdigest/ 
go test
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
