### PR TITLE
feat: Add support for GitHub API commit

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -111,3 +111,4 @@ disableconditions
 neverrun
 conditionids
 hom
+fileoperations

--- a/.github/actions/spelling/patterns.txt
+++ b/.github/actions/spelling/patterns.txt
@@ -94,3 +94,6 @@ UTF-8'(?!en)\w+'\S+
 # Terraform Hashes
 h1:[0-9A-Za-z\/=+]+
 zh:[0-9A-Za-z]+
+
+# marker to ignore all code on line
+^.*\/\/ no-spell-check-line$

--- a/pkg/plugins/scms/github/main.go
+++ b/pkg/plugins/scms/github/main.go
@@ -150,7 +150,7 @@ type Spec struct {
 	//
 	//  default: true
 	WorkingBranch *bool `yaml:",omitempty"`
-	//  "commitUsingApi" defines if Updatecli should use Github GraphQL API to create the commit.
+	//  "commitUsingApi" defines if Updatecli should use GitHub GraphQL API to create the commit.
 	//
 	//  compatible:
 	//	  * scm

--- a/pkg/plugins/scms/github/mocks.go
+++ b/pkg/plugins/scms/github/mocks.go
@@ -34,6 +34,11 @@ func (mock *MockGitHubClient) Query(ctx context.Context, q interface{}, variable
 		mt, _ := mock.mockedQuery.(*changelogQuery)
 		*qt = *mt
 		return mock.mockedErr
+	case *commitQuery:
+		qt, _ := q.(*commitQuery)
+		mt, _ := mock.mockedQuery.(*commitQuery)
+		*qt = *mt
+		return mock.mockedErr
 	default:
 		return fmt.Errorf("mock error: unsupported type for the provided query (%v)", q)
 	}

--- a/pkg/plugins/scms/github/scm.go
+++ b/pkg/plugins/scms/github/scm.go
@@ -116,7 +116,9 @@ func (g *Github) CreateCommit(workingDir string, commitMessage string) error {
 	_, workingBranch, _ := g.GetBranches()
 
 	// Make sure branch is published
-	g.PushBranch(workingBranch)
+	if err := g.PushBranch(workingBranch); err != nil {
+		return err
+	}
 
 	files, err := g.nativeGitHandler.GetChangedFiles(workingDir)
 	if err != nil {

--- a/pkg/plugins/scms/github/scm.go
+++ b/pkg/plugins/scms/github/scm.go
@@ -1,11 +1,14 @@
 package github
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"os"
 
+	"github.com/shurcooL/githubv4"
 	"github.com/sirupsen/logrus"
+	"github.com/updatecli/updatecli/pkg/plugins/utils"
 )
 
 func (g *Github) GetBranches() (sourceBranch, workingBranch, targetBranch string) {
@@ -67,23 +70,97 @@ func (g *Github) Clone() (string, error) {
 // Commit run `git commit`.
 func (g *Github) Commit(message string) error {
 
+	workingDir := g.GetDirectory()
+
 	// Generate the conventional commit message
 	commitMessage, err := g.Spec.CommitMessage.Generate(message)
 	if err != nil {
 		return err
 	}
 
-	err = g.nativeGitHandler.Commit(
-		g.Spec.User,
-		g.Spec.Email,
-		commitMessage,
-		g.GetDirectory(),
-		g.Spec.GPG.SigningKey,
-		g.Spec.GPG.Passphrase,
-	)
+	if g.commitUsingApi {
+		err = g.CreateCommit(workingDir, commitMessage)
+		if err != nil {
+			return err
+		}
+
+	} else {
+		err = g.nativeGitHandler.Commit(
+			g.Spec.User,
+			g.Spec.Email,
+			commitMessage,
+			workingDir,
+			g.Spec.GPG.SigningKey,
+			g.Spec.GPG.Passphrase,
+		)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+type githubCommit struct {
+	CreateCommitOnBranch struct {
+		Commit struct {
+			URL string
+			OID string
+		}
+	} `graphql:"createCommitOnBranch(input:$input)"`
+}
+
+func (g *Github) CreateCommit(workingDir string, commitMessage string) error {
+	var m githubCommit
+
+	_, workingBranch, _ := g.GetBranches()
+
+	// Make sure branch is published
+	g.PushBranch(workingBranch)
+
+	files, err := g.nativeGitHandler.GetChangedFiles(workingDir)
 	if err != nil {
 		return err
 	}
+	// process added / modified files:
+	additions := make([]githubv4.FileAddition, 0, len(files))
+	for _, f := range files {
+		fullPath := fmt.Sprintf("%s/%s", workingDir, f)
+		enc, err := utils.Base64EncodeFile(fullPath)
+		if err != nil {
+			return err
+		}
+		additions = append(additions, githubv4.FileAddition{
+			Path:     githubv4.String(f),
+			Contents: githubv4.Base64String(enc),
+		})
+	}
+
+	repositoryName := fmt.Sprintf("%s/%s", g.Spec.Owner, g.Spec.Repository)
+	headOid, err := g.nativeGitHandler.GetLatestCommitHash(workingDir)
+	if err != nil {
+		return err
+	}
+
+	input := githubv4.CreateCommitOnBranchInput{
+		Branch: githubv4.CommittableBranch{
+			RepositoryNameWithOwner: githubv4.NewString(githubv4.String(repositoryName)),
+			BranchName:              githubv4.NewString(githubv4.String(fmt.Sprintf("refs/heads/%s", workingBranch))),
+		},
+		ExpectedHeadOid: githubv4.GitObjectID(headOid),
+		Message: githubv4.CommitMessage{
+			Headline: githubv4.String(commitMessage),
+		},
+		FileChanges: &githubv4.FileChanges{
+			Additions: &additions,
+		},
+	}
+
+	if err := g.client.Mutate(context.Background(), &m, input, nil); err != nil {
+		return err
+	}
+
+	logrus.Debugf("commit created: %s", m.CreateCommitOnBranch.Commit.URL)
 	return nil
 }
 
@@ -125,6 +202,12 @@ func (g *Github) IsRemoteBranchUpToDate() (bool, error) {
 
 // Push run `git push` on the GitHub remote branch if not already created.
 func (g *Github) Push() (bool, error) {
+
+	// If the commit is done using the GitHub API, we don't need to push
+	// the commit as it is done in the same operation.
+	if g.commitUsingApi {
+		return true, nil
+	}
 
 	return g.nativeGitHandler.Push(
 		g.Spec.Username,

--- a/pkg/plugins/scms/github/scm_test.go
+++ b/pkg/plugins/scms/github/scm_test.go
@@ -1,0 +1,122 @@
+package github
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/shurcooL/githubv4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCommit(t *testing.T) {
+	tests := []struct {
+		name          string
+		spec          Spec
+		commitMsg     string
+		mockedQuery   *commitQuery
+		mockedError   error
+		wantChangelog string
+		wantErr       bool
+	}{
+		{
+			name: "Case with error returned from query",
+			spec: Spec{
+				Owner:      "updatecli",
+				Repository: "updatecli",
+				Username:   "joe",
+				Token:      "SuperSecretToken",
+			},
+			commitMsg:   "test commit",
+			mockedQuery: &commitQuery{},
+			mockedError: fmt.Errorf("Dummy error from github.com."),
+			wantErr:     true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.NotNil(t, tt.mockedQuery)
+
+			sut, err := New(tt.spec, "id1")
+
+			require.NoError(t, err)
+
+			sut.client = &MockGitHubClient{
+				mockedQuery: tt.mockedQuery,
+				mockedErr:   tt.mockedError,
+			}
+
+			err = sut.CreateCommit(tt.spec.Directory, tt.commitMsg)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestProcessChangedFiles(t *testing.T) {
+	tests := []struct {
+		name    string
+		create  bool
+		files   []string
+		want    []githubv4.FileAddition
+		wantErr bool
+	}{
+		{
+			name:   "Case with valid files",
+			create: true,
+			files:  []string{"file1.txt", "file2.txt"},
+			want: []githubv4.FileAddition{
+				{
+					Path:     githubv4.String("file1.txt"),
+					Contents: githubv4.Base64String("dGVzdCBjb250ZW50MA=="),
+				},
+				{
+					Path:     githubv4.String("file2.txt"),
+					Contents: githubv4.Base64String("dGVzdCBjb250ZW50MQ=="),
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:    "Case with error encoding file",
+			create:  false,
+			files:   []string{"file1.txt"},
+			want:    []githubv4.FileAddition{},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tempDir, err := os.MkdirTemp("", "")
+			require.NoError(t, err)
+
+			defer os.RemoveAll(tempDir)
+
+			if tt.create {
+				for i, file := range tt.files {
+					tempFile, err := os.Create(filepath.Join(tempDir, filepath.Base(file)))
+					require.NoError(t, err)
+					defer os.Remove(tempFile.Name())
+					tempFile.WriteString("test content" + strconv.Itoa(i))
+				}
+			}
+
+			got, err := processChangedFiles(tempDir, tt.files)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+			}
+
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/plugins/scms/github/scm_test.go
+++ b/pkg/plugins/scms/github/scm_test.go
@@ -76,11 +76,11 @@ func TestProcessChangedFiles(t *testing.T) {
 			want: []githubv4.FileAddition{
 				{
 					Path:     githubv4.String("file1.txt"),
-					Contents: githubv4.Base64String("dGVzdCBjb250ZW50MA=="),
+					Contents: githubv4.Base64String("dGVzdCBjb250ZW50MA=="), // no-spell-check-line
 				},
 				{
 					Path:     githubv4.String("file2.txt"),
-					Contents: githubv4.Base64String("dGVzdCBjb250ZW50MQ=="),
+					Contents: githubv4.Base64String("dGVzdCBjb250ZW50MQ=="), // no-spell-check-line
 				},
 			},
 			wantErr: false,
@@ -106,7 +106,8 @@ func TestProcessChangedFiles(t *testing.T) {
 					tempFile, err := os.Create(filepath.Join(tempDir, filepath.Base(file)))
 					require.NoError(t, err)
 					defer os.Remove(tempFile.Name())
-					tempFile.WriteString("test content" + strconv.Itoa(i))
+					_, err = tempFile.WriteString("test content" + strconv.Itoa(i))
+					require.NoError(t, err)
 				}
 			}
 

--- a/pkg/plugins/utils/fileoperations.go
+++ b/pkg/plugins/utils/fileoperations.go
@@ -1,0 +1,27 @@
+package utils
+
+import (
+	"bytes"
+	"encoding/base64"
+	"io"
+	"os"
+)
+
+func Base64EncodeFile(path string) (string, error) {
+	in, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer in.Close()
+
+	buf := bytes.Buffer{}
+	encoder := base64.NewEncoder(base64.StdEncoding, &buf)
+
+	if _, err := io.Copy(encoder, in); err != nil {
+		return "", err
+	}
+	if err := encoder.Close(); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}

--- a/pkg/plugins/utils/fileoperations_test.go
+++ b/pkg/plugins/utils/fileoperations_test.go
@@ -1,0 +1,38 @@
+package utils
+
+import (
+	"encoding/base64"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBase64EncodeFile(t *testing.T) {
+	fileContent := "test file content"
+	tmpfile, err := os.CreateTemp("", "testfile")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpfile.Name())
+	defer tmpfile.Close()
+
+	_, err = tmpfile.WriteString(fileContent)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	encodedString, err := Base64EncodeFile(tmpfile.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	decodedBytes, err := base64.StdEncoding.DecodeString(encodedString)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	decodedString := string(decodedBytes)
+
+	assert.Equal(t, fileContent, decodedString, "Decoded string does not match original content")
+}

--- a/pkg/plugins/utils/filepath_test.go
+++ b/pkg/plugins/utils/filepath_test.go
@@ -69,6 +69,7 @@ func TestFindFilesMatchingPathPattern(t *testing.T) {
 		{
 			filepath: "*_test.go",
 			expectedFoundFiles: []string{
+				"fileoperations_test.go",
 				"filepath_test.go",
 			},
 		},
@@ -81,6 +82,8 @@ func TestFindFilesMatchingPathPattern(t *testing.T) {
 		{
 			filepath: "*.go",
 			expectedFoundFiles: []string{
+				"fileoperations.go",
+				"fileoperations_test.go",
 				"filepath.go",
 				"filepath_test.go",
 			},

--- a/pkg/plugins/utils/gitgeneric/main.go
+++ b/pkg/plugins/utils/gitgeneric/main.go
@@ -29,6 +29,7 @@ type GitHandler interface {
 	Clone(username, password, URL, workingDir string, withSubmodules *bool) error
 	Commit(user, email, message, workingDir string, signingKey string, passphrase string) error
 	GetChangedFiles(workingDir string) ([]string, error)
+	GetLatestCommitHash(workingDir string) (string, error)
 	IsSimilarBranch(a, b, workingDir string) (bool, error)
 	IsLocalBranchPublished(baseBranch, workingBranch, username, password, workingDir string) (bool, error)
 	NewTag(tag, message, workingDir string) (bool, error)
@@ -208,6 +209,21 @@ func (g GoGit) GetChangedFiles(workingDir string) ([]string, error) {
 	}
 
 	return filesChanged, nil
+}
+
+// GetLatestCommitHash returns the latest commit hash from the working directory
+func (g GoGit) GetLatestCommitHash(workingDir string) (string, error) {
+	gitRepository, err := git.PlainOpen(workingDir)
+	if err != nil {
+		return "", err
+	}
+
+	head, err := gitRepository.Head()
+	if err != nil {
+		return "", err
+	}
+
+	return head.Hash().String(), nil
 }
 
 // Add run `git add`.


### PR DESCRIPTION
Fix #1914 

This pull request adds support for GitHub API commit. It allows Github SCM to commit a file in a GitHub repository using the GitHub API instead of using native Git.

The GitHub commit API is useful when a user is using the [automated token from Github Actions](https://docs.github.com/en/enterprise-cloud@latest/actions/security-guides/automatic-token-authentication) as it creates a signed commit automatically, removing the requirement of using a bot account with a GPG key configured.

For now I've hidden this feature behind the `commitUsingApi` (not loving the parameter name, happy for suggestions).

In addition I changed the Github pull request action to check if working branch is ahead using the API instead of relying on the native Git handler as I kept running in to issues where Github Actions wasn't recognizing changes done (not exactly sure why, but I think this will 100% ensure that the commit is available in Github).

As can be seen in the below screenshot, the commit is shown as verified with the Github Actions bot user committing the changes.
![image](https://github.com/updatecli/updatecli/assets/31220729/a29c04d9-85f6-4de4-9780-45c06e4338ac)

## Test

Build my fork and use the Github SCM with `commitUsingApi: true`.
