### PR TITLE
feat(compose lint): support lint compose policies

### DIFF
--- a/cmd/compose.go
+++ b/cmd/compose.go
@@ -18,4 +18,6 @@ var (
 		Use:   "compose",
 		Short: "compose executes specific Updatecli compose tasks such as diff or apply",
 	}
+	// policyFolder represents the policy folder
+	policyFolder string
 )

--- a/cmd/compose_lint.go
+++ b/cmd/compose_lint.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var (
+	composeLintPolicyRootDir string
+	composeLintCmd           = &cobra.Command{
+		Use:   "lint <path>",
+		Short: "lint compose policy",
+		Args:  cobra.MatchAll(cobra.MaximumNArgs(1)),
+		Run: func(cmd *cobra.Command, args []string) {
+
+			composeLintPolicyRootDir = "updatecli/policies"
+			if len(args) == 1 {
+				composeLintPolicyRootDir = args[0]
+			}
+
+			err := run("compose/lint")
+			if err != nil {
+				logrus.Errorf("command failed: %s", err)
+				os.Exit(1)
+			}
+
+		},
+	}
+)
+
+func init() {
+	composeLintCmd.Flags().StringVarP(&policyFolder, "policy", "p", "updatecli/policies", "Define the policy folder")
+
+	composeCmd.AddCommand(composeLintCmd)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -146,6 +146,13 @@ func run(command string) error {
 			logrus.Errorf("%s %s", result.FAILURE, err)
 		}
 
+	case "compose/lint":
+
+		err := e.Lint(composeLintPolicyRootDir)
+		if err != nil {
+			logrus.Errorf("%s %s", result.FAILURE, err)
+		}
+
 	case "manifest/upgrade":
 		err := e.ManifestUpgrade(manifestUpgradeInPlace)
 		if err != nil {

--- a/pkg/core/engine/lint.go
+++ b/pkg/core/engine/lint.go
@@ -1,0 +1,72 @@
+package engine
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/afero"
+)
+
+func (e *Engine) Lint(rootDir string) error {
+	PrintTitle("Lint Updatecli policies")
+	fs := afero.NewOsFs()
+	policies, err := processDirectoriesWithPolicyYaml(fs, rootDir)
+	if err != nil {
+		logrus.Errorf("command failed: %s", err)
+		os.Exit(1)
+	}
+
+	for _, policy := range policies {
+		fmt.Println("Policy directory:", policy)
+		_, err := verifyPolicyFiles(fs, policy)
+		if err != nil {
+			logrus.Errorf("  * %s for policy %s\n", err, policy)
+			continue
+		}
+		// TODO: validate at the end.
+	}
+	return nil
+}
+
+// processDirectoriesWithPolicyYaml returns the folders with the Policy.yaml
+func processDirectoriesWithPolicyYaml(fs afero.Fs, rootFolder string) ([]string, error) {
+	const policyFileName = "Policy.yaml"
+
+	var dirs []string
+	err := afero.Walk(fs, rootFolder, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if info.Mode().IsRegular() && filepath.Base(path) == policyFileName {
+			dir := filepath.Dir(path)
+			dirs = append(dirs, dir)
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return dirs, nil
+}
+
+// verifyPolicyFiles checks if the required policy files exist in the given directory.
+func verifyPolicyFiles(fs afero.Fs, policyDir string) (bool, error) {
+	requiredFiles := []string{"values.yaml", "README.md", "Policy.yaml", "CHANGELOG.md"}
+
+	for _, file := range requiredFiles {
+		filePath := filepath.Join(policyDir, file)
+		if _, err := fs.Stat(filePath); os.IsNotExist(err) {
+			return false, fmt.Errorf("file '%s' missing", filePath)
+		} else if err != nil {
+			return false, err
+		}
+	}
+
+	return true, nil
+}

--- a/pkg/core/engine/lint_test.go
+++ b/pkg/core/engine/lint_test.go
@@ -1,0 +1,80 @@
+package engine
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/require"
+)
+
+func setupTestDirectoryStructure(fs afero.Fs, basePath string, structure map[string]bool) error {
+	for path, isDir := range structure {
+		fullPath := filepath.Join(basePath, path)
+		if isDir {
+			if err := fs.MkdirAll(fullPath, 0755); err != nil {
+				return err
+			}
+		} else {
+			if _, err := fs.Create(fullPath); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func TestProcessDirectoriesWithPolicyYaml(t *testing.T) {
+	fs := afero.NewMemMapFs()
+
+	baseDir := "/test"
+	fs.MkdirAll(baseDir, 0755)
+
+	// Define the directory structure for the test
+	structure := map[string]bool{
+		"dirWithPolicy/Policy.yaml":           false,
+		"dirWithoutPolicy/otherfile.txt":      false,
+		"emptyDir":                            true,
+		"nestedDirWithPolicy/a/b/c":           true,
+		"nestedDirWithPolicy/a/b/Policy.yaml": false,
+	}
+
+	if err := setupTestDirectoryStructure(fs, baseDir, structure); err != nil {
+		t.Fatalf("Failed to setup test directory structure: %s", err)
+	}
+
+	tests := []struct {
+		name     string
+		baseDir  string
+		expected bool
+	}{
+		{"DirWithPolicy", filepath.Join(baseDir, "dirWithPolicy"), true},
+		{"DirWithoutPolicy", filepath.Join(baseDir, "dirWithoutPolicy"), false},
+		{"EmptyDir", filepath.Join(baseDir, "emptyDir"), false},
+		{"NestedDirWithPolicy", filepath.Join(baseDir, "nestedDirWithPolicy"), true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := processDirectoriesWithPolicyYaml(fs, tt.baseDir)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, len(got) == 1)
+		})
+	}
+}
+
+func TestVerifyPolicyFiles(t *testing.T) {
+	fs := afero.NewMemMapFs()
+
+	dirName := "/policies"
+	fileName := "/policies/policy.yaml"
+	err := fs.Mkdir(dirName, 0755)
+	require.NoError(t, err, "creating directory should not produce an error")
+
+	_, err = fs.Create(fileName)
+	require.NoError(t, err, "creating policy file should not produce an error")
+
+	got, err := verifyPolicyFiles(fs, dirName)
+	require.Error(t, err, "verifyPolicyFiles should produce an error")
+	require.Equal(t, got, false)
+}


### PR DESCRIPTION
Fix #XXX

Replace shell scripting in https://github.com/updatecli/policies/blob/main/.ci/scripts/release.bash#L41-L122 with a CLI command, for such I decided to use `updatecli compose lint <path>`.

I have yet to implement everything, just a tiny validation. Please let me know what your thoughts are.


## Test

To test this pull request, you can run the following commands:

```shell
cd <to_package_directory>
go test
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
