### PR TITLE
feat(helm): Helm Autodiscovery ignore local dependencies

### DIFF
--- a/pkg/plugins/autodiscovery/helm/dependencies.go
+++ b/pkg/plugins/autodiscovery/helm/dependencies.go
@@ -74,6 +74,11 @@ func (h Helm) discoverHelmDependenciesManifests() ([][]byte, error) {
 			sourceVersionFilterKind := "semver"
 			sourceVersionFilterPattern := "*"
 
+			if strings.HasPrefix(dependency.Repository, "file://") {
+				logrus.Debugf("Ignoring dependency %q for chart %q as it is a local dependency\n", chartName, dependency.Name)
+				continue
+			}
+
 			if !h.spec.VersionFilter.IsZero() {
 				sourceVersionFilterKind = h.versionFilter.Kind
 				sourceVersionFilterPattern, err = h.versionFilter.GreaterThanPattern(dependency.Version)

--- a/pkg/plugins/autodiscovery/helm/test/testdata-3/chart/sample/Chart.yaml
+++ b/pkg/plugins/autodiscovery/helm/test/testdata-3/chart/sample/Chart.yaml
@@ -3,3 +3,7 @@ description: A test chart for updatecli
 name: test3
 version: 1.0.0
 
+dependencies:
+  - name: monitoring
+    repository: file://charts/monitoring
+


### PR DESCRIPTION
While testing Updatecli on https://github.com/rancher/partner-charts 
I noticed a lot of failure due to chart relying on local dependencies such as https://github.com/rancher/partner-charts/blob/e1e19c33fc319281e60f74e36103979d120bdac4/charts/trilio/k8s-triliovault-operator/Chart.yaml#L11

I think it's better to ignore them until figure out the goal of specifying a dependency version...
<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
cd pkg/plugins/autodiscovery/helm/test/ 
go test
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
