### PR TITLE
chore: removing version pinning in updatecli workflow

### DIFF
--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -23,8 +23,6 @@ jobs:
         uses: "actions/checkout@v4"
       - name: "Setup updatecli"
         uses: "updatecli/updatecli-action@v2"
-        with:
-          version: "v0.76.0-rc.4"
       - name: Set up Go
         uses: actions/setup-go@v5
         with:


### PR DESCRIPTION
<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
cd <to_package_directory>
go test
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
