### PR TITLE
chore: show extra warning for git scm

### DIFF
--- a/pkg/plugins/scms/git/main.go
+++ b/pkg/plugins/scms/git/main.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -153,8 +154,27 @@ func New(s Spec, pipelineID string) (*Git, error) {
 		s.Branch = "main"
 	}
 
-	workingBranch := false
-	if s.WorkingBranch != nil {
+	var workingBranch bool
+	switch s.WorkingBranch {
+	case nil:
+		workingBranch = false
+
+		if s.Force {
+			errorMsg := fmt.Sprintf(`
+	Better safe than sorry.
+
+	The scm force option set to true means that Updatecli is going to run "git push --force"
+	Some target plugin, like the shell one, run "git commit -A" to catch all changes done by that target.
+	Because the Git scm plugin has by default the workingBranch option set to false,
+	Updatecli may be pushing unwanted changes to the branch %q.
+
+	If you know what you are doing, please set the workingBranch option to false in your configuration file to ignore this error message.
+	`, s.Branch)
+
+			logrus.Errorln(errorMsg)
+			return nil, errors.New("wrong configuration, better safe than sorry")
+		}
+	default:
 		workingBranch = *s.WorkingBranch
 	}
 

--- a/pkg/plugins/scms/git/main.go
+++ b/pkg/plugins/scms/git/main.go
@@ -161,15 +161,15 @@ func New(s Spec, pipelineID string) (*Git, error) {
 
 		if s.Force {
 			errorMsg := fmt.Sprintf(`
-	Better safe than sorry.
+Better safe than sorry.
 
-	The scm force option set to true means that Updatecli is going to run "git push --force"
-	Some target plugin, like the shell one, run "git commit -A" to catch all changes done by that target.
-	Because the Git scm plugin has by default the workingBranch option set to false,
-	Updatecli may be pushing unwanted changes to the branch %q.
+The scm force option set to true means that Updatecli is going to run "git push --force"
+Some target plugin, like the shell one, run "git commit -A" to catch all changes done by that target.
+Because the Git scm plugin has by default the workingBranch option set to false,
+Updatecli may be pushing unwanted changes to the branch %q.
 
-	If you know what you are doing, please set the workingBranch option to false in your configuration file to ignore this error message.
-	`, s.Branch)
+If you know what you are doing, please set the workingBranch option to false in your configuration file to ignore this error message.
+`, s.Branch)
 
 			logrus.Errorln(errorMsg)
 			return nil, errors.New("wrong configuration, better safe than sorry")


### PR DESCRIPTION
This pullrequest introduces an error message if an Updatecli manifest using the git scm provider relies on force set to true and the default behavior for the workingBranch which is set to false.

As explained in the error message, it can lead to unexpected behavior 

```
Better safe than sorry.

The scm force option set to true means that Updatecli is going to run "git push --force"
Some target plugin, like the shell one, run "git commit -A" to catch all changes done by that target.
Because the Git scm plugin has by default the workingBranch option set to false,
Updatecli may be pushing unwanted changes to the branch %q.
If you know what you are doing, please set the workingBranch option to false in your configuration file to ignore this error message
```

I am not adding this message to the other provider as the default workingBranch is set to true by default

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
cd <to_package_directory>
go test
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
