### PR TITLE
fix: always set report name

### DIFF
--- a/pkg/core/pipeline/condition/main.go
+++ b/pkg/core/pipeline/condition/main.go
@@ -60,7 +60,6 @@ func (c *Condition) Run(source string) (err error) {
 	defer c.Result.SetConsoleOutput(&consoleOutput)
 
 	c.Result.Result = result.FAILURE
-	c.Result.Name = c.Config.ResourceConfig.Name
 
 	condition, err := resource.New(c.Config.ResourceConfig)
 	if err != nil {

--- a/pkg/core/pipeline/conditions.go
+++ b/pkg/core/pipeline/conditions.go
@@ -32,6 +32,9 @@ func (p *Pipeline) RunConditions() (globalResult bool, err error) {
 		condition := p.Conditions[id]
 		condition.Config = p.Config.Spec.Conditions[id]
 
+		// Ensure the result named contains the up to date condition name after templating
+		condition.Result.Name = condition.Config.ResourceConfig.Name
+
 		logrus.Infof("\n%s\n", id)
 		logrus.Infof("%s\n", strings.Repeat("-", len(id)))
 

--- a/pkg/core/pipeline/source/main.go
+++ b/pkg/core/pipeline/source/main.go
@@ -89,7 +89,6 @@ func (s *Source) Run() (err error) {
 
 	err = source.Source(workingDir, &s.Result)
 
-	s.Result.Name = s.Config.ResourceConfig.Name
 	s.Output = s.Result.Information
 
 	if err != nil {

--- a/pkg/core/pipeline/sources.go
+++ b/pkg/core/pipeline/sources.go
@@ -28,6 +28,9 @@ func (p *Pipeline) RunSources() error {
 		source := p.Sources[id]
 		source.Config = p.Config.Spec.Sources[id]
 
+		// Ensure the result named contains the up to date source name after templating
+		source.Result.Name = source.Config.ResourceConfig.Name
+
 		logrus.Infof("\n%s\n", id)
 		logrus.Infof("%s\n", strings.Repeat("-", len(id)))
 

--- a/pkg/core/pipeline/target/main.go
+++ b/pkg/core/pipeline/target/main.go
@@ -107,11 +107,6 @@ func (t *Target) Run(source string, o *Options) (err error) {
 		return err
 	}
 
-	// Ensure the result named contains the up to date target name
-	// after templating
-	t.Result.Name = t.Config.ResourceConfig.Name
-	t.Result.DryRun = o.DryRun
-
 	// If no scm configuration provided then stop early
 	if t.Scm == nil {
 		err = target.Target(source, nil, o.DryRun, &t.Result)

--- a/pkg/core/pipeline/targets.go
+++ b/pkg/core/pipeline/targets.go
@@ -44,6 +44,10 @@ func (p *Pipeline) RunTargets() error {
 		target := p.Targets[id]
 		target.Config = p.Config.Spec.Targets[id]
 
+		// Ensure the result named contains the up to date target name after templating
+		target.Result.Name = target.Config.ResourceConfig.Name
+		target.Result.DryRun = target.DryRun
+
 		shouldSkipTarget := false
 
 		for _, parentTarget := range target.Config.DependsOn {


### PR DESCRIPTION
While reviewing https://github.com/updatecli/updatecli/pull/1782 I noticed that if a target is skipped or in a fail state, then the report name is not correctly show up.

There were situation where the function that update the report wasn't reach

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands to the correct output:

```shell
go build -o bin/updatecli . 
./bin/updatecli diff --config e2e/updatecli.d/success.d/command.yaml 
```

<details><summary>Console output - Before</summary>

```
REPORTS:



⚠ Test Various target scenario:
	Source:
		✔ [1] Should be succeeding
	Condition:
		✔ [1] Should be succeeding
	Target:
		✔ [1] Should be succeeding
		⚠ [5] Should be succeeding and report change
		- [6] 
		✔ [7] Should be run

```

</details>


<details><summary>Console output - After</summary>

```
REPORTS:


⚠ Test Various target scenario:
	Source:
		✔ [1] Should be succeeding
	Condition:
		✔ [1] Should be succeeding
	Target:
		✔ [1] Should be succeeding
		⚠ [5] Should be succeeding and report change
		- [6] Should be skipped
		✔ [7] Should be run
```

</details>

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
