### PR TITLE
fix: use API for creating branch and fetching hashes when committing using Github API

### DIFF
--- a/pkg/plugins/scms/github/main.go
+++ b/pkg/plugins/scms/github/main.go
@@ -550,3 +550,18 @@ type refQuery struct {
 		}
 	} `graphql:"createRef(input:$input)"`
 }
+
+func (g *Github) createBranch(branchName string, repositoryId string, headOid string) error {
+	var query refQuery
+
+	input := githubv4.CreateRefInput{
+		RepositoryID: repositoryId,
+		Name:         githubv4.String(fmt.Sprintf("refs/heads/%s", branchName)),
+		Oid:          githubv4.GitObjectID(headOid),
+	}
+
+	if err := g.client.Mutate(context.Background(), &query, input, nil); err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
Related to #1914 and issues described in [this comment](https://github.com/updatecli/updatecli/issues/1914#issuecomment-2080851598).

Note: I will probably not have time to add any tests this week, so feel free to take over @olblak or if approve if you feel it's good enough since most are API actions that can't be properly tested without integration tests.

The previous implementation used native Git to both create the working branch and fetching latest commit hash used when committing using API. This caused issues when using multiple targets with the same SCM due to the local cloned repository not having pulled the latest changes from the remote branch, which meant that `PushBranch` reverted changes done in the first target that ran.

To fix this, I've added the following: 

- Latest commit hashes are fetched from Github API instead of the native Git handler.
- Branch is now created using the Github API if an existing branch is not found.

## Test

- Build forked repository and branch and run with a [manifest that contains one SCM and multiple targets that uses the SCM](https://github.com/olblak/kubernetes-marketplace/blob/master/.github/updatecli/updatecli.d/kubewarden.yaml).

## Additional Information

### Potential improvement

The `queryHeadOid` function use much of the same code as `queryRepository` but this function fails if the working branch is not available due to it being used as an input. We could probably rework this to be a more dynamic struct, but I think having an explicit function that only fetches the required information (i.e. hashes) makes sense even if it's not following DRY.