### PR TITLE
feat(transformers) show transformation as info messages

### DIFF
--- a/pkg/core/transformer/main.go
+++ b/pkg/core/transformer/main.go
@@ -118,17 +118,20 @@ func (t *Transformers) Apply(input string) (string, error) {
 	output := input
 
 	err := t.Validate()
-
 	if err != nil {
 		return "", err
 	}
 
-	for _, transformer := range *t {
-		output, err = transformer.Apply(output)
+	logrus.Info("[transformers]\n")
 
+	for _, transformer := range *t {
+		previous := output
+		output, err = transformer.Apply(output)
 		if err != nil {
 			return "", err
 		}
+
+		logrus.Infof("✔ Result correctly transformed from %q to %q", previous, output)
 	}
 	return output, nil
 }


### PR DESCRIPTION
Fix #730

This PR introduces a log message (info level) when transformer are set up.

Example of output:

```
add
---
The shell 🐚 command "/bin/sh /var/folders/96/_x2r301n2d3_n_1s9hw4tg240000gp/T/updatecli/bin/58715a42e445bcda6902cec8477df16a3c91d4ae520e1df1c741bb5faa923f9d.sh" ran successfully with the following output:
----
1.0.0
----
✔ shell command executed successfully
[transformers]
✔ Result correctly transformed from "1.0.0" to "1.0.0-alpha"
✔ Result correctly transformed from "1.0.0-alpha" to "v1.0.0-alpha"
```

Also tested without transformer: no `[transformers]` log line.

## Test

To test this pull request, you can run the following commands:

```shell
cd <to_package_directory>
go test
```

## Additional Information

### Tradeoff

N.A.

### Potential improvement

N.A.
