### PR TITLE
fix: committing with `commitusingapi` should use github username

### DIFF
--- a/pkg/plugins/scms/github/scm.go
+++ b/pkg/plugins/scms/github/scm.go
@@ -101,7 +101,7 @@ func (g *Github) Commit(message string) error {
 
 	} else {
 		err = g.nativeGitHandler.Commit(
-			g.Spec.User,
+			g.Spec.Username,
 			g.Spec.Email,
 			commitMessage,
 			workingDir,


### PR DESCRIPTION
Fix #2362

Switch the username to commit via the api from `user` to `username`


## Additional Information


### Potential improvement

As discussed with @olblak, it's not the first time this mismatch happens, the options are confusing. We should:
- deprecate "username" for "githubusername"
- deprecate "user" for "gituser"
