### PR TITLE
feat: move shareable policies out of experimental

### DIFF
--- a/cmd/compose_apply.go
+++ b/cmd/compose_apply.go
@@ -18,12 +18,6 @@ var (
 		Short: "apply checks and apply changes defined by the compose file",
 		Run: func(cmd *cobra.Command, args []string) {
 
-			// TODO: To be removed once not experimental anymore
-			if !experimental {
-				logrus.Warningf("The 'compose' subcommand requires the flag experimental to work, such as:\n\t`updatecli compose apply --experimental`")
-				os.Exit(1)
-			}
-
 			c, err := compose.New(composeCmdFile)
 			if err != nil {
 				logrus.Errorf("command failed: %s", err)

--- a/cmd/compose_diff.go
+++ b/cmd/compose_diff.go
@@ -14,12 +14,6 @@ var (
 		Short: "diff show changes defined by the compose file",
 		Run: func(cmd *cobra.Command, args []string) {
 
-			// TODO: To be removed once not experimental anymore
-			if !experimental {
-				logrus.Warningf("The 'compose' subcommand requires the flag experimental to work, such as:\n\t`updatecli compose diff --experimental`")
-				os.Exit(1)
-			}
-
 			c, err := compose.New(composeCmdFile)
 			if err != nil {
 				logrus.Errorf("command failed: %s", err)

--- a/cmd/compose_show.go
+++ b/cmd/compose_show.go
@@ -15,12 +15,6 @@ var (
 		Short: "show manifest(s) defined by the compose file that should be executed",
 		Run: func(cmd *cobra.Command, args []string) {
 
-			// TODO: To be removed once not experimental anymore
-			if !experimental {
-				logrus.Warningf("The 'compose' subcommand requires the flag experimental to work, such as:\n\t`updatecli compose show --experimental`")
-				os.Exit(1)
-			}
-
 			c, err := compose.New(composeCmdFile)
 			if err != nil {
 				logrus.Errorf("command failed: %s", err)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -241,12 +241,6 @@ func getPolicyFilesFromRegistry() error {
 		return nil
 	}
 
-	// TODO: To be removed once not experimental anymore
-	if !experimental {
-		logrus.Warningf("The 'oci registry' feature requires the flag --experimental to be set")
-		os.Exit(1)
-	}
-
 	for _, policy := range policyReferences {
 		policyManifest, policyValues, policySecrets, err := registry.Pull(policy, disableTLS)
 		if err != nil {


### PR DESCRIPTION
This pullrequest allows to use shareable policies without specifying the flag `--experimental`

## Test

To test this pull request, you can run the following commands

```
go build -o bin/updatecli . 
./bin/updatecli diff ghcr.io/updatecli/policies/nodejs/githubaction:0.4.0@sha256:aeb512401d128f791cffed7ad6c7c79c5d30c012f57e410e7cb5027f4d360833 
./bin/updatecli compose diff -f update-compose.yaml

```
## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
