### PR TITLE
feat(scm): add BasicAuth to stash

### DIFF
--- a/pkg/plugins/resources/stash/client/main.go
+++ b/pkg/plugins/resources/stash/client/main.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/drone/go-scm/scm"
 	"github.com/drone/go-scm/scm/driver/stash"
+	"github.com/drone/go-scm/scm/transport"
 	"github.com/drone/go-scm/scm/transport/oauth2"
 	"github.com/sirupsen/logrus"
 )
@@ -38,14 +39,23 @@ func New(s Spec) (Client, error) {
 	}
 
 	if len(s.Token) >= 0 {
-		client.Client = &http.Client{
-			Transport: &oauth2.Transport{
-				Source: oauth2.StaticTokenSource(
-					&scm.Token{
-						Token: s.Token,
-					},
-				),
-			},
+		if len(s.Username) >= 0 {
+			client.Client = &http.Client{
+				Transport: &transport.BasicAuth{
+					Username: s.Username,
+					Password: s.Token,
+				},
+			}
+		} else {
+			client.Client = &http.Client{
+				Transport: &oauth2.Transport{
+					Source: oauth2.StaticTokenSource(
+						&scm.Token{
+							Token: s.Token,
+						},
+					),
+				},
+			}
 		}
 	}
 


### PR DESCRIPTION
PR plugins doesn't support BasicAuth even though Username is provided.

## Test

I have no idea to test this module. I have tested manually over a bitbucket server.

## Additional Information

### Tradeoff

### Potential improvement

add BasicAuth support to the other plugins
