### PR TITLE
feat(terraform/lock): parse provider hostname onto lock download client

### DIFF
--- a/pkg/plugins/resources/terraform/lock/main.go
+++ b/pkg/plugins/resources/terraform/lock/main.go
@@ -68,19 +68,21 @@ func New(spec interface{}) (*TerraformLock, error) {
 		}
 	}
 
-	lockIndex, err := lock.NewDefaultIndex()
-	if err != nil {
-		return nil, err
-	}
-
-	newResource.lockIndex = lockIndex
-
 	provider, err := terraformRegistryAddress.ParseProviderSource(newResource.spec.Provider)
 	if err != nil {
 		return nil, err
 	}
 
 	newResource.provider = provider
+
+	client, err := lock.NewProviderDownloaderClient(lock.TFRegistryConfig{
+		BaseURL: fmt.Sprintf("https://%s/", provider.Hostname),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	newResource.lockIndex = lock.NewIndex(client)
 
 	return newResource, nil
 }


### PR DESCRIPTION
This enables support for opentofu for lock files.

The provider already supported providing full provider names ex: `registry.opentofu.org/hashicorp/hcp`, but the hostname wasn't parsed onto the lock client (Which defaults to `registry.terraform.io`). By passing this on it adds support for opentofu with very little changes.

Part of: https://github.com/updatecli/updatecli/issues/1861

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
go test ./pkg/plugins/resources/terraform/lock/
```

Also tested with existing terraform project.

```shell
go build -o ./bin/updatecli
cd ../../terraform-project
tofu init  # which updates lock file with registry.opentofu.org
../../bin/updatecli diff
```

Then adding the hostname to the provider:

```yaml
targets:
  provider:
    name: 'Bump hashicorp/hcp to {{ source "latestRelease" }}'
    kind: terraform/lock
    sourceid: latestRelease
    spec:
      files:
        - .terraform.lock.hcl
      provider: registry.opentofu.org/hashicorp/hcp
      skipconstraints: true
      platforms:
        - darwin_amd64
        - linux_amd64
        - windows_amd64
```

Produces the following output:

```text
provider
--------

**Dry Run enabled**

2024/01/14 20:34:18 [DEBUG] providerIndex.createProviderVersion: registry.opentofu.org/hashicorp/hcp, 0.80.0, darwin_amd64
2024/01/14 20:34:18 [DEBUG] Client.ProviderPackageMetadata: GET https://registry.opentofu.org/v1/providers/hashicorp/hcp/0.80.0/download/darwin/amd64
2024/01/14 20:34:18 [DEBUG] ProviderDownloaderClient.download: GET https://github.com/opentofu/terraform-provider-hcp/releases/download/v0.80.0/terraform-provider-hcp_0.80.0_darwin_amd64.zip
2024/01/14 20:34:19 [DEBUG] ProviderDownloaderClient.download: GET https://github.com/opentofu/terraform-provider-hcp/releases/download/v0.80.0/terraform-provider-hcp_0.80.0_SHA256SUMS
2024/01/14 20:34:20 [DEBUG] providerIndex.createProviderVersion: registry.opentofu.org/hashicorp/hcp, 0.80.0, linux_amd64
2024/01/14 20:34:20 [DEBUG] Client.ProviderPackageMetadata: GET https://registry.opentofu.org/v1/providers/hashicorp/hcp/0.80.0/download/linux/amd64
2024/01/14 20:34:20 [DEBUG] ProviderDownloaderClient.download: GET https://github.com/opentofu/terraform-provider-hcp/releases/download/v0.80.0/terraform-provider-hcp_0.80.0_linux_amd64.zip
2024/01/14 20:34:22 [DEBUG] ProviderDownloaderClient.download: GET https://github.com/opentofu/terraform-provider-hcp/releases/download/v0.80.0/terraform-provider-hcp_0.80.0_SHA256SUMS
2024/01/14 20:34:22 [DEBUG] providerIndex.createProviderVersion: registry.opentofu.org/hashicorp/hcp, 0.80.0, windows_amd64
2024/01/14 20:34:22 [DEBUG] Client.ProviderPackageMetadata: GET https://registry.opentofu.org/v1/providers/hashicorp/hcp/0.80.0/download/windows/amd64
2024/01/14 20:34:22 [DEBUG] ProviderDownloaderClient.download: GET https://github.com/opentofu/terraform-provider-hcp/releases/download/v0.80.0/terraform-provider-hcp_0.80.0_windows_amd64.zip
2024/01/14 20:34:23 [DEBUG] ProviderDownloaderClient.download: GET https://github.com/opentofu/terraform-provider-hcp/releases/download/v0.80.0/terraform-provider-hcp_0.80.0_SHA256SUMS
⚠ - "registry.opentofu.org/hashicorp/hcp" updated from "0.79.0" to "0.80.0" in file ".terraform.lock.hcl"
```


## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

Further investigation into differences between opentofu and terraform as they deveop.

Add documentation for opentofu support.

Provider support for opentofu still needs to be added.

<!-- Please describe, if any, potential improvement that you are envisioning -->
