### PR TITLE
fix(dockerdigest): Allow to specify none linux os

### DIFF
--- a/pkg/plugins/resources/dockerdigest/source.go
+++ b/pkg/plugins/resources/dockerdigest/source.go
@@ -11,7 +11,7 @@ import (
 
 // Source retrieves Docker image tag digest from a registry
 func (ds *DockerDigest) Source(workingDir string, resultSource *result.Source) error {
-	refTag := ""
+	refTag := "latest"
 	refName := ds.spec.Image
 
 	if ds.spec.Tag != "" {


### PR DESCRIPTION
This pullrequest fixes the dockerdigest plugin by allowing to set different os than linux


<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

<details><summary>updatecli.yaml</summary>

```
name: Get digest
sources:
  tag/windows/amd64:
    kind: dockerimage
    spec:
      architecture: windows/amd64
      image: eclipse-temurin
  digest/windows/amd64:
    kind: dockerdigest
    spec:
      architecture: windows/amd64
      image: eclipse-temurin
      tag: 8u402-b06-jre
      
conditions:
  digest/windows/amd64:
    kind: dockerimage
    disablesourceinput: true
    spec:
      architecture: windows/amd64
      image: eclipse-temurin
      tag: latest
```

</details>

<details><summary>Before fix</summary>

```
##############
# GET DIGEST #
##############


SOURCES
=======

tag/windows/amd64
-----------------
Searching for version matching pattern "latest"
✔ Docker Image Tag "latest" found matching pattern "latest"

digest/windows/amd64
--------------------
ERROR: ✗ unable to retrieve image eclipse-temurin:8u402-b06-jre: no child with platform linux/windows/amd64 in index eclipse-temurin:8u402-b06-jre
ERROR: { ✗   { {  } }   ERROR: ✗ unable to retrieve image eclipse-temurin:8u402-b06-jre: no child with platform linux/windows/amd64 in index eclipse-temurin:8u402-b06-jre
} unable to retrieve image eclipse-temurin:8u402-b06-jre: no child with platform linux/windows/amd64 in index eclipse-temurin:8u402-b06-jre
Pipeline "Get digest" failed
Skipping due to:
	sources stage:	"unable to retrieve image eclipse-temurin:8u402-b06-jre: no child with platform linux/windows/amd64 in index eclipse-temurin:8u402-b06-jre"

=============================

REPORTS:



✗ Get digest:
	Source:
		✗ [digest/windows/amd64] 
		✔ [tag/windows/amd64] 
	Condition:
		- [digest/windows/amd64] 

Run Summary
===========
Pipeline(s) run:
  * Changed:	0
  * Failed:	1
  * Skipped:	0
  * Succeeded:	0
  * Total:	1
ERROR: ✗ 1 over 1 pipeline failed
ERROR: command failed: 1 over 1 pipeline failed
[1]    3597 exit 1     updatecli diff --config /tmp/updatecli.yaml
```

</details>


<details><summary>After fix</summary>

```
++++++++++++
+ PIPELINE +
++++++++++++



##############
# GET DIGEST #
##############


SOURCES
=======

digest/windows/amd64
--------------------
✔ Docker Image Tag eclipse-temurin:8u402-b06-jre resolved to digest index.docker.io/library/eclipse-temurin:8u402-b06-jre@sha256:a4d0749b3dd4ee66ca0bb1d1c8d5c66740aad7f9992331b882db089d63b83d4f

tag/windows/amd64
-----------------
Searching for version matching pattern "latest"
✔ Docker Image Tag "latest" found matching pattern "latest"


CONDITIONS:
===========

digest/windows/amd64
--------------------
✔ docker image eclipse-temurin:latest found

=============================

REPORTS:



- Get digest:
	Source:
		✔ [digest/windows/amd64] 
		✔ [tag/windows/amd64] 
	Condition:
		✔ [digest/windows/amd64] 

Run Summary
===========
Pipeline(s) run:
  * Changed:	0
  * Failed:	0
  * Skipped:	1
  * Succeeded:	0
  * Total:	1
```

</details>

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
