### PR TITLE
fix: update goreleaser config to be v2 compliant

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -38,7 +38,7 @@ jobs:
           version: v1.59.1
           install-mode: "binary"
       - name: Install GoReleaser
-        uses: goreleaser/goreleaser-action@v5
+        uses: goreleaser/goreleaser-action@v6
         with:
           install-only: true
       - name: Show GoReleaser version

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,7 +31,7 @@ jobs:
           go-version: 1.22.5
         id: go
       - name: Install GoReleaser
-        uses: goreleaser/goreleaser-action@v5
+        uses: goreleaser/goreleaser-action@v6
         with:
           install-only: true
       - name: Show GoReleaser version

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,4 +1,5 @@
 ---
+version: 2
 archives:
   - name_template: >-
       {{ .ProjectName }}_
@@ -45,7 +46,7 @@ before:
 
 brews:
   - name: updatecli
-    folder: Formula
+    directory: Formula
     repository:
       owner: updatecli
       name: homebrew-updatecli
@@ -83,7 +84,7 @@ builds:
 
 changelog:
   ## Delegate Changelog to release-drafter
-  skip: true
+  disable: true
 
 checksum:
   name_template: 'checksums.txt'


### PR DESCRIPTION
update goreleaser config to be v2 compliant

cfr https://goreleaser.com/deprecations/#removed-in-v2

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
make build.all
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
