### PR TITLE
chore: show updatecli compose information on console output

### DIFF
--- a/pkg/core/compose/file.go
+++ b/pkg/core/compose/file.go
@@ -74,6 +74,13 @@ func LoadFile(filename string) (*Spec, error) {
 	sanitizePath(composeSpec.Env_files)
 
 	for i := range composeSpec.Policies {
+		if composeSpec.Policies[i].Name == "" {
+			composeSpec.Policies[i].Name = fmt.Sprintf("policy-%d - local", i)
+			if composeSpec.Policies[i].Policy != "" {
+				composeSpec.Policies[i].Name = fmt.Sprintf("policy-%d- %s", i, composeSpec.Policies[i].Policy)
+
+			}
+		}
 		sanitizePath(composeSpec.Policies[i].Config)
 		sanitizePath(composeSpec.Policies[i].Values)
 		sanitizePath(composeSpec.Policies[i].Secrets)

--- a/pkg/core/compose/main.go
+++ b/pkg/core/compose/main.go
@@ -77,7 +77,7 @@ func (c *Compose) GetPolicies(disableTLS bool) ([]manifest.Manifest, error) {
 		policyValues = append(policyValues, c.spec.Policies[i].Values...)
 		policySecrets = append(policySecrets, c.spec.Policies[i].Secrets...)
 
-		showDetectedfiles := func(files []string, fileType string) {
+		showDetectedFiles := func(files []string, fileType string) {
 			switch len(files) {
 			case 0:
 				logrus.Debugf("\t%s: nothing detected", fileType)
@@ -91,9 +91,9 @@ func (c *Compose) GetPolicies(disableTLS bool) ([]manifest.Manifest, error) {
 			}
 		}
 
-		showDetectedfiles(policyManifest, "manifest")
-		showDetectedfiles(policyValues, "value")
-		showDetectedfiles(policySecrets, "secret")
+		showDetectedFiles(policyManifest, "manifest")
+		showDetectedFiles(policyValues, "value")
+		showDetectedFiles(policySecrets, "secret")
 
 		manifests = append(manifests, manifest.Manifest{
 			Manifests: policyManifest,


### PR DESCRIPTION
Fix #2285 

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
go build -o bin/updatecli .
./bin/updatecli compose show
```

<details><summary>Console Output</summary>

```
Loading Updatecli compose file: "update-compose.yaml"
7 policies detected:
	* Policy 0: "Local Updatecli Website Policies"
	* Policy 1: "Update Updatecli policies"
	* Policy 2: "Golang Version"
	* Policy 3: "Major Golang Module update"
	* Policy 4: "Minor Golang Module update"
	* Policy 5: "Patch Golang Module update"
	* Policy 6: "Update golangci-lint"

Initializing policy: "Local Updatecli Website Policies"
	manifest: updatecli/updatecli.d
	value: updatecli/values.d/scm.yaml

Initializing policy: "Update Updatecli policies"
	manifest: /tmp/updatecli/store/46e599fb7e874ee3f1c9cf5e4dd64b328a15d61d03e106176b19a07683afde29/updatecli.d/default.tpl
	values:
		* /tmp/updatecli/store/46e599fb7e874ee3f1c9cf5e4dd64b328a15d61d03e106176b19a07683afde29/values.yaml
		* updatecli/values.d/scm.yaml
		* updatecli/values.d/update-compose.yaml

Initializing policy: "Golang Version"
	manifest: /tmp/updatecli/store/8bdbd911916c45288b85e7437ef8e140966321177128ca2460d21a2e5c7eedd8/updatecli.d/default.tpl
	values:
		* /tmp/updatecli/store/8bdbd911916c45288b85e7437ef8e140966321177128ca2460d21a2e5c7eedd8/values.yaml
		* updatecli/values.d/scm.yaml

Initializing policy: "Major Golang Module update"
	manifest: /tmp/updatecli/store/ed6cb09539f31d0d9a2747ec50792f69da130ea8ad5a107cd954aa26d9a0b05f/updatecli.d/default.tpl
	values:
		* /tmp/updatecli/store/ed6cb09539f31d0d9a2747ec50792f69da130ea8ad5a107cd954aa26d9a0b05f/values.yaml
		* updatecli/values.d/scm.yaml
		* updatecli/values.d/golang_major.yaml

Initializing policy: "Minor Golang Module update"
	manifest: /tmp/updatecli/store/ed6cb09539f31d0d9a2747ec50792f69da130ea8ad5a107cd954aa26d9a0b05f/updatecli.d/default.tpl
	values:
		* /tmp/updatecli/store/ed6cb09539f31d0d9a2747ec50792f69da130ea8ad5a107cd954aa26d9a0b05f/values.yaml
		* updatecli/values.d/scm.yaml
		* updatecli/values.d/golang_minor.yaml

Initializing policy: "Patch Golang Module update"
	manifest: /tmp/updatecli/store/ed6cb09539f31d0d9a2747ec50792f69da130ea8ad5a107cd954aa26d9a0b05f/updatecli.d/default.tpl
	values:
		* /tmp/updatecli/store/ed6cb09539f31d0d9a2747ec50792f69da130ea8ad5a107cd954aa26d9a0b05f/values.yaml
		* updatecli/values.d/scm.yaml
		* updatecli/values.d/golang_patch.yaml

Initializing policy: "Update golangci-lint"
	manifest: /tmp/updatecli/store/099fe49e355afe82b36d5ecc8cb30014fd2938700b55aa0fdfce7169c77d3071/updatecli.d/default.yaml
	values:
		* /tmp/updatecli/store/099fe49e355afe82b36d5ecc8cb30014fd2938700b55aa0fdfce7169c77d3071/values.yaml
		* updatecli/values.d/scm.yaml


+++++++++++
+ PREPARE +
+++++++++++

Loading Pipeline "updatecli/updatecli.d/updatecli.yaml"
WARNING: Updatecli binary version is unset. This means you are using a development version that ignores manifest version constraint.
Loading Pipeline "updatecli/updatecli.d/venom.yaml"
Loading Pipeline "/tmp/updatecli/store/46e599fb7e874ee3f1c9cf5e4dd64b328a15d61d03e106176b19a07683afde29/updatecli.d/default.tpl"
Loading Pipeline "/tmp/updatecli/store/8bdbd911916c45288b85e7437ef8e140966321177128ca2460d21a2e5c7eedd8/updatecli.d/default.tpl"
Loading Pipeline "/tmp/updatecli/store/ed6cb09539f31d0d9a2747ec50792f69da130ea8ad5a107cd954aa26d9a0b05f/updatecli.d/default.tpl"
Loading Pipeline "/tmp/updatecli/store/ed6cb09539f31d0d9a2747ec50792f69da130ea8ad5a107cd954aa26d9a0b05f/updatecli.d/default.tpl"
Loading Pipeline "/tmp/updatecli/store/ed6cb09539f31d0d9a2747ec50792f69da130ea8ad5a107cd954aa26d9a0b05f/updatecli.d/default.tpl"
Loading Pipeline "/tmp/updatecli/store/099fe49e355afe82b36d5ecc8cb30014fd2938700b55aa0fdfce7169c77d3071/updatecli.d/default.yaml"

SCM repository retrieved: 1
^C
[1]    172983 interrupt  ./bin/updatecli compose show

```
</details>

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
