### PR TITLE
fix(file): ignore searchpattern not found when used with matchpattern

### DIFF
--- a/pkg/plugins/resources/file/condition.go
+++ b/pkg/plugins/resources/file/condition.go
@@ -85,9 +85,9 @@ func (f *File) condition(source string) (bool, error) {
 			}
 
 			if !reg.MatchString(file.content) {
-				if f.spec.SearchPattern && f.spec.IgnoreNotFound {
-					// If we are using a search pattern and we have ignore not found,
-					// then we don't want to return an error if the pattern is not found.
+				if f.spec.SearchPattern {
+					// When using both a file path pattern AND a content matching regex, then we want to ignore files that don't match the pattern
+					// as otherwise we trigger error for files we don't care about.
 					logrus.Debugf("No match found for pattern %q in file %q, removing it from the list of files to update", f.spec.MatchPattern, filePath)
 					delete(f.files, filePath)
 					continue
@@ -101,6 +101,12 @@ func (f *File) condition(source string) (bool, error) {
 				)
 				return false, nil
 			}
+
+			if len(f.files) == 0 {
+				logrus.Debugf("no file found matching criteria")
+				return false, nil
+			}
+
 			logrus.Infof("%s %s matched the pattern %q", result.SUCCESS, logMessage, f.spec.MatchPattern)
 		}
 

--- a/pkg/plugins/resources/file/condition.go
+++ b/pkg/plugins/resources/file/condition.go
@@ -85,6 +85,14 @@ func (f *File) condition(source string) (bool, error) {
 			}
 
 			if !reg.MatchString(file.content) {
+				if f.spec.SearchPattern && f.spec.IgnoreNotFound {
+					// If we are using a search pattern and we have ignore not found,
+					// then we don't want to return an error if the pattern is not found.
+					logrus.Debugf("No match found for pattern %q in file %q, removing it from the list of files to update", f.spec.MatchPattern, filePath)
+					delete(f.files, filePath)
+					continue
+				}
+
 				logrus.Infof(
 					"%s %s did not match the pattern %q",
 					result.FAILURE,

--- a/pkg/plugins/resources/file/main.go
+++ b/pkg/plugins/resources/file/main.go
@@ -121,6 +121,13 @@ type Spec struct {
 
 	*/
 	SearchPattern bool `yaml:",omitempty"`
+	/*
+	   ignorenotfound defines if the MatchPattern should be ignored if not found
+
+	   remark:
+	       This attribute is only used when SearchPattern is set to true.
+	*/
+	IgnoreNotFound bool `yaml:",omitempty"`
 }
 
 // File defines a resource of kind "file"

--- a/pkg/plugins/resources/file/main.go
+++ b/pkg/plugins/resources/file/main.go
@@ -121,13 +121,6 @@ type Spec struct {
 
 	*/
 	SearchPattern bool `yaml:",omitempty"`
-	/*
-	   ignorenotfound defines if the MatchPattern should be ignored if not found
-
-	   remark:
-	       This attribute is only used when SearchPattern is set to true.
-	*/
-	IgnoreNotFound bool `yaml:",omitempty"`
 }
 
 // File defines a resource of kind "file"


### PR DESCRIPTION
Fix #1765 

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
cd <to_package_directory>
go test
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
