### PR TITLE
chore: only run updatecli on targeted branch main

### DIFF
--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -3,7 +3,9 @@ on:
   release:
   workflow_dispatch:
   push:
+    branches: [main]
   pull_request:
+    branches: [main]
   schedule:
     # * is a special character in YAML so you have to quote this string
     # Run at 12:00 on Friday.”


### PR DESCRIPTION
It doesn't make sense to run updatecli for push and pullrequest targeting another branch than the main one