### PR TITLE
fix: update fleet git repository used for e2e test

### DIFF
--- a/e2e/updatecli.d/warning.d/autodiscovery/fleet/git.yaml
+++ b/e2e/updatecli.d/warning.d/autodiscovery/fleet/git.yaml
@@ -3,7 +3,7 @@ scms:
   fleet-lab:
     kind: git 
     spec:
-      url: https://github.com/olblak/fleet-lab.git
+      url: https://github.com/updatecli-test/fleet-lab.git
     
 autodiscovery:
   # scmid is applied to all crawlers

--- a/e2e/updatecli.d/warning.d/autodiscovery/fleet/githubPullrequest.yaml
+++ b/e2e/updatecli.d/warning.d/autodiscovery/fleet/githubPullrequest.yaml
@@ -3,7 +3,7 @@ scms:
   fleet-lab:
     kind: github
     spec:
-      owner: olblak
+      owner: updatecli-test
       repository: fleet-lab
       token: '{{ requiredEnv "GITHUB_TOKEN" }}'
       username: '{{ requiredEnv "GITHUB_ACTOR" }}'


### PR DESCRIPTION
I decided to move https://github.com/olblak/fleet-lab.git private so I created a small copy on https://github.com/updatecli-test/fleet-lab.git