### PR TITLE
fix(scaffold): use default values.yaml

### DIFF
--- a/pkg/core/scaffold/config.go
+++ b/pkg/core/scaffold/config.go
@@ -66,16 +66,16 @@ name: Default pipeline name
 
 func (s *Scaffold) scaffoldConfig(rootDir string) error {
 
-	configDir = filepath.Join(rootDir, s.ConfigDir)
+	defaultConfigDir = filepath.Join(rootDir, s.ConfigDir)
 
-	if _, err := os.Stat(configDir); os.IsNotExist(err) {
-		err := os.MkdirAll(configDir, 0755)
+	if _, err := os.Stat(defaultConfigDir); os.IsNotExist(err) {
+		err := os.MkdirAll(defaultConfigDir, 0755)
 		if err != nil {
 			return err
 		}
 	}
 
-	configFilePath := filepath.Join(configDir, configFile)
+	configFilePath := filepath.Join(defaultConfigDir, configFile)
 
 	// If the config already exist, we don't overwrite it
 	if _, err := os.Stat(configFilePath); err == nil {

--- a/pkg/core/scaffold/main.go
+++ b/pkg/core/scaffold/main.go
@@ -7,20 +7,20 @@ import (
 var (
 	// defaultPolicyFile is the default policy file name
 	defaultPolicyFile = "Policy.yaml"
-	// defaultValuesDir is the default values directory name
-	defaultValuesDir = "values.d"
 	// defaultSecretsDir is the default secrets directory name
 	defaultSecretsDir = "secrets.d"
-	// configDir is the default config directory name
-	configDir = "updatecli.d"
+	// defaultConfigDir is the default config directory name
+	defaultConfigDir = "updatecli.d"
+	// defaultValuesFile is the default values file name
+	defaultValuesFile = "values.yaml"
 )
 
 // Scaffold is the main structure to scaffold a new Updatecli policy
 type Scaffold struct {
 	// PolicyFile is the policy file name
 	PolicyFile string
-	// ValuesDir is the values directory name
-	ValuesDir string
+	// ValuesFile is the values directory name
+	ValuesFile string
 	// SecretsDir is the secrets directory name
 	SecretsDir string
 	// ConfigDir is the config directory name
@@ -36,10 +36,10 @@ func (s *Scaffold) Init() {
 		}
 	}
 
-	setDefaultValues(&s.ConfigDir, configDir)
+	setDefaultValues(&s.ConfigDir, defaultConfigDir)
 	setDefaultValues(&s.PolicyFile, defaultPolicyFile)
 	setDefaultValues(&s.SecretsDir, defaultSecretsDir)
-	setDefaultValues(&s.ValuesDir, defaultValuesDir)
+	setDefaultValues(&s.ValuesFile, defaultValuesFile)
 }
 
 // Run scaffold a new Updatecli policy
@@ -47,7 +47,7 @@ func (s *Scaffold) Run(rootDir string) error {
 	s.Init()
 	logrus.Debugf("Initialize an Updatecli policy")
 
-	err := s.scaffoldPolicy(&PolicySpec{}, rootDir, s.PolicyFile)
+	err := s.scaffoldPolicy(&PolicySpec{}, rootDir)
 	if err != nil {
 		return err
 	}

--- a/pkg/core/scaffold/main_test.go
+++ b/pkg/core/scaffold/main_test.go
@@ -26,8 +26,7 @@ func TestRun(t *testing.T) {
 
 	assert.FileExists(t, filepath.Join(testRootDir, "README.md"))
 
-	assert.DirExists(t, filepath.Join(testRootDir, "values.d"))
-	assert.FileExists(t, filepath.Join(testRootDir, "values.d", "default.yaml"))
+	assert.FileExists(t, filepath.Join(testRootDir, "values.yaml"))
 
 	assert.FileExists(t, filepath.Join(testRootDir, "CHANGELOG.md"))
 

--- a/pkg/core/scaffold/policy.go
+++ b/pkg/core/scaffold/policy.go
@@ -100,7 +100,7 @@ func (p *PolicySpec) sanitize() {
 }
 
 // scaffoldPolicy scaffold a new Updatecli policy file
-func (s *Scaffold) scaffoldPolicy(p *PolicySpec, dirname, filename string) error {
+func (s *Scaffold) scaffoldPolicy(p *PolicySpec, dirname string) error {
 
 	p.sanitize()
 
@@ -111,7 +111,7 @@ func (s *Scaffold) scaffoldPolicy(p *PolicySpec, dirname, filename string) error
 		}
 	}
 
-	policyFilePath := filepath.Join(dirname, filename)
+	policyFilePath := filepath.Join(dirname, s.PolicyFile)
 
 	if _, err := os.Stat(policyFilePath); err == nil {
 		logrus.Infof("Skipping, policy already exist: %s", policyFilePath)

--- a/pkg/core/scaffold/values.go
+++ b/pkg/core/scaffold/values.go
@@ -8,7 +8,6 @@ import (
 )
 
 var (
-	valuesFile     string = "default.yaml"
 	valuesTemplate string = `---
 # Values.yaml contains settings that be used from Updatecli manifest.
 # scm:
@@ -24,7 +23,7 @@ var (
 
 func (s *Scaffold) scaffoldValues(dirname string) error {
 
-	dirname = filepath.Join(dirname, "values.d")
+	dirname = filepath.Join(dirname)
 
 	if _, err := os.Stat(dirname); os.IsNotExist(err) {
 		err := os.MkdirAll(dirname, 0755)
@@ -33,7 +32,7 @@ func (s *Scaffold) scaffoldValues(dirname string) error {
 		}
 	}
 
-	valuesFilePath := filepath.Join(dirname, valuesFile)
+	valuesFilePath := filepath.Join(dirname, s.ValuesFile)
 
 	if _, err := os.Stat(valuesFilePath); err == nil {
 		logrus.Infof("Skipping, values already exist: %s", valuesFilePath)


### PR DESCRIPTION
This pullrequest replaces generate the default values file using `values.yaml` instead of `values.d/default.yaml`.
In the process I also renamed a few variable to be more consistent with other similar variables.

A scaffolded policy looks like 

```
.
├── CHANGELOG.md
├── Policy.yaml
├── README.md
├── updatecli.d
│   └── default.yaml
└── values.yaml
```

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
 cd pkg/core/scaffold/
go test .
go build -o bin/updatecli .
./bin/updatecli manifest init /tmp/test2/
# Verify 
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
