### PR TITLE
fix: correctly load default Updatecli manifest

### DIFF
--- a/pkg/core/engine/configuration.go
+++ b/pkg/core/engine/configuration.go
@@ -20,7 +20,8 @@ func (e *Engine) LoadConfigurations() error {
 	ErrNoManifestDetectedCounter := 0
 
 	for i := range e.Options.Manifests {
-		if e.Options.Manifests[i].IsZero() {
+		// If no manifest file is specified, we try to detect one
+		if len(e.Options.Manifests[i].Manifests) == 0 {
 			// Updatecli tries to load the file updatecli.yaml if no manifest was specified
 			// If updatecli.yaml doesn't exists then Updatecli parses the directory updatecli.d for any manifests.
 			// if there is no manifests in the directory updatecli.d then Updatecli returns no manifest files.


### PR DESCRIPTION
Fix #1722

Previously I was only loading the default manifest if no arguments were provided. 
Instead I want to load default manifest, only if none were specified

## Test

To test this pull request, you can run the following commands:
/

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
