### PR TITLE
fix(npm-source): Deprecated field can be bool

### DIFF
--- a/pkg/plugins/resources/npm/main.go
+++ b/pkg/plugins/resources/npm/main.go
@@ -45,7 +45,7 @@ type distTags struct {
 type versions struct {
 	Name       string
 	Version    string
-	Deprecated string
+	Deprecated interface{}
 }
 
 type Data struct {


### PR DESCRIPTION
updatecli diff returns an error when the deprecated field is a bool.

```
json: cannot unmarshal bool into Go struct field versions.Versions.Deprecated of type string
```

I was testing it on a `package.json` with `react` and `react-dom`. The exact output below:
```
################################
# BUMP "REACT" PACKAGE VERSION #
################################


SOURCES
=======

npm
---
ERROR: error unmarshalling json: "json: cannot unmarshal bool into Go struct field versions.Versions.Deprecated of type string"
ERROR: ✗ json: cannot unmarshal bool into Go struct field versions.Versions.Deprecated of type string
ERROR: ✗ json: cannot unmarshal bool into Go struct field versions.Versions.Deprecated of type string
Pipeline "Bump \"react\" package version" failed
Skipping due to:
        sources stage:  "json: cannot unmarshal bool into Go struct field versions.Versions.Deprecated of type string"


####################################
# BUMP "REACT-DOM" PACKAGE VERSION #
####################################


SOURCES
=======

npm
---
ERROR: error unmarshalling json: "json: cannot unmarshal bool into Go struct field versions.Versions.Deprecated of type string"
ERROR: ✗ json: cannot unmarshal bool into Go struct field versions.Versions.Deprecated of type string
ERROR: ✗ json: cannot unmarshal bool into Go struct field versions.Versions.Deprecated of type string
Pipeline "Bump \"react-dom\" package version" failed
Skipping due to:
        sources stage:  "json: cannot unmarshal bool into Go struct field versions.Versions.Deprecated of type string"
```

This should make it possible to unmarshal Deprecated fields of type string and bool.

I did not check all occurrences of the struct and the field, maybe it's required to convert to a specific type somwhere, e.g. in `pkg/plugins/resources/npm/changelog.go` (couldn't find out where it is invoked exactly, because it's my first time using updatecli and I'm quite new to it).