### PR TITLE
Fix comment that break the generated doc

### DIFF
--- a/pkg/plugins/resources/file/main.go
+++ b/pkg/plugins/resources/file/main.go
@@ -67,7 +67,7 @@ type Spec struct {
 	Content string `yaml:",omitempty"`
 	/*
 
-	   `forcecreate`` defines if nonexistent file(s) should be created
+	   `forcecreate` defines if nonexistent file(s) should be created
 
 	   compatible:
 	       * target


### PR DESCRIPTION
Fix a comment that break the generated doc

## Test

See [doc](https://www.updatecli.io/docs/plugins/resource/file/#_parameters) for `forcecreate`

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
