### PR TITLE
fix: always try to update existing pullrequest description

### DIFF
--- a/pkg/core/pipeline/actions.go
+++ b/pkg/core/pipeline/actions.go
@@ -30,12 +30,7 @@ func (p *Pipeline) RunActions(pipelineState string) error {
 			continue
 		}
 
-		isMatchingState := true
-		for i := range relatedTargets {
-			if p.Targets[relatedTargets[i]].Result.Result != pipelineState {
-				isMatchingState = false
-			}
-		}
+		isMatchingState := p.isMatchingState(pipelineState, relatedTargets)
 
 		// No need to proceed if the action doesn't contain target in the right state.
 		if !isMatchingState {
@@ -253,4 +248,29 @@ func getActionTitle(action action.Action) string {
 		}
 	}
 	return "No action title could be found"
+}
+
+func (p *Pipeline) isMatchingState(state string, targets []string) bool {
+	var r bool
+	switch state {
+
+	// All targets must have the same state
+	case result.SUCCESS, result.FAILURE, result.SKIPPED:
+		r = true
+		for i := range targets {
+			if p.Targets[targets[i]].Result.Result != state {
+				r = false
+			}
+		}
+
+	// If at least one target is in ATTENTION state, then the action must be executed
+	default:
+		r = false
+		for i := range targets {
+			if p.Targets[targets[i]].Result.Result == state {
+				r = true
+			}
+		}
+	}
+	return r
 }

--- a/pkg/plugins/scms/github/pullrequest.go
+++ b/pkg/plugins/scms/github/pullrequest.go
@@ -164,20 +164,6 @@ func (p *PullRequest) CreateAction(report reports.Action, resetDescription bool)
 
 	p.repository = repository
 
-	// Check if they are changes that need to be published otherwise exit
-	isAhead := p.isAhead()
-	logrus.Debugf("Branch %s is %s of %s", workingBranch, p.repository.Status, sourceBranch)
-
-	if err != nil {
-		return err
-	}
-
-	if !isAhead {
-		logrus.Debugf("GitHub pullrequest not needed")
-
-		return nil
-	}
-
 	// Check if there is already a pullRequest for current pipeline
 	err = p.getRemotePullRequest(resetDescription)
 	if err != nil {
@@ -195,6 +181,18 @@ func (p *PullRequest) CreateAction(report reports.Action, resetDescription bool)
 	// tags,assignee,etc.
 	if err := p.updatePullRequest(); err != nil {
 		return err
+	}
+
+	// Check if they are changes that need to be published otherwise exit
+	// It's worth mentioning that at this time, changes have already been published
+	// The goal is just to not open a pull request if there is no changes
+	isAhead := p.isAhead()
+	logrus.Debugf("Branch %s is %s of %s", workingBranch, p.repository.Status, sourceBranch)
+
+	if !isAhead {
+		logrus.Debugf("GitHub pullrequest not needed")
+
+		return nil
 	}
 
 	// Now that the pullrequest has been updated with the new report, we can now close it if needed.


### PR DESCRIPTION
Fix a regression introduced in https://github.com/updatecli/updatecli/pull/2046 when pipeline wouldn't update existing pullrequest.

This pullrequest also better identify action state to avoid running multiple time the same action

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
/
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
