### PR TITLE
feat: close GitHub pullrequest when no file changed

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -110,3 +110,4 @@ alwaysrun
 disableconditions
 neverrun
 conditionids
+hom

--- a/_typos.toml
+++ b/_typos.toml
@@ -17,3 +17,4 @@ extend-ignore-re = [
 [default.extend-words]
 # Don't correct the surname "Teh"
 lQOsBGIqZEEBCACOnlRGd40w2SvqxFe0FRtBhruQIHLWpWAkYxz6otNRuCAkK7w1 = "lQOsBGIqZEEBCACOnlRGd40w2SvqxFe0FRtBhruQIHLWpWAkYxz6otNRuCAkK7w1"
+hom = "hom"

--- a/pkg/core/pipeline/action/main.go
+++ b/pkg/core/pipeline/action/main.go
@@ -35,6 +35,7 @@ var (
 // ActionHandler interface defines required functions to be an action
 type ActionHandler interface {
 	CreateAction(report reports.Action, resetDescription bool) error
+	CleanAction(report reports.Action) error
 }
 
 // Config define action provided via an updatecli configuration

--- a/pkg/core/pipeline/actions.go
+++ b/pkg/core/pipeline/actions.go
@@ -101,12 +101,19 @@ func (p *Pipeline) RunActions() error {
 
 		// No need to execute the action if no target require attention
 		if len(action.Report.Targets) == 0 {
+			if !p.Options.Target.DryRun {
+				// At least we try to clean existing pullrequest
+				err = action.Handler.CleanAction(action.Report)
+				if err != nil {
+					return err
+				}
+			}
 			continue
 		}
 
 		// Must action.Report.ID and action.Report.Title must be set after actionTarget are set
 		actionTitle := action.Title
-		// If an action spec do not have a tittle, then we use the one specified by the pipeline spec title
+		// If an action spec do not have a title, then we use the one specified by the pipeline spec title
 		if actionTitle == "" && p.Config.Spec.Name != "" {
 			actionTitle = p.Config.Spec.Name
 		} else if actionTitle == "" && p.Config.Spec.Title != "" {

--- a/pkg/core/pipeline/actions.go
+++ b/pkg/core/pipeline/actions.go
@@ -113,7 +113,7 @@ func (p *Pipeline) RunActions() error {
 
 		// Must action.Report.ID and action.Report.Title must be set after actionTarget are set
 		actionTitle := action.Title
-		// If an action spec do not have a title, then we use the one specified by the pipeline spec title
+		// If an action spec doesn't have a title, then we use the one specified by the pipeline spec title
 		if actionTitle == "" && p.Config.Spec.Name != "" {
 			actionTitle = p.Config.Spec.Name
 		} else if actionTitle == "" && p.Config.Spec.Title != "" {

--- a/pkg/core/pipeline/sort.go
+++ b/pkg/core/pipeline/sort.go
@@ -105,10 +105,6 @@ func SortedSourcesKeys(sources *map[string]source.Source) (result []string, err 
 
 	}
 
-	if err != nil {
-		return result, err
-	}
-
 	return result, err
 }
 
@@ -182,10 +178,6 @@ func SortedConditionsKeys(conditions *map[string]condition.Condition) (result []
 
 	}
 
-	if err != nil {
-		return result, err
-	}
-
 	return result, err
 }
 
@@ -257,10 +249,6 @@ func SortedTargetsKeys(targets *map[string]target.Target) (result []string, err 
 		result[j] = val.(string)
 		j++
 
-	}
-
-	if err != nil {
-		return result, err
 	}
 
 	return result, err

--- a/pkg/core/reports/actions.go
+++ b/pkg/core/reports/actions.go
@@ -57,6 +57,14 @@ func MergeFromString(old, new string) string {
 	var oldReport Actions
 	var newReport Actions
 
+	if old == "" && new != "" {
+		return new
+	}
+
+	if old != "" && new == "" {
+		return old
+	}
+
 	err := unmarshal([]byte(old), &oldReport)
 	if err != nil {
 		logrus.Errorf("failed parsing old report: %s", err)

--- a/pkg/plugins/resources/gitea/pullrequest/clean.go
+++ b/pkg/plugins/resources/gitea/pullrequest/clean.go
@@ -1,0 +1,12 @@
+package pullrequest
+
+import (
+	"github.com/sirupsen/logrus"
+	"github.com/updatecli/updatecli/pkg/core/reports"
+)
+
+// CleanAction verify if existing action requires some operations
+func (g *Gitea) CleanAction(report reports.Action) error {
+	logrus.Debugln("cleaning Gitea pull-request is not yet supported. Feel free to open an issue to mark your interest.")
+	return nil
+}

--- a/pkg/plugins/resources/gitea/pullrequest/clean.go
+++ b/pkg/plugins/resources/gitea/pullrequest/clean.go
@@ -5,7 +5,7 @@ import (
 	"github.com/updatecli/updatecli/pkg/core/reports"
 )
 
-// CleanAction verify if existing action requires some operations
+// CleanAction verifies if an existing action requires some operations
 func (g *Gitea) CleanAction(report reports.Action) error {
 	logrus.Debugln("cleaning Gitea pull-request is not yet supported. Feel free to open an issue to mark your interest.")
 	return nil

--- a/pkg/plugins/resources/gitlab/mergerequest/clean.go
+++ b/pkg/plugins/resources/gitlab/mergerequest/clean.go
@@ -5,7 +5,7 @@ import (
 	"github.com/updatecli/updatecli/pkg/core/reports"
 )
 
-// CleanAction verify if existing action requires some operations
+// CleanAction verifies if existing action requires some operations
 func (g *Gitlab) CleanAction(report reports.Action) error {
 	logrus.Debugln("cleaning GitLab merge request is not yet supported. Feel free to open an issue to mark your interest.")
 	return nil

--- a/pkg/plugins/resources/gitlab/mergerequest/clean.go
+++ b/pkg/plugins/resources/gitlab/mergerequest/clean.go
@@ -1,0 +1,12 @@
+package mergerequest
+
+import (
+	"github.com/sirupsen/logrus"
+	"github.com/updatecli/updatecli/pkg/core/reports"
+)
+
+// CleanAction verify if existing action requires some operations
+func (g *Gitlab) CleanAction(report reports.Action) error {
+	logrus.Debugln("cleaning Gitlab merge request is not yet supported. Feel free to open an issue to mark your interest.")
+	return nil
+}

--- a/pkg/plugins/resources/gitlab/mergerequest/clean.go
+++ b/pkg/plugins/resources/gitlab/mergerequest/clean.go
@@ -7,6 +7,6 @@ import (
 
 // CleanAction verify if existing action requires some operations
 func (g *Gitlab) CleanAction(report reports.Action) error {
-	logrus.Debugln("cleaning Gitlab merge request is not yet supported. Feel free to open an issue to mark your interest.")
+	logrus.Debugln("cleaning GitLab merge request is not yet supported. Feel free to open an issue to mark your interest.")
 	return nil
 }

--- a/pkg/plugins/resources/stash/pullrequest/clean.go
+++ b/pkg/plugins/resources/stash/pullrequest/clean.go
@@ -5,8 +5,8 @@ import (
 	"github.com/updatecli/updatecli/pkg/core/reports"
 )
 
-// CleanAction verify if existing action requires some operations
+// CleanAction verifies if an existing action requires some operations
 func (s *Stash) CleanAction(report reports.Action) error {
-	logrus.Debugln("cleaning Gitea pull-request is not yet supported. Feel free to open an issue to mark your interest.")
+	logrus.Debugln("cleaning Stash pull-request is not yet supported. Feel free to open an issue to mark your interest.")
 	return nil
 }

--- a/pkg/plugins/resources/stash/pullrequest/clean.go
+++ b/pkg/plugins/resources/stash/pullrequest/clean.go
@@ -1,0 +1,12 @@
+package pullrequest
+
+import (
+	"github.com/sirupsen/logrus"
+	"github.com/updatecli/updatecli/pkg/core/reports"
+)
+
+// CleanAction verify if existing action requires some operations
+func (s *Stash) CleanAction(report reports.Action) error {
+	logrus.Debugln("cleaning Gitea pull-request is not yet supported. Feel free to open an issue to mark your interest.")
+	return nil
+}

--- a/pkg/plugins/scms/github/comment.go
+++ b/pkg/plugins/scms/github/comment.go
@@ -1,0 +1,41 @@
+package github
+
+import (
+	"context"
+
+	"github.com/shurcooL/githubv4"
+	"github.com/sirupsen/logrus"
+)
+
+// IssueComment represents the data returned
+// by the GitHub API when adding a comment to an issue
+// cfr https://docs.github.com/en/graphql/reference/objects#issuecomment
+type IssueComment struct {
+	ID   string
+	URL  string
+	Body string
+}
+
+// addComment is mutation to add a comment to a GitHub pullrequest
+func (p *PullRequest) addComment(ID, body string) error {
+
+	var mutation struct {
+		AddComment struct {
+			Comment IssueComment
+		} `graphql:"addComment(input: $input)"`
+	}
+
+	logrus.Debugf("Commenting GitHub pull-request %s", ID)
+
+	input := githubv4.AddCommentInput{
+		SubjectID: githubv4.ID(ID),
+		Body:      githubv4.String(body),
+	}
+
+	err := p.gh.client.Mutate(context.Background(), &mutation, input, nil)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/plugins/scms/github/pullrequest.go
+++ b/pkg/plugins/scms/github/pullrequest.go
@@ -211,9 +211,9 @@ func (p *PullRequest) CreateAction(report reports.Action, resetDescription bool)
 		if err := p.EnablePullRequestAutoMerge(); err != nil {
 			switch err.Error() {
 			case ErrAutomergeNotAllowOnRepository.Error():
-				logrus.Warningln("Automerge can't be enabled. Make sure to all it on the repository.")
+				logrus.Errorln("Automerge can't be enabled. Make sure to all it on the repository.")
 			case ErrPullRequestIsInCleanStatus.Error():
-				logrus.Warningln("Automerge can't be enabled. Make sure to have branch protection rules enabled on the repository.")
+				logrus.Errorln("Automerge can't be enabled. Make sure to have branch protection rules enabled on the repository.")
 			default:
 				logrus.Debugf("Error enabling automerge: %s", err.Error())
 			}

--- a/pkg/plugins/scms/github/pullrequest.go
+++ b/pkg/plugins/scms/github/pullrequest.go
@@ -112,7 +112,7 @@ func NewAction(spec ActionSpec, gh *Github) (PullRequest, error) {
 	}, err
 }
 
-// CleanAction verify if existing action requires some cleanup such as closing a pullrequest with no changes.
+// CleanAction verifies if an existing action requires some cleanup such as closing a pullrequest with no changes.
 func (p *PullRequest) CleanAction(report reports.Action) error {
 
 	repository, err := p.gh.queryRepository()

--- a/pkg/plugins/scms/github/pullrequest.go
+++ b/pkg/plugins/scms/github/pullrequest.go
@@ -27,7 +27,7 @@ import (
 var (
 	ErrAutomergeNotAllowOnRepository = errors.New("automerge is not allowed on repository")
 	ErrBadMergeMethod                = errors.New("wrong merge method defined, accepting one of 'squash', 'merge', 'rebase', or ''")
-	ErrPullResquestIsInCleanStatus   = errors.New("Pull request Pull request is in clean status")
+	ErrPullRequestIsInCleanStatus    = errors.New("Pull request Pull request is in clean status")
 )
 
 // PullRequest contains multiple fields mapped to GitHub V4 api
@@ -212,7 +212,7 @@ func (p *PullRequest) CreateAction(report reports.Action, resetDescription bool)
 			switch err.Error() {
 			case ErrAutomergeNotAllowOnRepository.Error():
 				logrus.Warningln("Automerge can't be enabled. Make sure to all it on the repository.")
-			case ErrPullResquestIsInCleanStatus.Error():
+			case ErrPullRequestIsInCleanStatus.Error():
 				logrus.Warningln("Automerge can't be enabled. Make sure to have branch protection rules enabled on the repository.")
 			default:
 				logrus.Debugf("Error enabling automerge: %s", err.Error())


### PR DESCRIPTION
This pullrequest allows the action `github/pullrequest` to automatically close pullrequest that have no file changed.
The situation will happens more frequently because of https://github.com/updatecli/updatecli/pull/2018

<!-- Describe the changes introduced by this pull request -->

## Test

Still missing some test case (automated or manual)

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

* It would be great to add such behavior to other SCM as well
*  I am wondering if it would make sense for Updatecli to also close old pullrequest with a message like `this pullrequest appears to be created by Updatecli more than 90 days ago, now closing`