### PR TITLE
fix: golang autodiscovery module update

### DIFF
--- a/pkg/plugins/autodiscovery/golang/dependency.go
+++ b/pkg/plugins/autodiscovery/golang/dependency.go
@@ -105,6 +105,7 @@ func (g Golang) discoverDependencyManifests() ([][]byte, error) {
 
 			manifests = append(manifests, moduleManifest)
 		}
+
 		// Test if the ignore rule based on path is respected
 		if len(g.spec.Ignore) > 0 {
 			if g.spec.Ignore.isMatchingRules(g.rootDir, relativeFoundFile, goVersion, "", "") {

--- a/pkg/plugins/autodiscovery/golang/matchingRule.go
+++ b/pkg/plugins/autodiscovery/golang/matchingRule.go
@@ -142,10 +142,17 @@ func (m MatchingRules) isGoVersionOnly() bool {
 	if len(m) == 0 {
 		return false
 	}
+
+	goOnlyFound := 0
 	for _, rule := range m {
-		if rule.GoVersion != "" && len(rule.Modules) > 0 {
-			return false
+		if rule.GoVersion != "" && len(rule.Modules) == 0 {
+			goOnlyFound++
 		}
 	}
-	return true
+
+	if goOnlyFound == len(m) && goOnlyFound > 0 {
+		return true
+	}
+
+	return false
 }

--- a/pkg/plugins/autodiscovery/golang/matchingRule_test.go
+++ b/pkg/plugins/autodiscovery/golang/matchingRule_test.go
@@ -157,3 +157,74 @@ func TestIsMatchingRule(t *testing.T) {
 		})
 	}
 }
+
+func TestIsGoOnly(t *testing.T) {
+
+	dataset := []struct {
+		name           string
+		rules          MatchingRules
+		expectedResult bool
+	}{
+		{
+			name: "Only path specified",
+			rules: MatchingRules{
+				MatchingRule{
+					Path: "go.mod",
+				},
+			},
+			expectedResult: false,
+		},
+		{
+			name: "Only go version specified",
+			rules: MatchingRules{
+				MatchingRule{
+					GoVersion: "*",
+				},
+			},
+			expectedResult: true,
+		},
+		{
+			name: "Multiple go version specified",
+			rules: MatchingRules{
+				MatchingRule{
+					GoVersion: "1.19.*",
+				},
+				MatchingRule{
+					GoVersion: ">=1.20.0",
+				},
+			},
+			expectedResult: true,
+		},
+		{
+			name: "Go version specified with second go module rule",
+			rules: MatchingRules{
+				MatchingRule{
+					GoVersion: "1.19.*",
+				},
+				MatchingRule{
+					Modules: map[string]string{
+						"github.com/updatecli/updatecli": "1.0.0",
+					},
+				},
+			},
+			expectedResult: false,
+		},
+		{
+			name: "Go version specified with go module within the same rule",
+			rules: MatchingRules{
+				MatchingRule{
+					GoVersion: "1.19.*",
+					Modules: map[string]string{
+						"github.com/updatecli/updatecli": "1.0.0",
+					},
+				},
+			},
+			expectedResult: false,
+		},
+	}
+
+	for _, d := range dataset {
+		gotReset := d.rules.isGoVersionOnly()
+		assert.Equal(t, d.expectedResult, gotReset)
+	}
+}


### PR DESCRIPTION
https://github.com/updatecli/updatecli/pull/2236 introduced a regression where only go version are updated and go modules are ignored

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
go build -o bin/updatecli .
./bin/updatecli diff --config e2e/updatecli.d/success.d/autodiscovery/golang/golangOnly.yaml # should only update go version
./bin/updatecli diff --config e2e/updatecli.d/success.d/autodiscovery/golang/patchOnly.yaml  # should only update go modules
cd pkg/plugins/autodiscovery/golang/
go test
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
