### PR TITLE
fix: use GitHub username to commit via GitHub instead of git user

### DIFF
--- a/pkg/plugins/scms/github/scm.go
+++ b/pkg/plugins/scms/github/scm.go
@@ -88,7 +88,7 @@ func (g *Github) Commit(message string) error {
 		}
 
 		err = g.nativeGitHandler.Pull(
-			g.Spec.User,
+			g.Spec.Username,
 			g.Spec.Token,
 			workingDir,
 			workingBranch,
@@ -101,7 +101,7 @@ func (g *Github) Commit(message string) error {
 
 	} else {
 		err = g.nativeGitHandler.Commit(
-			g.Spec.Username,
+			g.Spec.User,
 			g.Spec.Email,
 			commitMessage,
 			workingDir,


### PR DESCRIPTION
Fix #2362 

Correctly fix the commitusingapi as #2363 changed the wrong if branch

## Test

To test this pull request, you can run the following commands:

```shell
cd <to_package_directory>
go test
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
