### PR TITLE
feat(autodiscovery/updatecli): Add updatecli compose autodiscovery

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -67,3 +67,5 @@ windowscore
 gha
 githubactions
 gitlabci
+githubaction
+netlify

--- a/e2e/updatecli.d/warning.d/autodiscovery/updatecli/git.yaml
+++ b/e2e/updatecli.d/warning.d/autodiscovery/updatecli/git.yaml
@@ -1,0 +1,16 @@
+name: "Updatecli autodiscovery using git scm"
+scms:
+  default:
+    kind: git 
+    spec:
+      url: https://github.com/updatecli/website.git
+      branch: master
+    
+autodiscovery:
+  scmid: default
+  crawlers:
+    updatecli:
+      versionfilter:
+#        kind: semver
+#        pattern: majoronly
+

--- a/pkg/core/pipeline/autodiscovery/main.go
+++ b/pkg/core/pipeline/autodiscovery/main.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/updatecli/updatecli/pkg/plugins/autodiscovery/cargo"
 	"github.com/updatecli/updatecli/pkg/plugins/autodiscovery/terraform"
+	"github.com/updatecli/updatecli/pkg/plugins/autodiscovery/updatecli"
 
 	"github.com/mitchellh/mapstructure"
 	"github.com/sirupsen/logrus"
@@ -32,6 +33,7 @@ var (
 			"maven":         maven.Spec{},
 			"npm":           npm.Spec{},
 			"rancher/fleet": fleet.Spec{},
+			"updatecli":     updatecli.Spec{},
 		},
 	}
 	// AutodiscoverySpecs is a map of all Autodiscovery specification
@@ -46,6 +48,7 @@ var (
 		"maven":         &maven.Spec{},
 		"npm":           &npm.Spec{},
 		"rancher/fleet": &fleet.Spec{},
+		"updatecli":     updatecli.Spec{},
 	}
 )
 
@@ -189,6 +192,18 @@ func New(spec Config, workDir string) (*AutoDiscovery, error) {
 
 		case "rancher/fleet":
 			crawler, err := fleet.New(
+				g.spec.Crawlers[kind],
+				workDir,
+				g.spec.ScmId)
+			if err != nil {
+				errs = append(errs, fmt.Errorf("%s - %s", kind, err))
+				continue
+			}
+
+			g.crawlers = append(g.crawlers, crawler)
+
+		case "updatecli":
+			crawler, err := updatecli.New(
 				g.spec.Crawlers[kind],
 				workDir,
 				g.spec.ScmId)

--- a/pkg/plugins/autodiscovery/updatecli/main.go
+++ b/pkg/plugins/autodiscovery/updatecli/main.go
@@ -1,0 +1,104 @@
+package updatecli
+
+import (
+	"strings"
+
+	"github.com/mitchellh/mapstructure"
+	"github.com/sirupsen/logrus"
+	"github.com/updatecli/updatecli/pkg/plugins/utils/docker"
+	"github.com/updatecli/updatecli/pkg/plugins/utils/version"
+)
+
+// Spec defines the Updatecli parameters.
+type Spec struct {
+	// rootdir defines the root directory used to recursively search for Updatecli manifest
+	RootDir string `yaml:",omitempty"`
+	// Ignore allows to specify rule to ignore "autodiscovery" a specific Updatecli based on a rule
+	Ignore MatchingRules `yaml:",omitempty"`
+	// Only allows to specify rule to only "autodiscovery" manifest for a specific Updatecli based on a rule
+	Only MatchingRules `yaml:",omitempty"`
+	// Auths provides a map of registry credentials where the key is the registry URL without scheme
+	Auths map[string]docker.InlineKeyChain `yaml:",omitempty"`
+	/*
+		versionfilter provides parameters to specify the version pattern used when generating manifest.
+
+		kind - semver
+			versionfilter of kind `semver` uses semantic versioning as version filtering
+			pattern accepts one of:
+				`patch` - patch only update patch version
+				`minor` - minor only update minor version
+				`major` - major only update major versions
+				`a version constraint` such as `>= 1.0.0`
+
+		kind - regex
+			versionfilter of kind `regex` uses regular expression as version filtering
+			pattern accepts a valid regular expression
+
+		example:
+		```
+			versionfilter:
+				kind: semver
+				pattern: minor
+		```
+
+		and its type like regex, semver, or just latest.
+	*/
+	VersionFilter version.Filter `yaml:",omitempty"`
+}
+
+// Updatecli hold all information needed to generate updatecli manifest.
+type Updatecli struct {
+	// spec defines the settings provided via an updatecli manifest
+	spec Spec
+	// rootdir defines the root directory from where looking for Updatecli
+	rootDir string
+	// scmID holds the scmID used by the newly generated manifest
+	scmID string
+	// versionFilter holds the "valid" version.filter, that might be different from the user-specified filter (Spec.VersionFilter)
+	versionFilter version.Filter
+}
+
+// New return a new valid Updatecli object.
+func New(spec interface{}, rootDir, scmID string) (Updatecli, error) {
+	var s Spec
+
+	err := mapstructure.Decode(spec, &s)
+	if err != nil {
+		return Updatecli{}, err
+	}
+
+	dir := rootDir
+	if len(s.RootDir) > 0 {
+		dir = s.RootDir
+	}
+
+	// Fallback to the current process path if no "rootdir" specified.
+	if len(dir) == 0 {
+		logrus.Errorln("no working directory defined")
+		return Updatecli{}, err
+	}
+
+	newFilter := s.VersionFilter
+	if s.VersionFilter.IsZero() {
+		// By default, Updatecli policies versioning use semantic versioning
+		newFilter.Kind = "semver"
+		newFilter.Pattern = "*"
+	}
+
+	return Updatecli{
+		spec:          s,
+		rootDir:       dir,
+		scmID:         scmID,
+		versionFilter: newFilter,
+	}, nil
+
+}
+
+// DiscoverManifests search for Updatecli compose file and generate Updatecli manifests.
+func (u Updatecli) DiscoverManifests() ([][]byte, error) {
+
+	logrus.Infof("\n\n%s\n", strings.ToTitle("Updatecli"))
+	logrus.Infof("%s\n", strings.Repeat("=", len("Updatecli")+1))
+
+	return u.discoverUpdatecliPolicyManifests()
+}

--- a/pkg/plugins/autodiscovery/updatecli/manifestTemplate.go
+++ b/pkg/plugins/autodiscovery/updatecli/manifestTemplate.go
@@ -1,0 +1,37 @@
+package updatecli
+
+const (
+	// manifestTemplate is the Go template used to generate Fleet manifests
+	manifestTemplate string = `name: '{{ .ManifestName }}'
+sources:
+  version:
+    name: '{{ .SourceVersionName }}'
+    kind: 'dockerimage'
+    spec:
+      image: '{{ .PolicyName }}'
+      versionfilter:
+        kind: '{{ .SourceVersionFilterKind }}'
+        pattern: '{{ .SourceVersionFilterPattern }}'
+  digest:
+    name: '{{ .SourceDigestName }}'
+    kind: 'dockerdigest'
+    dependson:
+     - version
+    spec:
+      image: '{{ .PolicyName }}'
+      tag: '{{ .SourceDigestTag }}'
+targets:
+  compose:
+    name: '{{ .TargetName }}'
+    kind: 'yaml'
+{{- if .ScmID }}
+    scmid: '{{ .ScmID }}'
+{{ end }}
+    spec:
+      file: '{{ .File }}'
+      key: '{{ .TargetKey }}'
+    transformers:
+      - addprefix: '{{ .PolicyName }}:'
+    sourceid: 'digest'
+`
+)

--- a/pkg/plugins/autodiscovery/updatecli/matchingRule.go
+++ b/pkg/plugins/autodiscovery/updatecli/matchingRule.go
@@ -20,6 +20,7 @@ type MatchingRules []MatchingRule
 // isMatchingRules checks if a specific file content matches the "only" rule
 func (m MatchingRules) isMatchingRules(rootDir, filePath, policyName, policyVersion string) bool {
 	var ruleResults []bool
+	var finaleResult bool
 
 	if len(m) > 0 {
 		for _, rule := range m {
@@ -92,11 +93,11 @@ func (m MatchingRules) isMatchingRules(rootDir, filePath, policyName, policyVers
 				}
 			}
 			if isAllMatching {
-				return true
+				finaleResult = true
 			}
 			ruleResults = []bool{}
 		}
 	}
 
-	return false
+	return finaleResult
 }

--- a/pkg/plugins/autodiscovery/updatecli/matchingRule.go
+++ b/pkg/plugins/autodiscovery/updatecli/matchingRule.go
@@ -20,7 +20,6 @@ type MatchingRules []MatchingRule
 // isMatchingRules checks if a specific file content matches the "only" rule
 func (m MatchingRules) isMatchingRules(rootDir, filePath, policyName, policyVersion string) bool {
 	var ruleResults []bool
-	var finaleResult bool
 
 	if len(m) > 0 {
 		for _, rule := range m {
@@ -93,11 +92,11 @@ func (m MatchingRules) isMatchingRules(rootDir, filePath, policyName, policyVers
 				}
 			}
 			if isAllMatching {
-				finaleResult = true
+				return true
 			}
 			ruleResults = []bool{}
 		}
 	}
 
-	return finaleResult
+	return false
 }

--- a/pkg/plugins/autodiscovery/updatecli/matchingRule.go
+++ b/pkg/plugins/autodiscovery/updatecli/matchingRule.go
@@ -1,0 +1,102 @@
+package updatecli
+
+import (
+	"path/filepath"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/sirupsen/logrus"
+)
+
+// MatchingRule allows to specifies rules to identify manifest
+type MatchingRule struct {
+	// Path specifies a Updatecli compose filepath pattern, the pattern requires to match all of name, not just a subpart of the path.
+	Path string
+	// Policies specifies a Updatecli policy
+	Policies map[string]string
+}
+
+type MatchingRules []MatchingRule
+
+// isMatchingRules checks if a specific file content matches the "only" rule
+func (m MatchingRules) isMatchingRules(rootDir, filePath, policyName, policyVersion string) bool {
+	var ruleResults []bool
+
+	if len(m) > 0 {
+		for _, rule := range m {
+			/*
+				Check if rule.Path is matching. Path accepts wildcard path
+			*/
+
+			if rule.Path != "" {
+				if filepath.IsAbs(rule.Path) {
+					filePath = filepath.Join(rootDir, filePath)
+				}
+
+				match, err := filepath.Match(rule.Path, filePath)
+
+				if err != nil {
+					logrus.Errorf("%s - %q", err, rule.Path)
+					continue
+				}
+				ruleResults = append(ruleResults, match)
+				if match {
+					logrus.Debugf("file path %q matching rule %q", filePath, rule.Path)
+				}
+			}
+
+			/*
+				Checks if policy is matching the policy constraint.
+			*/
+
+			if len(rule.Policies) > 0 {
+				if policyName != "" {
+					match := false
+				outPolicy:
+					for rulePolicyName, rulePolicyVersion := range rule.Policies {
+						if policyName == rulePolicyName {
+							if rulePolicyVersion == "" {
+								match = true
+								break outPolicy
+							}
+
+							v, err := semver.NewVersion(policyVersion)
+							if err != nil {
+								match = policyVersion == rulePolicyVersion
+								logrus.Debugf("%q - %s", policyVersion, err)
+								break outPolicy
+							}
+
+							c, err := semver.NewConstraint(rulePolicyVersion)
+							if err != nil {
+								match = policyVersion == rulePolicyVersion
+								logrus.Debugf("%q %s", err, rulePolicyVersion)
+								break outPolicy
+							}
+
+							match = c.Check(v)
+							break outPolicy
+						}
+					}
+					ruleResults = append(ruleResults, match)
+				}
+
+			}
+
+			/*
+				If at least one rule is failing then we return false
+			*/
+			isAllMatching := true
+			for i := range ruleResults {
+				if !ruleResults[i] {
+					isAllMatching = false
+				}
+			}
+			if isAllMatching {
+				return true
+			}
+			ruleResults = []bool{}
+		}
+	}
+
+	return false
+}

--- a/pkg/plugins/autodiscovery/updatecli/matchingRule_test.go
+++ b/pkg/plugins/autodiscovery/updatecli/matchingRule_test.go
@@ -1,0 +1,176 @@
+package updatecli
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsMatchingRule(t *testing.T) {
+
+	dataset := []struct {
+		rules          MatchingRules
+		name           string
+		filePath       string
+		policyName     string
+		policyVersion  string
+		rootDir        string
+		expectedResult bool
+	}{
+		{
+			rules: MatchingRules{
+				MatchingRule{
+					Path: "update-compose.yaml",
+				},
+			},
+			filePath:       "update-compose.yaml",
+			expectedResult: true,
+		},
+		{
+			rules: MatchingRules{
+				MatchingRule{
+					Path: "update-compose.yaml",
+				},
+			},
+			filePath:       "./website/update-compose.yaml",
+			expectedResult: false,
+		},
+		{
+			rules: MatchingRules{
+				MatchingRule{
+					Path: "update-compose.yaml",
+					Policies: map[string]string{
+						"ghcr.io/updatecli/policies/policies/nodejs/githubaction": "0.1.0",
+					},
+				},
+			},
+			filePath:       "update-compose.yaml",
+			policyName:     "ghcr.io/updatecli/policies/policies/nodejs/githubaction",
+			policyVersion:  "0.1.0",
+			expectedResult: true,
+		},
+		{
+			rules: MatchingRules{
+				MatchingRule{
+					Path: "update-compose.yaml",
+					Policies: map[string]string{
+						"ghcr.io/updatecli/policies/policies/nodejs/githubaction": "0.1.0",
+					},
+				},
+			},
+			filePath:       "update-compose.yaml",
+			policyName:     "ghcr.io/updatecli/policies/policies/nodejs/githubaction",
+			expectedResult: false,
+		},
+		{
+			rules: MatchingRules{
+				MatchingRule{
+					Path: "update-compose.yaml",
+					Policies: map[string]string{
+						"ghcr.io/updatecli/policies/policies/nodejs/githubaction": "",
+					},
+				},
+			},
+			filePath:       "update-compose.yaml",
+			policyName:     "ghcr.io/updatecli/policies/policies/nodejs/githubaction",
+			policyVersion:  "0.1.0",
+			expectedResult: true,
+		},
+		{
+			rules: MatchingRules{
+				MatchingRule{
+					Path: "update-compose.yaml",
+					Policies: map[string]string{
+						"ghcr.io/updatecli/policies/policies/nodejs/githubaction": "",
+					},
+				},
+			},
+			filePath:       "update-compose.yaml",
+			policyName:     "ghcr.io/updatecli/policies/policies/nodejs/githubaction",
+			expectedResult: true,
+		},
+		{
+			rules: MatchingRules{
+				MatchingRule{
+					Path: "update-compose.yaml",
+					Policies: map[string]string{
+						"ghcr.io/updatecli/policies/policies/nodejs/githubaction": "0.1.0",
+					},
+				},
+			},
+			filePath:       "update-compose.yaml",
+			policyName:     "ghcr.io/updatecli/policies/policies/nodejs/netlify",
+			expectedResult: false,
+		},
+		{
+			rules: MatchingRules{
+				MatchingRule{
+					Path: "website/update-compose.yaml",
+					Policies: map[string]string{
+						"ghcr.io/updatecli/policies/policies/nodejs/githubaction": "",
+					},
+				},
+			},
+			filePath:       "update-compose.yaml",
+			policyName:     "ghcr.io/updatecli/policies/policies/nodejs/githubaction",
+			expectedResult: false,
+		},
+		{
+			rules: MatchingRules{
+				MatchingRule{
+					Path: "update-compose.yaml",
+				},
+				MatchingRule{
+					Policies: map[string]string{
+						"ghcr.io/updatecli/policies/policies/nodejs/githubaction": "0.1.0",
+					},
+				},
+			},
+			filePath:       "update-compose.yaml",
+			policyName:     "ghcr.io/updatecli/policies/policies/nodejs/githubaction",
+			expectedResult: true,
+		},
+		{
+			rules: MatchingRules{
+				MatchingRule{
+					Path: "update-compose.yaml",
+				},
+				MatchingRule{
+					Policies: map[string]string{
+						"ghcr.io/updatecli/policies/policies/nodejs/githubaction": ">=0.1.0",
+					},
+				},
+			},
+			filePath:       "update-compose.yaml",
+			policyName:     "ghcr.io/updatecli/policies/policies/nodejs/githubaction",
+			policyVersion:  "0.1.0",
+			expectedResult: true,
+		},
+		{
+			rules: MatchingRules{
+				MatchingRule{
+					Path: "update-compose.yaml",
+					Policies: map[string]string{
+						"ghcr.io/updatecli/policies/policies/nodejs/githubaction": ">=1.0.0",
+					},
+				},
+			},
+			filePath:       "update-compose.yaml",
+			policyName:     "ghcr.io/updatecli/policies/policies/nodejs/githubaction",
+			policyVersion:  "0.1.0",
+			expectedResult: false,
+		},
+	}
+
+	for _, d := range dataset {
+		t.Run(d.name, func(t *testing.T) {
+			gotResult := d.rules.isMatchingRules(
+				d.rootDir,
+				d.filePath,
+				d.policyName,
+				d.policyVersion)
+
+			assert.Equal(t, d.expectedResult, gotResult)
+		})
+	}
+}

--- a/pkg/plugins/autodiscovery/updatecli/policies.go
+++ b/pkg/plugins/autodiscovery/updatecli/policies.go
@@ -1,0 +1,149 @@
+package updatecli
+
+import (
+	"bytes"
+	"fmt"
+	"path/filepath"
+	"text/template"
+
+	"github.com/sirupsen/logrus"
+)
+
+var (
+	// DefaultFilePattern specifies accepted Helm chart metadata filename
+	DefaultFilePattern [1]string = [1]string{"update-compose.yaml"}
+)
+
+// discoverUpdatecliPolicyManifests search recursively from a root directory for Updatecli compose file
+func (u Updatecli) discoverUpdatecliPolicyManifests() ([][]byte, error) {
+
+	var manifests [][]byte
+
+	foundUpdateComposeFiles, err := searchUpdatecliComposeFiles(
+		u.rootDir,
+		DefaultFilePattern[:])
+
+	if err != nil {
+		return nil, err
+	}
+
+	for _, foundUpdateComposeFile := range foundUpdateComposeFiles {
+		logrus.Debugf("parsing file %q", foundUpdateComposeFile)
+
+		relativeUpdateComposeFile, err := filepath.Rel(u.rootDir, foundUpdateComposeFile)
+		if err != nil {
+			// Jump to the next Update compose file if current failed
+			logrus.Debugln(err)
+			continue
+		}
+
+		updateComposeRelativeMetadataPath := filepath.Dir(relativeUpdateComposeFile)
+		composeFilename := filepath.Base(updateComposeRelativeMetadataPath)
+
+		metadata, err := getComposeFileMetadata(foundUpdateComposeFile)
+		if err != nil {
+			logrus.Debugln(err)
+			continue
+		}
+
+		if metadata == nil {
+			continue
+		}
+
+		if len(metadata.Policies) == 0 {
+			continue
+		}
+
+		for i, policy := range metadata.Policies {
+			policyName, policyVersion, err := getPolicyName(policy.Policy)
+			if err != nil {
+				logrus.Debugln(err)
+				continue
+			}
+
+			logrus.Debugf("policy name: %q detected", policyName)
+
+			switch policyVersion {
+			case "": // No version specified
+				logrus.Debug("No version detected")
+			case "latest":
+				logrus.Debug("latest version detected")
+			default:
+				logrus.Debugf("version %q detected", policyVersion)
+			}
+
+			if len(u.spec.Ignore) > 0 {
+				if u.spec.Ignore.isMatchingRules(u.rootDir, relativeUpdateComposeFile, policyName, policyVersion) {
+					logrus.Debugf("Ignoring Updatecli policy %q from %q, as matching ignore rule(s)\n", policyName, composeFilename)
+					continue
+				}
+			}
+
+			if len(u.spec.Only) > 0 {
+				if !u.spec.Ignore.isMatchingRules(u.rootDir, relativeUpdateComposeFile, policyName, policyVersion) {
+					logrus.Debugf("Ignoring Updatecli policy %q from %q, as not matching only rule(s)\n", policyName, composeFilename)
+					continue
+				}
+			}
+
+			tmpl, err := template.New("manifest").Parse(manifestTemplate)
+			if err != nil {
+				logrus.Debugln(err)
+				continue
+			}
+
+			sourceVersionFilterKind := "semver"
+			sourceVersionFilterPattern := "*"
+			if !u.spec.VersionFilter.IsZero() {
+				sourceVersionFilterKind = u.versionFilter.Kind
+				if policyVersion != "latest" {
+					sourceVersionFilterPattern, err = u.versionFilter.GreaterThanPattern(policyVersion)
+					if err != nil {
+						logrus.Debugf("building version filter pattern: %s", err)
+						sourceVersionFilterPattern = "*"
+					}
+				}
+			}
+
+			params := struct {
+				ManifestName               string
+				PolicyName                 string
+				SourceVersionID            string
+				SourceVersionName          string
+				SourceVersionFilterKind    string
+				SourceVersionFilterPattern string
+				SourceDigestID             string
+				SourceDigestName           string
+				SourceDigestTag            string
+				TargetName                 string
+				TargetKey                  string
+				File                       string
+				ScmID                      string
+			}{
+				ManifestName:               fmt.Sprintf("deps(updatecli/policy): bump %q Updatecli policy version", policyName),
+				PolicyName:                 policyName,
+				SourceVersionID:            "version",
+				SourceVersionName:          fmt.Sprintf("Get latest %q Updatecli policy version", policyName),
+				SourceDigestID:             "digest",
+				SourceDigestName:           fmt.Sprintf("Get latest %q Updatecli policy digest", policyName),
+				SourceDigestTag:            "{{ source \"version\" }}",
+				SourceVersionFilterKind:    sourceVersionFilterKind,
+				SourceVersionFilterPattern: sourceVersionFilterPattern,
+				TargetName:                 fmt.Sprintf("deps(updatecli/policy): bump %q Updatecli version policy", policyName),
+				TargetKey:                  fmt.Sprintf("$.policies[%d].policy", i),
+				File:                       foundUpdateComposeFile,
+				ScmID:                      u.scmID,
+			}
+
+			manifest := bytes.Buffer{}
+			if err := tmpl.Execute(&manifest, params); err != nil {
+				logrus.Debugln(err)
+				continue
+			}
+
+			manifests = append(manifests, manifest.Bytes())
+		}
+	}
+
+	return manifests, nil
+}

--- a/pkg/plugins/autodiscovery/updatecli/test/main_test.go
+++ b/pkg/plugins/autodiscovery/updatecli/test/main_test.go
@@ -1,0 +1,203 @@
+package updatecli
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/updatecli/updatecli/pkg/core/config"
+	"github.com/updatecli/updatecli/pkg/core/pipeline/resource"
+	"github.com/updatecli/updatecli/pkg/core/pipeline/source"
+	"github.com/updatecli/updatecli/pkg/core/pipeline/target"
+	"github.com/updatecli/updatecli/pkg/core/transformer"
+	updatecli "github.com/updatecli/updatecli/pkg/plugins/autodiscovery/updatecli"
+	"github.com/updatecli/updatecli/pkg/plugins/resources/dockerdigest"
+	"github.com/updatecli/updatecli/pkg/plugins/resources/dockerimage"
+	"github.com/updatecli/updatecli/pkg/plugins/resources/yaml"
+	"github.com/updatecli/updatecli/pkg/plugins/utils/test"
+	"github.com/updatecli/updatecli/pkg/plugins/utils/version"
+)
+
+func TestDiscoverManifests(t *testing.T) {
+	testdata := []struct {
+		name              string
+		rootDir           string
+		expectedPipelines []config.Spec
+	}{
+		{
+			name:    "Scenario 1",
+			rootDir: "testdata",
+			expectedPipelines: []config.Spec{
+				{
+
+					Name: `deps(updatecli/policy): bump "ghcr.io/updatecli/policies/policies/nodejs/githubaction" Updatecli policy version`,
+					Sources: map[string]source.Config{
+						"version": {
+							ResourceConfig: resource.ResourceConfig{
+								Name: `Get latest "ghcr.io/updatecli/policies/policies/nodejs/githubaction" Updatecli policy version`,
+								Kind: "dockerimage",
+								Spec: dockerimage.Spec{
+									Image: "ghcr.io/updatecli/policies/policies/nodejs/githubaction",
+									VersionFilter: version.Filter{
+										Kind:    "semver",
+										Pattern: "*",
+									},
+								},
+							},
+						},
+						"digest": {
+							ResourceConfig: resource.ResourceConfig{
+								Name: `Get latest "ghcr.io/updatecli/policies/policies/nodejs/githubaction" Updatecli policy digest`,
+								Kind: "dockerdigest",
+								DependsOn: []string{
+									"version",
+								},
+								Spec: dockerdigest.Spec{
+									Image: "ghcr.io/updatecli/policies/policies/nodejs/githubaction",
+									Tag:   `{{ source "version" }}`,
+								},
+							},
+						},
+					},
+					Targets: map[string]target.Config{
+						"compose": {
+							SourceID: "digest",
+							ResourceConfig: resource.ResourceConfig{
+								Name: `deps(updatecli/policy): bump "ghcr.io/updatecli/policies/policies/nodejs/githubaction" Updatecli version policy`,
+								Kind: "yaml",
+								Spec: yaml.Spec{
+									File: "testdata/website/update-compose.yaml",
+									Key:  "$.policies[1].policy",
+								},
+								Transformers: []transformer.Transformer{
+									{
+										AddPrefix: "ghcr.io/updatecli/policies/policies/nodejs/githubaction:",
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+
+					Name: `deps(updatecli/policy): bump "ghcr.io/updatecli/policies/policies/nodejs/netlify" Updatecli policy version`,
+					Sources: map[string]source.Config{
+						"version": {
+							ResourceConfig: resource.ResourceConfig{
+								Name: `Get latest "ghcr.io/updatecli/policies/policies/nodejs/netlify" Updatecli policy version`,
+								Kind: "dockerimage",
+								Spec: dockerimage.Spec{
+									Image: "ghcr.io/updatecli/policies/policies/nodejs/netlify",
+									VersionFilter: version.Filter{
+										Kind:    "semver",
+										Pattern: "*",
+									},
+								},
+							},
+						},
+						"digest": {
+							ResourceConfig: resource.ResourceConfig{
+								Name: `Get latest "ghcr.io/updatecli/policies/policies/nodejs/netlify" Updatecli policy digest`,
+								Kind: "dockerdigest",
+								DependsOn: []string{
+									"version",
+								},
+								Spec: dockerdigest.Spec{
+									Image: "ghcr.io/updatecli/policies/policies/nodejs/netlify",
+									Tag:   `{{ source "version" }}`,
+								},
+							},
+						},
+					},
+					Targets: map[string]target.Config{
+						"compose": {
+							SourceID: "digest",
+							ResourceConfig: resource.ResourceConfig{
+								Name: `deps(updatecli/policy): bump "ghcr.io/updatecli/policies/policies/nodejs/netlify" Updatecli version policy`,
+								Kind: "yaml",
+								Spec: yaml.Spec{
+									File: "testdata/website/update-compose.yaml",
+									Key:  "$.policies[2].policy",
+								},
+								Transformers: []transformer.Transformer{
+									{
+										AddPrefix: "ghcr.io/updatecli/policies/policies/nodejs/netlify:",
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+
+					Name: `deps(updatecli/policy): bump "ghcr.io/updatecli/policies/policies/hugo/netlify" Updatecli policy version`,
+					Sources: map[string]source.Config{
+						"version": {
+							ResourceConfig: resource.ResourceConfig{
+								Name: `Get latest "ghcr.io/updatecli/policies/policies/hugo/netlify" Updatecli policy version`,
+								Kind: "dockerimage",
+								Spec: dockerimage.Spec{
+									Image: "ghcr.io/updatecli/policies/policies/hugo/netlify",
+									VersionFilter: version.Filter{
+										Kind:    "semver",
+										Pattern: "*",
+									},
+								},
+							},
+						},
+						"digest": {
+							ResourceConfig: resource.ResourceConfig{
+								Name: `Get latest "ghcr.io/updatecli/policies/policies/hugo/netlify" Updatecli policy digest`,
+								Kind: "dockerdigest",
+								DependsOn: []string{
+									"version",
+								},
+								Spec: dockerdigest.Spec{
+									Image: "ghcr.io/updatecli/policies/policies/hugo/netlify",
+									Tag:   `{{ source "version" }}`,
+								},
+							},
+						},
+					},
+					Targets: map[string]target.Config{
+						"compose": {
+							SourceID: "digest",
+							ResourceConfig: resource.ResourceConfig{
+								Name: `deps(updatecli/policy): bump "ghcr.io/updatecli/policies/policies/hugo/netlify" Updatecli version policy`,
+								Kind: "yaml",
+								Spec: yaml.Spec{
+									File: "testdata/website/update-compose.yaml",
+									Key:  "$.policies[3].policy",
+								},
+								Transformers: []transformer.Transformer{
+									{
+										AddPrefix: "ghcr.io/updatecli/policies/policies/hugo/netlify:",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range testdata {
+
+		t.Run(tt.name, func(t *testing.T) {
+			updatecli, err := updatecli.New(
+				updatecli.Spec{
+					RootDir: tt.rootDir,
+				}, "", "")
+			require.NoError(t, err)
+
+			pipelines, err := updatecli.DiscoverManifests()
+			require.NoError(t, err)
+
+			for i := range tt.expectedPipelines {
+				test.AssertConfigSpecEqualByteArray(t, &tt.expectedPipelines[i], string(pipelines[i]))
+			}
+
+			require.Equal(t, len(tt.expectedPipelines), len(pipelines))
+		})
+	}
+}

--- a/pkg/plugins/autodiscovery/updatecli/test/testdata/website/update-compose.yaml
+++ b/pkg/plugins/autodiscovery/updatecli/test/testdata/website/update-compose.yaml
@@ -1,0 +1,21 @@
+policies:
+  - name: Local Updatecli Website Policies
+    config:
+      - updatecli/updatecli.d/
+
+  - name: Handle Nodejs version in githubaction
+    policy: ghcr.io/updatecli/policies/policies/nodejs/githubaction:latest
+    values:
+      - updatecli/values.d/scm.yaml
+      - updatecli/values.d/nodejs.yaml
+
+  - name: Handle Nodejs version in Netlify
+    policy: ghcr.io/updatecli/policies/policies/nodejs/netlify:0.1.0
+    values:
+      - updatecli/values.d/scm.yaml
+      - updatecli/values.d/nodejs.yaml
+
+  - name: Handle Hugo version in Netlify
+    policy: ghcr.io/updatecli/policies/policies/hugo/netlify:0.4.0@sha256:353d6cf2eb909c50bdb8d088f0df8ef53b0f90aec725a7a0c2b75ebe8d3352c1
+    values:
+      - updatecli/values.d/scm.yaml

--- a/pkg/plugins/autodiscovery/updatecli/utils.go
+++ b/pkg/plugins/autodiscovery/updatecli/utils.go
@@ -1,0 +1,102 @@
+package updatecli
+
+import (
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	"github.com/updatecli/updatecli/pkg/core/compose"
+	goyaml "gopkg.in/yaml.v3"
+)
+
+// searchUpdatecliComposeFiles search, recursively, for every Updatecli compose files starting from a root directory.
+func searchUpdatecliComposeFiles(rootDir string, files []string) ([]string, error) {
+
+	composeFiles := []string{}
+
+	// To do switch to WalkDir which is more efficient, introduced in 1.16
+	err := filepath.Walk(rootDir, func(path string, info fs.FileInfo, err error) error {
+		if err != nil {
+			fmt.Printf("prevent panic by handling failure accessing a path %q: %v\n", path, err)
+			return err
+		}
+
+		for _, f := range files {
+			match, err := filepath.Match(f, info.Name())
+			if err != nil {
+				logrus.Errorln(err)
+				continue
+			}
+			if match {
+				composeFiles = append(composeFiles, path)
+			}
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	logrus.Debugf("%d potential Updatecli manifest(s) found", len(composeFiles))
+
+	return composeFiles, nil
+}
+
+// getComposeFileMetadata loads file content from an Updatecli compose file.
+func getComposeFileMetadata(filename string) (*compose.Spec, error) {
+
+	var composeFile compose.Spec
+
+	if _, err := os.Stat(filename); err != nil {
+		return nil, err
+	}
+
+	v, err := os.Open(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	defer v.Close()
+
+	content, err := io.ReadAll(v)
+	if err != nil {
+		return nil, err
+	}
+
+	err = goyaml.Unmarshal(content, &composeFile)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if len(composeFile.Policies) == 0 {
+		return nil, nil
+	}
+
+	for _, value := range composeFile.Policies {
+		logrus.Debugf("Name: %q\n", value.Policy)
+	}
+
+	return &composeFile, nil
+}
+
+func getPolicyName(policy string) (name, version string, err error) {
+	policyNameArray := strings.Split(policy, "@")
+	policyNameArray = strings.Split(policyNameArray[0], ":")
+
+	if len(policyNameArray) > 1 {
+		version = policyNameArray[1]
+	}
+	name = policyNameArray[0]
+
+	if name == "" {
+		return "", "", fmt.Errorf("policy name is empty")
+	}
+	return name, version, nil
+}

--- a/pkg/plugins/autodiscovery/updatecli/utils_test.go
+++ b/pkg/plugins/autodiscovery/updatecli/utils_test.go
@@ -1,0 +1,115 @@
+package updatecli
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/updatecli/updatecli/pkg/core/compose"
+)
+
+func TestSearchFiles(t *testing.T) {
+
+	gotFiles, err := searchUpdatecliComposeFiles(
+		"test/testdata/website", DefaultFilePattern[:])
+	if err != nil {
+		t.Errorf("%s\n", err)
+	}
+	expectedFile := "test/testdata/website/update-compose.yaml"
+
+	if len(gotFiles) == 0 {
+		t.Errorf("Expecting file %q but got none", expectedFile)
+		return
+	}
+
+	if gotFiles[0] != expectedFile {
+		t.Errorf("Expecting file %q but got %q", expectedFile, gotFiles[0])
+	}
+}
+
+func TestListUpdatecliPolicies(t *testing.T) {
+
+	gotMetadata, err := getComposeFileMetadata(
+		"test/testdata/website/update-compose.yaml")
+	if err != nil {
+		t.Errorf("%s\n", err)
+	}
+	expectedPolicies := []compose.Policy{
+		{
+			Name: "Local Updatecli Website Policies",
+			Config: []string{
+				"updatecli/updatecli.d/",
+			},
+		},
+		{
+			Name:   "Handle Nodejs version in githubaction",
+			Policy: "ghcr.io/updatecli/policies/policies/nodejs/githubaction:latest",
+			Values: []string{
+				"updatecli/values.d/scm.yaml",
+				"updatecli/values.d/nodejs.yaml",
+			},
+		},
+		{
+			Name:   "Handle Nodejs version in Netlify",
+			Policy: "ghcr.io/updatecli/policies/policies/nodejs/netlify:0.1.0",
+			Values: []string{
+				"updatecli/values.d/scm.yaml",
+				"updatecli/values.d/nodejs.yaml",
+			},
+		},
+		{
+			Name:   "Handle Hugo version in Netlify",
+			Policy: "ghcr.io/updatecli/policies/policies/hugo/netlify:0.4.0@sha256:353d6cf2eb909c50bdb8d088f0df8ef53b0f90aec725a7a0c2b75ebe8d3352c1",
+			Values: []string{
+				"updatecli/values.d/scm.yaml",
+			},
+		},
+	}
+
+	require.Equal(t, expectedPolicies, gotMetadata.Policies)
+}
+
+func TestGetPolicyName(t *testing.T) {
+	testdata := []struct {
+		name            string
+		expectedName    string
+		expectedVersion string
+		expectedErr     bool
+		expectedErrMsg  string
+	}{
+		{
+			name:            "ghcr.io/updatecli/policies/hugo/netlify:latest",
+			expectedName:    "ghcr.io/updatecli/policies/hugo/netlify",
+			expectedVersion: "latest",
+		},
+		{
+			name:           "",
+			expectedErr:    true,
+			expectedErrMsg: "policy name is empty",
+		},
+		{
+			name:            "ghcr.io/updatecli/policies/hugo/netlify:0.5.0@sha256:121231231",
+			expectedName:    "ghcr.io/updatecli/policies/hugo/netlify",
+			expectedVersion: "0.5.0",
+		},
+		{
+			name:            "ghcr.io/updatecli/policies/hugo/netlify:0.5.0@sha256",
+			expectedName:    "ghcr.io/updatecli/policies/hugo/netlify",
+			expectedVersion: "0.5.0",
+		},
+	}
+
+	for _, tt := range testdata {
+
+		t.Run(tt.name, func(t *testing.T) {
+
+			gotName, gotVersion, gotErr := getPolicyName(tt.name)
+
+			if tt.expectedErr {
+				require.Equal(t, gotErr.Error(), tt.expectedErrMsg)
+			}
+
+			require.Equal(t, tt.expectedName, gotName)
+			require.Equal(t, tt.expectedVersion, gotVersion)
+		})
+	}
+}


### PR DESCRIPTION
This pullrequest add a new autodiscovery plugin for Updatecli compose file

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
cd pkg/plugins/autodiscovery/updatecli/
go test ./...
go build -o bin/updatecli
./bin/updatecli diff --config e2e/updatecli.d/warning.d/autodiscovery/updatecli --experimental
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

As already explained in https://github.com/updatecli/updatecli/issues/1709, because Updatecli are OCI artifacts we can use the dockerimage and dockerdigest plugin but console output feels a bit wrong because it keeps mentioning "docker" and Updatecli policies are not docker images
