### PR TITLE
feat: introduces a new resource "http" (source only)

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -74,3 +74,9 @@ longhornio
 searchpattern
 crds
 mockito
+nofollowredirects
+returnresponseheader
+responseasserts
+updateclihttp
+Metadatas
+statuscode

--- a/e2e/updatecli.d/success.d/http.yaml
+++ b/e2e/updatecli.d/success.d/http.yaml
@@ -1,0 +1,80 @@
+name: End to end test of the 'http' resource kind
+pipelineid: "e2e/http"
+
+# Sources of type http returns either the body or a header
+sources:
+  # Returns the content of the 'maven-metadata.xml' file content as source (multi-line, direct HTTP/200)
+  getJenkinsWarArtifactMetadatas:
+    kind: http
+    spec:
+      url: https://repo.jenkins-ci.org/releases/org/jenkins-ci/main/jenkins-war/maven-metadata.xml
+  # Returns the content of the 'checksums.txt' file content as source (multi-line, following redirections HTTP/3xx)
+  getUpdatecli0.65.1Checksums:
+    kind: http
+    spec:
+      url: https://github.com/updatecli/updatecli/releases/download/v0.65.1/checksums.txt # HTTP/302 (GitHub redirection to raw.githubusercontent.com)
+  ## Empty Source due to HTTP/3xx not followed (e.g. empty body)
+  getUpdatecli0.65.1ChecksumsNoFollow:
+    kind: http
+    spec:
+      url: https://github.com/updatecli/updatecli/releases/download/v0.65.1/checksums.txt # HTTP/302 (GitHub redirection to raw.githubusercontent.com)
+      request:
+        nofollowredirects: true # Default is false
+  # Returns the content of the Header 'Location' (e.g. the target of the HTTP redirect)
+  getRedirectLocationForUpdatecliLinuxAmd64Archive:
+    kind: http
+    spec:
+      url: https://github.com/updatecli/updatecli/releases/download/v0.65.1/updatecli_Linux_arm64.tar.gz
+      returnresponseheader: Location
+  # Returns the content of the 'maven-metadata.xml' file from the private URL (custom headers for the request)
+  getWithCustomRequest:
+    kind: http
+    spec:
+      url: https://repo.jenkins-ci.org/releases/org/jenkins-ci/main/jenkins-war/maven-metadata.xml
+      request:
+        headers:
+          Authorization: 'Bearer Token'
+          Accept: 'application/xml'
+        verb: GET
+  ## Source fails with an error: the URL returns HTTP/404 (same for server-side errors such as HTTP/5xx)
+  # failOnHttpError:
+  #   kind: http
+  #   spec:
+  #     url: https://google.com/do-not-exist
+
+
+conditions:
+  # Returns 'true' if the specified URL returns HTTP/1xx, HTTP/2xx or HTTP/3xx
+  checkForURL:
+    kind: http
+    sourceid: getJenkinsWarArtifactMetadatas
+    spec:
+      url: https://repo.jenkins-ci.org/releases/org/jenkins-ci/main/jenkins-war/maven-metadata.xml
+  ## Conditions returns 'false' as the URL returns HTTP/404
+  ## If there is an HTTP/500 (server side error) then the conditions fails with an ERROR (different than returning false which "skips" the pipeline)
+  # checkForNonExistingUrl:
+  #   kind: http
+  #   sourceid: getJenkinsWarArtifactMetadatas
+  #   spec:
+  #     url: https://google.com/do-not-exist
+  # Returns 'true' if the specified URL returns HTTP/1xx, HTTP/2xx or HTTP/3xx to the custom request (custom verb and headers)
+  checkWithCustomRequest:
+    kind: http
+    sourceid: getJenkinsWarArtifactMetadatas
+    spec:
+      url: https://repo.jenkins-ci.org/releases/org/jenkins-ci/main/jenkins-war/maven-metadata.xml
+      request:
+        headers:
+          Authorization: 'Bearer Token'
+          Accept: 'application/xml'
+        verb: HEAD
+  # Returns 'true' if the response code is HTTP/302 and has header "Content-Type" set to "application/xhtml"
+  getUpdatecli0.65.1Checksums:
+    kind: http
+    sourceid: getJenkinsWarArtifactMetadatas
+    spec:
+      url: https://github.com/updatecli/updatecli/releases/download/v0.65.1/checksums.txt # HTTP/302 (GitHub redirection to raw.githubusercontent.com)
+      responseasserts:
+        statuscode: 302
+        headers:
+          Content-Type: "text/html; charset=utf-8"

--- a/pkg/core/pipeline/resource/main.go
+++ b/pkg/core/pipeline/resource/main.go
@@ -39,6 +39,7 @@ import (
 	terraformProvider "github.com/updatecli/updatecli/pkg/plugins/resources/terraform/provider"
 	terraformRegistry "github.com/updatecli/updatecli/pkg/plugins/resources/terraform/registry"
 	"github.com/updatecli/updatecli/pkg/plugins/resources/toml"
+	updateclihttp "github.com/updatecli/updatecli/pkg/plugins/resources/updateclihttp"
 	"github.com/updatecli/updatecli/pkg/plugins/resources/xml"
 	"github.com/updatecli/updatecli/pkg/plugins/resources/yaml"
 )
@@ -155,6 +156,10 @@ func New(rs ResourceConfig) (resource Resource, err error) {
 
 		return helm.New(rs.Spec)
 
+	case "http":
+
+		return updateclihttp.New(rs.Spec)
+
 	case "jenkins":
 
 		return jenkins.New(rs.Spec)
@@ -249,6 +254,7 @@ func GetResourceMapping() map[string]interface{} {
 		"golang/module":      &gomodule.Spec{},
 		"hcl":                &hcl.Spec{},
 		"helmchart":          &helm.Spec{},
+		"http":               &updateclihttp.Spec{},
 		"jenkins":            &jenkins.Spec{},
 		"json":               &json.Spec{},
 		"maven":              &maven.Spec{},

--- a/pkg/plugins/resources/cargopackage/spec.go
+++ b/pkg/plugins/resources/cargopackage/spec.go
@@ -5,7 +5,7 @@ import (
 	"github.com/updatecli/updatecli/pkg/plugins/utils/version"
 )
 
-// Spec defines a specification for a "dockerimage" resource
+// Spec defines a specification for a "cargopackage" resource
 // parsed from an updatecli manifest file
 type Spec struct {
 	// !deprecated, please use Registry.URL

--- a/pkg/plugins/resources/file/condition.go
+++ b/pkg/plugins/resources/file/condition.go
@@ -12,7 +12,7 @@ import (
 	"github.com/updatecli/updatecli/pkg/core/text"
 )
 
-// ConditionFromSCM test if a file content from SCM match the content provided via configuration.
+// Condition test if a file content matches the content provided via configuration.
 // If the configuration doesn't specify a value then it fall back to the source output
 func (f *File) Condition(source string, scm scm.ScmHandler, resultCondition *result.Condition) error {
 

--- a/pkg/plugins/resources/updateclihttp/condition.go
+++ b/pkg/plugins/resources/updateclihttp/condition.go
@@ -1,0 +1,64 @@
+package updateclihttp
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
+	"github.com/updatecli/updatecli/pkg/core/result"
+)
+
+// Condition tests if the response of the specified HTTP request meets assertion.
+// If the configuration doesn't specify any assertion, then it only checks for successful HTTP get result (HTTP/1xx, HTTP/2xx or HTTP/3xx)
+func (h *Http) Condition(source string, scm scm.ScmHandler, resultCondition *result.Condition) error {
+	resultCondition.Result = result.FAILURE
+	resultCondition.Pass = false
+	var failureMessages []string
+
+	conditionResult := true
+
+	httpRes, err := h.performHttpRequest()
+	if err != nil {
+		return err
+	}
+	defer httpRes.Body.Close()
+
+	if h.spec.ResponseAsserts.StatusCode > 0 {
+		if httpRes.StatusCode != h.spec.ResponseAsserts.StatusCode {
+			failureMessages = append(failureMessages, fmt.Sprintf("Received status code %d while expecting %d.", httpRes.StatusCode, h.spec.ResponseAsserts.StatusCode))
+			conditionResult = false
+		}
+	} else {
+		// Only return an error if the HTTP status code is a server-side error: not found is not an error (but a condition failure)
+		if httpRes.StatusCode >= http.StatusInternalServerError {
+			return &ErrHttpError{resStatusCode: httpRes.StatusCode}
+		}
+		if httpRes.StatusCode >= http.StatusNotFound {
+			failureMessages = append(failureMessages, fmt.Sprintf("Received status code %d which is >= 400, e.g. client or server HTTP error", httpRes.StatusCode))
+			conditionResult = false
+		}
+	}
+
+	if len(h.spec.ResponseAsserts.Headers) > 0 {
+		for key, value := range h.spec.ResponseAsserts.Headers {
+			foundValue := httpRes.Header.Get(key)
+
+			if foundValue != value {
+				failureMessages = append(failureMessages, fmt.Sprintf("Found value %q for header %q while expecting %q", foundValue, key, value))
+				conditionResult = false
+			}
+		}
+	}
+
+	resultCondition.Pass = conditionResult
+	if conditionResult {
+		resultCondition.Result = result.SUCCESS
+		resultCondition.Description = fmt.Sprintf("[http] condition with URL: %q passed", h.spec.Url)
+	} else {
+		resultCondition.Result = result.FAILURE
+		resultCondition.Description = fmt.Sprintf("[http] condition with URL: %q did NOT pass with the following errors: %s", h.spec.Url, strings.Join(failureMessages, "\n"))
+	}
+
+	return nil
+}

--- a/pkg/plugins/resources/updateclihttp/condition.go
+++ b/pkg/plugins/resources/updateclihttp/condition.go
@@ -9,8 +9,10 @@ import (
 	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
-// Condition tests if the response of the specified HTTP request meets assertion.
-// If the configuration doesn't specify any assertion, then it only checks for successful HTTP get result (HTTP/1xx, HTTP/2xx or HTTP/3xx)
+/*
+Condition tests if the response of the specified HTTP request meets assertion.
+If no assertion is specified, it only checks for successful HTTP response code (HTTP/1xx, HTTP/2xx or HTTP/3xx).
+*/
 func (h *Http) Condition(source string, scm scm.ScmHandler, resultCondition *result.Condition) error {
 	resultCondition.Result = result.FAILURE
 	resultCondition.Pass = false

--- a/pkg/plugins/resources/updateclihttp/condition_test.go
+++ b/pkg/plugins/resources/updateclihttp/condition_test.go
@@ -1,0 +1,156 @@
+package updateclihttp
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/updatecli/updatecli/pkg/core/httpclient"
+	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
+	"github.com/updatecli/updatecli/pkg/core/result"
+)
+
+func TestCondition(t *testing.T) {
+	tests := []struct {
+		name                  string
+		spec                  Spec
+		source                string
+		scm                   scm.ScmHandler
+		mockedHTTPStatusCode  int
+		mockedHTTPBody        string
+		mockedHTTPRespHeaders http.Header
+		mockedHttpError       error
+		want                  bool
+		wantErr               error
+	}{
+		{
+			name: "Success case with existing URL",
+			spec: Spec{
+				Url: "https://repo.jenkins-ci.org/releases/org/jenkins-ci/main/jenkins-war/maven-metadata.xml",
+			},
+			mockedHTTPStatusCode: http.StatusOK,
+			want:                 true,
+		},
+		{
+			name: "Success case with custom request and existing URL",
+			spec: Spec{
+				Url: "https://repo.jenkins-ci.org/releases/org/jenkins-ci/main/jenkins-war/maven-metadata.xml",
+				Request: Request{
+					Verb: "HEAD",
+					Headers: map[string]string{
+						"Authorization": "Bearer Token",
+					},
+				},
+			},
+			mockedHTTPStatusCode: http.StatusOK,
+			want:                 true,
+		},
+		{
+			name: "Success case with assertions",
+			spec: Spec{
+				Url: "https://repo.jenkins-ci.org/releases/org/jenkins-ci/main/jenkins-war/nope",
+				ResponseAsserts: ResponseAsserts{
+					StatusCode: 500,
+					Headers: map[string]string{
+						"Location": "https://google.com",
+					},
+				},
+			},
+			mockedHTTPStatusCode: http.StatusInternalServerError,
+			mockedHTTPRespHeaders: http.Header{
+				"Location":     {"https://google.com"},
+				"Content-Type": {"application/xml"},
+			},
+			want: true,
+		},
+		{
+			name: "Failing case with not-existing URL",
+			spec: Spec{
+				Url: "https://repo.jenkins-ci.org/releases/org/jenkins-ci/main/jenkins-war/nope",
+			},
+			mockedHTTPStatusCode: http.StatusNotFound,
+			want:                 false,
+		},
+		{
+			name: "Failing case with unmet assertion on status code",
+			spec: Spec{
+				Url: "https://repo.jenkins-ci.org/releases/org/jenkins-ci/main/jenkins-war/maven-metadata.xml",
+				ResponseAsserts: ResponseAsserts{
+					StatusCode: 500,
+					Headers: map[string]string{
+						"Location": "https://google.com",
+					},
+				},
+			},
+			mockedHTTPStatusCode: http.StatusOK,
+			mockedHTTPRespHeaders: http.Header{
+				"Location":     {"https://google.com"},
+				"Content-Type": {"application/xml"},
+			},
+			want: false,
+		},
+		{
+			name: "Failing case with unmet assertion on headers code",
+			spec: Spec{
+				Url: "https://repo.jenkins-ci.org/releases/org/jenkins-ci/main/jenkins-war/maven-metadata.xml",
+				ResponseAsserts: ResponseAsserts{
+					StatusCode: 200,
+					Headers: map[string]string{
+						"Location": "https://google.com",
+					},
+				},
+			},
+			mockedHTTPStatusCode: http.StatusOK,
+			want:                 false,
+		},
+		{
+			name: "Error (and failing) case when HTTP code is >= 500",
+			spec: Spec{
+				Url: "https://repo.jenkins-ci.org/releases/org/jenkins-ci/main/jenkins-war/maven-metadata.xml",
+			},
+			mockedHTTPStatusCode: http.StatusInternalServerError,
+			wantErr:              &ErrHttpError{resStatusCode: http.StatusInternalServerError},
+			want:                 false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sut, sutErr := New(tt.spec)
+			require.NoError(t, sutErr)
+
+			sut.httpClient = &httpclient.MockClient{
+				DoFunc: func(req *http.Request) (*http.Response, error) {
+					body := tt.mockedHTTPBody
+					statusCode := tt.mockedHTTPStatusCode
+					return &http.Response{
+						StatusCode: statusCode,
+						Body:       io.NopCloser(strings.NewReader(body)),
+						Header:     tt.mockedHTTPRespHeaders,
+					}, tt.mockedHttpError
+				},
+			}
+
+			got := &result.Condition{}
+			gotErr := sut.Condition(tt.source, tt.scm, got)
+
+			if tt.wantErr != nil {
+				require.Error(t, gotErr)
+				assert.Equal(t, got.Result, result.FAILURE)
+				assert.Equal(t, tt.wantErr, gotErr)
+				return
+			}
+
+			require.NoError(t, gotErr)
+			assert.Equal(t, tt.want, got.Pass)
+
+			if tt.want {
+				assert.Equal(t, got.Result, result.SUCCESS)
+			} else {
+				assert.Equal(t, got.Result, result.FAILURE)
+			}
+		})
+	}
+}

--- a/pkg/plugins/resources/updateclihttp/errors.go
+++ b/pkg/plugins/resources/updateclihttp/errors.go
@@ -1,0 +1,11 @@
+package updateclihttp
+
+import "fmt"
+
+type ErrHttpError struct {
+	resStatusCode int
+}
+
+func (e *ErrHttpError) Error() string {
+	return fmt.Sprintf("[http] status code %d received while 1XX, 2XX or 3XX is expected.", e.resStatusCode)
+}

--- a/pkg/plugins/resources/updateclihttp/main.go
+++ b/pkg/plugins/resources/updateclihttp/main.go
@@ -17,8 +17,12 @@ type Http struct {
 	httpReq    *http.Request
 }
 
-// New returns a reference to a newly initialized (TODO)
-// or an error if the provided Spec triggers a validation error.
+/*
+*
+New returns a reference to a newly initialized Http resource
+or an error if the provided Spec triggers a validation error.
+*
+*/
 func New(spec interface{}) (*Http, error) {
 
 	newSpec := Spec{}

--- a/pkg/plugins/resources/updateclihttp/main.go
+++ b/pkg/plugins/resources/updateclihttp/main.go
@@ -1,0 +1,89 @@
+package updateclihttp
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/mitchellh/mapstructure"
+	"github.com/sirupsen/logrus"
+	"github.com/updatecli/updatecli/pkg/core/httpclient"
+)
+
+// Http defines a resource of type "http"
+type Http struct {
+	spec       Spec
+	httpClient httpclient.HTTPClient
+	httpReq    *http.Request
+}
+
+// New returns a reference to a newly initialized (TODO)
+// or an error if the provided Spec triggers a validation error.
+func New(spec interface{}) (*Http, error) {
+
+	newSpec := Spec{}
+
+	err := mapstructure.Decode(spec, &newSpec)
+	if err != nil {
+		return nil, err
+	}
+
+	if newSpec.Url == "" {
+		return nil, fmt.Errorf("spec.url is not set but required.")
+	}
+
+	if newSpec.ResponseAsserts.StatusCode != 0 || len(newSpec.ResponseAsserts.Headers) > 0 {
+		// This resource is a condition as the asserts are specified
+		if newSpec.ReturnResponseHeader != "" {
+			// Cannot be both source and condition
+			return nil, fmt.Errorf("Cannot define both spec.responseasserts (source only) and spec.responseasserts (condition only).")
+		}
+	}
+
+	httpClient := http.DefaultClient
+	httpClient.Transport = httpclient.NewThrottledTransport(1*time.Second, 1, http.DefaultTransport)
+
+	// Do not follow redirect as per https://pkg.go.dev/net/http when we want to get a header from original request
+	httpClient.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		if newSpec.ReturnResponseHeader != "" || newSpec.Request.NoFollowRedirects || newSpec.ResponseAsserts.StatusCode > 0 || len(newSpec.ResponseAsserts.Headers) > 0 {
+			logrus.Debugf("spec.returnresponseheader defined: HTTP client won't follow redirects")
+			return http.ErrUseLastResponse
+		}
+
+		return nil
+	}
+
+	httpVerb := http.MethodGet
+	if newSpec.Request.Verb != "" {
+		httpVerb = newSpec.Request.Verb
+	}
+	httpReq, err := http.NewRequest(httpVerb, newSpec.Url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	newResource := &Http{
+		spec:       newSpec,
+		httpClient: httpClient,
+		httpReq:    httpReq,
+	}
+
+	return newResource, nil
+}
+
+// Changelog returns the changelog for this resource, or an empty string if not supported
+func (h *Http) Changelog() string {
+	return h.spec.Url
+}
+
+func (h *Http) performHttpRequest() (*http.Response, error) {
+	logrus.Debugf("[http] Request to execute: %v", h.httpReq)
+	httpRes, err := h.httpClient.Do(h.httpReq)
+	if err != nil {
+		return nil, err
+	}
+
+	logrus.Debugf("[http] Response received: %v", httpRes)
+
+	return httpRes, nil
+}

--- a/pkg/plugins/resources/updateclihttp/main_test.go
+++ b/pkg/plugins/resources/updateclihttp/main_test.go
@@ -1,0 +1,112 @@
+package updateclihttp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNew(t *testing.T) {
+	tests := []struct {
+		name     string
+		url      string
+		spec     Spec
+		wantSpec Spec
+		wantErr  bool
+	}{
+		{
+			name: "Normal case with default index",
+			spec: Spec{
+				Url: "https://www.google.com",
+			},
+			wantSpec: Spec{
+				Url: "https://www.google.com",
+			},
+		},
+		{
+			name: "Source to return response header instead of body with custom request",
+			spec: Spec{
+				Url:                  "https://www.google.com",
+				ReturnResponseHeader: "Location",
+				Request: Request{
+					Verb: "POST",
+					Body: multiLineText,
+					Headers: map[string]string{
+						"Authorization": "Bearer Token",
+						"Accept":        "application/json",
+					},
+				},
+			},
+			wantSpec: Spec{
+				Url:                  "https://www.google.com",
+				ReturnResponseHeader: "Location",
+				Request: Request{
+					Verb: "POST",
+					Body: multiLineText,
+					Headers: map[string]string{
+						"Authorization": "Bearer Token",
+						"Accept":        "application/json",
+					},
+				},
+			},
+		},
+		{
+			name: "Condition with asserts on the response",
+			spec: Spec{
+				Url: "https://www.google.com",
+				ResponseAsserts: ResponseAsserts{
+					StatusCode: 404,
+					Headers: map[string]string{
+						"Content-Type":    "application/json",
+						"x-frame-options": "DENY",
+					},
+				},
+			},
+			wantSpec: Spec{
+				Url: "https://www.google.com",
+				ResponseAsserts: ResponseAsserts{
+					StatusCode: 404,
+					Headers: map[string]string{
+						"Content-Type":    "application/json",
+						"x-frame-options": "DENY",
+					},
+				},
+			},
+		},
+		{
+			name: "Error when trying to create a resource with asserts (condition only) and a ReturnResponseHeader (source only)",
+			spec: Spec{
+				Url:                  "https://www.google.com",
+				ReturnResponseHeader: "Content-Type",
+				ResponseAsserts: ResponseAsserts{
+					StatusCode: 404,
+					Headers: map[string]string{
+						"Content-Type":    "application/json",
+						"x-frame-options": "DENY",
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Error when trying to create a resource without URL",
+			spec: Spec{
+				ReturnResponseHeader: "Content-Type",
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, gotErr := New(tt.spec)
+			if tt.wantErr {
+				require.Error(t, gotErr)
+				return
+			}
+
+			require.NoError(t, gotErr)
+			assert.Equal(t, tt.wantSpec, got.spec)
+		})
+	}
+}

--- a/pkg/plugins/resources/updateclihttp/source.go
+++ b/pkg/plugins/resources/updateclihttp/source.go
@@ -9,7 +9,7 @@ import (
 	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
-// Source returns content from the response of the specified HTTP request (defaults to the body)
+// Source returns content from the response of the specified HTTP request (defaults to the body).
 func (h *Http) Source(workingDir string, resultSource *result.Source) error {
 	resultSource.Result = result.FAILURE
 

--- a/pkg/plugins/resources/updateclihttp/source.go
+++ b/pkg/plugins/resources/updateclihttp/source.go
@@ -1,0 +1,45 @@
+package updateclihttp
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/sirupsen/logrus"
+	"github.com/updatecli/updatecli/pkg/core/result"
+)
+
+// Source returns content from the response of the specified HTTP request (defaults to the body)
+func (h *Http) Source(workingDir string, resultSource *result.Source) error {
+	resultSource.Result = result.FAILURE
+
+	httpRes, err := h.performHttpRequest()
+	if err != nil {
+		return err
+	}
+	defer httpRes.Body.Close()
+
+	if httpRes.StatusCode >= http.StatusBadRequest {
+		return &ErrHttpError{resStatusCode: httpRes.StatusCode}
+	}
+
+	resultSource.Result = result.SUCCESS
+	resultSource.Description = fmt.Sprintf("[http] response received from %q.", h.spec.Url)
+
+	if h.spec.ReturnResponseHeader != "" {
+		resultSource.Information = httpRes.Header.Get(h.spec.ReturnResponseHeader)
+		logrus.Debugf("[http] source: header %q found with %d characters", h.spec.ReturnResponseHeader, len(resultSource.Information))
+	} else {
+		b, err := io.ReadAll(httpRes.Body)
+		if err != nil {
+			return err
+		}
+		bodyContent := string(b)
+
+		logrus.Debugf("[http] source: response body received (with %d characters)", len(bodyContent))
+
+		resultSource.Information = bodyContent
+	}
+
+	return nil
+}

--- a/pkg/plugins/resources/updateclihttp/source_test.go
+++ b/pkg/plugins/resources/updateclihttp/source_test.go
@@ -1,0 +1,114 @@
+package updateclihttp
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/updatecli/updatecli/pkg/core/httpclient"
+	"github.com/updatecli/updatecli/pkg/core/result"
+)
+
+const (
+	multiLineText string = `
+<?xml version="1.0" encoding="UTF-8"?>
+<metadata>
+	<groupId>org.jenkins-ci.main</groupId>
+	<artifactId>jenkins-war</artifactId>
+	<versioning>
+		<latest>2.432</latest>
+		<release>2.426.1</release>
+		<versions>
+			<version>2.432</version>
+		</versions>
+		<lastUpdated>20231115143950</lastUpdated>
+	</versioning>
+</metadata>`
+	monoLineText string = "https://azcopyvnext.azureedge.net/releases/release-10.21.2-20231106/azcopy_linux_amd64_10.21.2.tar.gz"
+)
+
+func TestSource(t *testing.T) {
+	tests := []struct {
+		name                  string
+		spec                  Spec
+		workingDir            string
+		mockedHTTPStatusCode  int
+		mockedHTTPBody        string
+		mockedHTTPRespHeaders http.Header
+		mockedHttpError       error
+		want                  string
+		wantStatus            string
+		wantErr               error
+	}{
+		{
+			name: "Normal case with default index",
+			spec: Spec{
+				Url: "https://repo.jenkins-ci.org/releases/org/jenkins-ci/main/jenkins-war/maven-metadata.xml",
+			},
+			mockedHTTPStatusCode: http.StatusOK,
+			mockedHTTPBody:       multiLineText,
+			want:                 multiLineText,
+			wantStatus:           result.SUCCESS,
+		},
+		{
+			name: "Normal case with header as result",
+			spec: Spec{
+				Url:                  "https://repo.jenkins-ci.org/releases/org/jenkins-ci/main/jenkins-war/maven-metadata.xml",
+				ReturnResponseHeader: "Location",
+				Request: Request{
+					Verb: "HEAD",
+				},
+			},
+			mockedHTTPStatusCode: http.StatusPermanentRedirect,
+			mockedHTTPRespHeaders: map[string][]string{
+				"Location": {monoLineText},
+			},
+			want:       monoLineText,
+			wantStatus: result.SUCCESS,
+		},
+		{
+			name: "Error when HTTP code is >= 400",
+			spec: Spec{
+				Url: "https://repo.jenkins-ci.org/releases/org/jenkins-ci/main/jenkins-war/maven-metadata.xml",
+			},
+			mockedHTTPStatusCode: http.StatusInternalServerError,
+			wantErr:              &ErrHttpError{resStatusCode: http.StatusInternalServerError},
+			wantStatus:           result.FAILURE,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sut, sutErr := New(tt.spec)
+			require.NoError(t, sutErr)
+
+			sut.httpClient = &httpclient.MockClient{
+				DoFunc: func(req *http.Request) (*http.Response, error) {
+					body := tt.mockedHTTPBody
+					statusCode := tt.mockedHTTPStatusCode
+					return &http.Response{
+						StatusCode: statusCode,
+						Body:       io.NopCloser(strings.NewReader(body)),
+						Header:     tt.mockedHTTPRespHeaders,
+					}, tt.mockedHttpError
+				},
+			}
+
+			got := result.Source{}
+			gotErr := sut.Source(tt.workingDir, &got)
+
+			if tt.wantErr != nil {
+				require.Error(t, gotErr)
+				assert.Equal(t, got.Result, result.FAILURE)
+				assert.Equal(t, tt.wantErr, gotErr)
+				return
+			}
+
+			require.NoError(t, gotErr)
+			assert.Equal(t, tt.wantStatus, got.Result)
+			assert.Equal(t, tt.want, got.Information)
+		})
+	}
+}

--- a/pkg/plugins/resources/updateclihttp/spec.go
+++ b/pkg/plugins/resources/updateclihttp/spec.go
@@ -1,0 +1,32 @@
+package updateclihttp
+
+// Spec defines a specification for a "http" resource
+// parsed from an updatecli manifest file
+type Spec struct {
+	// [S][C] Specifies the URL to use for the HTTP request of this resource
+	Url string `yaml:",omitempty"`
+	// [S] Specifies the header to return value instead of body
+	ReturnResponseHeader string
+	// [S][C] Specifies custom HTTP request parameters
+	Request Request
+	// [C] Specifies assertions on the HTTP response
+	ResponseAsserts ResponseAsserts
+}
+
+type Request struct {
+	// [S][C] Specifies the HTTP verb for the request to be used. Defaults to "GET".
+	Verb string `yaml:",omitempty"`
+	// [S][C] Specifies the HTTP body for the request to be used. Defaults to "" (empty string).
+	Body string `yaml:",omitempty"`
+	// [S][C] Specifies the HTTP headers for the request to be used. Defaults to an empty map.
+	Headers map[string]string `yaml:",inline,omitempty"`
+	// [S][C] Specifies whether or not to follow redirect. Default to false (e.g. follow), unless spec.returnresponseheader is true
+	NoFollowRedirects bool `yaml:",omitempty"`
+}
+
+type ResponseAsserts struct {
+	// [C] Specifies a set of assertions on the HTTP response headers.
+	Headers map[string]string `yaml:",inline,omitempty"`
+	// [C] Specifies an assertion on the HTTP response status code.
+	StatusCode int `yaml:",omitempty"`
+}

--- a/pkg/plugins/resources/updateclihttp/spec.go
+++ b/pkg/plugins/resources/updateclihttp/spec.go
@@ -1,32 +1,54 @@
 package updateclihttp
 
-// Spec defines a specification for a "http" resource
-// parsed from an updatecli manifest file
+/*
+Spec defines a specification for a "http" resource
+parsed from an updatecli manifest file.
+*/
 type Spec struct {
-	// [S][C] Specifies the URL to use for the HTTP request of this resource
+	/*
+		[S][C] Specifies the URL of the HTTP request for this resource.
+	*/
 	Url string `yaml:",omitempty"`
-	// [S] Specifies the header to return value instead of body
+	/*
+		[S] Specifies the header to return as source value (instead of the body).
+	*/
 	ReturnResponseHeader string
-	// [S][C] Specifies custom HTTP request parameters
+	/*
+		[S][C] Customizes the HTTP request to emit.
+	*/
 	Request Request
-	// [C] Specifies assertions on the HTTP response
+	/*
+		[C] Specifies a set of custom assertions on the HTTP response for the condition.
+	*/
 	ResponseAsserts ResponseAsserts
 }
 
 type Request struct {
-	// [S][C] Specifies the HTTP verb for the request to be used. Defaults to "GET".
+	/*
+		[S][C] Specifies a custom HTTP request verb. Defaults to "GET".
+	*/
 	Verb string `yaml:",omitempty"`
-	// [S][C] Specifies the HTTP body for the request to be used. Defaults to "" (empty string).
+	/*
+		[S][C] Specifies a custom HTTP request body. Defaults to "" (empty string).
+	*/
 	Body string `yaml:",omitempty"`
-	// [S][C] Specifies the HTTP headers for the request to be used. Defaults to an empty map.
+	/*
+		[S][C] Specifies custom HTTP request headers. Defaults to an empty map.
+	*/
 	Headers map[string]string `yaml:",inline,omitempty"`
-	// [S][C] Specifies whether or not to follow redirect. Default to false (e.g. follow), unless spec.returnresponseheader is true
+	/*
+		[S][C] Specifies whether or not to follow redirects. Default to false (e.g. follow HTTP redirections) unless spec.returnresponseheader is set to true (source only).
+	*/
 	NoFollowRedirects bool `yaml:",omitempty"`
 }
 
 type ResponseAsserts struct {
-	// [C] Specifies a set of assertions on the HTTP response headers.
+	/*
+		[C] Specifies a set of assertions on the HTTP response headers.
+	*/
 	Headers map[string]string `yaml:",inline,omitempty"`
-	// [C] Specifies an assertion on the HTTP response status code.
+	/*
+		[C] Specifies a custom assertion on the HTTP response status code.
+	*/
 	StatusCode int `yaml:",omitempty"`
 }

--- a/pkg/plugins/resources/updateclihttp/target.go
+++ b/pkg/plugins/resources/updateclihttp/target.go
@@ -1,0 +1,11 @@
+package updateclihttp
+
+import (
+	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
+	"github.com/updatecli/updatecli/pkg/core/result"
+)
+
+// Target
+func (h *Http) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
+	return nil
+}

--- a/pkg/plugins/resources/updateclihttp/target.go
+++ b/pkg/plugins/resources/updateclihttp/target.go
@@ -5,7 +5,7 @@ import (
 	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
-// Target
+// Target is not implemented. If you ever feel the need, you can still open a GitHub issue with a valid usecase.
 func (h *Http) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
 	return nil
 }


### PR DESCRIPTION
Implements #268

This PR introduces a new resource of type `http` with source and condition capability.

The initial UX proposal has been updated to ensure separation between source and condition are easier (see the E2E test).

Here is a "complete reference example":

```
sources:
  getWithCustomRequest:
    kind: http
    spec:
      url: https://repo.jenkins-ci.org/releases/org/jenkins-ci/main/jenkins-war/maven-metadata.xml
      request:
        headers:
          Authorization: 'Bearer Token'
          Accept: 'application/xml'
        verb: GET

conditions:
  checkWithCustomRequest:
    kind: http
    sourceid: getJenkinsWarArtifactMetadatas
    spec:
      url: https://repo.jenkins-ci.org/releases/org/jenkins-ci/main/jenkins-war/maven-metadata.xml
      request:
        headers:
          Authorization: 'Bearer Token'
          Accept: 'application/xml'
        verb: HEAD
      responseasserts:
        statuscode: 302
        headers:
          Content-Type: "text/html; charset=utf-8"
```

## Test

To test this pull request, you can run the following commands:

```shell
cd ./pkg/plugins/resources/updateclihttp/
go test
```

## Additional Information

- For a source, both HTTP/4xx and HTTP/5xx response status code are considered a failure (as both client and server side errors are not expected to provide a body). This behavior can be adapted on a subsequent PR if we have a use case to retrieve a body on a HTTP/404 error.
- For a condition there are 2 cases:
  - If no assertion is provided, HTTP/5xx is considered an error, while HTTP/4xx is considered a non passing condition.
  - If assertion is provided, then the status code is compared to the provided status code assertion