### PR TITLE
deps: don't group go module minor update

### DIFF
--- a/updatecli/updatecli.d/golang/minor.yaml
+++ b/updatecli/updatecli.d/golang/minor.yaml
@@ -25,7 +25,7 @@ actions:
 autodiscovery:
   scmid: default
   actionid:  default
-  groupby: all
+  groupby: individual
   crawlers:
     golang/gomod:
       versionfilter:


### PR DESCRIPTION
Well I am giving another attempt at open minor version update individually as the current approach doesn't work 
https://github.com/updatecli/updatecli/pulls