### PR TITLE
feat: Allow to override updatecli autodiscovery files

### DIFF
--- a/pkg/plugins/autodiscovery/updatecli/policies.go
+++ b/pkg/plugins/autodiscovery/updatecli/policies.go
@@ -10,8 +10,8 @@ import (
 )
 
 var (
-	// DefaultFilePattern specifies accepted Helm chart metadata filename
-	DefaultFilePattern [1]string = [1]string{"update-compose.yaml"}
+	// DefaultFiles specifies accepted Helm chart metadata filename
+	DefaultFiles []string = []string{"update-compose.yaml"}
 )
 
 // discoverUpdatecliPolicyManifests search recursively from a root directory for Updatecli compose file
@@ -21,7 +21,7 @@ func (u Updatecli) discoverUpdatecliPolicyManifests() ([][]byte, error) {
 
 	foundUpdateComposeFiles, err := searchUpdatecliComposeFiles(
 		u.rootDir,
-		DefaultFilePattern[:])
+		u.files[:])
 
 	if err != nil {
 		return nil, err

--- a/pkg/plugins/autodiscovery/updatecli/test/main_test.go
+++ b/pkg/plugins/autodiscovery/updatecli/test/main_test.go
@@ -187,6 +187,7 @@ func TestDiscoverManifests(t *testing.T) {
 			updatecli, err := updatecli.New(
 				updatecli.Spec{
 					RootDir: tt.rootDir,
+					Files:   []string{"update-compose.yaml"},
 				}, "", "")
 			require.NoError(t, err)
 

--- a/pkg/plugins/autodiscovery/updatecli/utils_test.go
+++ b/pkg/plugins/autodiscovery/updatecli/utils_test.go
@@ -10,7 +10,7 @@ import (
 func TestSearchFiles(t *testing.T) {
 
 	gotFiles, err := searchUpdatecliComposeFiles(
-		"test/testdata/website", DefaultFilePattern[:])
+		"test/testdata/website", DefaultFiles[:])
 	if err != nil {
 		t.Errorf("%s\n", err)
 	}


### PR DESCRIPTION
Allows to override the default file "update-compose.yaml" used by the updatecli autodiscovery 

## Test

To test this pull request, you can run the following commands:

```shell
pkg/plugins/autodiscovery/updatecli/
go test
pkg/plugins/autodiscovery/updatecli/test
go test
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
