### PR TITLE
fix: updatecli compose caching

### DIFF
--- a/pkg/core/registry/pull.go
+++ b/pkg/core/registry/pull.go
@@ -22,8 +22,6 @@ import (
 // Pull pulls an OCI image from a registry.
 func Pull(ociName string, disableTLS bool) (manifests []string, values []string, secrets []string, err error) {
 
-	logrus.Infof("Pulling Updatecli policy %q\n", ociName)
-
 	ref, err := registry.ParseReference(ociName)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("parse reference: %w", err)
@@ -55,32 +53,18 @@ func Pull(ociName string, disableTLS bool) (manifests []string, values []string,
 	}
 
 	// 2.5 Get remote manifest digest
-	remoteManifestSpec, _, err := oras.Fetch(ctx, repo, ref.String(), oras.DefaultFetchOptions)
+	remoteManifestSpec, remoteManifestReader, err := oras.Fetch(ctx, repo, ref.String(), oras.DefaultFetchOptions)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("fetch: %w", err)
 	}
 
-	// Create a file policyRootDir
-	policyRootDir := filepath.Join(getReferencePath(remoteManifestSpec.Digest.String())...)
-
-	policyRootDirFileInfo, err := os.Stat(policyRootDir)
-	// If store path exist and is a directory then we do nothing
-	if err == nil {
-		if policyRootDirFileInfo.IsDir() {
-			logrus.Debugf("\t* directory %s already exist, skipping pull", policyRootDir)
-			return nil, nil, nil, nil
-		}
-		// If store path is not a directory then we delete it
-		// so we can recreate it as a directory
-		err := os.Remove(policyRootDir)
-		if err != nil {
-			return nil, nil, nil, fmt.Errorf("resetting file %s: %w", policyRootDir, err)
-		}
-	} else {
-		if !errors.Is(err, os.ErrNotExist) {
-			return nil, nil, nil, fmt.Errorf("getting information about %s: %w", policyRootDir, err)
-		}
+	remoteManifestData, err := content.ReadAll(remoteManifestReader, remoteManifestSpec)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("fetch remote content: %w", err)
 	}
+
+	// Create the policy root directory
+	policyRootDir := filepath.Join(getReferencePath(remoteManifestSpec.Digest.String())...)
 
 	fs, err := file.New(policyRootDir)
 	if err != nil {
@@ -89,41 +73,33 @@ func Pull(ociName string, disableTLS bool) (manifests []string, values []string,
 	defer fs.Close()
 
 	// 3. Copy from the remote repository to the file store
-	manifestDescriptor, err := oras.Copy(ctx, repo, ref.Reference, fs, ref.Reference, oras.DefaultCopyOptions)
-	if err != nil {
-		return nil, nil, nil, fmt.Errorf("copy: %w", err)
-	}
 
-	manifestData, err := content.FetchAll(ctx, fs, manifestDescriptor)
-	if err != nil {
-		return nil, nil, nil, fmt.Errorf("fetch manifest: %w", err)
-	}
+	// Fetch the remote mainfst
 
-	spec := spec.Manifest{}
-	err = json.Unmarshal(manifestData, &spec)
-	if err != nil {
-		return nil, nil, nil, fmt.Errorf("unmarshal manifest: %w", err)
-	}
+	remoteManifests, remoteValues, remoteSecrets, err := getUpdatecliFilesFromManifestLayers(remoteManifestData, policyRootDir)
 
-	for _, layer := range spec.Layers {
-		switch layer.MediaType {
-		case updatecliManifestMediaType:
-			if title, ok := layer.Annotations["org.opencontainers.image.title"]; ok && title != "" {
-				manifests = append(manifests, filepath.Join(policyRootDir, title))
-			}
+	manifests = remoteManifests
+	values = remoteValues
+	secrets = remoteSecrets
 
-		case updatecliValueMediaType:
-			if title, ok := layer.Annotations["org.opencontainers.image.title"]; ok && title != "" {
-				values = append(values, filepath.Join(policyRootDir, title))
-			}
+	if isPolicyFilesExistLocally(policyRootDir, remoteManifests, remoteValues, remoteSecrets) {
+		logrus.Debugf("Policy %q already available in:\n\t* %s\n", ociName, policyRootDir)
+	} else {
+		logrus.Infof("Pulling Updatecli policy %q\n", ociName)
 
-		case updatecliSecretMediaType:
-			if title, ok := layer.Annotations["org.opencontainers.image.title"]; ok && title != "" {
-				secrets = append(secrets, filepath.Join(policyRootDir, title))
-			}
+		manifestDescriptor, err := oras.Copy(ctx, repo, ref.Reference, fs, ref.Reference, oras.DefaultCopyOptions)
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("copy: %w", err)
+		}
 
-		default:
-			logrus.Warningf("unknown media type: %q\n", layer.MediaType)
+		manifestData, err := content.FetchAll(ctx, fs, manifestDescriptor)
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("fetch manifest: %w", err)
+		}
+
+		manifests, values, secrets, err = getUpdatecliFilesFromManifestLayers(manifestData, policyRootDir)
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("get media types from layers: %w", err)
 		}
 	}
 
@@ -161,4 +137,88 @@ func getReferencePath(ref string) []string {
 	refPath = append(refPath, strings.TrimPrefix(ref, "sha256:"))
 
 	return refPath
+}
+
+// getUpdatecliFilesFromManifestLayers returns the list of manifests, values and secrets from an OCI manifest
+func getUpdatecliFilesFromManifestLayers(manifestData []byte, policyRootDir string) (
+	manifests []string, values []string, secrets []string, err error) {
+
+	spec := spec.Manifest{}
+	err = json.Unmarshal(manifestData, &spec)
+	if err != nil {
+		return []string{}, []string{}, []string{}, fmt.Errorf("unmarshal manifest: %w", err)
+	}
+
+	for _, layer := range spec.Layers {
+		switch layer.MediaType {
+		case updatecliManifestMediaType:
+			if title, ok := layer.Annotations["org.opencontainers.image.title"]; ok && title != "" {
+				manifests = append(manifests, filepath.Join(policyRootDir, title))
+			}
+
+		case updatecliValueMediaType:
+			if title, ok := layer.Annotations["org.opencontainers.image.title"]; ok && title != "" {
+				values = append(values, filepath.Join(policyRootDir, title))
+			}
+
+		case updatecliSecretMediaType:
+			if title, ok := layer.Annotations["org.opencontainers.image.title"]; ok && title != "" {
+				secrets = append(secrets, filepath.Join(policyRootDir, title))
+			}
+
+		default:
+			logrus.Warningf("unknown media type: %q\n", layer.MediaType)
+		}
+	}
+
+	return manifests, values, secrets, nil
+}
+
+/*
+isPolicyFilesExistLocally returns true if the policy files are already available locally.
+note it does not check if the files are up to date, only if they exist locally.
+*/
+func isPolicyFilesExistLocally(policyRootDir string, manifests, values, secrets []string) bool {
+
+	errs := []error{}
+
+	policyRootDirFileInfo, err := os.Stat(policyRootDir)
+	// If store path exist and is a directory then we do nothing
+	if err == nil {
+		if !policyRootDirFileInfo.IsDir() {
+			errs = append(errs, fmt.Errorf("policy root dir %s already exist and is not a directory", policyRootDir))
+		}
+	} else {
+		if !errors.Is(err, os.ErrNotExist) {
+			errs = append(errs, fmt.Errorf("getting information about %s: %w", policyRootDir, err))
+		}
+	}
+
+	isFileExist := func(files []string) {
+		for _, f := range files {
+			_, err := os.Stat(f)
+			if err == nil {
+				continue
+			}
+			if errors.Is(err, os.ErrNotExist) {
+				errs = append(errs, fmt.Errorf("%s does not exist locally", f))
+			} else {
+				errs = append(errs, fmt.Errorf("something went wrong while checking if %s exist: %w", f, err))
+			}
+		}
+	}
+
+	isFileExist(manifests)
+	isFileExist(values)
+	isFileExist(secrets)
+
+	if len(errs) > 0 {
+		for i := range errs {
+			logrus.Debugln(errs[i])
+		}
+		return false
+	}
+
+	return true
+
 }


### PR DESCRIPTION
Fix #1867

Well the first iteration was plainly wrong.
This pullrequest also checks that all files needed are downloaded and not only the root directory

## Test

Test locally that

1. Running multiple time only pull the policy once
2. Deleting file in the policy root directory will trigger a new pull during the next run

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
