### PR TITLE
chore: sort reports by results

### DIFF
--- a/pkg/core/engine/run.go
+++ b/pkg/core/engine/run.go
@@ -24,6 +24,8 @@ func (e *Engine) Run() (err error) {
 		}
 	}
 
+	e.Reports.Sort()
+
 	err = e.Reports.Show()
 	if err != nil {
 		return err

--- a/pkg/core/reports/main.go
+++ b/pkg/core/reports/main.go
@@ -2,6 +2,7 @@ package reports
 
 import (
 	"bytes"
+	"sort"
 	"text/template"
 
 	"github.com/sirupsen/logrus"
@@ -69,6 +70,32 @@ func (r *Reports) Show() error {
 	logrus.Infof(reports)
 
 	return nil
+}
+
+// Sort reports by result in the following order
+// SUCCESS > SKIPPED > ATTENTION > FAILURE > UNKNOWN
+func (r *Reports) Sort() {
+	reports := *r
+
+	sort.SliceStable(reports, func(i, j int) bool {
+		resultToInteger := func(state string) int {
+			switch state {
+			case result.SUCCESS:
+				return 0
+			case result.SKIPPED:
+				return 1
+			case result.ATTENTION:
+				return 2
+			case result.FAILURE:
+				return 3
+			default:
+				return 4
+			}
+		}
+
+		return resultToInteger(reports[i].Result) < resultToInteger(reports[j].Result)
+	})
+
 }
 
 // Summary display a summary of

--- a/pkg/core/reports/main_test.go
+++ b/pkg/core/reports/main_test.go
@@ -1,0 +1,43 @@
+package reports
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/updatecli/updatecli/pkg/core/result"
+)
+
+func TestSortReports(t *testing.T) {
+	reports := Reports{
+		Report{Result: result.SUCCESS},
+		Report{Result: result.ATTENTION},
+		Report{Result: result.SKIPPED},
+		Report{Result: result.FAILURE},
+		Report{Result: result.SUCCESS},
+		Report{Result: result.SUCCESS},
+	}
+
+	sorted := Reports{
+		Report{Result: result.SUCCESS},
+		Report{Result: result.SUCCESS},
+		Report{Result: result.SUCCESS},
+		Report{Result: result.SKIPPED},
+		Report{Result: result.ATTENTION},
+		Report{Result: result.FAILURE},
+	}
+
+	getResults := func(result Reports) []string {
+		var r []string
+		for _, report := range result {
+			r = append(r, report.Result)
+		}
+		return r
+	}
+
+	reports.Sort()
+
+	reportsResults := getResults(reports)
+	sortedResults := getResults(sorted)
+
+	assert.Equal(t, sortedResults, reportsResults, "Reports are not sorted")
+}


### PR DESCRIPTION
UX improvement, this pull request sorts reports results so we first see failed pipelines at the bottom.
This should allows to better identify failed pipelines after an Updatecli execution

<details><summary>Example</summary>

```
⚠ deps(go): bump module go.mozilla.org/sops/v3:
	Source:
		✔ [module] Get latest golang module go.mozilla.org/sops/v3 version
	Target:
		⚠ [module] deps(go): bump module go.mozilla.org/sops/v3 to v3.8.1


⚠ deps(golang): bump Go version:
	Source:
		✔ [go] Get latest Go version
	Target:
		⚠ [go] deps(golang): bump Go version to 1.22.2


✗ deps(go): bump module github.com/nirasan/go-oauth-pkce-code-verifier:
	Source:
		✗ [module] Get latest golang module github.com/nirasan/go-oauth-pkce-code-verifier version
	Target:
		- [module] 
		- [tidy] 


✗ deps(go): bump module golang.org/x/exp:
	Source:
		✗ [module] Get latest golang module golang.org/x/exp version
	Target:
		- [module] 
		- [tidy] 
```
</details>

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
cd <to_package_directory>
go test
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
