### PR TITLE
github: note username is needed when using github private repositories

### DIFF
--- a/pkg/plugins/scms/github/main.go
+++ b/pkg/plugins/scms/github/main.go
@@ -104,7 +104,7 @@ type Spec struct {
 	//    * scm
 	//
 	//  remark:
-	//    the token is usually enough to authenticate with GitHub API.
+	//    the token is usually enough to authenticate with GitHub API. Needed when working with GitHub private repositories.
 	Username string `yaml:",omitempty"`
 	//  "user" specifies the user associated with new git commit messages created by Updatecli
 	//


### PR DESCRIPTION
Fix #XXX

<!-- Describe the changes introduced by this pull request -->
Update docs about the `username` in GitHub

## Test

Given

```yaml

scms:
  default:
    kind: github
    spec:
      user: '{{ requiredEnv "GITHUB_ACTOR" }}'
      owner: your-org
      repository: your-private-repo
      token: '{{ requiredEnv "GITHUB_TOKEN" }}'
      branch: main
```

When running

```bash
$ GITHUB_TOKEN=$(gh auth token) \
   GITHUB_ACTOR=my-actor \
   updatecli diff --config  updatecli.d/bump.yml --debug
```

Then it fails with:
```bash
TARGETS
========
bump
-----------

**Dry Run enabled**
DEBUG: checkout git branch "updatecli_main_updatecli-bump", based on "main"
DEBUG: authentication required

ERROR: something went wrong in target "bump" : "authentication required"

Pipeline "Bump snapshot version" failed
Skipping due to:
	targets stage:	"something went wrong during target execution"
```

## Additional Information

If I use a public repository, it works without the `username`.

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
