### PR TITLE
fix: golang autodiscovery with module only

### DIFF
--- a/pkg/plugins/autodiscovery/golang/dependency.go
+++ b/pkg/plugins/autodiscovery/golang/dependency.go
@@ -114,6 +114,10 @@ func (g Golang) discoverDependencyManifests() ([][]byte, error) {
 			manifests = append(manifests, moduleManifest)
 		}
 
+		if g.spec.Only.isGoModuleOnly() {
+			return manifests, nil
+		}
+
 		// Test if the ignore rule based on path is respected
 		if len(g.spec.Ignore) > 0 {
 			if g.spec.Ignore.isMatchingRules(g.rootDir, relativeFoundFile, goVersion, "", "") {

--- a/pkg/plugins/autodiscovery/golang/matchingRule.go
+++ b/pkg/plugins/autodiscovery/golang/matchingRule.go
@@ -156,3 +156,23 @@ func (m MatchingRules) isGoVersionOnly() bool {
 
 	return false
 }
+
+func (m MatchingRules) isGoModuleOnly() bool {
+	// If there is no rule then we assume it is not only go version
+	if len(m) == 0 {
+		return false
+	}
+
+	moduleOnly := 0
+	for _, rule := range m {
+		if rule.GoVersion == "" && len(rule.Modules) > 0 {
+			moduleOnly++
+		}
+	}
+
+	if moduleOnly == len(m) && moduleOnly > 0 {
+		return true
+	}
+
+	return false
+}


### PR DESCRIPTION
Before this pullrequest, a manifest like:

```
autodiscovery:
  scmid: default
  actionid:  default
  groupby: all 
  crawlers:
    golang/gomod:
      rootdir: pkg/plugins/resources/go/gomod/testdata
      versionfilter:
        kind: semver
        pattern: patch
      only:
        - modules:
            github.com/beevik/etree: ""
```

Would try to both update the module "github.com/beevik/etree" and the go version specified in the go.mod
With this pullrequest, Updatecli only update the Golang module

## Test

To test this pull request, you can run the following commands:

```shell
cd <to_package_directory>
go test
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
