### PR TITLE
feat(dockerfile) support multiple files

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -57,3 +57,7 @@ joho
 godotenv
 filechecksum
 errdef
+mcr
+nanoserver
+ltsc
+windowscore

--- a/e2e/updatecli.d/success.d/dockerfile/Dockerfile
+++ b/e2e/updatecli.d/success.d/dockerfile/Dockerfile
@@ -1,0 +1,2 @@
+FROM alpine:3.18
+ARG APP_VERSION=1.0.0

--- a/e2e/updatecli.d/success.d/dockerfile/Dockerfile.nanoserver
+++ b/e2e/updatecli.d/success.d/dockerfile/Dockerfile.nanoserver
@@ -1,0 +1,2 @@
+FROM mcr.microsoft.com/windows/nanoserver:ltsc2019
+ARG APP_VERSION=1.0.0

--- a/e2e/updatecli.d/success.d/dockerfile/Dockerfile.windowscore
+++ b/e2e/updatecli.d/success.d/dockerfile/Dockerfile.windowscore
@@ -1,0 +1,2 @@
+FROM mcr.microsoft.com/windows/server:ltsc2022
+ARG APP_VERSION=1.0.0

--- a/e2e/updatecli.d/success.d/dockerfile/dockerfile.yaml
+++ b/e2e/updatecli.d/success.d/dockerfile/dockerfile.yaml
@@ -1,0 +1,43 @@
+name: Test Dockerfile condition and target
+
+sources:
+  appVersion:
+    kind: shell
+    spec:
+      command: echo 1.0.0
+
+conditions:
+  checkForArgAppVersionForLinux:
+    kind: dockerfile
+    spec:
+      file: e2e/updatecli.d/success.d/dockerfile/Dockerfile
+      instruction:
+        keyword: "ARG"
+        matcher: "APP_VERSION"
+  checkForArgAppVersionForWindows:
+    kind: dockerfile
+    spec:
+      files:
+        - e2e/updatecli.d/success.d/dockerfile/Dockerfile.nanoserver
+        - e2e/updatecli.d/success.d/dockerfile/Dockerfile.windowscore
+      instruction:
+        keyword: "ARG"
+        matcher: "APP_VERSION"
+
+targets:
+  setAppVersionForLinux:
+    kind: dockerfile
+    spec:
+      file: e2e/updatecli.d/success.d/dockerfile/Dockerfile
+      instruction:
+        keyword: "ARG"
+        matcher: "APP_VERSION"
+  setAppVersionForWindows:
+    kind: dockerfile
+    spec:
+      files:
+        - e2e/updatecli.d/success.d/dockerfile/Dockerfile.nanoserver
+        - e2e/updatecli.d/success.d/dockerfile/Dockerfile.windowscore
+      instruction:
+        keyword: "ARG"
+        matcher: "APP_VERSION"

--- a/e2e/updatecli.d/success.d/dockerfile/dockerfile.yaml
+++ b/e2e/updatecli.d/success.d/dockerfile/dockerfile.yaml
@@ -1,4 +1,5 @@
 name: Test Dockerfile condition and target
+pipelineid: "e2e/dockerfile"
 
 sources:
   appVersion:


### PR DESCRIPTION
This PR adds the support of multiple files for the resources of kind `dockerfile` (conditions and targets).

Use cases:
- It is an additional feature to help for #1026.
- Also, on the Jenkins project, we have cases were we want to update the same instruction to multiple files: https://github.com/jenkinsci/docker-agent/blob/1182cad9d14ece000ab38433eee05daf1872a993/updatecli/updatecli.d/remoting.yaml#L37-L81


## Test

To test this pull request, you can run the following commands:

```shell
cd pkg/plugins/resources/dockerfile
go test
```

Please note that a new e2e test as added for `dockerfile` which tests the current `file` (for non regression) and the new `files`.

I've tested this E2E test locally with a `diff` and an `apply`. The only untested part is when using with an SCM.

## Additional Information

### Tradeoff

Using autodiscovery would help, of course but we want to control the list of files for now.

### Potential improvement

N.A.
