### PR TITLE
feat: dockerfile autodiscovery handle digest

### DIFF
--- a/pkg/plugins/autodiscovery/dockerfile/dockerfile.go
+++ b/pkg/plugins/autodiscovery/dockerfile/dockerfile.go
@@ -19,13 +19,13 @@ var (
 	}
 )
 
-func (h Dockerfile) discoverDockerfileManifests() ([][]byte, error) {
+func (d Dockerfile) discoverDockerfileManifests() ([][]byte, error) {
 
 	var manifests [][]byte
 
 	foundDockerfiles, err := searchDockerfiles(
-		h.rootDir,
-		h.filematch)
+		d.rootDir,
+		d.filematch)
 
 	if err != nil {
 		return nil, err
@@ -34,7 +34,7 @@ func (h Dockerfile) discoverDockerfileManifests() ([][]byte, error) {
 	for _, foundDockerfile := range foundDockerfiles {
 
 		logrus.Debugf("parsing file %q", foundDockerfile)
-		relativeFoundDockerfile, err := filepath.Rel(h.rootDir, foundDockerfile)
+		relativeFoundDockerfile, err := filepath.Rel(d.rootDir, foundDockerfile)
 		if err != nil {
 			// Let try the next one if it fails
 			logrus.Debugln(err)
@@ -56,32 +56,26 @@ func (h Dockerfile) discoverDockerfileManifests() ([][]byte, error) {
 
 		for _, instruction := range instructions {
 
-			// For the time being, it's not possible to retrieve a list of tag for a specific digest
-			// without a significant amount f api call. More information on following issue
-			// https://github.com/google/go-containerregistry/issues/1297
-			// until a better solution, we don't handle docker image digest
-			if strings.Contains(instruction.image, "@sha256") {
-				logrus.Debugf("Docker Digest is not supported at the moment for %q", instruction.image)
+			imageName, imageTag, imageDigest, err := dockerimage.ParseOCIReferenceInfo(instruction.image)
+			if err != nil {
+				return nil, fmt.Errorf("parsing image %q: %s", instruction.image, err)
+			}
+
+			/*
+				// For the time being, it's not possible to retrieve a list of tag for a specific digest
+				// without a significant amount f api call. More information on following issue
+				// https://github.com/google/go-containerregistry/issues/1297
+				// until a better solution, we don't handle docker image digest
+			*/
+			if imageDigest != "" && imageTag == "" {
+				logrus.Debugf("docker digest without specified tag is not supported at the moment for %q", instruction.image)
 				continue
 			}
 
-			imageArray := strings.Split(instruction.image, ":")
-
-			// Get container image name and tag
-			imageName := ""
-			imageTag := ""
-			switch len(imageArray) {
-			case 2:
-				imageName = imageArray[0]
-				imageTag = imageArray[1]
-			case 1:
-				imageName = imageArray[0]
-			}
-
 			// Test if the ignore rule based on path is respected
-			if len(h.spec.Ignore) > 0 {
-				if h.spec.Ignore.isMatchingRule(
-					h.rootDir,
+			if len(d.spec.Ignore) > 0 {
+				if d.spec.Ignore.isMatchingRule(
+					d.rootDir,
 					relativeFoundDockerfile,
 					instruction.image,
 					instruction.arch,
@@ -95,9 +89,9 @@ func (h Dockerfile) discoverDockerfileManifests() ([][]byte, error) {
 			}
 
 			// Test if the only rule based on path is respected
-			if len(h.spec.Only) > 0 {
-				if !h.spec.Only.isMatchingRule(
-					h.rootDir,
+			if len(d.spec.Only) > 0 {
+				if !d.spec.Only.isMatchingRule(
+					d.rootDir,
 					relativeFoundDockerfile,
 					instruction.image,
 					instruction.arch) {
@@ -109,26 +103,32 @@ func (h Dockerfile) discoverDockerfileManifests() ([][]byte, error) {
 				}
 			}
 
-			sourceSpec := dockerimage.NewDockerImageSpecFromImage(imageName, imageTag, h.spec.Auths)
+			sourceSpec := dockerimage.NewDockerImageSpecFromImage(imageName, imageTag, d.spec.Auths)
 
-			if sourceSpec == nil {
+			if sourceSpec == nil && !d.digest {
 				logrus.Debugln("no source spec detected")
 				continue
 			}
 
+			versionFilterKind := d.versionFilter.Kind
+			versionFilterPattern := d.versionFilter.Pattern
+			tagFilter := "*"
+
+			if sourceSpec != nil {
+				versionFilterKind = sourceSpec.VersionFilter.Kind
+				versionFilterPattern = sourceSpec.VersionFilter.Pattern
+				tagFilter = sourceSpec.TagFilter
+			}
+
 			// If a versionfilter is specified in the manifest then we want to be sure that it takes precedence
-			if !h.spec.VersionFilter.IsZero() {
-				sourceSpec.VersionFilter.Kind = h.versionFilter.Kind
-				sourceSpec.VersionFilter.Pattern, err = h.versionFilter.GreaterThanPattern(imageTag)
-				sourceSpec.TagFilter = ""
+			if !d.spec.VersionFilter.IsZero() {
+				versionFilterKind = d.versionFilter.Kind
+				versionFilterPattern, err = d.versionFilter.GreaterThanPattern(imageTag)
+				tagFilter = ""
 				if err != nil {
 					logrus.Debugf("building version filter pattern: %s", err)
 					sourceSpec.VersionFilter.Pattern = "*"
 				}
-			}
-
-			if instruction.arch != "" {
-				sourceSpec.Architecture = instruction.arch
 			}
 
 			if err != nil {
@@ -147,38 +147,51 @@ func (h Dockerfile) discoverDockerfileManifests() ([][]byte, error) {
 				targetMatcher = strings.TrimSuffix(targetMatcher, instruction.trimArgSuffix)
 			}
 
-			tmpl, err := template.New("manifest").Parse(manifestTemplate)
-			if err != nil {
-				logrus.Debugln(err)
-				continue
+			var tmpl *template.Template
+			if d.digest && sourceSpec != nil {
+				tmpl, err = template.New("manifest").Parse(manifestTemplateDigestAndLatest)
+				if err != nil {
+					return nil, err
+				}
+			} else if d.digest && sourceSpec == nil {
+				tmpl, err = template.New("manifest").Parse(manifestTemplateDigest)
+				if err != nil {
+					return nil, err
+				}
+			} else if !d.digest && sourceSpec != nil {
+				tmpl, err = template.New("manifest").Parse(manifestTemplateLatest)
+				if err != nil {
+					return nil, err
+				}
+			} else {
+				logrus.Infoln("No source spec detected")
+				return nil, nil
 			}
 
 			params := struct {
-				ManifestName         string
 				ImageName            string
+				ImageTag             string
+				ScmID                string
 				SourceID             string
 				TargetID             string
 				TargetFile           string
-				TargetName           string
 				TargetKeyword        string
 				TargetMatcher        string
 				TagFilter            string
 				VersionFilterKind    string
 				VersionFilterPattern string
-				ScmID                string
 			}{
-				ManifestName:         fmt.Sprintf("Bump Docker image tag for %q", imageName),
 				ImageName:            imageName,
+				ImageTag:             imageTag,
+				ScmID:                d.scmID,
 				SourceID:             imageName,
 				TargetID:             imageName,
-				TargetName:           fmt.Sprintf("[%s] Bump Docker image tag in %q", imageName, relativeFoundDockerfile),
 				TargetFile:           relativeFoundDockerfile,
 				TargetKeyword:        instruction.name,
 				TargetMatcher:        targetMatcher,
-				TagFilter:            sourceSpec.TagFilter,
-				VersionFilterKind:    sourceSpec.VersionFilter.Kind,
-				VersionFilterPattern: sourceSpec.VersionFilter.Pattern,
-				ScmID:                h.scmID,
+				TagFilter:            tagFilter,
+				VersionFilterKind:    versionFilterKind,
+				VersionFilterPattern: versionFilterPattern,
 			}
 
 			manifest := bytes.Buffer{}

--- a/pkg/plugins/autodiscovery/dockerfile/main.go
+++ b/pkg/plugins/autodiscovery/dockerfile/main.go
@@ -13,6 +13,10 @@ import (
 // For Fields that requires it, we can use the struct Dockerfile
 // Spec defines the parameters which can be provided to the Dockerfile crawler.
 type Spec struct {
+	/*
+		digest provides parameters to specify if the generated manifest should use a digest on top of the tag.
+	*/
+	Digest *bool `yaml:",omitempty"`
 	// RootDir defines the root directory used to recursively search for Helm Chart
 	RootDir string `yaml:",omitempty"`
 	// Ignore allows to specify rule to ignore autodiscovery a specific Helm based on a rule
@@ -52,6 +56,8 @@ type Spec struct {
 
 // Dockerfile hold all information needed to generate Dockerfile manifest.
 type Dockerfile struct {
+	// digest holds the value of the digest parameter
+	digest bool
 	// spec defines the settings provided via an updatecli manifest
 	spec Spec
 	// rootDir defines the root directory from where looking for Helm Chart
@@ -92,7 +98,13 @@ func New(spec interface{}, rootDir, scmID string) (Dockerfile, error) {
 		newFilter.Pattern = "*"
 	}
 
+	digest := true
+	if s.Digest != nil {
+		digest = *s.Digest
+	}
+
 	d := Dockerfile{
+		digest:        digest,
 		spec:          s,
 		rootDir:       dir,
 		filematch:     DefaultFileMatch,
@@ -108,10 +120,10 @@ func New(spec interface{}, rootDir, scmID string) (Dockerfile, error) {
 
 }
 
-func (h Dockerfile) DiscoverManifests() ([][]byte, error) {
+func (d Dockerfile) DiscoverManifests() ([][]byte, error) {
 
 	logrus.Infof("\n\n%s\n", strings.ToTitle("Dockerfile"))
 	logrus.Infof("%s\n", strings.Repeat("=", len("Dockerfile")+1))
 
-	return h.discoverDockerfileManifests()
+	return d.discoverDockerfileManifests()
 }

--- a/pkg/plugins/autodiscovery/dockerfile/manifestTemplate.go
+++ b/pkg/plugins/autodiscovery/dockerfile/manifestTemplate.go
@@ -1,12 +1,12 @@
 package dockerfile
 
 var (
-	// manifestTemplate is the Go template used to generate
+	// manifestTemplateLatest is the Go template used to generate
 	// Updatecli manifests
-	manifestTemplate string = `name: '{{ .ManifestName }}'
+	manifestTemplateLatest string = `name: 'deps(dockerfile): bump "{{ .ImageName }}" tag'
 sources:
   {{ .SourceID }}:
-    name: '[{{ .ImageName }}] Get latest Docker image tag'
+    name: 'get latest image tag for "{{ .ImageName }}"'
     kind: 'dockerimage'
     spec:
       image: '{{ .ImageName }}'
@@ -16,7 +16,7 @@ sources:
         pattern: '{{ .VersionFilterPattern }}'
 targets:
   {{ .TargetID }}:
-    name: '{{ .TargetName }}'
+    name: 'deps(dockerfile): bump image "{{ .ImageName }}" tag'
     kind: 'dockerfile'
 {{- if .ScmID }}
     scmid: '{{ .ScmID }}'
@@ -27,5 +27,60 @@ targets:
         keyword: '{{ .TargetKeyword }}'
         matcher: '{{ .TargetMatcher }}'
     sourceid: '{{ .SourceID }}'
+`
+	manifestTemplateDigestAndLatest string = `name: 'deps(dockerfile): bump "{{ .ImageName }}" digest'
+sources:
+  {{ .SourceID }}:
+    name: 'get latest image tag for "{{ .ImageName }}"'
+    kind: 'dockerimage'
+    spec:
+      image: '{{ .ImageName }}'
+      tagfilter: '{{ .TagFilter }}'
+      versionfilter:
+        kind: '{{ .VersionFilterKind }}'
+        pattern: '{{ .VersionFilterPattern }}'
+  {{ .SourceID }}-digest:
+    name: 'get latest image "{{ .ImageName }}" digest'
+    kind: 'dockerdigest'
+    spec:
+      image: '{{ .ImageName }}'
+      tag: '{{ "{{" }} source "{{ .SourceID }}" {{ "}}" }}'
+    dependson:
+      - '{{ .SourceID }}'
+targets:
+  {{ .TargetID }}:
+    name: 'deps(dockerfile): bump image "{{ .ImageName }}" digest'
+    kind: 'dockerfile'
+{{- if .ScmID }}
+    scmid: '{{ .ScmID }}'
+{{ end }}
+    spec:
+      file: '{{ .TargetFile }}'
+      instruction:
+        keyword: '{{ .TargetKeyword }}'
+        matcher: '{{ .TargetMatcher }}'
+    sourceid: '{{ .SourceID }}-digest'
+`
+	manifestTemplateDigest string = `name: 'deps(dockerfile): bump image "{{ .ImageName }}" digest'
+sources:
+  {{ .SourceID }}-digest:
+    name: 'get latest image "{{ .ImageName }}" digest'
+    kind: 'dockerdigest'
+    spec:
+      image: '{{ .ImageName }}'
+      tag: '{{ .ImageTag }}'
+targets:
+  {{ .TargetID }}:
+    name: 'deps(dockerfile): bump image "{{ .ImageName }}" digest'
+    kind: 'dockerfile'
+{{- if .ScmID }}
+    scmid: '{{ .ScmID }}'
+{{ end }}
+    spec:
+      file: '{{ .TargetFile }}'
+      instruction:
+        keyword: '{{ .TargetKeyword }}'
+        matcher: '{{ .TargetMatcher }}'
+    sourceid: '{{ .SourceID }}-digest'
 `
 )

--- a/pkg/plugins/autodiscovery/dockerfile/test/main_test.go
+++ b/pkg/plugins/autodiscovery/dockerfile/test/main_test.go
@@ -3,16 +3,9 @@ package test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/updatecli/updatecli/pkg/core/config"
-	"github.com/updatecli/updatecli/pkg/core/pipeline/resource"
-	"github.com/updatecli/updatecli/pkg/core/pipeline/source"
-	"github.com/updatecli/updatecli/pkg/core/pipeline/target"
 	autodiscoveryDockerfile "github.com/updatecli/updatecli/pkg/plugins/autodiscovery/dockerfile"
-	"github.com/updatecli/updatecli/pkg/plugins/resources/dockerfile"
-	"github.com/updatecli/updatecli/pkg/plugins/resources/dockerimage"
-	"github.com/updatecli/updatecli/pkg/plugins/utils/test"
-	"github.com/updatecli/updatecli/pkg/plugins/utils/version"
 )
 
 func TestDiscoverManifests(t *testing.T) {
@@ -24,106 +17,151 @@ func TestDiscoverManifests(t *testing.T) {
 	testdata := []struct {
 		name              string
 		rootDir           string
-		expectedPipelines []config.Spec
+		digest            bool
+		expectedPipelines []string
 	}{
 		{
 			name:    "Scenario 1",
 			rootDir: "testdata/updatecli-action",
-			expectedPipelines: []config.Spec{
-				{
-					Name: "Bump Docker image tag for \"updatecli/updatecli\"",
-					Sources: map[string]source.Config{
-						"updatecli/updatecli": {
-							ResourceConfig: resource.ResourceConfig{
-								Name: "[updatecli/updatecli] Get latest Docker image tag",
-								Kind: "dockerimage",
-								Spec: dockerimage.Spec{
-									Image:     "updatecli/updatecli",
-									TagFilter: `^v\d*(\.\d*){2}$`,
-									VersionFilter: version.Filter{
-										Kind:    "semver",
-										Pattern: ">=v0.25.0",
-									},
-								},
-							},
-						},
-					},
-					Targets: map[string]target.Config{
-						"updatecli/updatecli": {
-							SourceID: "updatecli/updatecli",
-							ResourceConfig: resource.ResourceConfig{
-								Name: "[updatecli/updatecli] Bump Docker image tag in \"Dockerfile\"",
-								Kind: "dockerfile",
-								Spec: dockerfile.Spec{
-									File: "Dockerfile",
-									Instruction: map[string]string{
-										"keyword": "FROM",
-										"matcher": "updatecli/updatecli",
-									},
-								},
-							},
-						},
-					},
-				},
-			},
+			digest:  true,
+			expectedPipelines: []string{`name: 'deps(dockerfile): bump image "updatecli/updatecli" digest'
+sources:
+  updatecli/updatecli-digest:
+    name: 'get latest image "updatecli/updatecli" digest'
+    kind: 'dockerdigest'
+    spec:
+      image: 'updatecli/updatecli'
+      tag: 'latest'
+targets:
+  updatecli/updatecli:
+    name: 'deps(dockerfile): bump image "updatecli/updatecli" digest'
+    kind: 'dockerfile'
+    spec:
+      file: 'Dockerfile'
+      instruction:
+        keyword: 'ARG'
+        matcher: 'updatecli_version'
+    sourceid: 'updatecli/updatecli-digest'
+`, `name: 'deps(dockerfile): bump "updatecli/updatecli" digest'
+sources:
+  updatecli/updatecli:
+    name: 'get latest image tag for "updatecli/updatecli"'
+    kind: 'dockerimage'
+    spec:
+      image: 'updatecli/updatecli'
+      tagfilter: '^v\d*(\.\d*){2}$'
+      versionfilter:
+        kind: 'semver'
+        pattern: '>=v0.25.0'
+  updatecli/updatecli-digest:
+    name: 'get latest image "updatecli/updatecli" digest'
+    kind: 'dockerdigest'
+    spec:
+      image: 'updatecli/updatecli'
+      tag: '{{ source "updatecli/updatecli" }}'
+    dependson:
+      - 'updatecli/updatecli'
+targets:
+  updatecli/updatecli:
+    name: 'deps(dockerfile): bump image "updatecli/updatecli" digest'
+    kind: 'dockerfile'
+    spec:
+      file: 'Dockerfile'
+      instruction:
+        keyword: 'FROM'
+        matcher: 'updatecli/updatecli'
+    sourceid: 'updatecli/updatecli-digest'
+`},
 		},
 		{
 			name:    "Scenario 2: arg with suffix",
 			rootDir: "testdata/jenkins",
-			expectedPipelines: []config.Spec{
-				{
-					Name: "Bump Docker image tag for \"jenkins/jenkins\"",
-					Sources: map[string]source.Config{
-						"jenkins/jenkins": {
-							ResourceConfig: resource.ResourceConfig{
-								Name: "[jenkins/jenkins] Get latest Docker image tag",
-								Kind: "dockerimage",
-								Spec: dockerimage.Spec{
-									Image:     "jenkins/jenkins",
-									TagFilter: `^\d*(\.\d*){2}-lts$`,
-									VersionFilter: version.Filter{
-										Kind:    "semver",
-										Pattern: ">=2.235.1-lts",
-									},
-								},
-							},
-						},
-					},
-					Targets: map[string]target.Config{
-						"jenkins/jenkins": {
-							SourceID: "jenkins/jenkins",
-							ResourceConfig: resource.ResourceConfig{
-								Name: "[jenkins/jenkins] Bump Docker image tag in \"Dockerfile\"",
-								Kind: "dockerfile",
-								Spec: dockerfile.Spec{
-									File: "Dockerfile",
-									Instruction: map[string]string{
-										"keyword": "ARG",
-										"matcher": "jenkins_version",
-									},
-								},
-							},
-						},
-					},
-				},
-			},
+			digest:  true,
+			expectedPipelines: []string{`name: 'deps(dockerfile): bump "jenkins/jenkins" digest'
+sources:
+  jenkins/jenkins:
+    name: 'get latest image tag for "jenkins/jenkins"'
+    kind: 'dockerimage'
+    spec:
+      image: 'jenkins/jenkins'
+      tagfilter: '^\d*(\.\d*){2}-lts$'
+      versionfilter:
+        kind: 'semver'
+        pattern: '>=2.235.1-lts'
+  jenkins/jenkins-digest:
+    name: 'get latest image "jenkins/jenkins" digest'
+    kind: 'dockerdigest'
+    spec:
+      image: 'jenkins/jenkins'
+      tag: '{{ source "jenkins/jenkins" }}'
+    dependson:
+      - 'jenkins/jenkins'
+targets:
+  jenkins/jenkins:
+    name: 'deps(dockerfile): bump image "jenkins/jenkins" digest'
+    kind: 'dockerfile'
+    spec:
+      file: 'Dockerfile'
+      instruction:
+        keyword: 'ARG'
+        matcher: 'jenkins_version'
+    sourceid: 'jenkins/jenkins-digest'
+`},
+		},
+		{
+			name:    "Scenario 3: Digest disabled",
+			rootDir: "testdata/updatecli-action",
+			digest:  false,
+			expectedPipelines: []string{`name: 'deps(dockerfile): bump "updatecli/updatecli" tag'
+sources:
+  updatecli/updatecli:
+    name: 'get latest image tag for "updatecli/updatecli"'
+    kind: 'dockerimage'
+    spec:
+      image: 'updatecli/updatecli'
+      tagfilter: '^v\d*(\.\d*){2}$'
+      versionfilter:
+        kind: 'semver'
+        pattern: '>=v0.25.0'
+targets:
+  updatecli/updatecli:
+    name: 'deps(dockerfile): bump image "updatecli/updatecli" tag'
+    kind: 'dockerfile'
+    spec:
+      file: 'Dockerfile'
+      instruction:
+        keyword: 'FROM'
+        matcher: 'updatecli/updatecli'
+    sourceid: 'updatecli/updatecli'
+`},
 		},
 	}
 
 	for _, tt := range testdata {
 
 		t.Run(tt.name, func(t *testing.T) {
+			digest := tt.digest
 			dockerfile, err := autodiscoveryDockerfile.New(
 				autodiscoveryDockerfile.Spec{
 					RootDir: tt.rootDir,
+					Digest:  &digest,
 				}, "", "")
 			require.NoError(t, err)
 
-			pipelines, err := dockerfile.DiscoverManifests()
+			rawPipelines, err := dockerfile.DiscoverManifests()
 			require.NoError(t, err)
 
-			for i := range tt.expectedPipelines {
-				test.AssertConfigSpecEqualByteArray(t, &tt.expectedPipelines[i], string(pipelines[i]))
+			if len(rawPipelines) == 0 {
+				t.Errorf("No pipelines found for %s", tt.name)
+			}
+
+			var pipelines []string
+			assert.Equal(t, len(tt.expectedPipelines), len(rawPipelines))
+
+			for i := range rawPipelines {
+				// We expect manifest generated by the autodiscovery to use the yaml syntax
+				pipelines = append(pipelines, string(rawPipelines[i]))
+				assert.Equal(t, tt.expectedPipelines[i], pipelines[i])
 			}
 		})
 	}

--- a/pkg/plugins/autodiscovery/dockerfile/test/testdata/updatecli-action/Dockerfile
+++ b/pkg/plugins/autodiscovery/dockerfile/test/testdata/updatecli-action/Dockerfile
@@ -2,7 +2,7 @@ ARG updatecli_version
 # Following FROM instruction should be ignore as we don't have enough information to guess the next one
 FROM updatecli/updatecli:${updatecli_version}
 
-FROM updatecli/updatecli:v0.25.0
+FROM updatecli/updatecli:v0.25.0@sha256:1fafb0905264413501df60d90a92ca32df8a2011cbfb4876ddff5ceb20c8f165
 
 ## As per https://docs.github.com/en/actions/creating-actions/dockerfile-support-for-github-actions#user
 # hadolint ignore=DL3002


### PR DESCRIPTION
No by default the Dockerfile autodiscovery plugin will insert a digest unless the parameter digest is set to false.
This feature now allows the following update 

* `updatecli/updatecli:latest` to `updatecli/updatecli:latest@sha256xxxx`
* `updatecli/updatecli:0.23.0` to `updatecli/updatecli:0.73.0@sha256xxx`
* `updatecli/updatecli:0.73.0@sha256xxx` to ``updatecli/updatecli:0.73.0@sha256yyy``

I also took the opportunity to update the generated template for using conventional commits messages like

`deps(dockerfile): bump image "updatecli/updatecli" digest`

And simplified the test

## Test

To test this pull request, you can run the following commands:

```shell
cd pkg/plugins/autodiscovery/dockerfile/
go test ./...
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
