### PR TITLE
refactor: remove useless git checkout after a git clone

### DIFF
--- a/pkg/plugins/scms/git/scm.go
+++ b/pkg/plugins/scms/git/scm.go
@@ -76,23 +76,6 @@ func (g *Git) Clone() (string, error) {
 		return "", err
 	}
 
-	sourceBranch, workingBranch, _ := g.GetBranches()
-
-	if len(workingBranch) > 0 && len(g.GetDirectory()) > 0 {
-		err := g.nativeGitHandler.Checkout(
-			g.spec.Username,
-			g.spec.Password,
-			sourceBranch,
-			workingBranch,
-			g.GetDirectory(),
-			true)
-
-		if err != nil {
-			logrus.Errorf("initial git checkout failed for repository %s - %s", g.GetURL(), err)
-			return "", err
-		}
-	}
-
 	return g.spec.Directory, nil
 }
 

--- a/pkg/plugins/scms/gitea/scm.go
+++ b/pkg/plugins/scms/gitea/scm.go
@@ -62,23 +62,6 @@ func (g *Gitea) Clone() (string, error) {
 		return "", err
 	}
 
-	sourceBranch, workingBranch, _ := g.GetBranches()
-
-	if len(workingBranch) > 0 && len(g.GetDirectory()) > 0 {
-		err = g.nativeGitHandler.Checkout(
-			g.Spec.Username,
-			g.Spec.Token,
-			sourceBranch,
-			workingBranch,
-			g.GetDirectory(),
-			true)
-	}
-
-	if err != nil {
-		logrus.Errorf("initial Gitea checkout failed for repository %q", g.GetURL())
-		return "", err
-	}
-
 	return g.Spec.Directory, nil
 }
 

--- a/pkg/plugins/scms/github/scm.go
+++ b/pkg/plugins/scms/github/scm.go
@@ -61,23 +61,6 @@ func (g *Github) Clone() (string, error) {
 		return "", err
 	}
 
-	sourceBranch, workingBranch, _ := g.GetBranches()
-
-	if len(workingBranch) > 0 && len(g.GetDirectory()) > 0 {
-		err = g.nativeGitHandler.Checkout(
-			g.Spec.Username,
-			g.Spec.Token,
-			sourceBranch,
-			workingBranch,
-			g.GetDirectory(),
-			true)
-	}
-
-	if err != nil {
-		logrus.Errorf("initial git checkout failed for GitHub repository %q", g.GetURL())
-		return "", err
-	}
-
 	return g.Spec.Directory, nil
 }
 

--- a/pkg/plugins/scms/gitlab/scm.go
+++ b/pkg/plugins/scms/gitlab/scm.go
@@ -65,23 +65,6 @@ func (g *Gitlab) Clone() (string, error) {
 		return "", err
 	}
 
-	sourceBranch, workingBranch, _ := g.GetBranches()
-
-	if len(workingBranch) > 0 && len(g.GetDirectory()) > 0 {
-		err = g.nativeGitHandler.Checkout(
-			g.Spec.Username,
-			g.Spec.Token,
-			sourceBranch,
-			workingBranch,
-			g.GetDirectory(),
-			true)
-	}
-
-	if err != nil {
-		logrus.Errorf("initial GitLab checkout failed for repository %q", g.GetURL())
-		return "", err
-	}
-
 	return g.Spec.Directory, nil
 }
 

--- a/pkg/plugins/scms/stash/scm.go
+++ b/pkg/plugins/scms/stash/scm.go
@@ -61,23 +61,6 @@ func (s *Stash) Clone() (string, error) {
 		return "", err
 	}
 
-	sourceBranch, workingBranch, _ := s.GetBranches()
-
-	if len(workingBranch) > 0 && len(s.GetDirectory()) > 0 {
-		err = s.nativeGitHandler.Checkout(
-			s.Spec.Username,
-			s.Spec.Token,
-			sourceBranch,
-			workingBranch,
-			s.GetDirectory(),
-			true)
-	}
-
-	if err != nil {
-		logrus.Errorf("initial Bitbucket checkout failed for repository %q", s.GetURL())
-		return "", err
-	}
-
 	return s.Spec.Directory, nil
 }
 


### PR DESCRIPTION
While working on https://github.com/updatecli/updatecli/pull/1964

I released that we always run git checkout the default branch(main) after a git clone operation.
even though a git checkout is done before each source/condition/targets

This initial git checkout seems useless and generate error in some situation 

We can easily reproduce the problem with the following manifests

<details><summary>updatecli.yaml</summary>

```
scms:
  default:
    kind: git 
    spec:
      url: https://github.com/crate-ci/typos.git
```

</details>

triggers 

<details><summary>Console Output</summary>

```
+++++++++++
+ PREPARE +
+++++++++++

Loading Pipeline "test.2.yaml"

SCM repository retrieved: 1
ERROR: initial git checkout failed for repository https://github.com/crate-ci/typos.git - reference not found
ERROR: err - reference not found
```

</details>

As updatecli tries to run a git checkout of the default branch "main" which doesn't exist on that repository

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
cd <to_package_directory>
go test
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
