### PR TITLE
fix: Restrict update-compose.yaml to automate update

### DIFF
--- a/updatecli/values.d/update-compose.yaml
+++ b/updatecli/values.d/update-compose.yaml
@@ -1,3 +1,5 @@
 spec:
   files:
     - "update-compose.yaml"
+  only:
+    - "update-compose.yaml"


### PR DESCRIPTION
The purpose of this pullrequest is to not update all update-compose.yaml located on this repository like on https://github.com/updatecli/updatecli/pull/2024