### PR TITLE
deps: bump updatecli to v0.76.0-rc.1

### DIFF
--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: "Setup updatecli"
         uses: "updatecli/updatecli-action@v2"
         with:
-          version: "v0.75.0-rc.2"
+          version: "v0.76.0-rc.1"
       - name: Set up Go
         uses: actions/setup-go@v5
         with:


### PR DESCRIPTION
Bump Updatecli version used in GitHub action to  v0.76.0-rc.1
## Test

To test this pull request, you can run the following commands:

```shell
cd <to_package_directory>
go test
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
