### PR TITLE
chore: factorize condition result code out of resource plugins

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -110,7 +110,7 @@ A short one-line description of the parameter
 
 ===== 3. Respect the contract
 
-Your 'packageName' must provides a `struct` which implements the `Resource` interface by defining the following functions:
+Your 'packageName' must provide a `struct` which implements the `Resource` interface by defining the following functions:
 
 [cols="1,2a,2", options="header"]
 .Rules

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -110,7 +110,7 @@ A short one-line description of the parameter
 
 ===== 3. Respect the contract
 
-Your 'packageName' must respect at least one of the following interface contract by defining appropriated functions.
+Your 'packageName' must provides a `struct` which implements the `Resource` interface by defining the following functions:
 
 [cols="1,2a,2", options="header"]
 .Rules
@@ -121,34 +121,25 @@ Your 'packageName' must respect at least one of the following interface contract
 
 | Source
 | ```
-type Spec interface {
-    Source() (string, error)
-}
+Source(workingDir string, resultSource *result.Source) error
 ```
 | Defines how a version will be retrieved then passed the following stages
 
 | Changelog
 | ```
-type Changelog interface {
-    Changelog(release string) (string, error)
-}
+Changelog() string
 ```
 | Retrieve the changelog for a specific source.
 
 | Condition
 | ```
-type Spec interface {
-    Condition(version string) (bool, error)
-    ConditionFromSCM(version string, scm scm.Scm) (bool, error)
-}
+Condition(source string, scm scm.ScmHandler) (pass bool, message string, err error)
 ```
 | Define a condition which has to pass in order to proceed
 
 | Target
 | ```
-type Spec interface {
-    Target(source string, scm scm.Scm, dryRun bool) (changed bool, files []string, message string, err error)
-
+Target(source string, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error
 ```
 | Define how a target file is updated
 

--- a/pkg/core/pipeline/condition/main.go
+++ b/pkg/core/pipeline/condition/main.go
@@ -74,15 +74,10 @@ func (c *Condition) Run(source string) (err error) {
 		}
 	}
 
-	switch c.Scm == nil {
-	case true:
-		err = condition.Condition(source, nil, &c.Result)
-		if err != nil {
-			return err
-		}
-	case false:
+	var s scm.ScmHandler
+	if c.Scm != nil {
 		// If scm is defined then clone the repository
-		s := *c.Scm
+		s = *c.Scm
 		if err != nil {
 			return err
 		}
@@ -94,11 +89,17 @@ func (c *Condition) Run(source string) (err error) {
 		if err != nil {
 			return err
 		}
+	}
 
-		err = condition.Condition(source, s, &c.Result)
-		if err != nil {
-			return err
-		}
+	ok, message, err := condition.Condition(source, s)
+	if ok {
+		c.Result.Result = result.SUCCESS
+	} else {
+		c.Result.Result = result.FAILURE
+	}
+	c.Result.Description = message
+	if err != nil {
+		return err
 	}
 
 	// FailWhen is used to reverse the expected condition value

--- a/pkg/core/pipeline/resource/main.go
+++ b/pkg/core/pipeline/resource/main.go
@@ -225,7 +225,7 @@ func New(rs ResourceConfig) (resource Resource, err error) {
 // Resource allow to manipulate a resource that can be a source, a condition or a target
 type Resource interface {
 	Source(workingDir string, sourceResult *result.Source) error
-	Condition(version string, scm scm.ScmHandler, resultCondition *result.Condition) error
+	Condition(version string, scm scm.ScmHandler) (pass bool, message string, err error)
 	Target(source string, scm scm.ScmHandler, dryRun bool, targetResult *result.Target) (err error)
 	Changelog() string
 }

--- a/pkg/plugins/resources/awsami/condition.go
+++ b/pkg/plugins/resources/awsami/condition.go
@@ -11,8 +11,6 @@ import (
 
 // Condition tests if an image matching the specific filters exists.
 func (a *AMI) Condition(source string, scm scm.ScmHandler) (pass bool, message string, err error) {
-	// func (a *AMI) Condition(source string, scm scm.ScmHandler, resultCondition *result.Condition) error {
-
 	if scm != nil {
 		logrus.Warningf("condition with SCM is not supported, please remove the scm block")
 		return false, "", errors.New("condition with SCM is not supported")

--- a/pkg/plugins/resources/awsami/condition.go
+++ b/pkg/plugins/resources/awsami/condition.go
@@ -7,21 +7,21 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
-	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
 // Condition tests if an image matching the specific filters exists.
-func (a *AMI) Condition(source string, scm scm.ScmHandler, resultCondition *result.Condition) error {
+func (a *AMI) Condition(source string, scm scm.ScmHandler) (pass bool, message string, err error) {
+	// func (a *AMI) Condition(source string, scm scm.ScmHandler, resultCondition *result.Condition) error {
 
 	if scm != nil {
 		logrus.Warningf("condition with SCM is not supported, please remove the scm block")
-		return errors.New("condition with SCM is not supported")
+		return false, "", errors.New("condition with SCM is not supported")
 	}
 
 	// It's an error if the upstream source is empty and the user does not provide any filter
 	// then it mean
 	if source == "" && len(a.Spec.Filters) == 0 {
-		return ErrNoFilter
+		return false, "", ErrNoFilter
 	}
 
 	isFilterDefined := func(filter string) (found bool) {
@@ -47,21 +47,13 @@ func (a *AMI) Condition(source string, scm scm.ScmHandler, resultCondition *resu
 			strings.ReplaceAll(a.Spec.String(), "\n", "\n  "), "\n "))
 
 	foundAMI, err := a.getLatestAmiID()
-
 	if err != nil {
-		return fmt.Errorf("getting latest AMI ID: %w", err)
+		return false, "", fmt.Errorf("getting latest AMI ID: %w", err)
 	}
 
 	if len(foundAMI) > 0 {
-		resultCondition.Description = fmt.Sprintf("AMI %q found\n", foundAMI)
-		resultCondition.Result = result.SUCCESS
-		resultCondition.Pass = true
-		return nil
+		return true, fmt.Sprintf("AMI %q found\n", foundAMI), nil
 	}
 
-	resultCondition.Result = result.FAILURE
-	resultCondition.Pass = false
-	resultCondition.Description = fmt.Sprintf("no AMI found matching criteria for region %s\n", a.Spec.Region)
-
-	return nil
+	return false, fmt.Sprintf("no AMI found matching criteria for region %s\n", a.Spec.Region), nil
 }

--- a/pkg/plugins/resources/awsami/condition_test.go
+++ b/pkg/plugins/resources/awsami/condition_test.go
@@ -20,7 +20,6 @@ func TestCondition(t *testing.T) {
 		d.ami.apiClient = mockDescribeImagesOutput{
 			Resp: d.mockedResponse,
 		}
-		// gotResult := result.Condition{}
 		got, _, gotErr := d.ami.Condition("", nil)
 
 		switch d.expectedError == nil {

--- a/pkg/plugins/resources/awsami/condition_test.go
+++ b/pkg/plugins/resources/awsami/condition_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
 func TestCondition(t *testing.T) {
@@ -21,18 +20,17 @@ func TestCondition(t *testing.T) {
 		d.ami.apiClient = mockDescribeImagesOutput{
 			Resp: d.mockedResponse,
 		}
-		gotResult := result.Condition{}
-		err := d.ami.Condition("", nil, &gotResult)
+		// gotResult := result.Condition{}
+		got, _, gotErr := d.ami.Condition("", nil)
 
 		switch d.expectedError == nil {
 		case true:
-			require.NoError(t, err)
+			require.NoError(t, gotErr)
 		case false:
-			require.ErrorIs(t, d.expectedError, err)
-
+			require.ErrorIs(t, d.expectedError, gotErr)
 		}
 
-		assert.Equal(t, d.expectedCondition, gotResult.Pass)
+		assert.Equal(t, d.expectedCondition, got)
 
 	}
 
@@ -58,10 +56,9 @@ func TestCondition(t *testing.T) {
 		},
 	}
 
-	gotResult := result.Condition{}
-	err := ami.Condition(imageID, nil, &gotResult)
+	got, _, gotErr := ami.Condition(imageID, nil)
 
-	require.NoError(t, err)
-	assert.Equal(t, true, gotResult.Pass)
+	require.NoError(t, gotErr)
+	assert.Equal(t, true, got)
 
 }

--- a/pkg/plugins/resources/cargopackage/condition.go
+++ b/pkg/plugins/resources/cargopackage/condition.go
@@ -6,11 +6,11 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
-	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
-// Condition test if a tag exists from a git repository specific from SCM
-func (cp *CargoPackage) Condition(source string, scm scm.ScmHandler, resultCondition *result.Condition) error {
+// Condition checks if a cargo package with a specific version is published
+// We assume that if we can't find the package version in the index, then it means it doesn't exist.
+func (cp *CargoPackage) Condition(source string, scm scm.ScmHandler) (pass bool, message string, err error) {
 	if scm != nil {
 		path := scm.GetDirectory()
 		if cp.spec.Registry.RootDir != "" {
@@ -26,37 +26,24 @@ func (cp *CargoPackage) Condition(source string, scm scm.ScmHandler, resultCondi
 		cp.registry.RootDir = path
 	}
 
-	return cp.condition(source, resultCondition)
-}
-
-// Condition checks if a cargo package with a specific version is published
-// We assume that if we can't find the package version in the index, then it means it doesn't exist.
-func (cp *CargoPackage) condition(source string, resultCondition *result.Condition) error {
 	versionToCheck := cp.spec.Version
 	if versionToCheck == "" {
 		versionToCheck = source
 	}
 	if len(versionToCheck) == 0 {
-		return errors.New("no version defined")
+		return false, "", errors.New("no version defined")
 	}
 
 	_, versions, err := cp.getVersions()
 	if err != nil {
-		return fmt.Errorf("getting cargo package version: %w", err)
+		return false, "", fmt.Errorf("getting cargo package version: %w", err)
 	}
 
 	for _, v := range versions {
 		if v == versionToCheck {
-			resultCondition.Result = result.SUCCESS
-			resultCondition.Pass = true
-			resultCondition.Description = fmt.Sprintf("release version %q available\n", versionToCheck)
-			return nil
+			return true, fmt.Sprintf("release version %q available\n", versionToCheck), nil
 		}
 	}
 
-	resultCondition.Result = result.FAILURE
-	resultCondition.Description = fmt.Sprintf("version %q doesn't exist\n", versionToCheck)
-	resultCondition.Pass = false
-
-	return nil
+	return false, fmt.Sprintf("version %q doesn't exist\n", versionToCheck), nil
 }

--- a/pkg/plugins/resources/cargopackage/condition_test.go
+++ b/pkg/plugins/resources/cargopackage/condition_test.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/updatecli/updatecli/pkg/core/result"
 	"github.com/updatecli/updatecli/pkg/plugins/utils/cargo"
 
 	"github.com/stretchr/testify/assert"
@@ -171,15 +170,14 @@ func TestCondition(t *testing.T) {
 			if tt.mockedResponse {
 				got.webClient = GetMockClient(tt.mockedUrl, tt.mockedToken, tt.mockedBody, tt.mockedHTTPStatusCode, tt.mockedHeaderFormat)
 			}
-			gotResult := result.Condition{}
 
-			err = got.Condition("", nil, &gotResult)
+			gotPass, _, gotErr := got.Condition("", nil)
 			if tt.expectedError {
-				assert.Error(t, err)
+				assert.Error(t, gotErr)
 				return
 			}
-			require.NoError(t, err)
-			assert.Equal(t, tt.expectedResult, gotResult.Pass)
+			require.NoError(t, gotErr)
+			assert.Equal(t, tt.expectedResult, gotPass)
 		})
 	}
 }

--- a/pkg/plugins/resources/csv/condition_test.go
+++ b/pkg/plugins/resources/csv/condition_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
 func TestCondition(t *testing.T) {
@@ -94,16 +93,16 @@ func TestCondition(t *testing.T) {
 
 			require.NoError(t, err)
 
-			gotResult := result.Condition{}
-			err = c.Condition("", nil, &gotResult)
+			got, _, gotErr := c.Condition("", nil)
 
 			if tt.wantErr {
-				assert.Equal(t, tt.expectedErrorMsg.Error(), err.Error())
-			} else {
-				require.NoError(t, err)
+				require.Error(t, gotErr)
+				assert.Equal(t, tt.expectedErrorMsg.Error(), gotErr.Error())
+				return
 			}
 
-			assert.Equal(t, tt.expectedResult, gotResult.Pass)
+			require.NoError(t, gotErr)
+			assert.Equal(t, tt.expectedResult, got)
 		})
 	}
 }

--- a/pkg/plugins/resources/dockerdigest/condition.go
+++ b/pkg/plugins/resources/dockerdigest/condition.go
@@ -8,11 +8,10 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/sirupsen/logrus"
 	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
-	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
 // Condition checks if a Docker image tag digest exists in a registry
-func (ds *DockerDigest) Condition(source string, scm scm.ScmHandler, resultCondition *result.Condition) error {
+func (ds *DockerDigest) Condition(source string, scm scm.ScmHandler) (pass bool, message string, err error) {
 	if scm != nil {
 		logrus.Warningln("scm is not supported, ignoring")
 	}
@@ -27,30 +26,17 @@ func (ds *DockerDigest) Condition(source string, scm scm.ScmHandler, resultCondi
 
 	ref, err := name.ParseReference(refName)
 	if err != nil {
-		return fmt.Errorf("invalid image %s: %w", refName, err)
+		return false, "", fmt.Errorf("invalid image %s: %w", refName, err)
 	}
 	_, err = remote.Head(ref, ds.options...)
-
 	if err != nil {
 		if strings.Contains(err.Error(), "unexpected status code 404") {
-
-			resultCondition.Result = result.FAILURE
-			resultCondition.Pass = false
-			resultCondition.Description = fmt.Sprintf("the Docker image %s doesn't exist.",
-				refName,
-			)
-			return nil
+			return false, fmt.Sprintf("the Docker image %s doesn't exist.", refName), nil
 		}
-		return err
+		return false, "", err
 	}
 
-	resultCondition.Result = result.SUCCESS
-	resultCondition.Pass = true
-	resultCondition.Description = fmt.Sprintf("the Docker image %s exists and is available.",
-		refName,
-	)
-
-	return nil
+	return true, fmt.Sprintf("the Docker image %s exists and is available.", refName), nil
 }
 
 // joinImageTagWithName handles the different kind of join tag

--- a/pkg/plugins/resources/dockerdigest/condition_test.go
+++ b/pkg/plugins/resources/dockerdigest/condition_test.go
@@ -91,17 +91,14 @@ func TestCondition(t *testing.T) {
 	}
 
 	for i := range TestCases {
-
 		t.Run(t.Name(), func(t *testing.T) {
 			DockerDigest, err := New(TestCases[i].spec)
 			require.NoError(t, err)
 
-			gotResult := result.Condition{}
+			got, _, gotErr := DockerDigest.Condition(TestCases[i].sourceOutput, nil)
 
-			err = DockerDigest.Condition(TestCases[i].sourceOutput, nil, &gotResult)
-			require.NoError(t, err)
-
-			assert.Equal(t, TestCases[i].expectedResult.Pass, gotResult.Pass)
+			require.NoError(t, gotErr)
+			assert.Equal(t, TestCases[i].expectedResult.Pass, got)
 		})
 	}
 }

--- a/pkg/plugins/resources/dockerfile/condition.go
+++ b/pkg/plugins/resources/dockerfile/condition.go
@@ -8,11 +8,10 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
-	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
 // Condition test if the Dockerfile contains the correct key/value
-func (d *Dockerfile) Condition(source string, scm scm.ScmHandler, resultCondition *result.Condition) error {
+func (d *Dockerfile) Condition(source string, scm scm.ScmHandler) (pass bool, message string, err error) {
 	globalPass := true
 	descriptionList := []string{}
 
@@ -22,11 +21,11 @@ func (d *Dockerfile) Condition(source string, scm scm.ScmHandler, resultConditio
 		}
 
 		if !d.contentRetriever.FileExists(file) {
-			return fmt.Errorf("the file %s does not exist", file)
+			return false, "", fmt.Errorf("the file %s does not exist", file)
 		}
 		dockerfileContent, err := d.contentRetriever.ReadAll(file)
 		if err != nil {
-			return fmt.Errorf("reading dockerfile: %w", err)
+			return false, "", fmt.Errorf("reading dockerfile: %w", err)
 		}
 
 		logrus.Debugf("\n🐋 On (Docker)file %q:\n\n", file)
@@ -49,16 +48,5 @@ func (d *Dockerfile) Condition(source string, scm scm.ScmHandler, resultConditio
 		}
 	}
 
-	resultCondition.Pass = globalPass
-
-	if globalPass {
-		resultCondition.Result = result.SUCCESS
-	} else {
-		resultCondition.Result = result.FAILURE
-	}
-
-	if len(descriptionList) > 0 {
-		resultCondition.Description = strings.Join(descriptionList, ", ")
-	}
-	return nil
+	return globalPass, strings.Join(descriptionList, ", "), nil
 }

--- a/pkg/plugins/resources/dockerfile/condition_test.go
+++ b/pkg/plugins/resources/dockerfile/condition_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
-	"github.com/updatecli/updatecli/pkg/core/result"
 	"github.com/updatecli/updatecli/pkg/core/text"
 )
 
@@ -100,8 +99,7 @@ func TestDockerfile_Condition(t *testing.T) {
 				files:            tt.files,
 			}
 
-			gotResult := result.Condition{}
-			gotErr := d.Condition(tt.inputSourceValue, tt.scm, &gotResult)
+			got, _, gotErr := d.Condition(tt.inputSourceValue, tt.scm)
 			if tt.wantErr != nil {
 				assert.Equal(t, tt.wantErr, gotErr)
 				return
@@ -109,7 +107,7 @@ func TestDockerfile_Condition(t *testing.T) {
 
 			require.NoError(t, gotErr)
 
-			assert.Equal(t, tt.wantChanged, gotResult.Pass)
+			assert.Equal(t, tt.wantChanged, got)
 		})
 	}
 }

--- a/pkg/plugins/resources/dockerimage/condition_test.go
+++ b/pkg/plugins/resources/dockerimage/condition_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
 func TestCondition(t *testing.T) {
@@ -85,16 +84,15 @@ func TestCondition(t *testing.T) {
 			got, err := New(tt.spec)
 			require.NoError(t, err)
 
-			gotResult := result.Condition{}
-			err = got.Condition(tt.source, nil, &gotResult)
+			gotPass, _, gotErr := got.Condition(tt.source, nil)
 
 			if tt.expectedError {
-				assert.Error(t, err)
+				assert.Error(t, gotErr)
 			} else {
-				require.NoError(t, err)
+				require.NoError(t, gotErr)
 			}
 
-			assert.Equal(t, tt.expectedResult, gotResult.Pass)
+			assert.Equal(t, tt.expectedResult, gotPass)
 		})
 	}
 }

--- a/pkg/plugins/resources/gitea/branch/condition.go
+++ b/pkg/plugins/resources/gitea/branch/condition.go
@@ -5,10 +5,9 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
-	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
-func (g *Gitea) Condition(source string, scm scm.ScmHandler, resultCondition *result.Condition) error {
+func (g *Gitea) Condition(source string, scm scm.ScmHandler) (pass bool, message string, err error) {
 	if scm != nil {
 		logrus.Warningf("Condition not supported for the plugin GitHub Release")
 	}
@@ -21,24 +20,18 @@ func (g *Gitea) Condition(source string, scm scm.ScmHandler, resultCondition *re
 	branches, err := g.SearchBranches()
 
 	if err != nil {
-		return err
+		return false, "", err
 	}
 
 	if len(branches) == 0 {
-		return fmt.Errorf("no Gitea branch found")
+		return false, "", fmt.Errorf("no Gitea branch found")
 	}
 
 	for _, b := range branches {
 		if b == branch {
-			resultCondition.Result = result.SUCCESS
-			resultCondition.Pass = true
-			resultCondition.Description = fmt.Sprintf("Gitea branch %q found", b)
-			return nil
+			return true, fmt.Sprintf("Gitea branch %q found", b), nil
 		}
 	}
 
-	resultCondition.Result = result.FAILURE
-	resultCondition.Description = fmt.Sprintf("no Gitea branch found matching pattern %q", g.versionFilter.Pattern)
-
-	return nil
+	return false, fmt.Sprintf("no Gitea branch found matching pattern %q", g.versionFilter.Pattern), nil
 }

--- a/pkg/plugins/resources/gitea/branch/condition_test.go
+++ b/pkg/plugins/resources/gitea/branch/condition_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
 func TestCondition(t *testing.T) {
@@ -67,8 +66,7 @@ func TestCondition(t *testing.T) {
 			g, gotErr := New(tt.manifest)
 			require.NoError(t, gotErr)
 
-			gotResult := result.Condition{}
-			gotErr = g.Condition("", nil, &gotResult)
+			gotPass, _, gotErr := g.Condition("", nil)
 
 			if tt.wantErr {
 				require.Error(t, gotErr)
@@ -76,7 +74,7 @@ func TestCondition(t *testing.T) {
 				require.NoError(t, gotErr)
 			}
 
-			assert.Equal(t, tt.wantResult, gotResult.Pass)
+			assert.Equal(t, tt.wantResult, gotPass)
 
 		})
 

--- a/pkg/plugins/resources/gitea/release/condition_test.go
+++ b/pkg/plugins/resources/gitea/release/condition_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
 func TestCondition(t *testing.T) {
@@ -106,8 +105,7 @@ func TestCondition(t *testing.T) {
 			g, gotErr := New(tt.manifest)
 			require.NoError(t, gotErr)
 
-			gotResult := result.Condition{}
-			gotErr = g.Condition("", nil, &gotResult)
+			gotResult, _, gotErr := g.Condition("", nil)
 
 			if tt.wantErr {
 				if assert.Error(t, gotErr) {
@@ -117,7 +115,7 @@ func TestCondition(t *testing.T) {
 				require.NoError(t, gotErr)
 			}
 
-			assert.Equal(t, tt.wantResult, gotResult.Pass)
+			assert.Equal(t, tt.wantResult, gotResult)
 
 		})
 

--- a/pkg/plugins/resources/gitea/tag/condition.go
+++ b/pkg/plugins/resources/gitea/tag/condition.go
@@ -5,10 +5,9 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
-	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
-func (g *Gitea) Condition(source string, scm scm.ScmHandler, resultCondition *result.Condition) error {
+func (g *Gitea) Condition(source string, scm scm.ScmHandler) (pass bool, message string, err error) {
 	if scm != nil {
 		logrus.Warningf("Condition not supported for the plugin Gitea tag")
 	}
@@ -20,25 +19,18 @@ func (g *Gitea) Condition(source string, scm scm.ScmHandler, resultCondition *re
 
 	tags, err := g.SearchTags()
 	if err != nil {
-		return fmt.Errorf("looking for Gitea tag: %w", err)
+		return false, "", fmt.Errorf("looking for Gitea tag: %w", err)
 	}
 
 	if len(tags) == 0 {
-		return fmt.Errorf("no Gitea Tags found")
+		return false, "", fmt.Errorf("no Gitea Tags found")
 	}
 
 	for _, t := range tags {
 		if t == tag {
-			resultCondition.Pass = true
-			resultCondition.Result = result.SUCCESS
-			resultCondition.Description = fmt.Sprintf("Gitea tag %q found", t)
-			return nil
+			return true, fmt.Sprintf("Gitea tag %q found", t), nil
 		}
 	}
 
-	resultCondition.Description = fmt.Sprintf("no Gitea tag found matching %q", g.spec.Tag)
-	resultCondition.Pass = false
-	resultCondition.Result = result.FAILURE
-
-	return nil
+	return false, fmt.Sprintf("no Gitea tag found matching %q", g.spec.Tag), nil
 }

--- a/pkg/plugins/resources/gitea/tag/condition_test.go
+++ b/pkg/plugins/resources/gitea/tag/condition_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
 func TestCondition(t *testing.T) {
@@ -103,8 +102,7 @@ func TestCondition(t *testing.T) {
 			g, gotErr := New(tt.manifest)
 			require.NoError(t, gotErr)
 
-			gotResult := result.Condition{}
-			gotErr = g.Condition("", nil, &gotResult)
+			gotPass, _, gotErr := g.Condition("", nil)
 
 			if tt.wantErr {
 				if assert.Error(t, gotErr) {
@@ -114,7 +112,7 @@ func TestCondition(t *testing.T) {
 				require.NoError(t, gotErr)
 			}
 
-			assert.Equal(t, tt.wantResult, gotResult.Pass)
+			assert.Equal(t, tt.wantResult, gotPass)
 		})
 
 	}

--- a/pkg/plugins/resources/gitlab/branch/condition.go
+++ b/pkg/plugins/resources/gitlab/branch/condition.go
@@ -4,24 +4,20 @@ import (
 	"fmt"
 
 	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
-	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
-func (g *Gitlab) Condition(source string, scm scm.ScmHandler, resultCondition *result.Condition) error {
+func (g *Gitlab) Condition(source string, scm scm.ScmHandler) (pass bool, message string, err error) {
 	if scm != nil {
-		return fmt.Errorf("Condition not supported for the plugin GitLab branch")
+		return false, "", fmt.Errorf("Condition not supported for the plugin GitLab branch")
 	}
 
 	branches, err := g.SearchBranches()
 	if err != nil {
-		return fmt.Errorf("looking for GitLab branch: %w", err)
+		return false, "", fmt.Errorf("looking for GitLab branch: %w", err)
 	}
 
 	if len(branches) == 0 {
-		resultCondition.Pass = false
-		resultCondition.Result = result.FAILURE
-		resultCondition.Description = "no GitLab branch found"
-		return nil
+		return false, "no GitLab branch found", nil
 	}
 
 	branch := source
@@ -30,16 +26,9 @@ func (g *Gitlab) Condition(source string, scm scm.ScmHandler, resultCondition *r
 	}
 	for _, b := range branches {
 		if b == branch {
-			resultCondition.Pass = true
-			resultCondition.Result = result.SUCCESS
-			resultCondition.Description = fmt.Sprintf("GitLab branch %q found", b)
-			return nil
+			return true, fmt.Sprintf("GitLab branch %q found", b), nil
 		}
 	}
 
-	resultCondition.Result = result.FAILURE
-	resultCondition.Pass = false
-	resultCondition.Description = fmt.Sprintf("no GitLab branch found matching pattern %q", g.versionFilter.Pattern)
-
-	return nil
+	return false, fmt.Sprintf("no GitLab branch found matching pattern %q", g.versionFilter.Pattern), nil
 }

--- a/pkg/plugins/resources/gitlab/branch/condition_test.go
+++ b/pkg/plugins/resources/gitlab/branch/condition_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
 func TestCondition(t *testing.T) {
@@ -85,8 +84,7 @@ func TestCondition(t *testing.T) {
 			g, gotErr := New(tt.manifest)
 			require.NoError(t, gotErr)
 
-			gotResult := result.Condition{}
-			gotErr = g.Condition("", nil, &gotResult)
+			gotResult, _, gotErr := g.Condition("", nil)
 
 			if tt.wantErr {
 				require.Error(t, gotErr)
@@ -94,7 +92,7 @@ func TestCondition(t *testing.T) {
 				require.NoError(t, gotErr)
 			}
 
-			assert.Equal(t, tt.wantResult, gotResult.Pass)
+			assert.Equal(t, tt.wantResult, gotResult)
 
 		})
 

--- a/pkg/plugins/resources/gitlab/release/condition_test.go
+++ b/pkg/plugins/resources/gitlab/release/condition_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
 func TestCondition(t *testing.T) {
@@ -117,8 +116,7 @@ func TestCondition(t *testing.T) {
 			g, gotErr := New(tt.manifest)
 			require.NoError(t, gotErr)
 
-			gotResult := result.Condition{}
-			gotErr = g.Condition("", nil, &gotResult)
+			gotResult, _, gotErr := g.Condition("", nil)
 
 			if tt.wantErr {
 				require.Error(t, gotErr)
@@ -126,7 +124,7 @@ func TestCondition(t *testing.T) {
 				require.NoError(t, gotErr)
 			}
 
-			assert.Equal(t, tt.wantResult, gotResult.Pass)
+			assert.Equal(t, tt.wantResult, gotResult)
 
 		})
 

--- a/pkg/plugins/resources/gitlab/tag/condition.go
+++ b/pkg/plugins/resources/gitlab/tag/condition.go
@@ -5,24 +5,20 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
-	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
-func (g *Gitlab) Condition(source string, scm scm.ScmHandler, resultCondition *result.Condition) error {
+func (g *Gitlab) Condition(source string, scm scm.ScmHandler) (pass bool, message string, err error) {
 	if scm != nil {
 		logrus.Warningf("Condition not supported for the plugin GitHub Release")
 	}
 
 	tags, err := g.SearchTags()
 	if err != nil {
-		return fmt.Errorf("looking for GitLab tags: %w", err)
+		return false, "", fmt.Errorf("looking for GitLab tags: %w", err)
 	}
 
 	if len(tags) == 0 {
-		resultCondition.Result = result.FAILURE
-		resultCondition.Pass = false
-		resultCondition.Description = "no GitLab tag found"
-		return nil
+		return false, "no GitLab tag found", nil
 	}
 
 	tag := source
@@ -31,16 +27,9 @@ func (g *Gitlab) Condition(source string, scm scm.ScmHandler, resultCondition *r
 	}
 	for _, t := range tags {
 		if t == tag {
-			resultCondition.Result = result.SUCCESS
-			resultCondition.Pass = true
-			resultCondition.Description = fmt.Sprintf("GitLab tag %q found", t)
-			return nil
+			return true, fmt.Sprintf("GitLab tag %q found", t), nil
 		}
 	}
 
-	resultCondition.Result = result.FAILURE
-	resultCondition.Pass = false
-	resultCondition.Description = fmt.Sprintf("no GitLab tag found matching pattern %q of kind %q", g.spec.VersionFilter.Pattern, g.spec.VersionFilter.Kind)
-
-	return nil
+	return false, fmt.Sprintf("no GitLab tag found matching pattern %q of kind %q", g.spec.VersionFilter.Pattern, g.spec.VersionFilter.Kind), nil
 }

--- a/pkg/plugins/resources/gitlab/tag/condition_test.go
+++ b/pkg/plugins/resources/gitlab/tag/condition_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
 func TestCondition(t *testing.T) {
@@ -99,8 +98,7 @@ func TestCondition(t *testing.T) {
 			g, gotErr := New(tt.manifest)
 			require.NoError(t, gotErr)
 
-			gotResult := result.Condition{}
-			gotErr = g.Condition("", nil, &gotResult)
+			gotResult, _, gotErr := g.Condition("", nil)
 
 			if tt.wantErr {
 				require.Error(t, gotErr)
@@ -108,7 +106,7 @@ func TestCondition(t *testing.T) {
 				require.NoError(t, gotErr)
 			}
 
-			assert.Equal(t, tt.wantResult, gotResult.Pass)
+			assert.Equal(t, tt.wantResult, gotResult)
 
 		})
 

--- a/pkg/plugins/resources/go/gomod/condition.go
+++ b/pkg/plugins/resources/go/gomod/condition.go
@@ -1,57 +1,48 @@
 package gomod
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
-	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
 // Condition checks if a specific stable Golang version is published
-func (g *GoMod) Condition(source string, scm scm.ScmHandler, resultCondition *result.Condition) error {
-	var err error
-
+func (g *GoMod) Condition(source string, scm scm.ScmHandler) (pass bool, message string, err error) {
 	versionToCheck := g.spec.Version
 	if versionToCheck == "" {
 		versionToCheck = source
 	}
 
 	if len(versionToCheck) == 0 {
-		return errors.New("no version defined")
+		return false, "no version defined", nil
 	}
 
 	g.foundVersion, err = g.version(g.filename)
 	if err != nil {
 		if err == ErrModuleNotFound {
-			return fmt.Errorf("module path %q not found", g.spec.Module)
+			return false, "", fmt.Errorf("module path %q not found", g.spec.Module)
 		}
 
-		return fmt.Errorf("looking for Golang version: %w", err)
+		return false, "", fmt.Errorf("looking for Golang version: %w", err)
 	}
 
 	if g.foundVersion == versionToCheck {
 		switch g.kind {
 		case kindGolang:
-			resultCondition.Result = result.SUCCESS
-			resultCondition.Pass = true
-			resultCondition.Description = fmt.Sprintf("Golang version %q found", g.foundVersion)
+			return true, fmt.Sprintf("Golang version %q found", g.foundVersion), nil
 
 		case kindModule:
-			resultCondition.Result = result.SUCCESS
-			resultCondition.Pass = true
-			resultCondition.Description = fmt.Sprintf("Module version %q found for %q", g.foundVersion, g.spec.Module)
+			return true, fmt.Sprintf("Module version %q found for %q", g.foundVersion, g.spec.Module), nil
 		}
-		return nil
 	}
 
 	switch g.kind {
 	case kindGolang:
-		return fmt.Errorf("golang version %q found, expecting %q",
-			g.foundVersion, versionToCheck)
+		return false, fmt.Sprintf("golang version %q found, expecting %q",
+			g.foundVersion, versionToCheck), nil
 	case kindModule:
-		return fmt.Errorf("golang module version %q found for %q, expecting %q",
-			g.foundVersion, g.spec.Module, versionToCheck)
+		return false, fmt.Sprintf("golang module version %q found for %q, expecting %q",
+			g.foundVersion, g.spec.Module, versionToCheck), nil
 	}
-	return fmt.Errorf("something unexpected happened")
+	return false, "", fmt.Errorf("something unexpected happened")
 }

--- a/pkg/plugins/resources/go/gomod/condition_test.go
+++ b/pkg/plugins/resources/go/gomod/condition_test.go
@@ -1,12 +1,10 @@
 package gomod
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
 func TestCondition(t *testing.T) {
@@ -31,34 +29,29 @@ func TestCondition(t *testing.T) {
 				Module:  "sigs.k8s.io/yaml",
 				Version: "v0.0.99",
 			},
-			expectedResult:   false,
-			expectedError:    true,
-			expectedErrorMsg: errors.New("golang module version \"v1.3.0\" found for \"sigs.k8s.io/yaml\", expecting \"v0.0.99\""),
+			expectedResult: false,
 		},
 		{
 			spec: Spec{
 				File:    "testdata/go.mod",
 				Version: "v0.0.99",
 			},
-			expectedResult:   false,
-			expectedError:    true,
-			expectedErrorMsg: errors.New("golang version \"1.20\" found, expecting \"v0.0.99\""),
+			expectedResult: false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := New(tt.spec)
 			require.NoError(t, err)
-			gotResult := result.Condition{}
-			err = got.Condition("", nil, &gotResult)
+			gotResult, _, gotErr := got.Condition("", nil)
 			if tt.expectedError {
-				if assert.Error(t, err) {
-					assert.Equal(t, err.Error(), tt.expectedErrorMsg.Error())
+				if assert.Error(t, gotErr) {
+					assert.Equal(t, gotErr.Error(), tt.expectedErrorMsg.Error())
 				}
 				return
 			}
-			require.NoError(t, err)
-			assert.Equal(t, tt.expectedResult, gotResult.Pass)
+			require.NoError(t, gotErr)
+			assert.Equal(t, tt.expectedResult, gotResult)
 		})
 	}
 }

--- a/pkg/plugins/resources/go/language/condition.go
+++ b/pkg/plugins/resources/go/language/condition.go
@@ -1,16 +1,14 @@
 package language
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/sirupsen/logrus"
 	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
-	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
 // Condition checks if a specific stable Golang version is published
-func (l *Language) Condition(source string, scm scm.ScmHandler, resultCondition *result.Condition) error {
+func (l *Language) Condition(source string, scm scm.ScmHandler) (pass bool, message string, err error) {
 	if scm != nil {
 		logrus.Debugln("scm is not supported")
 	}
@@ -19,22 +17,19 @@ func (l *Language) Condition(source string, scm scm.ScmHandler, resultCondition 
 		versionToCheck = source
 	}
 	if len(versionToCheck) == 0 {
-		return errors.New("no version defined")
+		return false, "", fmt.Errorf("no version defined")
 	}
 
 	versions, err := l.versions()
 	if err != nil {
-		return fmt.Errorf("searching golang version: %w", err)
+		return false, "", fmt.Errorf("searching golang version: %w", err)
 	}
 
 	for _, v := range versions {
 		if v == versionToCheck {
-			resultCondition.Pass = true
-			resultCondition.Result = result.SUCCESS
-			resultCondition.Description = fmt.Sprintf("Golang version %q available", versionToCheck)
-			return nil
+			return true, fmt.Sprintf("Golang version %q available", versionToCheck), nil
 		}
 	}
 
-	return fmt.Errorf("golang version %q doesn't exist", versionToCheck)
+	return false, fmt.Sprintf("golang version %q doesn't exist", versionToCheck), nil
 }

--- a/pkg/plugins/resources/go/language/condition_test.go
+++ b/pkg/plugins/resources/go/language/condition_test.go
@@ -1,12 +1,10 @@
 package language
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
 func TestCondition(t *testing.T) {
@@ -29,9 +27,7 @@ func TestCondition(t *testing.T) {
 			spec: Spec{
 				Version: "1.11.1111",
 			},
-			expectedResult:   false,
-			expectedError:    true,
-			expectedErrorMsg: errors.New("golang version \"1.11.1111\" doesn't exist"),
+			expectedResult: false,
 		},
 	}
 	for _, tt := range tests {
@@ -39,8 +35,7 @@ func TestCondition(t *testing.T) {
 			got, err := New(tt.spec)
 			require.NoError(t, err)
 
-			gotResult := result.Condition{}
-			err = got.Condition("", nil, &gotResult)
+			gotResult, _, err := got.Condition("", nil)
 			if tt.expectedError {
 				if assert.Error(t, err) {
 					assert.Equal(t, tt.expectedErrorMsg.Error(), err.Error())
@@ -48,7 +43,7 @@ func TestCondition(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
-			assert.Equal(t, tt.expectedResult, gotResult.Pass)
+			assert.Equal(t, tt.expectedResult, gotResult)
 		})
 	}
 

--- a/pkg/plugins/resources/go/module/condition.go
+++ b/pkg/plugins/resources/go/module/condition.go
@@ -1,36 +1,31 @@
 package gomodule
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
-	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
 // Condition checks if a go module with a specific version is published
-func (g *GoModule) Condition(source string, scm scm.ScmHandler, resultCondition *result.Condition) error {
+func (g *GoModule) Condition(source string, scm scm.ScmHandler) (pass bool, message string, err error) {
 	versionToCheck := g.Spec.Version
 	if versionToCheck == "" {
 		versionToCheck = source
 	}
 	if len(versionToCheck) == 0 {
-		return errors.New("no version defined")
+		return false, "", fmt.Errorf("no version defined")
 	}
 
 	_, versions, err := g.versions()
 	if err != nil {
-		return fmt.Errorf("searching version: %w", err)
+		return false, "", fmt.Errorf("searching version: %w", err)
 	}
 
 	for _, v := range versions {
 		if v == versionToCheck {
-			resultCondition.Pass = true
-			resultCondition.Result = result.SUCCESS
-			resultCondition.Description = fmt.Sprintf("version %q available", versionToCheck)
-			return nil
+			return true, fmt.Sprintf("version %q available", versionToCheck), nil
 		}
 	}
 
-	return fmt.Errorf("version %q doesn't exist", versionToCheck)
+	return false, fmt.Sprintf("version %q doesn't exist", versionToCheck), nil
 }

--- a/pkg/plugins/resources/go/module/condition_test.go
+++ b/pkg/plugins/resources/go/module/condition_test.go
@@ -1,12 +1,10 @@
 package gomodule
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
 func TestCondition(t *testing.T) {
@@ -39,25 +37,22 @@ func TestCondition(t *testing.T) {
 				Module:  "github.com/MakeNowJust/heredoc",
 				Version: "v0.0.0",
 			},
-			expectedResult:   true,
-			expectedError:    true,
-			expectedErrorMsg: errors.New("version \"v0.0.0\" doesn't exist"),
+			expectedResult: false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := New(tt.spec)
 			require.NoError(t, err)
-			gotResult := result.Condition{}
-			err = got.Condition("", nil, &gotResult)
+			gotResult, _, gotErr := got.Condition("", nil)
 			if tt.expectedError {
-				if assert.Error(t, err) {
-					assert.Equal(t, tt.expectedErrorMsg.Error(), err.Error())
+				if assert.Error(t, gotErr) {
+					assert.Equal(t, tt.expectedErrorMsg.Error(), gotErr.Error())
 				}
 				return
 			}
-			require.NoError(t, err)
-			assert.Equal(t, tt.expectedResult, gotResult.Pass)
+			require.NoError(t, gotErr)
+			assert.Equal(t, tt.expectedResult, gotResult)
 		})
 	}
 

--- a/pkg/plugins/resources/hcl/condition_test.go
+++ b/pkg/plugins/resources/hcl/condition_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
 func TestCondition(t *testing.T) {
@@ -92,16 +91,15 @@ func TestCondition(t *testing.T) {
 
 			require.NoError(t, err)
 
-			gotResult := result.Condition{}
-			err = h.Condition(tt.source, nil, &gotResult)
+			gotResult, _, gotErr := h.Condition(tt.source, nil)
 
 			if tt.wantErr {
-				assert.Equal(t, tt.expectedErrorMsg.Error(), err.Error())
+				assert.Equal(t, tt.expectedErrorMsg.Error(), gotErr.Error())
 			} else {
-				require.NoError(t, err)
+				require.NoError(t, gotErr)
 			}
 
-			assert.Equal(t, tt.expectedResult, gotResult.Pass)
+			assert.Equal(t, tt.expectedResult, gotResult)
 		})
 	}
 }

--- a/pkg/plugins/resources/helm/condition.go
+++ b/pkg/plugins/resources/helm/condition.go
@@ -8,14 +8,13 @@ import (
 	"helm.sh/helm/v3/pkg/repo"
 
 	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
-	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
 // Condition checks if a specific chart version exist
-func (c *Chart) Condition(source string, scm scm.ScmHandler, resultCondition *result.Condition) error {
+func (c *Chart) Condition(source string, scm scm.ScmHandler) (pass bool, message string, err error) {
 
 	if strings.HasPrefix(c.spec.URL, "oci://") {
-		return c.OCICondition(source, scm, resultCondition)
+		return c.OCICondition(source, scm)
 	}
 
 	if c.spec.Version != "" {
@@ -25,12 +24,11 @@ func (c *Chart) Condition(source string, scm scm.ScmHandler, resultCondition *re
 	}
 
 	var index repo.IndexFile
-	var err error
 
 	if strings.HasPrefix(c.spec.URL, "https://") || strings.HasPrefix(c.spec.URL, "http://") {
 		index, err = c.GetRepoIndexFromURL()
 		if err != nil {
-			return err
+			return false, "", err
 		}
 	} else {
 		rootDir := ""
@@ -39,22 +37,19 @@ func (c *Chart) Condition(source string, scm scm.ScmHandler, resultCondition *re
 		}
 		index, err = c.GetRepoIndexFromFile(rootDir)
 		if err != nil {
-			return err
+			return false, "", err
 		}
 	}
 
-	message := ""
+	baseMessage := ""
 	if c.spec.Version != "" {
-		message = fmt.Sprintf(" for version '%s'", c.spec.Version)
+		baseMessage = fmt.Sprintf(" for version '%s'", c.spec.Version)
 	}
 
 	if index.Has(c.spec.Name, c.spec.Version) {
-		resultCondition.Pass = true
-		resultCondition.Result = result.SUCCESS
-		resultCondition.Description = fmt.Sprintf("Helm Chart %q is available on %s%s", c.spec.Name, c.spec.URL, message)
-		return nil
+		return true, fmt.Sprintf("Helm Chart %q is available on %s%s", c.spec.Name, c.spec.URL, baseMessage), nil
 	}
 
-	return fmt.Errorf("the Helm chart %q isn't available on %s%s", c.spec.Name, c.spec.URL, message)
+	return false, fmt.Sprintf("the Helm chart %q isn't available on %s%s", c.spec.Name, c.spec.URL, baseMessage), nil
 
 }

--- a/pkg/plugins/resources/helm/condition_test.go
+++ b/pkg/plugins/resources/helm/condition_test.go
@@ -1,12 +1,10 @@
 package helm
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
 func TestCondition(t *testing.T) {
@@ -31,9 +29,7 @@ func TestCondition(t *testing.T) {
 				Name:    "jenkins",
 				Version: "999",
 			},
-			expected:             false,
-			expectedError:        true,
-			expectedErrorMessage: errors.New("the Helm chart \"jenkins\" isn't available on https://kubernetes-charts.storage.googleapis.com for version '999'"),
+			expected: false,
 		},
 		{
 			chart: Spec{
@@ -41,9 +37,7 @@ func TestCondition(t *testing.T) {
 				Name:    "jenkins",
 				Version: "999",
 			},
-			expected:             false,
-			expectedError:        true,
-			expectedErrorMessage: errors.New("the Helm chart \"jenkins\" isn't available on https://charts.jenkins.io for version '999'"),
+			expected: false,
 		},
 		// Disabling the test for now as the GitHub Action doesn't have credentials nor allowed to anonymously query the ghcr.io API
 		//{
@@ -63,8 +57,6 @@ func TestCondition(t *testing.T) {
 		//		Version: "v9.9.9",
 		//	},
 		//	expected:             false,
-		//	expectedError:        true,
-		//	expectedErrorMessage: errors.New("the OCI Helm chart ghcr.io/olblak/charts/upgrade-responder:v9.9.9 doesn't exist"),
 		//},
 	}
 
@@ -73,19 +65,18 @@ func TestCondition(t *testing.T) {
 			got, err := New(tt.chart)
 			require.NoError(t, err)
 
-			gotResult := result.Condition{}
-			err = got.Condition("", nil, &gotResult)
+			gotResult, _, gotErr := got.Condition("", nil)
 
 			switch tt.expectedError {
 			case true:
-				if assert.Error(t, err) {
-					assert.Equal(t, tt.expectedErrorMessage.Error(), err.Error())
+				if assert.Error(t, gotErr) {
+					assert.Equal(t, tt.expectedErrorMessage.Error(), gotErr.Error())
 				}
 				return
 			case false:
-				require.NoError(t, err)
+				require.NoError(t, gotErr)
 			}
-			assert.Equal(t, tt.expected, gotResult.Pass)
+			assert.Equal(t, tt.expected, gotResult)
 		})
 	}
 }

--- a/pkg/plugins/resources/jenkins/condition_test.go
+++ b/pkg/plugins/resources/jenkins/condition_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/updatecli/updatecli/pkg/core/result"
 	"github.com/updatecli/updatecli/pkg/plugins/utils/mavenmetadata"
 )
 
@@ -95,15 +94,14 @@ func TestJenkins_Condition(t *testing.T) {
 				mavenMetaHandler: tt.mockedMetadataHandler,
 			}
 
-			gotResult := result.Condition{}
-			gotErr := sut.Condition(tt.source, nil, &gotResult)
+			got, _, gotErr := sut.Condition(tt.source, nil)
 			if tt.wantErr {
 				require.Error(t, gotErr)
 				return
 			}
 
 			require.NoError(t, gotErr)
-			assert.Equal(t, tt.want, gotResult.Pass)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/pkg/plugins/resources/json/condition_test.go
+++ b/pkg/plugins/resources/json/condition_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
 func TestCondition(t *testing.T) {
@@ -86,16 +85,15 @@ func TestCondition(t *testing.T) {
 
 			require.NoError(t, err)
 
-			gotResult := result.Condition{}
-			err = j.Condition("", nil, &gotResult)
+			got, _, gotErr := j.Condition("", nil)
 
 			if tt.wantErr {
-				assert.Equal(t, tt.expectedErrorMsg.Error(), err.Error())
+				assert.Equal(t, tt.expectedErrorMsg.Error(), gotErr.Error())
 			} else {
-				require.NoError(t, err)
+				require.NoError(t, gotErr)
 			}
 
-			assert.Equal(t, tt.expectedResult, gotResult.Pass)
+			assert.Equal(t, tt.expectedResult, got)
 		})
 	}
 }

--- a/pkg/plugins/resources/maven/condition.go
+++ b/pkg/plugins/resources/maven/condition.go
@@ -6,11 +6,10 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
-	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
 // Condition tests if a specific version exist on the maven repository
-func (m *Maven) Condition(source string, scm scm.ScmHandler, resultCondition *result.Condition) error {
+func (m *Maven) Condition(source string, scm scm.ScmHandler) (pass bool, message string, err error) {
 
 	if scm != nil {
 		logrus.Warningf("SCM configuration is not supported for maven condition, aborting")
@@ -24,28 +23,22 @@ func (m *Maven) Condition(source string, scm scm.ScmHandler, resultCondition *re
 		// metadataURL contains the URL without username/password
 		metadataURL, err := trimUsernamePasswordFromURL(metadataHandler.GetMetadataURL())
 		if err != nil {
-			return fmt.Errorf("trying to parse Maven metadata url: %s", err)
+			return false, "", fmt.Errorf("trying to parse Maven metadata url: %s", err)
 		}
 
 		versions, err := metadataHandler.GetVersions()
 		if err != nil {
-			return err
+			return false, "", err
 		}
 
 		for _, version := range versions {
 			if version == m.spec.Version {
-				resultCondition.Pass = true
-				resultCondition.Result = result.SUCCESS
-				resultCondition.Description = fmt.Sprintf("Version %s is available on the Maven Repository (%s)",
-					m.spec.Version, metadataURL)
-				return nil
+				return true, fmt.Sprintf("Version %s is available on the Maven Repository (%s)",
+					m.spec.Version, metadataURL), nil
 			}
 		}
 	}
 
-	resultCondition.Result = result.FAILURE
-	resultCondition.Pass = false
-	resultCondition.Description = fmt.Sprintf("Version %s is not found for Maven artifact (%s/%s)",
-		m.spec.Version, m.spec.GroupID, m.spec.ArtifactID)
-	return nil
+	return false, fmt.Sprintf("Version %s is not found for Maven artifact (%s/%s)",
+		m.spec.Version, m.spec.GroupID, m.spec.ArtifactID), nil
 }

--- a/pkg/plugins/resources/maven/condition_test.go
+++ b/pkg/plugins/resources/maven/condition_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/updatecli/updatecli/pkg/core/result"
 	"github.com/updatecli/updatecli/pkg/plugins/utils/mavenmetadata"
 )
 
@@ -82,15 +81,14 @@ func TestCondition(t *testing.T) {
 				},
 			}
 
-			gotResult := result.Condition{}
-			gotErr := sut.Condition(tt.source, nil, &gotResult)
+			gotResult, _, gotErr := sut.Condition(tt.source, nil)
 			if tt.wantErr {
 				require.Error(t, gotErr)
 				return
 			}
 
 			require.NoError(t, gotErr)
-			assert.Equal(t, tt.want, gotResult.Pass)
+			assert.Equal(t, tt.want, gotResult)
 		})
 	}
 }

--- a/pkg/plugins/resources/npm/condition.go
+++ b/pkg/plugins/resources/npm/condition.go
@@ -6,12 +6,10 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
-	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
 // Condition checks that an Npm package version exist
-func (n Npm) Condition(source string, scm scm.ScmHandler, resultCondition *result.Condition) error {
-
+func (n Npm) Condition(source string, scm scm.ScmHandler) (pass bool, message string, err error) {
 	if scm != nil {
 		logrus.Warningf("SCM configuration is not supported for npm condition, aborting")
 
@@ -22,26 +20,19 @@ func (n Npm) Condition(source string, scm scm.ScmHandler, resultCondition *resul
 		versionToCheck = source
 	}
 	if len(versionToCheck) == 0 {
-		return errors.New("no version defined")
+		return false, "", errors.New("no version defined")
 	}
 
 	_, versions, err := n.getVersions()
 	if err != nil {
-		return err
+		return false, "", err
 	}
 
 	for _, v := range versions {
 		if v == versionToCheck {
-			resultCondition.Pass = true
-			resultCondition.Result = result.SUCCESS
-			resultCondition.Description = fmt.Sprintf("release version %q available", versionToCheck)
-			return nil
+			return true, fmt.Sprintf("release version %q available", versionToCheck), nil
 		}
 	}
 
-	resultCondition.Result = result.FAILURE
-	resultCondition.Pass = false
-	resultCondition.Description = fmt.Sprintf("Version %q doesn't exist\n", versionToCheck)
-
-	return nil
+	return false, fmt.Sprintf("Version %q doesn't exist\n", versionToCheck), nil
 }

--- a/pkg/plugins/resources/npm/condition_test.go
+++ b/pkg/plugins/resources/npm/condition_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
 func TestCondition(t *testing.T) {
@@ -120,10 +119,9 @@ func TestCondition(t *testing.T) {
 				assert.Error(t, err)
 				return
 			}
-			gotResult := result.Condition{}
-			err = got.Condition("", nil, &gotResult)
-			require.NoError(t, err)
-			assert.Equal(t, tt.expectedResult, gotResult.Pass)
+			gotResult, _, gotErr := got.Condition("", nil)
+			require.NoError(t, gotErr)
+			assert.Equal(t, tt.expectedResult, gotResult)
 		})
 	}
 

--- a/pkg/plugins/resources/shell/condition_test.go
+++ b/pkg/plugins/resources/shell/condition_test.go
@@ -5,8 +5,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
-	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
 func TestShell_Condition(t *testing.T) {
@@ -65,84 +63,16 @@ func TestShell_Condition(t *testing.T) {
 			gotErr := s.InitChangedIf()
 			require.NoError(t, gotErr)
 
-			gotResult := result.Condition{}
-			gotErr = s.Condition(tt.source, nil, &gotResult)
+			gotResult, _, gotErr := s.Condition(tt.source, nil)
 
 			if tt.wantErr {
 				assert.Error(t, gotErr)
-				assert.False(t, gotResult.Pass)
 				return
 			}
 
 			require.NoError(t, gotErr)
-			assert.Equal(t, tt.wantResult, gotResult.Pass)
+			assert.Equal(t, tt.wantResult, gotResult)
 			assert.Equal(t, tt.wantCommand, mock.GotCommand.Cmd)
-		})
-	}
-}
-
-func TestShell_ConditionFromSCM(t *testing.T) {
-	tests := []struct {
-		name          string
-		command       string
-		source        string
-		scmDir        string
-		wantResult    bool
-		wantErr       bool
-		wantCommand   string
-		commandResult commandResult
-		shell         string
-	}{
-		{
-			name:        "Successful Condition in existing SCM",
-			command:     "echo Hello",
-			shell:       "/bin/bash",
-			source:      "1.2.3",
-			scmDir:      "/dummy/dir",
-			wantResult:  true,
-			wantErr:     false,
-			wantCommand: "/bin/bash" + " " + wantedScriptFilename(t, "echo Hello 1.2.3"),
-			commandResult: commandResult{
-				ExitCode: 0,
-				Stdout:   "Hello",
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			mce := MockCommandExecutor{
-				Result: tt.commandResult,
-			}
-			ms := scm.MockScm{
-				WorkingDir: tt.scmDir,
-			}
-			s := Shell{
-				executor: &mce,
-				spec: Spec{
-					Command: tt.command,
-					Shell:   tt.shell,
-				},
-				interpreter: tt.shell,
-			}
-
-			// InitSuccess Criteria
-			gotErr := s.InitChangedIf()
-			require.NoError(t, gotErr)
-
-			gotResult := result.Condition{}
-			gotErr = s.Condition(tt.source, &ms, &gotResult)
-
-			if tt.wantErr {
-				assert.Error(t, gotErr)
-				assert.False(t, gotResult.Pass)
-				return
-			}
-
-			require.NoError(t, gotErr)
-			assert.Equal(t, tt.wantResult, gotResult.Pass)
-
-			assert.Equal(t, tt.wantCommand, mce.GotCommand.Cmd)
-			assert.Equal(t, tt.scmDir, mce.GotCommand.Dir)
 		})
 	}
 }

--- a/pkg/plugins/resources/terraform/lock/condition_test.go
+++ b/pkg/plugins/resources/terraform/lock/condition_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/minamijoyo/tfupdate/lock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
 func TestCondition(t *testing.T) {
@@ -139,16 +138,15 @@ func TestCondition(t *testing.T) {
 
 			l.lockIndex = lock.NewMockIndex(providerVersions)
 
-			gotResult := result.Condition{}
-			err = l.Condition(tt.source, nil, &gotResult)
+			gotResult, _, gotErr := l.Condition(tt.source, nil)
 
 			if tt.wantErr {
-				assert.Equal(t, tt.expectedErrorMsg.Error(), err.Error())
+				assert.Equal(t, tt.expectedErrorMsg.Error(), gotErr.Error())
 			} else {
-				require.NoError(t, err)
+				require.NoError(t, gotErr)
 			}
 
-			assert.Equal(t, tt.expectedResult, gotResult.Pass)
+			assert.Equal(t, tt.expectedResult, gotResult)
 		})
 	}
 }

--- a/pkg/plugins/resources/terraform/provider/condition_test.go
+++ b/pkg/plugins/resources/terraform/provider/condition_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
 func TestCondition(t *testing.T) {
@@ -83,16 +82,15 @@ func TestCondition(t *testing.T) {
 
 			require.NoError(t, err)
 
-			gotResult := result.Condition{}
-			err = l.Condition(tt.source, nil, &gotResult)
+			gotResult, _, gotErr := l.Condition(tt.source, nil)
 
 			if tt.wantErr {
-				assert.Equal(t, tt.expectedErrorMsg.Error(), err.Error())
+				assert.Equal(t, tt.expectedErrorMsg.Error(), gotErr.Error())
 			} else {
-				require.NoError(t, err)
+				require.NoError(t, gotErr)
 			}
 
-			assert.Equal(t, tt.expectedResult, gotResult.Pass)
+			assert.Equal(t, tt.expectedResult, gotResult)
 		})
 	}
 }

--- a/pkg/plugins/resources/terraform/registry/condition.go
+++ b/pkg/plugins/resources/terraform/registry/condition.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Condition checks if a specific version is published
-func (t *TerraformRegistry) Condition(source string, scm scm.ScmHandler, resultCondition *result.Condition) error {
+func (t *TerraformRegistry) Condition(source string, scm scm.ScmHandler) (pass bool, message string, err error) {
 	if scm != nil {
 		logrus.Debugln("scm is not supported")
 	}
@@ -21,20 +21,17 @@ func (t *TerraformRegistry) Condition(source string, scm scm.ScmHandler, resultC
 	}
 
 	if len(versionToCheck) == 0 {
-		return fmt.Errorf("%s version undefined", result.FAILURE)
+		return false, "", fmt.Errorf("%s version undefined", result.FAILURE)
 	}
 
 	versions, err := t.versions()
 	if err != nil {
-		return fmt.Errorf("%s retrieving terraform registry version: %w", result.FAILURE, err)
+		return false, "", fmt.Errorf("%s retrieving terraform registry version: %w", result.FAILURE, err)
 	}
 
 	if slices.Contains(versions, versionToCheck) {
-		resultCondition.Pass = true
-		resultCondition.Result = result.SUCCESS
-		resultCondition.Description = fmt.Sprintf("Terraform registry version %q available", versionToCheck)
-		return nil
+		return true, fmt.Sprintf("Terraform registry version %q available", versionToCheck), nil
 	}
 
-	return fmt.Errorf("%s terraform registry version %q doesn't exist", result.FAILURE, versionToCheck)
+	return false, fmt.Sprintf("%s terraform registry version %q doesn't exist", result.FAILURE, versionToCheck), nil
 }

--- a/pkg/plugins/resources/terraform/registry/condition_test.go
+++ b/pkg/plugins/resources/terraform/registry/condition_test.go
@@ -1,7 +1,6 @@
 package registry
 
 import (
-	"errors"
 	"io"
 	"net/http"
 	"strings"
@@ -10,7 +9,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/updatecli/updatecli/pkg/core/httpclient"
-	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
 func TestCondition(t *testing.T) {
@@ -83,11 +81,9 @@ func TestCondition(t *testing.T) {
 				Name:      "kubernetes",
 				Version:   "2.22.1111",
 			},
-			expectedResult:   false,
-			expectedUrl:      "https://registry.terraform.io/v1/providers/hashicorp/kubernetes",
-			expectedError:    true,
-			expectedErrorMsg: errors.New(`✗ terraform registry version "2.22.1111" doesn't exist`),
-			mockedHttpBody:   `{ "versions" : ["2.23.0"] }`,
+			expectedResult: false,
+			expectedUrl:    "https://registry.terraform.io/v1/providers/hashicorp/kubernetes",
+			mockedHttpBody: `{ "versions" : ["2.23.0"] }`,
 		},
 	}
 	for _, tt := range tests {
@@ -110,16 +106,15 @@ func TestCondition(t *testing.T) {
 				},
 			}
 
-			gotResult := result.Condition{}
-			err = got.Condition(tt.source, nil, &gotResult)
+			gotResult, _, gotErr := got.Condition(tt.source, nil)
 			if tt.expectedError {
-				if assert.Error(t, err) {
-					assert.Equal(t, tt.expectedErrorMsg.Error(), err.Error())
+				if assert.Error(t, gotErr) {
+					assert.Equal(t, tt.expectedErrorMsg.Error(), gotErr.Error())
 				}
 				return
 			}
-			require.NoError(t, err)
-			assert.Equal(t, tt.expectedResult, gotResult.Pass)
+			require.NoError(t, gotErr)
+			assert.Equal(t, tt.expectedResult, gotResult)
 		})
 	}
 }

--- a/pkg/plugins/resources/toml/condition_test.go
+++ b/pkg/plugins/resources/toml/condition_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
 func TestCondition(t *testing.T) {
@@ -100,16 +99,15 @@ func TestCondition(t *testing.T) {
 
 			require.NoError(t, err)
 
-			gotResult := result.Condition{}
-			err = toml.Condition("", nil, &gotResult)
+			gotResult, _, gotErr := toml.Condition("", nil)
 
 			if tt.wantErr {
-				assert.Equal(t, tt.expectedErrorMsg.Error(), err.Error())
+				assert.Equal(t, tt.expectedErrorMsg.Error(), gotErr.Error())
 			} else {
-				require.NoError(t, err)
+				require.NoError(t, gotErr)
 			}
 
-			assert.Equal(t, tt.expectedResult, gotResult.Pass)
+			assert.Equal(t, tt.expectedResult, gotResult)
 		})
 	}
 }

--- a/pkg/plugins/resources/updateclihttp/condition_test.go
+++ b/pkg/plugins/resources/updateclihttp/condition_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/updatecli/updatecli/pkg/core/httpclient"
 	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
-	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
 func TestCondition(t *testing.T) {
@@ -133,24 +132,18 @@ func TestCondition(t *testing.T) {
 				},
 			}
 
-			got := &result.Condition{}
-			gotErr := sut.Condition(tt.source, tt.scm, got)
+			got, _, gotErr := sut.Condition(tt.source, tt.scm)
 
 			if tt.wantErr != nil {
 				require.Error(t, gotErr)
-				assert.Equal(t, got.Result, result.FAILURE)
 				assert.Equal(t, tt.wantErr, gotErr)
 				return
 			}
 
 			require.NoError(t, gotErr)
-			assert.Equal(t, tt.want, got.Pass)
+			assert.Equal(t, tt.want, got)
 
-			if tt.want {
-				assert.Equal(t, got.Result, result.SUCCESS)
-			} else {
-				assert.Equal(t, got.Result, result.FAILURE)
-			}
+			assert.Equal(t, got, tt.want)
 		})
 	}
 }

--- a/pkg/plugins/resources/xml/condition_test.go
+++ b/pkg/plugins/resources/xml/condition_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
 func TestCondition(t *testing.T) {
@@ -87,16 +86,15 @@ func TestCondition(t *testing.T) {
 
 			require.NoError(t, err)
 
-			gotResult := result.Condition{}
-			err = x.Condition("", nil, &gotResult)
+			gotResult, _, gotErr := x.Condition("", nil)
 
 			if tt.wantErr {
-				assert.Equal(t, tt.expectedErrorMsg.Error(), err.Error())
+				assert.Equal(t, tt.expectedErrorMsg.Error(), gotErr.Error())
 			} else {
-				require.NoError(t, err)
+				require.NoError(t, gotErr)
 			}
 
-			assert.Equal(t, tt.expectedResult, gotResult.Pass)
+			assert.Equal(t, tt.expectedResult, gotResult)
 		})
 	}
 

--- a/pkg/plugins/resources/yaml/condition_test.go
+++ b/pkg/plugins/resources/yaml/condition_test.go
@@ -6,8 +6,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
-	"github.com/updatecli/updatecli/pkg/core/result"
 	"github.com/updatecli/updatecli/pkg/core/text"
 )
 
@@ -547,124 +545,14 @@ repos:
 
 			assert.NoError(t, err)
 
-			gotResult := result.Condition{}
-			gotErr := y.Condition(tt.inputSourceValue, nil, &gotResult)
+			gotResult, _, gotErr := y.Condition(tt.inputSourceValue, nil)
 			if tt.isErrorWanted {
 				assert.Error(t, gotErr)
 				return
 			}
 
 			require.NoError(t, gotErr)
-			assert.Equal(t, tt.isResultWanted, gotResult.Pass)
-			for filePath := range tt.files {
-				assert.Equal(t, tt.wantedContents[filePath], mockedText.Contents[filePath])
-			}
-		})
-	}
-}
-
-func Test_ConditionFromSCM(t *testing.T) {
-	tests := []struct {
-		name             string
-		spec             Spec
-		files            map[string]file
-		inputSourceValue string
-		mockedContents   map[string]string
-		mockedError      error
-		wantedContents   map[string]string
-		isResultWanted   bool
-		isErrorWanted    bool
-		scm              scm.ScmHandler
-	}{
-		{
-			name: "Passing case with no input source and only specified value",
-			spec: Spec{
-				File:  "test.yaml",
-				Key:   "github.owner",
-				Value: "olblak",
-			},
-			files: map[string]file{
-				"/tmp/test.yaml": {
-					filePath:         "/tmp/test.yaml",
-					originalFilePath: "/tmp/test.yaml",
-				},
-			},
-			scm: &scm.MockScm{
-				WorkingDir: "/tmp",
-			},
-			mockedContents: map[string]string{
-				"/tmp/test.yaml": `---
-github:
-  owner: olblak
-  repository: charts
-`,
-			},
-			wantedContents: map[string]string{
-				"/tmp/test.yaml": `---
-github:
-  owner: olblak
-  repository: charts
-`,
-			},
-			isResultWanted: true,
-		},
-		{
-			name: "Passing case with one 'Files' no input source and only specified value",
-			spec: Spec{
-				Files: []string{
-					"test.yaml",
-				},
-				Key:   "github.owner",
-				Value: "olblak",
-			},
-			files: map[string]file{
-				"/tmp/test.yaml": {
-					filePath:         "/tmp/test.yaml",
-					originalFilePath: "/tmp/test.yaml",
-				},
-			},
-			scm: &scm.MockScm{
-				WorkingDir: "/tmp",
-			},
-			mockedContents: map[string]string{
-				"/tmp/test.yaml": `---
-github:
-  owner: olblak
-  repository: charts
-`,
-			},
-			wantedContents: map[string]string{
-				"/tmp/test.yaml": `---
-github:
-  owner: olblak
-  repository: charts
-`,
-			},
-			isResultWanted: true,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			mockedText := text.MockTextRetriever{
-				Contents: tt.mockedContents,
-				Err:      tt.mockedError,
-			}
-
-			y, err := New(tt.spec)
-			y.contentRetriever = &mockedText
-			y.files = tt.files
-
-			assert.NoError(t, err)
-
-			gotResult := result.Condition{}
-			gotErr := y.Condition(tt.inputSourceValue, tt.scm, &gotResult)
-			if tt.isErrorWanted {
-				assert.Error(t, gotErr)
-				return
-			}
-
-			require.NoError(t, gotErr)
-			assert.Equal(t, tt.isResultWanted, gotResult.Pass)
+			assert.Equal(t, tt.isResultWanted, gotResult)
 			for filePath := range tt.files {
 				assert.Equal(t, tt.wantedContents[filePath], mockedText.Contents[filePath])
 			}


### PR DESCRIPTION
This PR factorizes condition result code out of resource plugins:

- Simplify code for plugins (easier for contributors to write/update resources as they have less things to handle and can focus on the resource code)
- Centralize result object configuration (we can now change resource condition behavior in the core without impacting resources)
- Separate condition result (true or false) from error (unexpected behavior such as network error) 
- Introduces the following behavioral changes (side effects of the PR):
  -  `githubrelease` condition returns `false` but no error anymore when no upstream errors are triggered, with the same textual output as before.
  -  `gittag` condition returns `false` but no error anymore when no upstream errors are triggered, with the same textual output as before.
  -  `golang` condition returns `false` but no error anymore when no upstream errors are triggered, with the same textual output as before
  -  `gomod` condition returns `false` but no error anymore when no upstream errors are triggered, with the same textual output as before
  -  `gomodule` condition returns `false` but no error anymore when no upstream errors are triggered, with the same textual output as before
  - (nit) Homogenize methods to return an error (`error.new()` vs. `fmt.Errorf()`)
  - (cleanup) removing obsolete "ConditionFromScm" tests

## Test

To test this pull request, you can run the following commands:

```shell
make test
```

## Additional Information

- Unit test are not checking for the message returned by the `Condition()` function. It wasn't before this PR, so I chose to focus on the refactor to avoid too much changes in this PR