### PR TITLE
fix: updatecli autodiscovery only matching rule

### DIFF
--- a/pkg/plugins/autodiscovery/updatecli/policies.go
+++ b/pkg/plugins/autodiscovery/updatecli/policies.go
@@ -80,7 +80,7 @@ func (u Updatecli) discoverUpdatecliPolicyManifests() ([][]byte, error) {
 			}
 
 			if len(u.spec.Only) > 0 {
-				if !u.spec.Ignore.isMatchingRules(u.rootDir, relativeUpdateComposeFile, policyName, policyVersion) {
+				if !u.spec.Only.isMatchingRules(u.rootDir, relativeUpdateComposeFile, policyName, policyVersion) {
 					logrus.Debugf("Ignoring Updatecli policy %q from %q, as not matching only rule(s)\n", policyName, composeFilename)
 					continue
 				}


### PR DESCRIPTION
updatecli autodiscovery only matching rule

## Test

Test manually

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
