### PR TITLE
feat: Remove authentication requirement to publish reports to Udash

### DIFF
--- a/pkg/core/engine/udash.go
+++ b/pkg/core/engine/udash.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/sirupsen/logrus"
 	"github.com/updatecli/updatecli/pkg/core/cmdoptions"
 	"github.com/updatecli/updatecli/pkg/core/udash"
 )
@@ -20,12 +21,23 @@ func (e *Engine) publishToUdash() error {
 		return nil
 	}
 
+	logrus.Infof("\n\n%s\n", strings.ToTitle("Udash - Experimental"))
+	logrus.Infof("%s\n\n", strings.Repeat("=", len("Udash - Experimental")+1))
+
+	udashConfigFile, found := udash.IsConfigFile()
+	if !found {
+		logrus.Infof("Skipping as no Udash configuration file found at %s", udashConfigFile)
+		return nil
+	}
+
 	for id := range e.Pipelines {
 		pipeline := e.Pipelines[id]
 		if err := udash.Publish(&pipeline.Report); err != nil &&
-			!errors.Is(err, udash.ErrNoUdashBearerToken) &&
 			!errors.Is(err, udash.ErrNoUdashAPIURL) {
 			errs = append(errs, pipeline.Name+err.Error())
+		}
+		if pipeline.Report.ReportURL != "" {
+			logrus.Infof("%s:\n\t=> %q", pipeline.Name, pipeline.Report.ReportURL)
 		}
 		e.Pipelines[id] = pipeline
 	}

--- a/pkg/core/pipeline/main.go
+++ b/pkg/core/pipeline/main.go
@@ -66,6 +66,7 @@ func (p *Pipeline) Init(config *config.Config, options Options) error {
 	p.Report.Targets = make(map[string]*result.Target, len(config.Spec.Targets))
 	p.Report.Name = config.Spec.Name
 	p.Report.Result = result.SKIPPED
+	p.Report.PipelineID = config.Spec.PipelineID
 
 	// Init scm
 	for id, scmConfig := range config.Spec.SCMs {
@@ -185,6 +186,8 @@ func (p *Pipeline) Init(config *config.Config, options Options) error {
 
 		r := p.Targets[id].Result
 		p.Report.Targets[id] = &r
+
+		p.Report.Targets[id].DryRun = r.DryRun
 	}
 	return nil
 

--- a/pkg/core/reports/main.go
+++ b/pkg/core/reports/main.go
@@ -13,7 +13,7 @@ import (
 const reportsTpl string = `
 =============================
 
-REPORTS:
+SUMMARY:
 
 
 {{ range . }}

--- a/pkg/core/reports/report.go
+++ b/pkg/core/reports/report.go
@@ -77,7 +77,9 @@ type Report struct {
 	Err    string
 	Result string
 	// ID defines the report ID
-	ID         string
+	ID string
+	// PipelineID represents the Updatecli manifest pipelineID
+	PipelineID string
 	Sources    map[string]*result.Source
 	Conditions map[string]*result.Condition
 	Targets    map[string]*result.Target

--- a/pkg/core/udash/helpers.go
+++ b/pkg/core/udash/helpers.go
@@ -47,3 +47,17 @@ func initConfigFile() (string, error) {
 
 	return filepath.Join(updatecliConfigDir, "udash.json"), nil
 }
+
+// IsConfigFile checks if the udash config file exists
+func IsConfigFile() (string, bool) {
+	configFile, err := initConfigFile()
+	if err != nil {
+		return configFile, false
+	}
+
+	if _, err := os.Stat(configFile); err != nil {
+		return configFile, false
+	}
+
+	return configFile, true
+}


### PR DESCRIPTION
This pullrequest is related to some ongoing experimentation with [github.com/updatecli/udash](https://github.com/updatecli/udash) and introduce the following changes

* Allow to publish reports to a Udash service without being authenticated
* Don't show error message if udash configuration file doesn't exist Fix #2181
* Refactor console output to better align with Action output now that they are executed after each pipeline  

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you'll need a local udash service as briefly explained on [github.com/updatecli/udash](https://github.com/updatecli/udash)

<details><summary>Console Output</summary>

```
ACTIONS
========



UDASH - EXPERIMENTAL
=====================

docs: bump updatecli version:
	=> "http://localhost:3030/pipeline/reports/01ab976f-c443-4502-bd37-78c63db9d357"
ci: bump Venom version:
	=> "http://localhost:3030/pipeline/reports/fabc11e3-a503-4b80-b838-9af3e9364a4e"

=============================

SUMMARY:



✔ docs: bump updatecli version:
	Source:
		✔ [latestVersion] Get latest updatecli release
	Condition:
		✔ [container] Ensure latest container image is publish
	Target:
		✔ [bugReport] docs: update updatecli version to v0.79.1
		✔ [cosign-checksums-txt-pem] docs: update checksums.txt.pem url with Updatecli version to v0.79.1
		✔ [cosign-checksums-txt-sig] docs: update checksums.txt.sig url with Updatecli version to v0.79.1
		✔ [cosign-container] docs: update issue template with Updatecli version to v0.79.1


✔ ci: bump Venom version:
	Source:
		✔ [latestVersion] Get latest Venom release
	Target:
		✔ [goWorkflow] ci: update Venom version to v1.2.0

```
</details>

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
