### PR TITLE
chore(ci): update workflow permissions to be least privilege

### DIFF
--- a/.github/workflows/add_issue_to_project.yaml
+++ b/.github/workflows/add_issue_to_project.yaml
@@ -4,6 +4,8 @@ on:
     types:
       - opened
 
+permissions: {}
+
 jobs:
   add-to-project:
     name: Add issue to Updatecli project

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -8,47 +8,53 @@ on:
     # The branches below must be a subset of the branches above
     branches: [main]
   schedule:
-    - cron: '0 5 * * 0'
+    - cron: "0 5 * * 0"
+
+permissions: {}
 
 jobs:
   analyse:
     name: Analyse
     runs-on: ubuntu-20.04
+    permissions:
+      contents: read
+      pull-requests: read
+      security-events: write
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-      with:
-        # We must fetch at least the immediate parents so that if this is
-        # a pull request then we can checkout the head.
-        fetch-depth: 2
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          # We must fetch at least the immediate parents so that if this is
+          # a pull request then we can checkout the head.
+          fetch-depth: 2
 
-    # If this run was triggered by a pull request event, then checkout
-    # the head of the pull request instead of the merge commit.
-    - run: git checkout HEAD^2
-      if: ${{ github.event_name == 'pull_request' }}
+      # If this run was triggered by a pull request event, then checkout
+      # the head of the pull request instead of the merge commit.
+      - run: git checkout HEAD^2
+        if: ${{ github.event_name == 'pull_request' }}
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
-      # Override language selection by uncommenting this and choosing your languages
-      with:
-        languages: go
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
+        # Override language selection by uncommenting this and choosing your languages
+        with:
+          languages: go
+      # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+      # If this step fails, then you should remove it and run the build manually (see below)
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v2
 
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 https://git.io/JvXDl
+      # ℹ️ Command-line programs to run using the OS shell.
+      # 📚 https://git.io/JvXDl
 
-    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-    #    and modify them (or add more) to build your code if your project
-    #    uses a compiled language
+      # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
+      #    and modify them (or add more) to build your code if your project
+      #    uses a compiled language
 
-    #- run: |
-    #   make bootstrap
-    #   make release
+      #- run: |
+      #   make bootstrap
+      #   make release
 
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v2

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -9,11 +9,17 @@ on:
       - main
   schedule:
     # Run full test once a day
-    - cron: '0 0 * * *'
+    - cron: "0 0 * * *"
+
+permissions: {}
+
 jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
     steps:
       # https://github.com/actions/setup-go
       - name: Set up Go

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -7,9 +7,15 @@ on:
     branches:
       - main
 
+permissions: {}
+
 jobs:
   update_release_draft:
     runs-on: ubuntu-20.04
+    permissions:
+      contents: write
+      pull-requests: write
+
     steps:
       - uses: release-drafter/release-drafter@v5
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,13 +3,16 @@ on:
   workflow_dispatch: null
   release:
     types: [published]
-permissions:
-  contents: write
-  id-token: write
-  packages: write
+
+permissions: {}
+
 jobs:
   build:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+      id-token: write
+      packages: write
     env:
       DOCKER_CLI_EXPERIMENTAL: "enabled"
       DOCKER_BUILDKIT: 1

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -59,16 +59,18 @@ name: Check Spelling
 on:
   push:
     branches:
-    - "**"
+      - "**"
     tags-ignore:
-    - "**"
+      - "**"
   pull_request_target:
     branches:
-    - "**"
+      - "**"
     types:
-    - 'opened'
-    - 'reopened'
-    - 'synchronize'
+      - "opened"
+      - "reopened"
+      - "synchronize"
+
+permissions: {}
 
 jobs:
   spelling:
@@ -87,31 +89,30 @@ jobs:
       # note: If you use only_check_changed_files, you do not want cancel-in-progress
       cancel-in-progress: true
     steps:
-    - name: check-spelling
-      id: spelling
-      uses: check-spelling/check-spelling@v0.0.21
-      with:
-        suppress_push_for_open_pull_request: 1
-        checkout: true
-        check_file_names: 1
-        spell_check_this: updatecli/updatecli@main
-        post_comment: 0
-        use_magic_file: 1
-        use_sarif: ${{ (!github.event.pull_request || (github.event.pull_request.head.repo.full_name == github.repository)) && 1 }}
-        extra_dictionary_limit: 10
-        dictionary_source_prefixes: |
-          {"cspell": "https://raw.githubusercontent.com/check-spelling/cspell-dicts/v20220816/dictionaries/", "cspell1": "https://raw.githubusercontent.com/check-spelling/cspell-dicts/v20230509/dictionaries/"}
-        extra_dictionaries:
-          cspell1:software-terms/dict/softwareTerms.txt
-          cspell1:golang/dict/go.txt
-          cspell1:npm/dict/npm.txt
-          cspell1:node/dict/node.txt
-          cspell1:python/src/python/python-lib.txt
-          cspell1:aws/aws.txt
-          cspell1:html/dict/html.txt
-          cspell1:k8s/dict/k8s.txt
-          cspell1:python/src/common/extra.txt
-          cspell1:filetypes/filetypes.txt
-          cspell1:django/dict/django.txt
-          cspell1:docker/src/docker-words.txt
-          cspell1:fullstack/dict/fullstack.txt
+      - name: check-spelling
+        id: spelling
+        uses: check-spelling/check-spelling@v0.0.21
+        with:
+          suppress_push_for_open_pull_request: 1
+          checkout: true
+          check_file_names: 1
+          spell_check_this: updatecli/updatecli@main
+          post_comment: 0
+          use_magic_file: 1
+          use_sarif: ${{ (!github.event.pull_request || (github.event.pull_request.head.repo.full_name == github.repository)) && 1 }}
+          extra_dictionary_limit: 10
+          dictionary_source_prefixes: |
+            {"cspell": "https://raw.githubusercontent.com/check-spelling/cspell-dicts/v20220816/dictionaries/", "cspell1": "https://raw.githubusercontent.com/check-spelling/cspell-dicts/v20230509/dictionaries/"}
+          extra_dictionaries: cspell1:software-terms/dict/softwareTerms.txt
+            cspell1:golang/dict/go.txt
+            cspell1:npm/dict/npm.txt
+            cspell1:node/dict/node.txt
+            cspell1:python/src/python/python-lib.txt
+            cspell1:aws/aws.txt
+            cspell1:html/dict/html.txt
+            cspell1:k8s/dict/k8s.txt
+            cspell1:python/src/common/extra.txt
+            cspell1:filetypes/filetypes.txt
+            cspell1:django/dict/django.txt
+            cspell1:docker/src/docker-words.txt
+            cspell1:fullstack/dict/fullstack.txt

--- a/.github/workflows/typos.yaml
+++ b/.github/workflows/typos.yaml
@@ -1,14 +1,18 @@
 name: Test Typos
 on: [pull_request]
 
+permissions: {}
+
 jobs:
   run:
     name: Spell Check with Typos
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
     steps:
-    - name: Checkout Actions Repository
-      uses: actions/checkout@v4
+      - name: Checkout Actions Repository
+        uses: actions/checkout@v4
 
-    - name: Check spelling of file.txt
-      uses: crate-ci/typos@master
-
+      - name: Check spelling of file.txt
+        uses: crate-ci/typos@master

--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -7,10 +7,16 @@ on:
   schedule:
     # * is a special character in YAML so you have to quote this string
     # Run at 12:00 on Friday.”
-    - cron: '0 12 * * 5'
+    - cron: "0 12 * * 5"
+
+permissions: {}
+
 jobs:
   updatecli:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v4"
@@ -19,7 +25,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version-file: 'go.mod'
+          go-version-file: "go.mod"
         id: go
       - name: "Run updatecli in dryrun"
         run: "updatecli diff --config ./updatecli/updatecli.d --experimental"


### PR DESCRIPTION
Was looking at the [scorecard](https://api.securityscorecards.dev/projects/github.com/updatecli/updatecli) and saw simple enough fix. 

Update token permissions to be [least privilege](https://github.com/ossf/scorecard/blob/0276a7cd7284e077f22b50208345201485029fbd/docs/checks.md#token-permissions).

<details><summary>Scorecard Details</summary>
<p>

```json
{
  "name": "Token-Permissions",
  "score": 0,
  "reason": "detected GitHub workflow tokens with excessive permissions",
  "details": [
    "Warn: no topLevel permission defined: .github/workflows/add_issue_to_project.yaml:1",
    "Warn: no topLevel permission defined: .github/workflows/codeql-analysis.yml:1",
    "Warn: no topLevel permission defined: .github/workflows/go.yaml:1",
    "Warn: no topLevel permission defined: .github/workflows/release-drafter.yml:1",
    "Warn: topLevel 'packages' permission set to 'write': .github/workflows/release.yaml:9",
    "Warn: topLevel 'contents' permission set to 'write': .github/workflows/release.yaml:7",
    "Warn: no topLevel permission defined: .github/workflows/spelling.yml:1",
    "Info: jobLevel 'contents' permission set to 'read': .github/workflows/spelling.yml:77",
    "Info: jobLevel 'pull-requests' permission set to 'read': .github/workflows/spelling.yml:78",
    "Info: jobLevel 'actions' permission set to 'read': .github/workflows/spelling.yml:79",
    "Warn: jobLevel 'security-events' permission set to 'write': .github/workflows/spelling.yml:80",
    "Warn: no topLevel permission defined: .github/workflows/typos.yaml:1",
    "Warn: no topLevel permission defined: .github/workflows/updatecli.yaml:1"
  ],
  "documentation": {
    "short": "Determines if the project's workflows follow the principle of least privilege.",
    "url": "https://github.com/ossf/scorecard/blob/0276a7cd7284e077f22b50208345201485029fbd/docs/checks.md#token-permissions"
  }
}
``` 

</p>
</details> 

I also let my IDE reformat yaml, let me know if you want the change without it.

## Test

To test this pull request, you can run the following commands:

```shell
scorecard --local . --checks Token-Permissions
```

<details><summary>After</summary>
<p>

```
scorecard --local . --checks Token-Permissions
Starting [Token-Permissions]
Finished [Token-Permissions]

RESULTS
-------
Aggregate score: 10.0 / 10

Check scores:
|---------|-------------------|--------------------------------|------------------------------------------------------------------------------------------------------------------|
|  SCORE  |       NAME        |             REASON             |                                            DOCUMENTATION/REMEDIATION                                             |
|---------|-------------------|--------------------------------|------------------------------------------------------------------------------------------------------------------|
| 10 / 10 | Token-Permissions | GitHub workflow tokens follow  | https://github.com/ossf/scorecard/blob/49c0eed3a423f00c872b5c3c9f1bbca9e8aae799/docs/checks.md#token-permissions |
|         |                   | principle of least privilege   |                                                                                                                  |
|---------|-------------------|--------------------------------|------------------------------------------------------------------------------------------------------------------|
``` 

</p>
</details> 

<details><summary>Before</summary>
<p>

```
scorecard --local . --checks Token-Permissions
Starting [Token-Permissions]
Finished [Token-Permissions]

RESULTS
-------
Aggregate score: 0.0 / 10

Check scores:
|--------|-------------------|--------------------------------|------------------------------------------------------------------------------------------------------------------|
| SCORE  |       NAME        |             REASON             |                                            DOCUMENTATION/REMEDIATION                                             |
|--------|-------------------|--------------------------------|------------------------------------------------------------------------------------------------------------------|
| 0 / 10 | Token-Permissions | detected GitHub workflow       | https://github.com/ossf/scorecard/blob/49c0eed3a423f00c872b5c3c9f1bbca9e8aae799/docs/checks.md#token-permissions |
|        |                   | tokens with excessive          |                                                                                                                  |
|        |                   | permissions                    |                                                                                                                  |
|--------|-------------------|--------------------------------|------------------------------------------------------------------------------------------------------------------|
``` 

</p>
</details> 

## Additional Information

I think the only workflows that are not run in the context of PR are:

 - `add_issue_to_project.yaml` - Which uses a PAT
 - `release-drafter.yml` - Which uses permissions based on [usage](https://github.com/release-drafter/release-drafter#usage)
 - `release.yml` - Which moved permissions from top level context to job level context.

### Potential improvement

Might want to add some linting around it so it doesn't get reverted. There are linters like [action-lint](https://github.com/rhysd/actionlint) out there.
