### PR TITLE
chore: rename update-compose.yaml to updatecli-compose.yaml

### DIFF
--- a/updatecli-compose.yaml
+++ b/updatecli-compose.yaml
@@ -9,7 +9,7 @@ policies:
     policy: ghcr.io/updatecli/policies/updatecli/autodiscovery:0.2.0@sha256:46e599fb7e874ee3f1c9cf5e4dd64b328a15d61d03e106176b19a07683afde29
     values:
       - updatecli/values.d/scm.yaml
-      - updatecli/values.d/update-compose.yaml
+      - updatecli/values.d/updatecli-compose.yaml
 
   - name: Golang Version
     policy: ghcr.io/updatecli/policies/golang/version:0.1.0

--- a/updatecli/values.d/update-compose.yaml
+++ b/updatecli/values.d/update-compose.yaml
@@ -1,5 +1,0 @@
-spec:
-  files:
-    - "update-compose.yaml"
-  only:
-    - "update-compose.yaml"

--- a/updatecli/values.d/updatecli-compose.yaml
+++ b/updatecli/values.d/updatecli-compose.yaml
@@ -1,0 +1,5 @@
+spec:
+  files:
+    - "updatecli-compose.yaml"
+  only:
+    - path: "updatecli-compose.yaml"


### PR DESCRIPTION
* rename `deprecated update-compose.yaml` to `updatecli-compose.yaml`
* fix updatecli only rule