### PR TITLE
fix: helm autodiscovery should ignore subcharts

### DIFF
--- a/pkg/plugins/autodiscovery/helm/dependencies.go
+++ b/pkg/plugins/autodiscovery/helm/dependencies.go
@@ -74,7 +74,7 @@ func (h Helm) discoverHelmDependenciesManifests() ([][]byte, error) {
 			sourceVersionFilterKind := "semver"
 			sourceVersionFilterPattern := "*"
 
-			if strings.HasPrefix(dependency.Repository, "file://") {
+			if strings.HasPrefix(dependency.Repository, "file://") || dependency.Repository == "" {
 				logrus.Debugf("Ignoring dependency %q for chart %q as it is a local dependency\n", chartName, dependency.Name)
 				continue
 			}

--- a/pkg/plugins/autodiscovery/helm/test/testdata-3/chart/sample/Chart.yaml
+++ b/pkg/plugins/autodiscovery/helm/test/testdata-3/chart/sample/Chart.yaml
@@ -6,4 +6,5 @@ version: 1.0.0
 dependencies:
   - name: monitoring
     repository: file://charts/monitoring
-
+  - name: monitoring
+    condition: monitoring.enabled


### PR DESCRIPTION
Fix #1876 

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
cd pkg/plugins/autodiscovery/helm/test/ 
go test
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
