### PR TITLE
Git SCM: Ignore missing action handler

### DIFF
--- a/pkg/core/pipeline/actions.go
+++ b/pkg/core/pipeline/actions.go
@@ -170,7 +170,7 @@ func (p *Pipeline) RunCleanActions() error {
 
 	for _, action := range p.Actions {
 		if !p.Options.Target.DryRun {
-			if (action.Handler != nil) {
+			if action.Handler != nil {
 				// At least we try to clean existing pullrequest
 				err := action.Handler.CleanAction(action.Report)
 				if err != nil {

--- a/pkg/core/pipeline/actions.go
+++ b/pkg/core/pipeline/actions.go
@@ -170,10 +170,12 @@ func (p *Pipeline) RunCleanActions() error {
 
 	for _, action := range p.Actions {
 		if !p.Options.Target.DryRun {
-			// At least we try to clean existing pullrequest
-			err := action.Handler.CleanAction(action.Report)
-			if err != nil {
-				errs = append(errs, err.Error())
+			if (action.Handler != nil) {
+				// At least we try to clean existing pullrequest
+				err := action.Handler.CleanAction(action.Report)
+				if err != nil {
+					errs = append(errs, err.Error())
+				}
 			}
 		}
 	}


### PR DESCRIPTION
For git scm action, the handler property on the action is nil. The [`RunCleanActions()` method](https://github.com/updatecli/updatecli/blob/main/pkg/core/pipeline/actions.go#L174) fails with a null pointer for these git scm actions on `updatecli apply`.

Stacktrace (updatecli version 0.82.2):

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x2bec58a]

goroutine 1 [running]:
github.com/updatecli/updatecli/pkg/core/pipeline.(*Pipeline).RunCleanActions(0xc00127b3f8)
        /home/runner/work/updatecli/updatecli/pkg/core/pipeline/actions.go:174 +0x14a
github.com/updatecli/updatecli/pkg/core/engine.(*Engine).runActions(0x5c924a0)
        /home/runner/work/updatecli/updatecli/pkg/core/engine/actions.go:34 +0x459
github.com/updatecli/updatecli/pkg/core/engine.(*Engine).Run(0x5c924a0)
        /home/runner/work/updatecli/updatecli/pkg/core/engine/run.go:25 +0x32a
github.com/updatecli/updatecli/cmd.run({0x34f5cdd?, 0x0?})
        /home/runner/work/updatecli/updatecli/cmd/root.go:101 +0xd7c
github.com/updatecli/updatecli/cmd.init.func5(0x5c46440?, {0x5d04820?, 0x0?, 0x0?})
        /home/runner/work/updatecli/updatecli/cmd/apply.go:47 +0x271
github.com/spf13/cobra.(*Command).execute(0x5c46440, {0x5d04820, 0x0, 0x0})
        /home/runner/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:987 +0xab1
github.com/spf13/cobra.(*Command).ExecuteC(0x5c458c0)
        /home/runner/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1115 +0x3ff
github.com/spf13/cobra.(*Command).Execute(...)
        /home/runner/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1039
github.com/updatecli/updatecli/cmd.Execute()
        /home/runner/work/updatecli/updatecli/cmd/root.go:49 +0x5b
main.main()
        /home/runner/work/updatecli/updatecli/main.go:8 +0xf
```

To test this pull request, you can run the following commands:

```
# download source code including updatecli.d/default.yaml
git clone https://in0rdr@git.in0rdr.ch/hivedav.git
git checkout fdfcb78e2a8194b3bfe3c1bf191b5d62f7363a22
cd hivedav

# fake the pipeline env
export BUILD_NUMBER=123
export PIPELINEID=123
export GIT_USERNAME="foo"
export GIT_PASSWORD="bar"
export GIT_AUTHOR_NAME="foo"
export GIT_AUTHOR_EMAIL="bar"

# run apply
updatecli apply
```

This should fail with an error that the authentication credentials are wrong (`GIT_PASSWORD`), which is expected behavior in this test case:
```
ERROR: push error: authentication required
```

However, with the patch, the `updatecli apply` should no longer run into a null pointer error.

## Additional Information

* Updatecli version: 0.82.2
* OS: NixOS 24.05 (Uakari)

I'm not aware of the meaning of the handlers, also, in the context of the [SCM of `kind` Git](https://www.updatecli.io/docs/plugins/scm/git). I only noticed that the apply would push something to the remote, when I skip the non-existent (nil) "handler" on the "action". Also, this null pointer is not a problem on `updatecli diff`, because this code is not run.

Below again the `updatecli.d/default.yaml` (this is also included in the reproduction steps above):

```yaml
name: Update go dependencies
# use jenkins $BUILD_NUMBER env var
pipelineid: {{ requiredEnv "BUILD_NUMBER" }}
scms:
  default:
    # https://www.updatecli.io/docs/core/scm
    kind: git
    spec:
      url: "https://git.in0rdr.ch/hivedav.git"
      # read git credentials from jenkins secret
      username: {{ requiredEnv "GIT_USERNAME" }}
      password: {{ requiredEnv "GIT_PASSWORD" }}
      user: {{ requiredEnv "GIT_AUTHOR_NAME" }}
      email: {{ requiredEnv "GIT_AUTHOR_EMAIL" }}
      # source branch
      branch: master
      # create remote target branch updatecli_master_$PIPELINEID to push changes
      workingbranch: true
      # reuse existing target branch updatecli_master_$PIPELINEID
      force: true

# Use source/target checks for modules without proper semver
sources:
  email:
    kind: golang/gomod
    scmid: default
    spec:
      module: github.com/jordan-wright/email
  ical:
    kind: golang/gomod
    scmid: default
    spec:
      module: github.com/emersion/go-ical
  cron:
    kind: golang/gomod
    scmid: default
    spec:
      module: gopkg.in/robfig/cron.v2
  termchalk:
    kind: golang/gomod
    scmid: default
    spec:
      module: github.com/pquerna/termchalk
targets:
  email:
    name: email
    sourceid: email
    kind: golang/gomod
    scmid: default
    spec:
      module: github.com/jordan-wright/email
  ical:
    name: ical
    sourceid: ical
    kind: golang/gomod
    scmid: default
    spec:
      module: github.com/emersion/go-ical
  cron:
    name: cron
    sourceid: cron
    kind: golang/gomod
    scmid: default
    spec:
      module: gopkg.in/robfig/cron.v2
  termchalk:
    name: termchalk
    sourceid: termchalk
    kind: golang/gomod
    scmid: default
    spec:
      module: github.com/pquerna/termchalk

# Use autodiscovery for modules with proper semver
# - https://www.updatecli.io/docs/guides/npm
# - https://www.updatecli.io/docs/core/autodiscovery
autodiscovery:
  scmid: default
  crawlers:
    golang/gomod:
      versionfilter:
        kind: semver
        pattern: major
      ignore:
        - modules:
            # Ignore modules without proper semver
            github.com/jordan-wright/email:
            github.com/emersion/go-ical:
            gopkg.in/robfig/cron.v2:
            github.com/pquerna/termchalk:

# Publish changes to workingbranch in git repo
actions:
  default:
    kind: git
    scmid: default
```