### PR TITLE
feat(action): show CI url in pullrequest body

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -57,3 +57,4 @@ joho
 godotenv
 filechecksum
 errdef
+chardata

--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -58,3 +58,4 @@ godotenv
 filechecksum
 errdef
 chardata
+pipelineurl

--- a/pkg/core/pipeline/action/main.go
+++ b/pkg/core/pipeline/action/main.go
@@ -55,7 +55,7 @@ type Config struct {
 		remarks:
 		* Only available for GitHub Action, GitLab, Jenkins
 	*/
-	PipelineURL bool `yaml:",omitempty"`
+	DisablePipelineURL bool `yaml:",omitempty"`
 }
 
 // Action is a struct used by an updatecli pipeline.

--- a/pkg/core/pipeline/action/main.go
+++ b/pkg/core/pipeline/action/main.go
@@ -49,6 +49,13 @@ type Config struct {
 	ScmID string `yaml:",omitempty"`
 	// !Deprecated in favor of `scmid`
 	DeprecatedScmID string `yaml:"scmID,omitempty" jsonschema:"-"`
+	/*
+		pipelineurl defines if a link to the Updatecli pipeline CI job should be added to the report.
+
+		remarks:
+		* Only available for GitHub Action, GitLab, Jenkins
+	*/
+	PipelineURL bool `yaml:",omitempty"`
 }
 
 // Action is a struct used by an updatecli pipeline.

--- a/pkg/core/pipeline/actions.go
+++ b/pkg/core/pipeline/actions.go
@@ -131,7 +131,7 @@ func (p *Pipeline) RunActions() error {
 			return fmt.Errorf("%d target(s) (%s) skipped for action %q", len(skippedTargetIDs), strings.Join(skippedTargetIDs, ","), id)
 		}
 
-		if action.Config.PipelineURL {
+		if !action.Config.DisablePipelineURL {
 			action.Report.UpdatePipelineURL()
 		}
 		if p.Options.Target.DryRun || !p.Options.Target.Push {

--- a/pkg/core/pipeline/actions.go
+++ b/pkg/core/pipeline/actions.go
@@ -131,6 +131,7 @@ func (p *Pipeline) RunActions() error {
 			return fmt.Errorf("%d target(s) (%s) skipped for action %q", len(skippedTargetIDs), strings.Join(skippedTargetIDs, ","), id)
 		}
 
+		action.Report.UpdatePipelineURL()
 		if p.Options.Target.DryRun || !p.Options.Target.Push {
 			if len(attentionTargetIDs) > 0 {
 				logrus.Infof("[Dry Run] An action of kind %q is expected.", action.Config.Kind)

--- a/pkg/core/pipeline/actions.go
+++ b/pkg/core/pipeline/actions.go
@@ -131,7 +131,9 @@ func (p *Pipeline) RunActions() error {
 			return fmt.Errorf("%d target(s) (%s) skipped for action %q", len(skippedTargetIDs), strings.Join(skippedTargetIDs, ","), id)
 		}
 
-		action.Report.UpdatePipelineURL()
+		if action.Config.PipelineURL {
+			action.Report.UpdatePipelineURL()
+		}
 		if p.Options.Target.DryRun || !p.Options.Target.Push {
 			if len(attentionTargetIDs) > 0 {
 				logrus.Infof("[Dry Run] An action of kind %q is expected.", action.Config.Kind)

--- a/pkg/core/reports/action.go
+++ b/pkg/core/reports/action.go
@@ -105,8 +105,8 @@ func (a Action) ToActionsString() string {
 
 // UpdatePipelineURL analyze the local environment to guess if Updatecli is executed from a CI pipeline
 func (a *Action) UpdatePipelineURL() {
-
 	// isGitHubActionWorkflow check if the current execution is running from a GitHub Action
+	// ref. https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
 	isGitHubActionWorkflow := func() bool {
 		if os.Getenv("GITHUB_ACTION") != "" &&
 			os.Getenv("GITHUB_SERVER_URL") != "" &&

--- a/pkg/core/reports/action.go
+++ b/pkg/core/reports/action.go
@@ -130,6 +130,7 @@ func (a *Action) UpdatePipelineURL() {
 	}
 
 	// isGitLabCI check if the current execution is running from a GitLab CI pipeline
+	// ref. https://docs.gitlab.com/ee/ci/variables/predefined_variables.html
 	isGitLabCI := func() bool {
 		if os.Getenv("GITLAB_CI") != "" &&
 			os.Getenv("CI_SERVER_URL") != "" &&

--- a/pkg/core/reports/action.go
+++ b/pkg/core/reports/action.go
@@ -111,7 +111,7 @@ func (a *Action) UpdatePipelineURL() {
 			os.Getenv("GITHUB_SERVER_URL") != "" &&
 			os.Getenv("GITHUB_REPOSITORY") != "" &&
 			os.Getenv("GITHUB_RUN_ID") != "" {
-			logrus.Debugln("Github Action pipeline detected")
+			logrus.Debugln("GitHub Action pipeline detected")
 			return true
 		}
 		return false
@@ -131,7 +131,7 @@ func (a *Action) UpdatePipelineURL() {
 	isGitLabCI := func() bool {
 		if os.Getenv("CI_SERVER_URL") != "" &&
 			os.Getenv("CI_JOB_URL") != "" {
-			logrus.Debugln("Gitlab CI pipeline detected")
+			logrus.Debugln("GitLab CI pipeline detected")
 			return true
 		}
 		return false

--- a/pkg/core/reports/action.go
+++ b/pkg/core/reports/action.go
@@ -131,7 +131,8 @@ func (a *Action) UpdatePipelineURL() {
 
 	// isGitLabCI check if the current execution is running from a GitLab CI pipeline
 	isGitLabCI := func() bool {
-		if os.Getenv("CI_SERVER_URL") != "" &&
+		if os.Getenv("GITLAB_CI") != "" &&
+			os.Getenv("CI_SERVER_URL") != "" &&
 			os.Getenv("CI_JOB_URL") != "" {
 			logrus.Debugln("GitLab CI pipeline detected")
 			return true

--- a/pkg/core/reports/action.go
+++ b/pkg/core/reports/action.go
@@ -15,7 +15,8 @@ type Action struct {
 	PipelineTitle string         `xml:"h3,omitempty"`
 	Description   string         `xml:"p,omitempty"`
 	Targets       []ActionTarget `xml:"details,omitempty"`
-	PipelineUrl   PipelineURL    `xml:"a,omitempty"`
+	// using a pointer to avoid empty tag
+	PipelineUrl *PipelineURL `xml:"a,omitempty"`
 }
 
 type ActionTargetChangelog struct {
@@ -138,12 +139,15 @@ func (a *Action) UpdatePipelineURL() {
 	}
 
 	if isGitHubActionWorkflow() {
+		a.PipelineUrl = &PipelineURL{}
 		a.PipelineUrl.Name = "GitHub Action pipeline link"
 		a.PipelineUrl.URL = fmt.Sprintf(os.Getenv("GITHUB_SERVER_URL")+"/%s/actions/runs/%s", os.Getenv("GITHUB_REPOSITORY"), os.Getenv("GITHUB_RUN_ID"))
 	} else if isJenkinsPipeline() {
+		a.PipelineUrl = &PipelineURL{}
 		a.PipelineUrl.Name = "Jenkins pipeline link"
-		a.PipelineUrl.URL = fmt.Sprintf(os.Getenv("BUILD_URL"))
+		a.PipelineUrl.URL = os.Getenv("BUILD_URL")
 	} else if isGitLabCI() {
+		a.PipelineUrl = &PipelineURL{}
 		a.PipelineUrl.Name = "GitLab CI pipeline link"
 		a.PipelineUrl.URL = fmt.Sprintf(os.Getenv("CI_SERVER_URL")+"/%s/-/jobs/%s", os.Getenv("CI_PROJECT_PATH"), os.Getenv("CI_JOB_ID"))
 	} else {

--- a/pkg/core/reports/action.go
+++ b/pkg/core/reports/action.go
@@ -119,6 +119,7 @@ func (a *Action) UpdatePipelineURL() {
 	}
 
 	// isJenkinsPipeline check if the current execution is running from a Jenkins pipeline
+	// ref. https://www.jenkins.io/doc/book/pipeline/jenkinsfile/#using-environment-variables
 	isJenkinsPipeline := func() bool {
 		if os.Getenv("JENKINS_URL") != "" &&
 			os.Getenv("BUILD_URL") != "" {

--- a/pkg/core/reports/action.go
+++ b/pkg/core/reports/action.go
@@ -137,16 +137,6 @@ func (a *Action) UpdatePipelineURL() {
 		return false
 	}
 
-	// isStashCI check if the current execution is running from a Stash CI pipeline
-	isStashCI := func() bool {
-		if os.Getenv("STASH_URL") != "" &&
-			os.Getenv("STASH_JOB_URL") != "" {
-			logrus.Debugln("Stash CI pipeline detected")
-			return true
-		}
-		return false
-	}
-
 	if isGitHubActionWorkflow() {
 		a.PipelineUrl.Name = "GitHub Action pipeline link"
 		a.PipelineUrl.URL = fmt.Sprintf(os.Getenv("GITHUB_SERVER_URL")+"/%s/actions/runs/%s", os.Getenv("GITHUB_REPOSITORY"), os.Getenv("GITHUB_RUN_ID"))
@@ -156,9 +146,6 @@ func (a *Action) UpdatePipelineURL() {
 	} else if isGitLabCI() {
 		a.PipelineUrl.Name = "GitLab CI pipeline link"
 		a.PipelineUrl.URL = fmt.Sprintf(os.Getenv("CI_SERVER_URL")+"/%s/-/jobs/%s", os.Getenv("CI_PROJECT_PATH"), os.Getenv("CI_JOB_ID"))
-	} else if isStashCI() {
-		a.PipelineUrl.Name = "Stash CI pipeline link"
-		a.PipelineUrl.URL = fmt.Sprintf(os.Getenv("STASH_URL")+"/%s/-/jobs/%s", os.Getenv("STASH_PROJECT_PATH"), os.Getenv("STASH_JOB_ID"))
 	} else {
 		logrus.Debugln("No CI pipeline detected")
 	}


### PR DESCRIPTION
Fix #1717 

<!-- Describe the changes introduced by this pull request -->

## Test

Well I don't see how to test this feature without taking the risk of conflicting with the GitHub Action environment used to test Updatecli so I am just doing manual testing at this stage.

We must use an Updatecli that need to change something



```shell
export GITHUB_ACTION="true" 
export GITHUB_SERVER_URL="https://github.com" 
export GITHUB_REPOSITORY="foo/bar" 
export GITHUB_RUN_ID="1658821493" 

./bin/updatecli diff --config updatecli/updatecli.d/venom.yaml --debug
```

Please note ` <a href="https://github.com/foo/bar/actions/runs/1658821493">GitHub Action pipeline link</a>` in the console output

<details><summary>Console Output</summary>

```
DEBUG: The expected action would have the following information:
	|	
	|	##Title:
	|	ci: bump Venom version to v1.0.1
	|	
	|	
	|	##Report:
	|	
	|	<Action id="1c70af8de95bd7989d99731b82355dfdd0fbd5981ebfef645550823023b51711">
	|	    <h3>ci: bump Venom version</h3>
	|	    <details id="dc3a5f47e02ede555033ee1e6cb765e5e88ea60e3352a90edb40cb190d142911">
	|	        <summary>ci: update Venom version to v1.0.1</summary>
	|	        <p>1 file(s) updated with &#34;VENOM_VERSION: v1.0.1&#34;:&#xA;&#x9;* .github/workflows/go.yaml&#xA;</p>
	|	        <details>
	|	            <summary>v1.0.1</summary>
	|	            <pre>&#xA;Release published on the 2021-12-13 16:52:12 +0000 UTC at the url https://github.com/ovh/venom/releases/tag/v1.0.1&#xA;&#xA;# Venom v1.0.1&#xD;&#xA;&#xD;&#xA;## What&#39;s Changed&#xD;&#xA;* fix: handle json number is assertions (#460) https://github.com/ovh/venom/pull/464&#xD;&#xA;&#xD;&#xA;**Full Changelog**: https://github.com/ovh/venom/compare/v1.0.0...v1.0.1</pre>
	|	        </details>
	|	    </details>
	|	    <a href="https://github.com/foo/bar/actions/runs/1658821493">GitHub Action pipeline link</a>
	|	</Action>
	|	
	|	=====
	|	

=============================

```

</details>

This pullrequest introduces in a new action setting `pipelineurl` such as 

```
actions:
    default:
        title: 'ci: bump Venom version to {{ source "latestVersion" }}'
        kind: github/pullrequest
        pipelineurl: true
        spec:
            automerge: true
            labels:
                - chore
                - skip-changelog
        scmid: default

```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

- [x] I need to gate this feature behind a setting at the action level
