### PR TITLE
feat: support sources for argocd autodiscovery

### DIFF
--- a/pkg/plugins/autodiscovery/argocd/application.go
+++ b/pkg/plugins/autodiscovery/argocd/application.go
@@ -19,12 +19,22 @@ type ArgoCDApplicationSpec struct {
 	ApiVersion string `yaml:"apiVersion"`
 	Kind       string `yaml:"kind"`
 	Spec       struct {
-		Source struct {
-			RepoURL        string `yaml:"repoURL"`
-			TargetRevision string `yaml:"targetRevision"`
-			Chart          string `yaml:"chart"`
-		}
+		Source  ApplicationSourceSpec
+		Sources []ApplicationSourceSpec
 	}
+}
+
+type ApplicationSourceSpec struct {
+	RepoURL        string `yaml:"repoURL"`
+	TargetRevision string `yaml:"targetRevision"`
+	Chart          string `yaml:"chart"`
+	Ref            string `yaml:"ref"`
+}
+
+// IsZero checks if the ApplicationSourceSpec is empty in the context of Updatecli
+// We prefer ignoring when chart and targetRevision are empty
+func (a ApplicationSourceSpec) IsZero() bool {
+	return a.RepoURL == "" || a.TargetRevision == "" || a.Chart == ""
 }
 
 func (f ArgoCD) discoverArgoCDManifests() ([][]byte, error) {
@@ -42,7 +52,7 @@ func (f ArgoCD) discoverArgoCDManifests() ([][]byte, error) {
 	for _, foundFile := range foundFiles {
 		logrus.Debugf("parsing file %q", foundFile)
 
-		relativeFoundFile, err := filepath.Rel(f.rootDir, foundFile)
+		relativeFilepath, err := filepath.Rel(f.rootDir, foundFile)
 		if err != nil {
 			// Let's try the next chart if one fail
 			logrus.Debugln(err)
@@ -50,93 +60,124 @@ func (f ArgoCD) discoverArgoCDManifests() ([][]byte, error) {
 		}
 
 		// Retrieve chart dependencies for each chart
-
-		data, err := loadApplicationData(foundFile)
+		data, err := readManifest(foundFile)
 		if err != nil {
 			logrus.Debugln(err)
 			continue
 		}
 
-		if data == nil {
-			continue
-		}
-
-		// Skip pipeline if at least of the helm chart or helm repository is not specified
-		if len(data.Spec.Source.Chart) == 0 || len(data.Spec.Source.RepoURL) == 0 {
-			continue
-		}
-
-		if len(f.spec.Ignore) > 0 {
-			if f.spec.Ignore.isMatchingRules(f.rootDir, relativeFoundFile, data.Spec.Source.RepoURL, data.Spec.Source.Chart, data.Spec.Source.TargetRevision) {
-				logrus.Debugf("Ignoring Helm chart %q from %q, as matching ignore rule(s)\n", data.Spec.Source.Chart, relativeFoundFile)
-				continue
-			}
-		}
-
-		if len(f.spec.Only) > 0 {
-			if !f.spec.Only.isMatchingRules(f.rootDir, relativeFoundFile, data.Spec.Source.RepoURL, data.Spec.Source.Chart, data.Spec.Source.TargetRevision) {
-				logrus.Debugf("Ignoring Helm chart %q from %q, as not matching only rule(s)\n", data.Spec.Source.Chart, relativeFoundFile)
-				continue
-			}
-		}
-
-		sourceVersionFilterKind := "semver"
-		sourceVersionFilterPattern := "*"
-
-		if !f.spec.VersionFilter.IsZero() {
-			sourceVersionFilterKind = f.versionFilter.Kind
-			sourceVersionFilterPattern, err = f.versionFilter.GreaterThanPattern(data.Spec.Source.TargetRevision)
+		if !data.Spec.Source.IsZero() {
+			manifest, err := f.generateManifestBySource(
+				data.Spec.Source,
+				relativeFilepath,
+				"$.spec.source",
+			)
 			if err != nil {
-				logrus.Debugf("building version filter pattern: %s", err)
-				sourceVersionFilterPattern = "*"
+				logrus.Errorf("error discovering application source: %s", err)
 			}
+
+			manifests = append(manifests, manifest)
 		}
 
-		tmpl, err := template.New("manifest").Parse(manifestTemplate)
-		if err != nil {
-			logrus.Debugln(err)
-			continue
-		}
+		for i, source := range data.Spec.Sources {
+			if source.IsZero() {
+				continue
+			}
 
-		params := struct {
-			ManifestName               string
-			ImageName                  string
-			ChartName                  string
-			ChartRepository            string
-			ManifestFile               string
-			ConditionID                string
-			SourceID                   string
-			SourceName                 string
-			SourceKind                 string
-			SourceVersionFilterKind    string
-			SourceVersionFilterPattern string
-			TargetID                   string
-			File                       string
-			ScmID                      string
-		}{
-			ManifestName:               fmt.Sprintf("deps(helm): bump Helm chart %q in ArgoCD manifest %q", data.Spec.Source.Chart, relativeFoundFile),
-			ChartName:                  data.Spec.Source.Chart,
-			ChartRepository:            data.Spec.Source.RepoURL,
-			ConditionID:                data.Spec.Source.Chart,
-			ManifestFile:               relativeFoundFile,
-			SourceID:                   data.Spec.Source.Chart,
-			SourceName:                 fmt.Sprintf("Get latest %q Helm chart version", data.Spec.Source.Chart),
-			SourceKind:                 "helmchart",
-			SourceVersionFilterKind:    sourceVersionFilterKind,
-			SourceVersionFilterPattern: sourceVersionFilterPattern,
-			TargetID:                   data.Spec.Source.Chart,
-			File:                       relativeFoundFile,
-			ScmID:                      f.scmID,
-		}
+			manifest, err := f.generateManifestBySource(
+				source,
+				relativeFilepath,
+				fmt.Sprintf("$.spec.sources[%d]", i),
+			)
+			if err != nil {
+				logrus.Errorf("error discovering application source: %s", err)
+			}
 
-		manifest := bytes.Buffer{}
-		if err := tmpl.Execute(&manifest, params); err != nil {
-			logrus.Debugln(err)
-			continue
+			manifests = append(manifests, manifest)
 		}
-
-		manifests = append(manifests, manifest.Bytes())
 	}
 
 	return manifests, nil
+}
+
+// generateManifestBySource generates an ArgoCD manifest for Updatecli based on the application source input
+func (f ArgoCD) generateManifestBySource(data ApplicationSourceSpec, file string, targetKey string) ([]byte, error) {
+
+	var err error
+
+	if data.IsZero() {
+		return nil, nil
+	}
+
+	if len(f.spec.Ignore) > 0 {
+		if f.spec.Ignore.isMatchingRules(f.rootDir, file, data.RepoURL, data.Chart, data.TargetRevision) {
+			logrus.Debugf("Ignoring Helm chart %q from %q, as matching ignore rule(s)\n", data.Chart, file)
+			return nil, nil
+		}
+	}
+
+	if len(f.spec.Only) > 0 {
+		if !f.spec.Only.isMatchingRules(f.rootDir, file, data.RepoURL, data.Chart, data.TargetRevision) {
+			logrus.Debugf("Ignoring Helm chart %q from %q, as not matching only rule(s)\n", data.Chart, file)
+			return nil, nil
+		}
+	}
+
+	sourceVersionFilterKind := "semver"
+	sourceVersionFilterPattern := "*"
+
+	if !f.spec.VersionFilter.IsZero() {
+		sourceVersionFilterKind = f.versionFilter.Kind
+		sourceVersionFilterPattern, err = f.versionFilter.GreaterThanPattern(data.TargetRevision)
+		if err != nil {
+			logrus.Debugf("building version filter pattern: %s", err)
+			sourceVersionFilterPattern = "*"
+		}
+	}
+
+	tmpl, err := template.New("manifest").Parse(manifestTemplate)
+	if err != nil {
+		logrus.Debugln(err)
+		return nil, nil
+	}
+
+	params := struct {
+		ManifestName               string
+		ImageName                  string
+		ChartName                  string
+		ChartRepository            string
+		ManifestFile               string
+		ConditionID                string
+		SourceID                   string
+		SourceName                 string
+		SourceKind                 string
+		SourceVersionFilterKind    string
+		SourceVersionFilterPattern string
+		TargetID                   string
+		TargetKey                  string
+		File                       string
+		ScmID                      string
+	}{
+		ManifestName:               fmt.Sprintf("deps(helm): bump Helm chart %q in ArgoCD manifest %q", data.Chart, file),
+		ChartName:                  data.Chart,
+		ChartRepository:            data.RepoURL,
+		ConditionID:                data.Chart,
+		ManifestFile:               file,
+		SourceID:                   data.Chart,
+		SourceName:                 fmt.Sprintf("Get latest %q Helm chart version", data.Chart),
+		SourceKind:                 "helmchart",
+		SourceVersionFilterKind:    sourceVersionFilterKind,
+		SourceVersionFilterPattern: sourceVersionFilterPattern,
+		TargetID:                   data.Chart,
+		TargetKey:                  targetKey,
+		File:                       file,
+		ScmID:                      f.scmID,
+	}
+
+	manifest := bytes.Buffer{}
+	if err = tmpl.Execute(&manifest, params); err != nil {
+		return nil, fmt.Errorf("error executing template: %w", err)
+	}
+
+	return manifest.Bytes(), nil
 }

--- a/pkg/plugins/autodiscovery/argocd/main_test.go
+++ b/pkg/plugins/autodiscovery/argocd/main_test.go
@@ -14,9 +14,14 @@ func TestDiscoverManifests(t *testing.T) {
 		expectedPipelines []string
 	}{
 		{
-			name:    "Scenario 1",
-			rootDir: "testdata",
-			expectedPipelines: []string{`name: 'deps(helm): bump Helm chart "sealed-secrets" in ArgoCD manifest "sealed-secrets/manifest.yaml"'
+			name:              "ArgoCD manifests discovered no source",
+			rootDir:           "testdata/empty",
+			expectedPipelines: []string{},
+		},
+		{
+			name:    "ArgoCD manifests discovery with a single source",
+			rootDir: "testdata/sealed-secrets",
+			expectedPipelines: []string{`name: 'deps(helm): bump Helm chart "sealed-secrets" in ArgoCD manifest "manifest.yaml"'
 sources:
   sealed-secrets:
     name: 'Get latest "sealed-secrets" Helm chart version'
@@ -33,7 +38,7 @@ conditions:
     kind: 'yaml'
     disablesourceinput: true
     spec:
-      file: 'sealed-secrets/manifest.yaml'
+      file: 'manifest.yaml'
       key: '$.spec.source.chart'
       value: 'sealed-secrets'
   sealed-secrets-repository:
@@ -41,16 +46,57 @@ conditions:
     kind: 'yaml'
     disablesourceinput: true
     spec:
-      file: 'sealed-secrets/manifest.yaml'
+      file: 'manifest.yaml'
       key: '$.spec.source.repoURL'
       value: 'https://bitnami-labs.github.io/sealed-secrets'
 targets:
   sealed-secrets:
-    name: 'deps(helm): bump Helm chart "sealed-secrets" in ArgoCD manifest "sealed-secrets/manifest.yaml"'
+    name: 'deps(helm): bump Helm chart "sealed-secrets" in ArgoCD manifest "manifest.yaml"'
     kind: 'yaml'
     spec:
-      file: 'sealed-secrets/manifest.yaml'
+      file: 'manifest.yaml'
       key: '$.spec.source.targetRevision'
+    sourceid: 'sealed-secrets'
+`},
+		},
+		{
+			name:    "ArgoCD manifests discovery with several sources",
+			rootDir: "testdata/sealed-secrets_sources",
+			expectedPipelines: []string{`name: 'deps(helm): bump Helm chart "sealed-secrets" in ArgoCD manifest "manifest.yaml"'
+sources:
+  sealed-secrets:
+    name: 'Get latest "sealed-secrets" Helm chart version'
+    kind: 'helmchart'
+    spec:
+      name: 'sealed-secrets'
+      url: 'https://bitnami-labs.github.io/sealed-secrets'
+      versionfilter:
+        kind: 'semver'
+        pattern: '*'
+conditions:
+  sealed-secrets-name:
+    name: 'Ensure Helm chart name sealed-secrets is specified'
+    kind: 'yaml'
+    disablesourceinput: true
+    spec:
+      file: 'manifest.yaml'
+      key: '$.spec.sources[0].chart'
+      value: 'sealed-secrets'
+  sealed-secrets-repository:
+    name: 'Ensure Helm chart repository https://bitnami-labs.github.io/sealed-secrets is specified'
+    kind: 'yaml'
+    disablesourceinput: true
+    spec:
+      file: 'manifest.yaml'
+      key: '$.spec.sources[0].repoURL'
+      value: 'https://bitnami-labs.github.io/sealed-secrets'
+targets:
+  sealed-secrets:
+    name: 'deps(helm): bump Helm chart "sealed-secrets" in ArgoCD manifest "manifest.yaml"'
+    kind: 'yaml'
+    spec:
+      file: 'manifest.yaml'
+      key: '$.spec.sources[0].targetRevision'
     sourceid: 'sealed-secrets'
 `},
 		},

--- a/pkg/plugins/autodiscovery/argocd/manifestTemplate.go
+++ b/pkg/plugins/autodiscovery/argocd/manifestTemplate.go
@@ -23,7 +23,7 @@ conditions:
 {{ end }}
     spec:
       file: '{{ .File }}'
-      key: '$.spec.source.chart'
+      key: '{{ .TargetKey }}.chart'
       value: '{{ .ChartName }}'
   {{ .ConditionID }}-repository:
     name: 'Ensure Helm chart repository {{ .ChartRepository }} is specified'
@@ -34,7 +34,7 @@ conditions:
 {{ end }}
     spec:
       file: '{{ .File }}'
-      key: '$.spec.source.repoURL'
+      key: '{{ .TargetKey }}.repoURL'
       value: '{{ .ChartRepository }}'
 targets:
   {{ .TargetID }}:
@@ -45,7 +45,7 @@ targets:
 {{ end }}
     spec:
       file: '{{ .File }}'
-      key: '$.spec.source.targetRevision'
+      key: '{{ .TargetKey }}.targetRevision'
     sourceid: '{{ .SourceID }}'
 `
 )

--- a/pkg/plugins/autodiscovery/argocd/testdata/empty/manifest.yaml
+++ b/pkg/plugins/autodiscovery/argocd/testdata/empty/manifest.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: sealed-secrets
+  namespace: argocd
+spec:
+  project: default
+  sources:
+    - chart: sealed-secrets
+      repoURL: https://bitnami-labs.github.io/sealed-secrets
+      helm:
+        releaseName: sealed-secrets
+    - repoURL: 'https://git.example.com/org/value-files.git'
+      targetRevision: HEAD
+      ref: values
+  destination:
+    server: "https://kubernetes.default.svc"
+    namespace: kubeseal

--- a/pkg/plugins/autodiscovery/argocd/testdata/sealed-secrets_sources/manifest.yaml
+++ b/pkg/plugins/autodiscovery/argocd/testdata/sealed-secrets_sources/manifest.yaml
@@ -1,0 +1,19 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: sealed-secrets
+  namespace: argocd
+spec:
+  project: default
+  sources:
+    - chart: sealed-secrets
+      repoURL: https://bitnami-labs.github.io/sealed-secrets
+      targetRevision: 1.16.1
+      helm:
+        releaseName: sealed-secrets
+    - repoURL: 'https://git.example.com/org/value-files.git'
+      targetRevision: HEAD
+      ref: values
+  destination:
+    server: "https://kubernetes.default.svc"
+    namespace: kubeseal

--- a/pkg/plugins/autodiscovery/argocd/utils_test.go
+++ b/pkg/plugins/autodiscovery/argocd/utils_test.go
@@ -2,6 +2,8 @@ package argocd
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestSearchFiles(t *testing.T) {
@@ -12,15 +14,17 @@ func TestSearchFiles(t *testing.T) {
 		t.Errorf("%s\n", err)
 	}
 
-	expectedFile := "testdata/sealed-secrets/manifest.yaml"
-	if gotFiles[0] != expectedFile {
-		t.Errorf("Expecting file %q but got %q", expectedFile, gotFiles[0])
+	expectedFiles := []string{
+		"testdata/sealed-secrets/manifest.yaml",
+		"testdata/sealed-secrets_sources/manifest.yaml",
 	}
+
+	assert.Equal(t, gotFiles, expectedFiles)
 }
 
 func TestListChartDependency(t *testing.T) {
 
-	gotChartData, err := loadApplicationData(
+	gotChartData, err := readManifest(
 		"testdata/sealed-secrets/manifest.yaml")
 	if err != nil {
 		t.Errorf("%s\n", err)


### PR DESCRIPTION
Fix #1911 

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
cd pkg/plugins/autodiscovery/argocd/
go test
go build -o bin/updatecli .
```

Tested using manifest

```
apiVersion: argoproj.io/v1alpha1
kind: Application
metadata:
  name: guestbook
  namespace: argocd
spec:
  project: default
  destination:
    server: https://kubernetes.default.svc
    namespace: default
  sources:
    - chart: elasticsearch
      repoURL: https://helm.elastic.co
      targetRevision: 8.5.0
    - repoURL: https://github.com/argoproj/argocd-example-apps.git
      path: guestbook
      targetRevision: HEAD
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
