### PR TITLE
feat(autodiscovery/helm) allow advanced ignore/only rule

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -69,3 +69,4 @@ githubactions
 gitlabci
 githubaction
 netlify
+longhornio

--- a/e2e/updatecli.d/warning.d/autodiscovery/helm/example.1.yaml
+++ b/e2e/updatecli.d/warning.d/autodiscovery/helm/example.1.yaml
@@ -10,11 +10,11 @@ autodiscovery:
   scmid: epinio
   crawlers:
     helm:
-      # To ignore specific path
-      #ignore:
-      #  # - path: <filepath relative to scm repository>
-      #  # - path: chart/*
-      #only:
-      #  # - path: <filepath relative to scm repository>
-      #  # - path: chart/*
-#
+      ignore:
+        - path: chart/epinio
+          dependencies:
+            "s3gw": ">0.0.1"
+        - path: chart/upgrade-responder
+          containers:
+            "longhornio/upgrade-responder": ""
+

--- a/pkg/plugins/autodiscovery/helm/matchingRule.go
+++ b/pkg/plugins/autodiscovery/helm/matchingRule.go
@@ -3,6 +3,7 @@ package helm
 import (
 	"path/filepath"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/sirupsen/logrus"
 )
 
@@ -10,67 +11,137 @@ import (
 type MatchingRule struct {
 	// Path specifies a Helm chart path pattern, the pattern requires to match all of name, not just a subpart of the path.
 	Path string
+	// Dependencies specifies a list of dependencies pattern.
+	Dependencies map[string]string
+	// Containers specifies a list of containers pattern.
+	Containers map[string]string
 }
 
 type MatchingRules []MatchingRule
 
-// isMatchingIgnoreRule checks if a specific file content matches the "ignore" rule
-func (m MatchingRules) isMatchingIgnoreRule(rootDir, relativePath string) bool {
-	result := false
+// isMatchingRules checks for each matchingRule if parameters are matching rules and then return true or false.
+func (m MatchingRules) isMatchingRules(rootDir, filePath, dependencyName, dependencyVersion, containerName, containerTag string) bool {
+	var ruleResults []bool
 
 	if len(m) > 0 {
 		for _, rule := range m {
-			logrus.Infof("Rule: %q\n", rule.Path)
-			logrus.Infof("Relative Found: %q\n", relativePath)
-			switch filepath.IsAbs(rule.Path) {
-			case true:
-				match, err := filepath.Match(rule.Path, filepath.Join(rootDir, relativePath))
+			/*
+			 Check if rule.Path is matching. Path accepts wildcard path
+			*/
+			if rule.Path != "" {
+				if filepath.IsAbs(rule.Path) {
+					filePath = filepath.Join(rootDir, filePath)
+				}
+
+				match, err := filepath.Match(rule.Path, filePath)
+
 				if err != nil {
 					logrus.Errorf("%s - %q", err, rule.Path)
+					continue
 				}
+				ruleResults = append(ruleResults, match)
 				if match {
-					result = true
-				}
-			case false:
-				match, err := filepath.Match(rule.Path, relativePath)
-				if err != nil {
-					logrus.Errorf("%s - %q", err, rule.Path)
-				}
-				if match {
-					result = true
+					logrus.Debugf("file path %q matching rule %q", filePath, rule.Path)
 				}
 			}
+
+			/*
+				Checks if dependency is matching the dependency constraint.
+				If both the dependency constraint is empty and no dependency name have been provided then we
+				assume the rule is not matching
+
+				Otherwise we checks both that version and module name are matching.
+				Version matching uses semantic versioning constraints if possible otherwise
+				just compare the version rule and the module version.
+			*/
+
+			if len(rule.Dependencies) > 0 {
+				match := false
+			outDependency:
+				for ruleDependencyName, ruleDependencyVersion := range rule.Dependencies {
+					if dependencyName == ruleDependencyName {
+						if ruleDependencyVersion == "" {
+							match = true
+							break outDependency
+						}
+
+						v, err := semver.NewVersion(dependencyVersion)
+						if err != nil {
+							match = dependencyVersion == ruleDependencyVersion
+							logrus.Debugf("%q - %s", dependencyVersion, err)
+							break outDependency
+						}
+
+						c, err := semver.NewConstraint(ruleDependencyVersion)
+						if err != nil {
+							match = dependencyVersion == ruleDependencyVersion
+							logrus.Debugf("%q %s", err, ruleDependencyVersion)
+							break outDependency
+						}
+
+						match = c.Check(v)
+						break outDependency
+					}
+				}
+				ruleResults = append(ruleResults, match)
+
+			}
+
+			/*
+				Checks if container is matching the container constraint.
+				If the dependency constraint is empty and no dependency name have been provided then we
+				assume the rule is not matching
+
+				Otherwise we checks both that version and module name are matching.
+				Version matching uses semantic versioning constraints if possible otherwise
+				just compare the version rule and the module version.
+			*/
+			if len(rule.Containers) > 0 {
+				match := false
+			outContainer:
+				for ruleContainerName, ruleContainerTag := range rule.Containers {
+					if containerName == ruleContainerName {
+						if ruleContainerTag == "" {
+							match = true
+							break outContainer
+						}
+
+						v, err := semver.NewVersion(containerTag)
+						if err != nil {
+							match = containerTag == ruleContainerTag
+							logrus.Debugf("%q - %s", containerTag, err)
+							break outContainer
+						}
+
+						c, err := semver.NewConstraint(ruleContainerTag)
+						if err != nil {
+							match = containerTag == ruleContainerTag
+							logrus.Debugf("%q %s", err, ruleContainerTag)
+							break outContainer
+						}
+
+						match = c.Check(v)
+						break outContainer
+					}
+				}
+				ruleResults = append(ruleResults, match)
+			}
+
+			/*
+				If at least one rule is failing then we return false
+			*/
+			isAllMatching := true
+			for i := range ruleResults {
+				if !ruleResults[i] {
+					isAllMatching = false
+				}
+			}
+			if isAllMatching {
+				return true
+			}
+			ruleResults = []bool{}
 		}
 	}
 
-	return result
-}
-
-// isMatchingOnlyRule checks if a specific file content matches the "only" rule
-func (m MatchingRules) isMatchingOnlyRule(rootDir, relativePath string) bool {
-	result := false
-	if len(m) > 0 {
-		for _, rule := range m {
-			switch filepath.IsAbs(rule.Path) {
-			case true:
-				match, err := filepath.Match(rule.Path, filepath.Join(rootDir, relativePath))
-				if err != nil {
-					logrus.Errorf("%s - %q", err, rule.Path)
-				}
-				if match {
-					result = true
-				}
-			case false:
-				match, err := filepath.Match(rule.Path, relativePath)
-				if err != nil {
-					logrus.Errorf("%s - %q", err, rule.Path)
-				}
-				if match {
-					result = true
-				}
-			}
-		}
-	}
-
-	return result
+	return false
 }

--- a/pkg/plugins/autodiscovery/helm/matchingRule_test.go
+++ b/pkg/plugins/autodiscovery/helm/matchingRule_test.go
@@ -1,0 +1,70 @@
+package helm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsMatchingRule(t *testing.T) {
+
+	dataset := []struct {
+		rules             MatchingRules
+		name              string
+		filePath          string
+		containerVersion  string
+		containerName     string
+		dependencyName    string
+		dependencyVersion string
+		rootDir           string
+		expectedResult    bool
+	}{
+		{
+			rules: MatchingRules{
+				MatchingRule{
+					Path: "test/testdata-1",
+				},
+			},
+			filePath:       "test/testdata-1",
+			expectedResult: true,
+		},
+		{
+			rules: MatchingRules{
+				MatchingRule{
+					Path: "testdata-1",
+				},
+			},
+			filePath:       "test/testdata-1",
+			expectedResult: false,
+		},
+		{
+			rules: MatchingRules{
+				MatchingRule{
+					Path: "test/testdata-1",
+					Dependencies: map[string]string{
+						"jenkins": "2.234",
+					},
+				},
+			},
+			filePath:          "test/testdata-1",
+			dependencyName:    "jenkins",
+			dependencyVersion: "2.234",
+			expectedResult:    true,
+		},
+	}
+
+	for _, d := range dataset {
+		t.Run(d.name, func(t *testing.T) {
+			gotResult := d.rules.isMatchingRules(
+				d.rootDir,
+				d.filePath,
+				d.dependencyName,
+				d.dependencyVersion,
+				d.containerName,
+				d.containerVersion,
+			)
+
+			assert.Equal(t, d.expectedResult, gotResult)
+		})
+	}
+}


### PR DESCRIPTION
Fix #1743 

This pullrequest allows more advance ignore/only rules.
It's now possible to use `helm dependency` and `container` in the matching rule

For example 

<details><summary>Only Update dependency `s3gw` in chart `chart/epinio` using version constraint</summary>

```
autodiscovery:
  # scmid is applied to all crawlers
  scmid: epinio
  crawlers:
    helm:
      only:
        - path: chart/epinio
          dependencies:
            "s3gw": ">1.0.0"
``` 

</details>

<details><summary>Only Update dependency `s3gw` in chart `chart/epinio` without version constraint</summary>

```
autodiscovery:
  # scmid is applied to all crawlers
  scmid: epinio
  crawlers:
    helm:
      only:
        - path: chart/epinio
          dependencies:
            "s3gw": ""
``` 

</details>

<details><summary>Only Update both dependency `s3gw` in chart `chart/epinio` using version constraint and container "longhorn/upgrade-responder"</summary>

```
autodiscovery:
  # scmid is applied to all crawlers
  scmid: epinio
  crawlers:
    helm:
      only:
        - path: chart/epinio
          dependencies:
            "s3gw": ">1.0.0"
        - path: chart/epinio
          containers:
            "longhorn/upgrade-responder": ""
``` 

</details>



<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
cd <to_package_directory>
go test
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

I didn't tested all possible scenarios...
