### PR TITLE
chore(tests) test and lint fixes

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -80,3 +80,4 @@ responseasserts
 updateclihttp
 Metadatas
 statuscode
+scmid

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,8 @@ version: ## Run the "version" updatecli's subcommand for smoke test
 
 .PHONY: test
 test: ## Execute the Golang's tests for updatecli
+# Docker is required for the full integration test. Quick fail if it is not present and running
+	docker info
 	go test ./... -race -coverprofile=coverage.txt -covermode=atomic
 
 test-short: ## Execute the Golang's tests for updatecli

--- a/pkg/core/compose/main_test.go
+++ b/pkg/core/compose/main_test.go
@@ -24,10 +24,10 @@ func TestGetPolicies(t *testing.T) {
 			expectedManifests: []manifest.Manifest{
 				{
 					Manifests: []string{
-						filepath.Join("/", "tmp", "updatecli", "store", "7aaff2727eef42f7d0add2d5ed3fd83f74a125420682bec7e4bc8835bb28e833", "updatecli.d", "default.tpl"),
+						filepath.Join(os.TempDir(), "updatecli", "store", "7aaff2727eef42f7d0add2d5ed3fd83f74a125420682bec7e4bc8835bb28e833", "updatecli.d", "default.tpl"),
 					},
 					Values: []string{
-						filepath.Join("/", "tmp", "updatecli", "store", "7aaff2727eef42f7d0add2d5ed3fd83f74a125420682bec7e4bc8835bb28e833", "values.yaml"),
+						filepath.Join(os.TempDir(), "updatecli", "store", "7aaff2727eef42f7d0add2d5ed3fd83f74a125420682bec7e4bc8835bb28e833", "values.yaml"),
 					},
 				},
 			},

--- a/pkg/core/pipeline/resource/main.go
+++ b/pkg/core/pipeline/resource/main.go
@@ -172,6 +172,10 @@ func New(rs ResourceConfig) (resource Resource, err error) {
 
 		return maven.New(rs.Spec)
 
+	case "npm":
+
+		return npm.New(rs.Spec)
+
 	case "shell":
 
 		return shell.New(rs.Spec)
@@ -204,17 +208,13 @@ func New(rs ResourceConfig) (resource Resource, err error) {
 
 		return toml.New(rs.Spec)
 
-	case "yaml":
-
-		return yaml.New(rs.Spec)
-
 	case "xml":
 
 		return xml.New(rs.Spec)
 
-	case "npm":
+	case "yaml":
 
-		return npm.New(rs.Spec)
+		return yaml.New(rs.Spec)
 
 	default:
 

--- a/pkg/core/pipeline/target/main.go
+++ b/pkg/core/pipeline/target/main.go
@@ -185,7 +185,7 @@ func (t *Target) Run(source string, o *Options) (err error) {
 					not every target have a name as it wasn't mandatory in the past
 					so we use the description as a fallback
 				*/
-				commitMessage := t.Config.Name
+				commitMessage := t.Config.ResourceConfig.Name
 				if commitMessage == "" {
 					commitMessage = t.Result.Description
 				}

--- a/pkg/core/registry/pullpush_test.go
+++ b/pkg/core/registry/pullpush_test.go
@@ -20,9 +20,9 @@ import (
 
 // TestPushPull is a test for the Push and Pull functions
 func TestPushPullPolicy(t *testing.T) {
-	//if testing.Short() {
-	//	t.Skip("skipping integration test")
-	//}
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
 
 	ctx := context.Background()
 	req := testcontainers.ContainerRequest{

--- a/pkg/plugins/resources/gitbranch/main.go
+++ b/pkg/plugins/resources/gitbranch/main.go
@@ -61,7 +61,7 @@ func New(spec interface{}) (*GitBranch, error) {
 func (gt *GitBranch) Validate() error {
 	validationErrors := []string{}
 	if gt.spec.Path == "" {
-		validationErrors = append(validationErrors, "Git working directory path is empty while it must be specified. Did you specify an `scmID` or a `spec.path`?")
+		validationErrors = append(validationErrors, "Git working directory path is empty while it must be specified. Did you specify a `scmid` or a `spec.path`?")
 	}
 
 	// Return all the validation errors if found any

--- a/pkg/plugins/resources/updateclihttp/target.go
+++ b/pkg/plugins/resources/updateclihttp/target.go
@@ -1,11 +1,13 @@
 package updateclihttp
 
 import (
+	"fmt"
+
 	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
 	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
 // Target is not implemented. If you ever feel the need, you can still open a GitHub issue with a valid usecase.
 func (h *Http) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
-	return nil
+	return fmt.Errorf("Target not supported for the plugin http")
 }


### PR DESCRIPTION
While working on #1775 , caught a few minor things which I've put in this PR.

I tried to split each one on distinct commit in case we need to NOT add all (or if you want me to split in distinct PRs as well : I don't mind).

Tl;DR;

- Unit ("short") tests should not be requiring Docker Engine
- Some integration tests require Docker Engine: we should fail fast when Docker is not present and running
- Tests doing assertions with `/tmp` must us the `os.TmpDir()` to ensure all contributors can have these tests executed with success on their operating system
- Old validation error message referencing `scmID` instead of `scmid`
- A fix on target commits which are trying to access an undefined field (fixup of #412 )

## Test

To test this pull request, you can run the following commands:

```shell
make tests
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
