### PR TITLE
feat: add a command to scaffold a new Policy

### DIFF
--- a/cmd/manifest_init.go
+++ b/cmd/manifest_init.go
@@ -1,0 +1,35 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	manifestInitPolicyRootDir string
+	manifestInitCmd           = &cobra.Command{
+		Args:  cobra.MatchAll(cobra.MaximumNArgs(1)),
+		Use:   "init <path>",
+		Short: "init a new Updatecli policy",
+		Run: func(cmd *cobra.Command, args []string) {
+
+			manifestInitPolicyRootDir = "."
+			if len(args) == 1 {
+				manifestInitPolicyRootDir = args[0]
+			}
+
+			err := run("manifest/init")
+			if err != nil {
+				logrus.Errorf("command failed: %s", err)
+				os.Exit(1)
+			}
+		},
+	}
+)
+
+func init() {
+	manifestCmd.AddCommand(manifestInitCmd)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -139,6 +139,13 @@ func run(command string) error {
 			logrus.Errorf("%s %s", result.FAILURE, err)
 		}
 
+	case "manifest/init":
+
+		err := e.Scaffold(manifestInitPolicyRootDir)
+		if err != nil {
+			logrus.Errorf("%s %s", result.FAILURE, err)
+		}
+
 	case "manifest/upgrade":
 		err := e.ManifestUpgrade(manifestUpgradeInPlace)
 		if err != nil {

--- a/pkg/core/engine/scaffold.go
+++ b/pkg/core/engine/scaffold.go
@@ -1,0 +1,23 @@
+package engine
+
+import (
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+	"github.com/updatecli/updatecli/pkg/core/scaffold"
+)
+
+func (e *Engine) Scaffold(rootDir string) error {
+
+	PrintTitle("Scaffold a new Updatecli policy")
+
+	s := scaffold.Scaffold{}
+
+	if err := s.Run(rootDir); err != nil {
+		return fmt.Errorf("unable to scaffold a new Updatecli policy - %s", err)
+	}
+
+	logrus.Infof("A new Updatecli policy has been scaffolded in %s", rootDir)
+
+	return nil
+}

--- a/pkg/core/scaffold/changelog.go
+++ b/pkg/core/scaffold/changelog.go
@@ -1,0 +1,50 @@
+package scaffold
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/sirupsen/logrus"
+)
+
+var (
+	changelogFile     string = "CHANGELOG.md"
+	changelogTemplate string = `# CHANGELOG
+
+## 0.1.0
+
+  * Initial release
+`
+)
+
+func (s *Scaffold) scaffoldChangelog(dirname string) error {
+
+	if _, err := os.Stat(dirname); os.IsNotExist(err) {
+		err := os.MkdirAll(dirname, 0755)
+		if err != nil {
+			return err
+		}
+	}
+
+	changelogFilePath := filepath.Join(dirname, changelogFile)
+
+	// If the changelog already exist, we don't overwrite it
+	if _, err := os.Stat(changelogFilePath); err == nil {
+		logrus.Infof("Skipping, changelog already exist: %s", changelogFilePath)
+		return nil
+	}
+
+	f, err := os.Create(changelogFilePath)
+	if err != nil {
+		return err
+	}
+
+	defer f.Close()
+
+	_, err = f.Write([]byte(changelogTemplate))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/core/scaffold/config.go
+++ b/pkg/core/scaffold/config.go
@@ -1,0 +1,98 @@
+package scaffold
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/sirupsen/logrus"
+)
+
+var (
+	configFile     string = "default.yaml"
+	configTemplate string = `---
+name: Default pipeline name
+
+## scms defines the source control management system to interact with.
+# scms:
+#   default:
+#     kind: github
+#     spec:
+#       owner: {{ .scm.default.owner }}
+#       repository: {{ .scm.default.repository }}
+#       branch: {{ .scm.default.branch }}
+#       user: {{ .scm.default.user }}
+#       email: {{ .scm.default.email }}
+#       username: {{ .scm.default.username }}
+#       token: {{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}
+
+## actions defines what to do when a target with the same scmid is modified.
+# actions:
+#   default:
+#     kind: "github/pullrequest"
+#     scmid: "default"
+#     spec:
+#       automerge: false
+#       labels:
+#         - "dependencies"
+
+## sources defines where to find the information.
+# sources:
+#   default:
+#     name: "Short source description"
+#     scmid: default
+#     kind: specify the source plugin to use
+#       spec:
+#         # Specify the source plugin specific configuration
+
+## conditions defines when to executes a target
+# conditions:
+#   default:
+#     name: "Short condition description"
+#     kind: specify the condition plugin to use
+#     scmid: default
+#     spec:
+#       # Specify the condition plugin specific configuration
+
+## targets defines where to apply the changes.
+# targets:
+#   default:
+#     name: "Short target description"
+#     kind: specify the target plugin to use
+#     scmid: default
+#     spec:
+#       # Specify the target plugin specific configuration
+`
+)
+
+func (s *Scaffold) scaffoldConfig(rootDir string) error {
+
+	configDir = filepath.Join(rootDir, s.ConfigDir)
+
+	if _, err := os.Stat(configDir); os.IsNotExist(err) {
+		err := os.MkdirAll(configDir, 0755)
+		if err != nil {
+			return err
+		}
+	}
+
+	configFilePath := filepath.Join(configDir, configFile)
+
+	// If the config already exist, we don't overwrite it
+	if _, err := os.Stat(configFilePath); err == nil {
+		logrus.Infof("Skipping, config already exist: %s", configFilePath)
+		return nil
+	}
+
+	f, err := os.Create(configFilePath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	_, err = f.Write([]byte(configTemplate))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/core/scaffold/main.go
+++ b/pkg/core/scaffold/main.go
@@ -1,0 +1,76 @@
+package scaffold
+
+import (
+	"github.com/sirupsen/logrus"
+)
+
+var (
+	// defaultPolicyFile is the default policy file name
+	defaultPolicyFile = "Policy.yaml"
+	// defaultValuesDir is the default values directory name
+	defaultValuesDir = "values.d"
+	// defaultSecretsDir is the default secrets directory name
+	defaultSecretsDir = "secrets.d"
+	// configDir is the default config directory name
+	configDir = "updatecli.d"
+)
+
+// Scaffold is the main structure to scaffold a new Updatecli policy
+type Scaffold struct {
+	// PolicyFile is the policy file name
+	PolicyFile string
+	// ValuesDir is the values directory name
+	ValuesDir string
+	// SecretsDir is the secrets directory name
+	SecretsDir string
+	// ConfigDir is the config directory name
+	ConfigDir string
+}
+
+// Init initialize a new scaffold
+func (s *Scaffold) Init() {
+
+	setDefaultValues := func(s *string, defaultValue string) {
+		if *s == "" {
+			*s = defaultValue
+		}
+	}
+
+	setDefaultValues(&s.ConfigDir, configDir)
+	setDefaultValues(&s.PolicyFile, defaultPolicyFile)
+	setDefaultValues(&s.SecretsDir, defaultSecretsDir)
+	setDefaultValues(&s.ValuesDir, defaultValuesDir)
+}
+
+// Run scaffold a new Updatecli policy
+func (s *Scaffold) Run(rootDir string) error {
+	s.Init()
+	logrus.Debugf("Initialize an Updatecli policy")
+
+	err := s.scaffoldPolicy(&PolicySpec{}, rootDir, s.PolicyFile)
+	if err != nil {
+		return err
+	}
+
+	err = s.scaffoldValues(rootDir)
+	if err != nil {
+		return err
+	}
+
+	err = s.scaffoldConfig(rootDir)
+	if err != nil {
+		return err
+	}
+
+	err = s.scaffoldReadme(rootDir)
+	if err != nil {
+		return err
+	}
+
+	err = s.scaffoldChangelog(rootDir)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/core/scaffold/main_test.go
+++ b/pkg/core/scaffold/main_test.go
@@ -1,0 +1,36 @@
+package scaffold
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRun(t *testing.T) {
+
+	testRootDir := filepath.Join(os.TempDir(), "updatecli", "test", "core", "scaffold")
+
+	s := Scaffold{}
+
+	err := s.Run(testRootDir)
+	require.NoError(t, err)
+
+	assert.DirExists(t, filepath.Join(testRootDir))
+	assert.FileExists(t, filepath.Join(testRootDir, "Policy.yaml"))
+
+	assert.DirExists(t, filepath.Join(testRootDir, "updatecli.d"))
+	assert.FileExists(t, filepath.Join(testRootDir, "updatecli.d", "default.yaml"))
+
+	assert.FileExists(t, filepath.Join(testRootDir, "README.md"))
+
+	assert.DirExists(t, filepath.Join(testRootDir, "values.d"))
+	assert.FileExists(t, filepath.Join(testRootDir, "values.d", "default.yaml"))
+
+	assert.FileExists(t, filepath.Join(testRootDir, "CHANGELOG.md"))
+
+	// Cleanup after test
+	os.RemoveAll(testRootDir)
+}

--- a/pkg/core/scaffold/policy.go
+++ b/pkg/core/scaffold/policy.go
@@ -1,0 +1,139 @@
+package scaffold
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"text/template"
+
+	"github.com/sirupsen/logrus"
+)
+
+var (
+	policyTemplate = `---
+# Policy.yaml contains metadata for the Updatecli policy.
+
+# Authors is the policy authors
+authors:
+{{- range $author := .Authors }}
+  - {{ $author }}
+{{- end }}
+
+# URL is the policy url
+url: {{ .URL }}
+
+# Documentation is the policy documentation URL
+documentation: {{ .Documentation }}
+
+# Source is the policy source URL
+source: {{ .Source }}
+
+# Version is the policy version. 
+version: {{ .Version }}
+
+# Vendor is the policy vendor
+vendor: {{ .Vendor }}
+
+# License is the policy licenses
+licenses:
+  - "{{ .License }}"
+
+# Description is the short policy description
+description: |
+  {{ .Description }}
+`
+	defaultAuthors       []string = []string{"Please insert an author for your policy"}
+	defaultDocumentation string   = "Please insert a documentation url for your policy"
+	defaultURL           string   = "Please insert a url for your policy"
+	defaultDescription   string   = "Please insert a description for your policy"
+	defaultLicense       string   = "Please insert a license for your policy"
+	defaultSource        string   = "Please insert the source url of the policy"
+	defaultVendor        string   = "Please insert a vendor for your policy"
+	defaultVersion       string   = "0.1.0"
+)
+
+// PolicySpec is the policy specification
+type PolicySpec struct {
+	// Authors is the policy authors
+	Authors []string
+	// Description is the policy description
+	Description string
+	// Documentation is the policy documentation URL
+	Documentation string
+	// License is the policy license
+	License string
+	// Source is the policy source URL
+	Source string
+	// Version is the policy version
+	Version string
+	// Vendor is the policy vendor
+	Vendor string
+	// URL is the policy url
+	URL string
+}
+
+// sanitize set default values for the policy specification
+func (p *PolicySpec) sanitize() {
+
+	setDefaultValues := func(s *string, defaultValue string) {
+		if *s == "" {
+			*s = defaultValue
+		}
+	}
+
+	setDefaultArrayValues := func(s *[]string, defaultValue []string) {
+		if len(*s) == 0 {
+			*s = defaultValue
+		}
+	}
+
+	setDefaultValues(&p.Description, defaultDescription)
+	setDefaultValues(&p.Documentation, defaultDocumentation)
+	setDefaultValues(&p.License, defaultLicense)
+	setDefaultValues(&p.Source, defaultSource)
+	setDefaultValues(&p.Vendor, defaultVendor)
+	setDefaultValues(&p.Version, defaultVersion)
+	setDefaultValues(&p.URL, defaultURL)
+
+	setDefaultArrayValues(&p.Authors, defaultAuthors)
+
+}
+
+// scaffoldPolicy scaffold a new Updatecli policy file
+func (s *Scaffold) scaffoldPolicy(p *PolicySpec, dirname, filename string) error {
+
+	p.sanitize()
+
+	if _, err := os.Stat(dirname); os.IsNotExist(err) {
+		err := os.MkdirAll(dirname, 0755)
+		if err != nil {
+			return err
+		}
+	}
+
+	policyFilePath := filepath.Join(dirname, filename)
+
+	if _, err := os.Stat(policyFilePath); err == nil {
+		logrus.Infof("Skipping, policy already exist: %s", policyFilePath)
+		return nil
+	}
+
+	f, err := os.Create(policyFilePath)
+	if err != nil {
+		return err
+	}
+
+	defer f.Close()
+
+	tmpl, err := template.New("policy").Parse(policyTemplate)
+	if err != nil {
+		return fmt.Errorf("unable to parse policy template: %s", err)
+	}
+
+	err = tmpl.Execute(f, p)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/core/scaffold/readme.go
+++ b/pkg/core/scaffold/readme.go
@@ -1,0 +1,124 @@
+package scaffold
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/sirupsen/logrus"
+)
+
+var (
+	readmeFile     string = "README.md"
+	readmeTemplate string = `# README
+
+## REQUIREMENTS
+
+Before using this policy, here is a list of requirements to meet:
+
+- [ ] Review the file [Policy.yaml](./Policy.yaml) and update the values to match your needs (see [documentation](https://www.updatecli.io/docs/core/shareandreuse/) section).
+- [ ] Review the file [values.d/default.yaml](./values.d/default.yaml) and update the values to match your needs.
+- [ ] Review the file [updatecli.d/default.yaml](./updatecli.d/default.yaml) and update the values to match your needs (see [documentation](https://www.updatecli.io/docs/core/configuration/) section).
+
+Feel free to delete this requirements section once you are done with the checklist.
+
+## DESCRIPTION
+
+<Please specify your policy description >
+
+
+## HOW TO USE
+
+**Show**
+
+They are two different approaches to see the content of this policy:
+
+Using the policy from the local filesystem by running:
+
+	updatecli manifest show --config updatecli.d --values values.d/default.yaml
+
+Using the policy from the registry by running:
+
+    updatecli manifest show $OCI_REGISTRY/< insert your policy name>:v0.1.0
+
+
+**Use**
+
+Similarly to the show command, they are two ways to execute an Updatecli policy, either using the local file or the one stored on the registry.
+
+Using the policy from the local filesystem by running:
+
+    updatecli diff --config updatecli.d --values values.d/default.yaml
+
+Using the policy from the registry by running:
+
+    updatecli diff ghcr.io/updatecli/policies/<a policy name>:v0.1.0
+
+
+If "diff" is replaced by "apply", then the policy will be executed in enforce mode.
+
+⚠ Any values files specified at runtime will override default values set from the policy bundle
+
+**Login**
+
+Regardless your Updatecli policy is meant to be public or private, you probably always want to be authenticated with your registry, by running:
+
+    docker login "$OCI_REGISTRY"
+
+INFO: OCI_REGISTRY can be any OCI compliant registry such as [Zot](https://github.com/project-zot/zot), [DockerHub](https://hub.docker.com), [ghcr.io](https://ghcr.io),etc.
+
+**Publish**
+
+Policies defines in this repository can be published to your registry by running:
+
+	updatecli manifest push \
+		--config updatecli.d \
+		--values values.d/default.yaml \
+    	--policy Policy.yaml \
+    	--tag "$OCI_REGISTRY/<insert your policy name>" \
+		.
+
+⚠ The tag is defined by the version field in the policy file
+⚠ The latest tag always represents the latest version published from
+a semantic versioning point of view.
+
+## NEXT STEPS
+
+Feel free to look on the [Updatecli documentation](https://updatecli.io) to learn more about how to use Updatecli.
+
+Another good starting point is to understand how to use [update-compose.yaml](https://www.updatecli.io/docs/core/compose/) to orchestrate multiple Updatecli policies.
+
+## CONTRIBUTING
+`
+)
+
+func (s *Scaffold) scaffoldReadme(dirname string) error {
+
+	if _, err := os.Stat(dirname); os.IsNotExist(err) {
+		err := os.MkdirAll(dirname, 0755)
+		if err != nil {
+			return err
+		}
+	}
+
+	readmeFilePath := filepath.Join(dirname, readmeFile)
+
+	// If the config already exist, we don't overwrite it
+	if _, err := os.Stat(readmeFilePath); err == nil {
+		logrus.Infof("Skipping, readme already exist: %s", readmeFilePath)
+		return nil
+	}
+
+	f, err := os.Create(readmeFilePath)
+	if err != nil {
+		return err
+	}
+
+	defer f.Close()
+
+	_, err = f.Write([]byte(readmeTemplate))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/core/scaffold/values.go
+++ b/pkg/core/scaffold/values.go
@@ -1,0 +1,56 @@
+package scaffold
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/sirupsen/logrus"
+)
+
+var (
+	valuesFile     string = "default.yaml"
+	valuesTemplate string = `---
+# Values.yaml contains settings that be used from Updatecli manifest.
+# scm:
+#   default:
+#     user: updatecli-bot
+#     email: updatecli-bot@updatecli.io
+#     owner: github_owner
+#     repository: github_repository
+#     username: "updatecli-bot"
+#     branch: main
+`
+)
+
+func (s *Scaffold) scaffoldValues(dirname string) error {
+
+	dirname = filepath.Join(dirname, "values.d")
+
+	if _, err := os.Stat(dirname); os.IsNotExist(err) {
+		err := os.MkdirAll(dirname, 0755)
+		if err != nil {
+			return err
+		}
+	}
+
+	valuesFilePath := filepath.Join(dirname, valuesFile)
+
+	if _, err := os.Stat(valuesFilePath); err == nil {
+		logrus.Infof("Skipping, values already exist: %s", valuesFilePath)
+		return nil
+	}
+
+	f, err := os.Create(valuesFilePath)
+	if err != nil {
+		return err
+	}
+
+	defer f.Close()
+
+	_, err = f.Write([]byte(valuesTemplate))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
This pullrequest adds a new command `updatecli manifest init .` to scaffold a new policy.
In the current state, it comes with zero customization and creates the following files:

* `README.md` which contains the policy documentation
* `Policy.yaml` that contains the policy metadata
* `values.d/default.yaml` which contains basic scm setting
* `updatecli.d/default.yaml` which is a placeholder for the first manifest
* `CHANGELOG.md` which contains a template to provide policy changelog information

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
go build -o bin/updatecli .
bin/updatecli manifest init /tmp/test
ls /tmp/test
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

I would like to provide some form of input
