### PR TITLE
fix: maven autodiscovery e2e test

### DIFF
--- a/e2e/updatecli.d/success.d/autodiscovery/maven/git.yaml
+++ b/e2e/updatecli.d/success.d/autodiscovery/maven/git.yaml
@@ -24,5 +24,7 @@ autodiscovery:
       #  - path: <filepath relative to scm repository>
       only:
         - artifactids:
-            "mockito-core": ""
+            "plugin": ""
+          groupid:
+            "org.jenkins-ci": ""
 


### PR DESCRIPTION
Apparently the maven dependency used in e2e has been removed

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
updatecli diff --config e2e/updatecli.d/success.d/autodiscovery/maven 
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
