### PR TITLE
feat: moving github parameter `usingcommitapi` out of experimental

### DIFF
--- a/pkg/plugins/scms/github/main.go
+++ b/pkg/plugins/scms/github/main.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/shurcooL/githubv4"
 
-	"github.com/updatecli/updatecli/pkg/core/cmdoptions"
 	"github.com/updatecli/updatecli/pkg/core/tmp"
 	"github.com/updatecli/updatecli/pkg/plugins/scms/git/commit"
 	"github.com/updatecli/updatecli/pkg/plugins/scms/git/sign"
@@ -235,11 +234,7 @@ func New(s Spec, pipelineID string) (*Github, error) {
 
 	commitUsingApi := false
 	if s.CommitUsingAPI != nil {
-		if !cmdoptions.Experimental {
-			return nil, fmt.Errorf("the commitusingapi option is an experimental behavior, please enable the experimental flag to use it")
-		}
 		commitUsingApi = *s.CommitUsingAPI
-
 	}
 
 	if force {


### PR DESCRIPTION
After testing, I didn't identify any issues with the `usingcommitapi` behavior so I think it's safe to move it out of experimental to get more user exposure to the feature as I think it should be the default behavior in the future for the scm GitHub plugin