### PR TITLE
feat: By default scm github/gitlab/stash/gitea uses force push

### DIFF
--- a/pkg/plugins/scms/git/main.go
+++ b/pkg/plugins/scms/git/main.go
@@ -172,7 +172,7 @@ If you know what you are doing, please set the workingBranch option to false in 
 `, s.Branch)
 
 			logrus.Errorln(errorMsg)
-			return nil, errors.New("wrong configuration, better safe than sorry")
+			return nil, errors.New("unclear configuration, better safe than sorry")
 		}
 	default:
 		workingBranch = *s.WorkingBranch

--- a/pkg/plugins/scms/gitea/scm.go
+++ b/pkg/plugins/scms/gitea/scm.go
@@ -91,7 +91,7 @@ func (g *Gitea) Checkout() error {
 		sourceBranch,
 		workingBranch,
 		g.Spec.Directory,
-		g.Spec.Force)
+		g.force)
 	if err != nil {
 		return err
 	}
@@ -128,14 +128,19 @@ func (g *Gitea) Push() (bool, error) {
 		g.Spec.Username,
 		g.Spec.Token,
 		g.GetDirectory(),
-		g.Spec.Force,
+		g.force,
 	)
 }
 
 // PushTag push tags
 func (g *Gitea) PushTag(tag string) error {
 
-	err := g.nativeGitHandler.PushTag(tag, g.Spec.Username, g.Spec.Token, g.GetDirectory(), g.Spec.Force)
+	err := g.nativeGitHandler.PushTag(
+		tag,
+		g.Spec.Username,
+		g.Spec.Token,
+		g.GetDirectory(),
+		g.force)
 	if err != nil {
 		return err
 	}
@@ -151,7 +156,7 @@ func (g *Gitea) PushBranch(branch string) error {
 		g.Spec.Username,
 		g.Spec.Token,
 		g.GetDirectory(),
-		g.Spec.Force)
+		g.force)
 	if err != nil {
 		return err
 	}

--- a/pkg/plugins/scms/github/main_test.go
+++ b/pkg/plugins/scms/github/main_test.go
@@ -12,6 +12,10 @@ import (
 	"github.com/updatecli/updatecli/pkg/plugins/scms/git/sign"
 )
 
+func boolPointer(b bool) *bool {
+	return &b
+}
+
 func TestNew(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -236,7 +240,7 @@ func TestMerge(t *testing.T) {
 				GPG: sign.GPGSpec{
 					SigningKey: "mine",
 				},
-				Force: false,
+				Force: boolPointer(false),
 				CommitMessage: commit.Commit{
 					Title: "Bye",
 				},
@@ -254,7 +258,7 @@ func TestMerge(t *testing.T) {
 				GPG: sign.GPGSpec{
 					SigningKey: "theirs",
 				},
-				Force: true,
+				Force: boolPointer(true),
 				CommitMessage: commit.Commit{
 					Title: "Hello There",
 				},
@@ -272,7 +276,7 @@ func TestMerge(t *testing.T) {
 				GPG: sign.GPGSpec{
 					SigningKey: "theirs",
 				},
-				Force: true,
+				Force: boolPointer(true),
 				CommitMessage: commit.Commit{
 					Title: "Hello There",
 				},
@@ -293,7 +297,7 @@ func TestMerge(t *testing.T) {
 				GPG: sign.GPGSpec{
 					SigningKey: "mine",
 				},
-				Force: false,
+				Force: boolPointer(false),
 				CommitMessage: commit.Commit{
 					Title: "Bye",
 				},
@@ -314,7 +318,7 @@ func TestMerge(t *testing.T) {
 				GPG: sign.GPGSpec{
 					SigningKey: "mine",
 				},
-				Force: false,
+				Force: boolPointer(false),
 				CommitMessage: commit.Commit{
 					Title: "Bye",
 				},
@@ -335,7 +339,7 @@ func TestMerge(t *testing.T) {
 				GPG: sign.GPGSpec{
 					SigningKey: "mine",
 				},
-				Force: false,
+				Force: boolPointer(false),
 				CommitMessage: commit.Commit{
 					Title: "Bye",
 				},

--- a/pkg/plugins/scms/github/scm.go
+++ b/pkg/plugins/scms/github/scm.go
@@ -97,7 +97,7 @@ func (g *Github) Checkout() error {
 		sourceBranch,
 		workingBranch,
 		g.Spec.Directory,
-		g.Spec.Force,
+		g.force,
 	)
 }
 
@@ -130,7 +130,7 @@ func (g *Github) Push() (bool, error) {
 		g.Spec.Username,
 		g.Spec.Token,
 		g.GetDirectory(),
-		g.Spec.Force,
+		g.force,
 	)
 }
 
@@ -142,7 +142,7 @@ func (g *Github) PushTag(tag string) error {
 		g.Spec.Username,
 		g.Spec.Token,
 		g.GetDirectory(),
-		g.Spec.Force,
+		g.force,
 	)
 	if err != nil {
 		return err
@@ -159,7 +159,7 @@ func (g *Github) PushBranch(branch string) error {
 		g.Spec.Username,
 		g.Spec.Token,
 		g.GetDirectory(),
-		g.Spec.Force)
+		g.force)
 	if err != nil {
 		return err
 	}

--- a/pkg/plugins/scms/gitlab/main.go
+++ b/pkg/plugins/scms/gitlab/main.go
@@ -2,6 +2,7 @@ package gitlab
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path"
 	"strings"
@@ -61,7 +62,7 @@ type Spec struct {
 	//  remark:
 	//    When force is set to true, Updatecli also recreates the working branches that
 	//    diverged from their base branch.
-	Force bool `yaml:",omitempty"`
+	Force *bool `yaml:",omitempty"`
 	//  "gpg" specifies the GPG key and passphrased used for commit signing.
 	//
 	//  compatible:
@@ -120,6 +121,7 @@ type Spec struct {
 
 // Gitlab contains information to interact with GitLab api
 type Gitlab struct {
+	force bool
 	// Spec contains inputs coming from updatecli configuration
 	Spec Spec
 	// client handle the api authentication
@@ -168,7 +170,31 @@ func New(spec interface{}, pipelineID string) (*Gitlab, error) {
 	workingBranch := true
 	if s.WorkingBranch != nil {
 		workingBranch = *s.WorkingBranch
+	}
 
+	force := true
+	if s.Force != nil {
+		force = *s.Force
+	}
+
+	if force {
+		if !workingBranch && s.Force == nil {
+			errorMsg := fmt.Sprintf(`
+Better safe than sorry.
+
+Updatecli may be pushing unwanted changes to the branch %q.
+
+The GitLab scm plugin has by default the force option set to true,
+The scm force option set to true means that Updatecli is going to run "git push --force"
+Some target plugin, like the shell one, run "git commit -A" to catch all changes done by that target.
+
+If you know what you are doing, please set the force option to true in your configuration file to ignore this error message.
+`, s.Branch)
+
+			logrus.Errorln(errorMsg)
+			return nil, errors.New("unclear configuration, better safe than sorry")
+
+		}
 	}
 
 	c, err := client.New(clientSpec)
@@ -179,6 +205,7 @@ func New(spec interface{}, pipelineID string) (*Gitlab, error) {
 
 	nativeGitHandler := gitgeneric.GoGit{}
 	g := Gitlab{
+		force:            force,
 		Spec:             s,
 		client:           c,
 		pipelineID:       pipelineID,

--- a/pkg/plugins/scms/gitlab/scm.go
+++ b/pkg/plugins/scms/gitlab/scm.go
@@ -101,7 +101,7 @@ func (g *Gitlab) Checkout() error {
 		sourceBranch,
 		workingBranch,
 		g.Spec.Directory,
-		g.Spec.Force,
+		g.force,
 	)
 	if err != nil {
 		return err
@@ -139,7 +139,7 @@ func (g *Gitlab) Push() (bool, error) {
 		g.Spec.Username,
 		g.Spec.Token,
 		g.GetDirectory(),
-		g.Spec.Force,
+		g.force,
 	)
 }
 
@@ -151,7 +151,7 @@ func (g *Gitlab) PushTag(tag string) error {
 		g.Spec.Username,
 		g.Spec.Token,
 		g.GetDirectory(),
-		g.Spec.Force,
+		g.force,
 	)
 	if err != nil {
 		return err
@@ -168,7 +168,7 @@ func (g *Gitlab) PushBranch(branch string) error {
 		g.Spec.Username,
 		g.Spec.Token,
 		g.GetDirectory(),
-		g.Spec.Force)
+		g.force)
 	if err != nil {
 		return err
 	}

--- a/pkg/plugins/scms/stash/scm.go
+++ b/pkg/plugins/scms/stash/scm.go
@@ -90,7 +90,7 @@ func (s *Stash) Checkout() error {
 		sourceBranch,
 		workingBranch,
 		s.Spec.Directory,
-		s.Spec.Force)
+		s.force)
 	if err != nil {
 		return err
 	}
@@ -127,13 +127,19 @@ func (s *Stash) Push() (bool, error) {
 		s.Spec.Username,
 		s.Spec.Token,
 		s.GetDirectory(),
-		s.Spec.Force)
+		s.force)
 }
 
 // PushTag push tags
 func (s *Stash) PushTag(tag string) error {
 
-	err := s.nativeGitHandler.PushTag(tag, s.Spec.Username, s.Spec.Token, s.GetDirectory(), s.Spec.Force)
+	err := s.nativeGitHandler.PushTag(
+		tag,
+		s.Spec.Username,
+		s.Spec.Token,
+		s.GetDirectory(),
+		s.force,
+	)
 	if err != nil {
 		return err
 	}
@@ -149,7 +155,7 @@ func (s *Stash) PushBranch(branch string) error {
 		s.Spec.Username,
 		s.Spec.Token,
 		s.GetDirectory(),
-		s.Spec.Force)
+		s.force)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
I started using 0.75.0-rc.1 and I am really annoyed that I now have to go over all my manifest for a behavior that I feel should be the default.
I would expected for any pipeline relying on a working branch created by Updatecli to be automatically recreated when the based branch is modified.

I already put in place a safeguard for the scm git plugin, because by default it doesn't create a working branch so if only force is set to true there is a risk to accidentally force push changes.
so the following pipeline would trigger an error

```
scms:
  default:
    kind: git 
    spec:
      url: git@github.com:updatecli/updatecli.git
      force: true
```

will trigger an error asking to set `workingbranch` to either true or false to show that the user understand the behavior

```
scms:
  default:
    kind: git 
    spec:
      url: git@github.com:updatecli/updatecli.git
      force: true
      workingbranch: false
```

This pull request set `force` to `true` for the scm plugins GitLab, Gitea, GitHub, Stash and provide additional safe guards for unclear configuration.

<details><summary>Unclear manifest</summary>

```
scms:
  default:
    kind: github
    spec:
      owner: olblak
      repository: updatecli
      token: '{{ requiredEnv "GITHUB_TOKEN" }}'
      workingbranch: false
```

</details>


<details><summary>Console output</summary>

```
+++++++++++
+ PREPARE +
+++++++++++

Loading Pipeline "/tmp/tt.yaml"
WARNING: Updatecli binary version is unset. This means you are using a development version that ignores manifest version constraint.
WARNING: no git branch specified, fallback to "main"
ERROR: Better safe than sorry.

Updatecli may be pushing unwanted changes to the branch "main".

The GitHub scm plugin has by default the force option set to true,
The scm force option set to true means that Updatecli is going to run "git push --force"
Some target plugin, like the shell one, run "git commit -A" to catch all changes done by that target.

If you know what you are doing, please set the force option to true in your configuration file to ignore this error message.
ERROR: failed loading pipeline(s)
	* "/tmp/tt.yaml" - unclear configuration, better safe than sorry

0 pipeline(s) successfully loaded

SCM repository retrieved: 0


++++++++++++++++++
+ AUTO DISCOVERY +
++++++++++++++++++

ERROR: ✗ no valid pipeline found
ERROR: command failed: no valid pipeline found
[1]    5346 exit 1     ./bin/updatecli diff --config /tmp/tt.yaml
```

</details>

## Test

To test this pull request, you can run the following commands:

```shell
cd <to_package_directory>
go test
```

## Additional Information

### Tradeoff

Different `force` behavior depending on the scm plugin. I guess the day we align the git plugin with the other ones, we'll be able to also align the force setting

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
