### PR TITLE
fix: for muliple pipelines report failure to load

### DIFF
--- a/pkg/core/engine/configuration.go
+++ b/pkg/core/engine/configuration.go
@@ -8,6 +8,8 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/updatecli/updatecli/pkg/core/config"
 	"github.com/updatecli/updatecli/pkg/core/pipeline"
+	"github.com/updatecli/updatecli/pkg/core/reports"
+	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
 // ReadConfigurations read every strategies configuration.
@@ -67,6 +69,12 @@ func (e *Engine) LoadConfigurations() error {
 			default:
 				err = fmt.Errorf("%q - %s", manifestFile, err)
 				errs = append(errs, err)
+				e.Reports = append(e.Reports,
+					reports.Report{
+						Result: result.FAILURE,
+						Err:    err.Error(),
+					},
+				)
 				continue
 			}
 
@@ -85,6 +93,12 @@ func (e *Engine) LoadConfigurations() error {
 					// don't initially fail as init. of the pipeline still fails even with a successful validation
 					err := fmt.Errorf("%q - %s", manifestFile, err)
 					errs = append(errs, err)
+					e.Reports = append(e.Reports,
+						reports.Report{
+							Result: result.FAILURE,
+							Err:    err.Error(),
+						},
+					)
 				}
 			}
 		}
@@ -108,5 +122,4 @@ func (e *Engine) LoadConfigurations() error {
 	}
 
 	return nil
-
 }

--- a/pkg/core/engine/configuration_test.go
+++ b/pkg/core/engine/configuration_test.go
@@ -1,0 +1,102 @@
+package engine
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/updatecli/updatecli/pkg/core/engine/manifest"
+)
+
+func TestLoadConfigurations(t *testing.T) {
+	tests := []struct {
+		name              string
+		wd                string
+		engine            Engine
+		expectedPipelines int
+		expectedReports   int
+		wantErr           bool
+		expectedError     string
+	}{
+		{
+			name: "Success - Default file",
+			wd:   "testdata/defaultManifestFilename",
+			engine: Engine{
+				Options: Options{
+					Manifests: []manifest.Manifest{
+						{},
+					},
+				},
+			},
+			expectedPipelines: 1,
+		},
+		{
+			name: "Success - Default manifest directory",
+			wd:   "testdata/defaultManifestDirname_single",
+			engine: Engine{
+				Options: Options{
+					Manifests: []manifest.Manifest{
+						{},
+					},
+				},
+			},
+			expectedPipelines: 1,
+		},
+		{
+			name: "Success - Default manifest directory multiple pipelines",
+			wd:   "testdata/defaultManifestDirname_multiple",
+			engine: Engine{
+				Options: Options{
+					Manifests: []manifest.Manifest{
+						{},
+					},
+				},
+			},
+			expectedPipelines: 2,
+		},
+		{
+			name: "Partial Success - Default manifest directory multiple pipelines one failure",
+			wd:   "testdata/defaultManifestDirname_multiple_failure",
+			engine: Engine{
+				Options: Options{
+					Manifests: []manifest.Manifest{
+						{},
+					},
+				},
+			},
+			expectedPipelines: 1,
+			expectedReports:   1,
+			wantErr:           true,
+			expectedError:     `"updatecli.d/failure.yaml" - scm ID "updatecli" from source ID "adopters" doesn't exist`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Cleanup(chdir(t, tt.wd))
+			gotErr := tt.engine.LoadConfigurations()
+			require.Equal(t, tt.expectedPipelines, len(tt.engine.Pipelines), "Pipelines count unexpected")
+			require.Equal(t, tt.expectedReports, len(tt.engine.Reports), "Reports count unexpected")
+			if tt.wantErr {
+				require.ErrorContains(t, gotErr, tt.expectedError)
+			} else {
+				require.NoError(t, gotErr)
+			}
+		})
+	}
+}
+
+func chdir(t *testing.T, dir string) func() {
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("chdir %s: %v", dir, err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	return func() {
+		if err := os.Chdir(wd); err != nil {
+			t.Fatalf("restoring working directory: %v", err)
+		}
+	}
+}

--- a/pkg/core/engine/testdata/defaultManifestDirname_multiple/updatecli.d/test.yaml
+++ b/pkg/core/engine/testdata/defaultManifestDirname_multiple/updatecli.d/test.yaml
@@ -1,0 +1,8 @@
+name: Test
+
+sources:
+  adopters:
+    name: "Get content from ADOPTERS.md"
+    kind: file
+    spec:
+      file: ADOPTERS.md

--- a/pkg/core/engine/testdata/defaultManifestDirname_multiple/updatecli.d/test2.yaml
+++ b/pkg/core/engine/testdata/defaultManifestDirname_multiple/updatecli.d/test2.yaml
@@ -1,0 +1,8 @@
+name: Test
+
+sources:
+  adopters:
+    name: "Get content from ADOPTERS.md"
+    kind: file
+    spec:
+      file: ADOPTERS.md

--- a/pkg/core/engine/testdata/defaultManifestDirname_multiple_failure/updatecli.d/failure.yaml
+++ b/pkg/core/engine/testdata/defaultManifestDirname_multiple_failure/updatecli.d/failure.yaml
@@ -1,0 +1,9 @@
+name: Test
+
+sources:
+  adopters:
+    name: "Get content from ADOPTERS.md"
+    kind: file
+    scmid: updatecli
+    spec:
+      file: ADOPTERS.md

--- a/pkg/core/engine/testdata/defaultManifestDirname_multiple_failure/updatecli.d/test.yaml
+++ b/pkg/core/engine/testdata/defaultManifestDirname_multiple_failure/updatecli.d/test.yaml
@@ -1,0 +1,8 @@
+name: Test
+
+sources:
+  adopters:
+    name: "Get content from ADOPTERS.md"
+    kind: file
+    spec:
+      file: ADOPTERS.md

--- a/pkg/core/engine/testdata/defaultManifestDirname_single/updatecli.d/test.yaml
+++ b/pkg/core/engine/testdata/defaultManifestDirname_single/updatecli.d/test.yaml
@@ -1,0 +1,8 @@
+name: Test
+
+sources:
+  adopters:
+    name: "Get content from ADOPTERS.md"
+    kind: file
+    spec:
+      file: ADOPTERS.md

--- a/pkg/core/engine/testdata/defaultManifestFilename/updatecli.yaml
+++ b/pkg/core/engine/testdata/defaultManifestFilename/updatecli.yaml
@@ -1,0 +1,8 @@
+name: Test
+
+sources:
+  adopters:
+    name: "Get content from ADOPTERS.md"
+    kind: file
+    spec:
+      file: ADOPTERS.md


### PR DESCRIPTION
Fix #1720

- Update LoadConfigurations to add error report
- Add LoadCongifurations tests

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
cd  pkg/core/engine/
go test
```

## Additional Information

Was done slightly differently that suggested in #1720 as `e.Reports` was available appended rather than charging the return.
