### PR TITLE
feat: add manifest push --overwrite flag

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -56,3 +56,4 @@ skippackaging
 joho
 godotenv
 filechecksum
+errdef

--- a/cmd/manifest_push.go
+++ b/cmd/manifest_push.go
@@ -15,6 +15,8 @@ var (
 	manifestPushFileStore string
 	// manifestPushPolicyFile is the path to the policy file containing policy metadata information
 	manifestPushPolicyFile string
+	// manifestPushOverwrite is a boolean to overwrite existing manifest(s) in the registry
+	manifestPushOverwrite bool
 
 	// manifestPushCmd is the Cobra command to push OCI registry manifest(s)
 	manifestPushCmd = &cobra.Command{
@@ -57,6 +59,7 @@ func init() {
 	manifestPushCmd.Flags().StringArrayVarP(&manifestPushPolicyReference, "tag", "t", []string{}, `Name and optionally a tag (format: "name:tag")`)
 	manifestPushCmd.Flags().StringArrayVar(&secretsFiles, "secrets", []string{}, "Sets secrets file uses for templating")
 	manifestPushCmd.Flags().BoolVar(&disableTLS, "disable-tls", false, "Disable TLS verification like '--disable-tls=true'")
+	manifestPushCmd.Flags().BoolVar(&manifestPushOverwrite, "overwrite", false, "Overwrite existing manifest(s) in the registry like '--overwrite=true'")
 
 	manifestCmd.AddCommand(manifestPushCmd)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -154,7 +154,16 @@ func run(command string) error {
 		}
 
 	case "manifest/push":
-		err := e.PushToRegistry(manifestFiles, valuesFiles, secretsFiles, manifestPushPolicyReference, disableTLS, manifestPushPolicyFile, manifestPushFileStore)
+		err := e.PushToRegistry(
+			manifestFiles,
+			valuesFiles,
+			secretsFiles,
+			manifestPushPolicyReference,
+			disableTLS,
+			manifestPushPolicyFile,
+			manifestPushFileStore,
+			manifestPushOverwrite)
+
 		if err != nil {
 			logrus.Errorf("%s %s", result.FAILURE, err)
 			return err

--- a/go.mod
+++ b/go.mod
@@ -54,6 +54,7 @@ require (
 	github.com/testcontainers/testcontainers-go v0.24.1
 	github.com/tomwright/dasel v1.27.3
 	github.com/zclconf/go-cty v1.14.1
+	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1
 	golang.org/x/text v0.13.0
 	golang.org/x/time v0.3.0
 	gopkg.in/ini.v1 v1.67.0
@@ -91,7 +92,6 @@ require (
 	github.com/yusufpapurcu/wmi v1.2.3 // indirect
 	go.opentelemetry.io/otel v1.14.0 // indirect
 	go.opentelemetry.io/otel/trace v1.14.0 // indirect
-	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1 // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230530153820-e85fd2cbaebc // indirect
 )

--- a/pkg/core/engine/registry.go
+++ b/pkg/core/engine/registry.go
@@ -22,7 +22,7 @@ func (e *Engine) PullFromRegistry(policyReference string, disableTLS bool) (err 
 }
 
 // PushToRegistry pushes an Updatecli policy to an OCI registry.
-func (e *Engine) PushToRegistry(manifests, valuesFiles, secretsFiles, policyReference []string, disableTLS bool, policyMetadataFile, fileStore string) error {
+func (e *Engine) PushToRegistry(manifests, valuesFiles, secretsFiles, policyReference []string, disableTLS bool, policyMetadataFile, fileStore string, overwrite bool) error {
 
 	PrintTitle("Registry")
 
@@ -58,7 +58,7 @@ func (e *Engine) PushToRegistry(manifests, valuesFiles, secretsFiles, policyRefe
 
 	relativeFromFileStore(manifests)
 
-	err := registry.Push(policyMetadataFile, manifests, valuesFiles, secretsFiles, policyReference, disableTLS, fileStore)
+	err := registry.Push(policyMetadataFile, manifests, valuesFiles, secretsFiles, policyReference, disableTLS, fileStore, overwrite)
 	if err != nil {
 		return err
 	}

--- a/pkg/core/registry/pullpush_test.go
+++ b/pkg/core/registry/pullpush_test.go
@@ -58,6 +58,7 @@ func TestPushPullPolicy(t *testing.T) {
 		expectedPullValuesFiles   []string
 		expectedPullSecretsFiles  []string
 		disableTLS                bool
+		overwrite                 bool
 	}{
 		{
 			name:                      "Validate that we can push and pull a policy using the latest tag, even thought the tag is ignored",
@@ -108,7 +109,19 @@ func TestPushPullPolicy(t *testing.T) {
 				data.toPushSecretFiles,
 				data.toPushPolicyName,
 				data.disableTLS,
-				data.toPushFileStore)
+				data.toPushFileStore,
+				data.overwrite)
+			require.NoError(t, err)
+
+			err = Push(
+				data.toPushPolicyFile,
+				data.toPushManifestFiles,
+				data.toPushValueFiles,
+				data.toPushSecretFiles,
+				data.toPushPolicyName,
+				data.disableTLS,
+				data.toPushFileStore,
+				data.overwrite)
 			require.NoError(t, err)
 
 			gotManifests, gotValues, gotSecrets, err := Pull(


### PR DESCRIPTION
By default, I don't want the command `updatecli manifest push` to overwrite an already published policy.

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
cd <to_package_directory>
go test
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
