### PR TITLE
Fix listing helm chart versions

### DIFF
--- a/pkg/plugins/resources/helm/source.go
+++ b/pkg/plugins/resources/helm/source.go
@@ -36,8 +36,8 @@ func (c *Chart) Source(workingDir string, resultSource *result.Source) error {
 	}
 
 	versions := []string{}
-	for _, entry := range entriesVersion {
-		versions = append(versions, entry.Version)
+	for i := len(entriesVersion) - 1; i >= 0; i-- {
+		versions = append(versions, entriesVersion[i].Version)
 	}
 
 	c.foundVersion, err = c.versionFilter.Search(versions)


### PR DESCRIPTION
Fix #1892

reverse the order of listing the helm chart versions from the index file

## Test

To test this pull request, you can run the following commands:
1- build the code
2- run the following source

```
sources:
  jenkins:
    kind: helmchart
    spec:
      url: https://charts.jenkins.io
      name: jenkins
      versionfilter:
        kind: "regex"
```
OR
```
sources:
  jenkins:
    kind: helmchart
    spec:
      url: https://charts.jenkins.io
      name: jenkins
      versionfilter:
        kind: "latest"
```

you should see that source has fetched the latest version