### PR TITLE
feat(dockerfile): source implementation

### DIFF
--- a/e2e/updatecli.d/success.d/dockerfile/Dockerfile.source
+++ b/e2e/updatecli.d/success.d/dockerfile/Dockerfile.source
@@ -1,0 +1,6 @@
+FROM alpine:3.18 as builder
+FROM alpine:3.18 AS tester
+ARG UPDATECLI_VERSION=
+LABEL org.opencontainers.image.test_version="2.0.0"
+FROM alpine:3.18
+LABEL org.opencontainers.image.version=2.0.0

--- a/e2e/updatecli.d/success.d/dockerfile/dockerfile_source.yaml
+++ b/e2e/updatecli.d/success.d/dockerfile/dockerfile_source.yaml
@@ -3,7 +3,7 @@ pipelineid: "e2e/dockerfile_source"
 
 sources:
   updatecli:
-    name: Last Github release
+    name: Last updatecli release
     kind: githubrelease
     spec:
       owner: updatecli

--- a/e2e/updatecli.d/success.d/dockerfile/dockerfile_source.yaml
+++ b/e2e/updatecli.d/success.d/dockerfile/dockerfile_source.yaml
@@ -1,0 +1,54 @@
+name: Test Dockerfile source
+pipelineid: "e2e/dockerfile_source"
+
+sources:
+  updatecli:
+    name: Last Github release
+    kind: githubrelease
+    spec:
+      owner: updatecli
+      repository: updatecli
+      token: '{{ requiredEnv "GITHUB_TOKEN" }}'
+  testerVersion:
+    name: Get Tester stage version
+    kind: dockerfile
+    spec:
+      file: e2e/updatecli.d/success.d/dockerfile/Dockerfile.source
+      stage: "tester"
+      instruction:
+        keyword: "LABEL"
+        matcher: "org.opencontainers.image.test_version"
+    transformers:
+      - trimprefix: '"'
+      - trimsuffix: '"'
+      - semverinc: patch
+  baseVersion:
+    name: Get Base version
+    kind: dockerfile
+    spec:
+      file: e2e/updatecli.d/success.d/dockerfile/Dockerfile.source
+      instruction:
+        keyword: "LABEL"
+        matcher: "org.opencontainers.image.version"
+
+targets:
+  setAppVersion:
+    kind: dockerfile
+    spec:
+      file: e2e/updatecli.d/success.d/dockerfile/Dockerfile.source
+      instruction:
+        keyword: "ARG"
+        matcher: "UPDATECLI_VERSION"
+    sourceid: updatecli
+  setTestVersion:
+    kind: dockerfile
+    spec:
+      files:
+        - e2e/updatecli.d/success.d/dockerfile/Dockerfile.source
+      instruction:
+        keyword: "LABEL"
+        matcher: "org.opencontainers.image.test_version"
+    sourceid: testerVersion
+    dependson:
+      - setAppVersion
+    dependsonchange: true

--- a/pkg/plugins/resources/dockerfile/condition.go
+++ b/pkg/plugins/resources/dockerfile/condition.go
@@ -30,7 +30,7 @@ func (d *Dockerfile) Condition(source string, scm scm.ScmHandler) (pass bool, me
 
 		logrus.Debugf("\n🐋 On (Docker)file %q:\n\n", file)
 
-		found := d.parser.FindInstruction([]byte(dockerfileContent))
+		found := d.parser.FindInstruction([]byte(dockerfileContent), d.spec.Stage)
 
 		switch found {
 		case true:

--- a/pkg/plugins/resources/dockerfile/condition_test.go
+++ b/pkg/plugins/resources/dockerfile/condition_test.go
@@ -39,6 +39,24 @@ func TestDockerfile_Condition(t *testing.T) {
 			wantChanged: true,
 		},
 		{
+			name:             "Not Found FROM with text parser and stage selection",
+			inputSourceValue: "1.16",
+			spec: Spec{
+				Instruction: map[string]string{
+					"keyword": "FROM",
+					"matcher": "ubuntu",
+				},
+				Stage: "builder",
+			},
+			files: []string{"FROM.Dockerfile"},
+			mockTest: text.MockTextRetriever{
+				Contents: map[string]string{
+					"FROM.Dockerfile": dockerfileFixture,
+				},
+			},
+			wantChanged: false,
+		},
+		{
 			name:             "Found FROM with text parser and absolute path",
 			inputSourceValue: "1.16",
 			spec: Spec{

--- a/pkg/plugins/resources/dockerfile/main.go
+++ b/pkg/plugins/resources/dockerfile/main.go
@@ -21,7 +21,11 @@ type Spec struct {
 	Instruction types.Instruction `yaml:"instruction,omitempty"`
 	// Value specifies the value for a specified Dockerfile instruction.
 	Value string `yaml:"value,omitempty"`
-	// Stage specifies the stage to extract the value from, if None specified, the latest stage will be used
+	// Stage can be used to further refined the scope
+	// For Sources:
+	// - If not defined, the last stage will be considered
+	// For Condition and Targets:
+	// - If not defined, all stages will be considered
 	Stage string `yaml:"value,omitempty"`
 }
 

--- a/pkg/plugins/resources/dockerfile/main.go
+++ b/pkg/plugins/resources/dockerfile/main.go
@@ -21,6 +21,9 @@ type Spec struct {
 	Instruction types.Instruction `yaml:"instruction,omitempty"`
 	// Value specifies the value for a specified Dockerfile instruction.
 	Value string `yaml:"value,omitempty"`
+	// Stage specifies the stage to extract the value from, if None specified, the latest stage will be used
+	// only for sources
+	Stage string `yaml:"value,omitempty"`
 }
 
 // Dockerfile defines a resource of kind "dockerfile"

--- a/pkg/plugins/resources/dockerfile/main.go
+++ b/pkg/plugins/resources/dockerfile/main.go
@@ -22,7 +22,6 @@ type Spec struct {
 	// Value specifies the value for a specified Dockerfile instruction.
 	Value string `yaml:"value,omitempty"`
 	// Stage specifies the stage to extract the value from, if None specified, the latest stage will be used
-	// only for sources
 	Stage string `yaml:"value,omitempty"`
 }
 

--- a/pkg/plugins/resources/dockerfile/main_test.go
+++ b/pkg/plugins/resources/dockerfile/main_test.go
@@ -125,6 +125,7 @@ func TestDockerfile_New(t *testing.T) {
 
 const dockerfileFixture = `FROM golang:1.15 AS builder
 ARG golang=3.0.0
+LABEL org.opencontainers.image.version=1.0.0
 COPY ./golang .
 RUN go get -d -v ./... && echo golang
 FROM golang

--- a/pkg/plugins/resources/dockerfile/mobyparser/main.go
+++ b/pkg/plugins/resources/dockerfile/mobyparser/main.go
@@ -27,7 +27,7 @@ var (
 	positionKeyRegex = regexp.MustCompile(`^(.*)\[[[:digit:]]*\]\[[[:digit:]]*\]$`)
 )
 
-func (m MobyParser) FindInstruction(dockerfileContent []byte) bool {
+func (m MobyParser) FindInstruction(dockerfileContent []byte, stage string) bool {
 
 	data, err := parser.Parse(bytes.NewReader(dockerfileContent))
 	if err != nil {
@@ -62,7 +62,7 @@ func (m MobyParser) FindInstruction(dockerfileContent []byte) bool {
 	return true
 }
 
-func (m MobyParser) ReplaceInstructions(dockerfileContent []byte, sourceValue string) ([]byte, types.ChangedLines, error) {
+func (m MobyParser) ReplaceInstructions(dockerfileContent []byte, sourceValue, stage string) ([]byte, types.ChangedLines, error) {
 
 	changed := make(types.ChangedLines)
 
@@ -118,10 +118,9 @@ func (m MobyParser) ReplaceInstructions(dockerfileContent []byte, sourceValue st
 	return []byte(newDockerfileContent), changed, nil
 }
 
-func (m MobyParser) GetInstruction(dockerfileContent []byte) []types.StageInstructionValue {
-	var stagesInstruction []types.StageInstructionValue
+func (m MobyParser) GetInstruction(dockerfileContent []byte, stage string) string {
 	// Not implemented
-	return stagesInstruction
+	return ""
 }
 
 func (m MobyParser) String() string {

--- a/pkg/plugins/resources/dockerfile/mobyparser/main.go
+++ b/pkg/plugins/resources/dockerfile/mobyparser/main.go
@@ -120,6 +120,7 @@ func (m MobyParser) ReplaceInstructions(dockerfileContent []byte, sourceValue, s
 
 func (m MobyParser) GetInstruction(dockerfileContent []byte, stage string) string {
 	// Not implemented
+	logrus.Warningf("Get Instruction is not yet supported for the MobyParser, if needed switch to the simpletextparser")
 	return ""
 }
 

--- a/pkg/plugins/resources/dockerfile/mobyparser/main.go
+++ b/pkg/plugins/resources/dockerfile/mobyparser/main.go
@@ -120,6 +120,7 @@ func (m MobyParser) ReplaceInstructions(dockerfileContent []byte, sourceValue st
 
 func (m MobyParser) GetInstruction(dockerfileContent []byte) []types.StageInstructionValue {
 	var stagesInstruction []types.StageInstructionValue
+	// Not implemented
 	return stagesInstruction
 }
 

--- a/pkg/plugins/resources/dockerfile/mobyparser/main.go
+++ b/pkg/plugins/resources/dockerfile/mobyparser/main.go
@@ -118,6 +118,11 @@ func (m MobyParser) ReplaceInstructions(dockerfileContent []byte, sourceValue st
 	return []byte(newDockerfileContent), changed, nil
 }
 
+func (m MobyParser) GetInstruction(dockerfileContent []byte) []types.StageInstructionValue {
+	var stagesInstruction []types.StageInstructionValue
+	return stagesInstruction
+}
+
 func (m MobyParser) String() string {
 	return fmt.Sprintf("%s %s", m.Instruction, m.Value)
 }

--- a/pkg/plugins/resources/dockerfile/mobyparser/main_test.go
+++ b/pkg/plugins/resources/dockerfile/mobyparser/main_test.go
@@ -307,7 +307,7 @@ func TestReplaceNode(t *testing.T) {
 
 func TestMobyParser_FindInstruction(t *testing.T) {
 	for i, data := range datasets {
-		found := data.spec.FindInstruction([]byte(data.dockerfile))
+		found := data.spec.FindInstruction([]byte(data.dockerfile), "")
 
 		if found != data.expectedFound {
 			t.Errorf("%d: Expected %s %s finding to be '%t', got '%t'",

--- a/pkg/plugins/resources/dockerfile/simpletextparser/keywords/arg.go
+++ b/pkg/plugins/resources/dockerfile/simpletextparser/keywords/arg.go
@@ -1,6 +1,7 @@
 package keywords
 
 import (
+	"fmt"
 	"strings"
 )
 
@@ -28,4 +29,19 @@ func (a Arg) IsLineMatching(originalLine, matcher string) bool {
 	found := strings.ToLower(parsedLine[0]) == "arg" && strings.HasPrefix(parsedLine[1], matcher)
 
 	return found
+}
+
+func (a Arg) GetValue(originalLine, matcher string) (string, error) {
+	if a.IsLineMatching(originalLine, matcher) {
+		// With an ARG instruction, we just need the rest of the 2nd "word"
+		parsedLine := strings.Fields(originalLine)
+		splittedArgValue := strings.Split(parsedLine[1], "=")
+		if len(splittedArgValue) < 2 {
+			// ARG without value
+			return "", nil
+		} else {
+			return splittedArgValue[1], nil
+		}
+	}
+	return "", fmt.Errorf("Value not found in line")
 }

--- a/pkg/plugins/resources/dockerfile/simpletextparser/keywords/arg.go
+++ b/pkg/plugins/resources/dockerfile/simpletextparser/keywords/arg.go
@@ -35,12 +35,12 @@ func (a Arg) GetValue(originalLine, matcher string) (string, error) {
 	if a.IsLineMatching(originalLine, matcher) {
 		// With an ARG instruction, we just need the rest of the 2nd "word"
 		parsedLine := strings.Fields(originalLine)
-		splittedArgValue := strings.Split(parsedLine[1], "=")
-		if len(splittedArgValue) < 2 {
+		splitArgValue := strings.Split(parsedLine[1], "=")
+		if len(splitArgValue) < 2 {
 			// ARG without value
 			return "", nil
 		} else {
-			return splittedArgValue[1], nil
+			return splitArgValue[1], nil
 		}
 	}
 	return "", fmt.Errorf("Value not found in line")

--- a/pkg/plugins/resources/dockerfile/simpletextparser/keywords/arg_test.go
+++ b/pkg/plugins/resources/dockerfile/simpletextparser/keywords/arg_test.go
@@ -148,3 +148,85 @@ func TestArg_IsLineMatching(t *testing.T) {
 		})
 	}
 }
+
+func TestArg_GetValue(t *testing.T) {
+	tests := []struct {
+		name         string
+		originalLine string
+		matcher      string
+		want         string
+		wantErr      bool
+	}{
+		{
+			name:         "Match",
+			originalLine: "ARG TERRAFORM_VERSION=0.13.6",
+			matcher:      "TERRAFORM_VERSION",
+			want:         "0.13.6",
+		},
+		{
+			name:         "Match (lower case instruction)",
+			originalLine: "arg TERRAFORM_VERSION=0.13.6",
+			matcher:      "TERRAFORM_VERSION",
+			want:         "0.13.6",
+		},
+		{
+			name:         "Match default value",
+			originalLine: "ARG TERRAFORM_VERSION",
+			matcher:      "TERRAFORM_VERSION",
+			want:         "",
+		},
+		{
+			name:         "Match empty value",
+			originalLine: "ARG TERRAFORM_VERSION=",
+			matcher:      "TERRAFORM_VERSION",
+			want:         "",
+		},
+		{
+			name:         "No Match at all",
+			originalLine: "ARG GOLANG_VERSION=1.15.7",
+			matcher:      "TERRAFORM_VERSION",
+			want:         "",
+			wantErr:      true,
+		},
+		{
+			name:         "No Match for key but value",
+			originalLine: "ARG GOLANG_VERSION=TERRAFORM_VERSION",
+			matcher:      "TERRAFORM_VERSION",
+			want:         "",
+			wantErr:      true,
+		},
+		{
+			name:         "No Match for lower case key",
+			originalLine: "ARG terraform_version=0.13.6",
+			matcher:      "TERRAFORM_VERSION",
+			want:         "",
+			wantErr:      true,
+		},
+		{
+			name:         "Empty line",
+			originalLine: "",
+			matcher:      "TERRAFORM_VERSION",
+			want:         "",
+			wantErr:      true,
+		},
+		{
+			name:         "Match and comment",
+			originalLine: "ARG TERRAFORM_VERSION=0.13.6 # Pin tf version",
+			matcher:      "TERRAFORM_VERSION",
+			want:         "0.13.6",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := Arg{}
+
+			got, gotErr := a.GetValue(tt.originalLine, tt.matcher)
+			if tt.wantErr {
+				assert.Error(t, gotErr)
+			} else {
+				assert.Equal(t, tt.want, got)
+			}
+
+		})
+	}
+}

--- a/pkg/plugins/resources/dockerfile/simpletextparser/keywords/env.go
+++ b/pkg/plugins/resources/dockerfile/simpletextparser/keywords/env.go
@@ -41,7 +41,7 @@ func (a Env) IsLineMatching(originalLine, matcher string) bool {
 
 func (a Env) GetValue(originalLine, matcher string) (string, error) {
 	if a.IsLineMatching(originalLine, matcher) {
-		// With an ARG instruction, we just need the rest of the 2nd "word"
+		// With an ENV instruction, we just need the rest of the 2nd "word"
 		parsedLine := strings.Fields(originalLine)
 		argValue := parsedLine[1]
 		// Legacy Docker allows for env without equals

--- a/pkg/plugins/resources/dockerfile/simpletextparser/keywords/env.go
+++ b/pkg/plugins/resources/dockerfile/simpletextparser/keywords/env.go
@@ -48,12 +48,12 @@ func (a Env) GetValue(originalLine, matcher string) (string, error) {
 		if !strings.Contains(argValue, "=") && len(parsedLine) >= 3 {
 			argValue = fmt.Sprintf("%s=%s", argValue, parsedLine[2])
 		}
-		splittedArgValue := strings.Split(argValue, "=")
-		if len(splittedArgValue) < 2 {
+		splitArgValue := strings.Split(argValue, "=")
+		if len(splitArgValue) < 2 {
 			// ENV without value
 			return "", nil
 		} else {
-			return splittedArgValue[1], nil
+			return splitArgValue[1], nil
 		}
 	}
 	return "", fmt.Errorf("Value not found in line")

--- a/pkg/plugins/resources/dockerfile/simpletextparser/keywords/env.go
+++ b/pkg/plugins/resources/dockerfile/simpletextparser/keywords/env.go
@@ -38,3 +38,23 @@ func (a Env) IsLineMatching(originalLine, matcher string) bool {
 
 	return found
 }
+
+func (a Env) GetValue(originalLine, matcher string) (string, error) {
+	if a.IsLineMatching(originalLine, matcher) {
+		// With an ARG instruction, we just need the rest of the 2nd "word"
+		parsedLine := strings.Fields(originalLine)
+		argValue := parsedLine[1]
+		// Legacy Docker allows for env without equals
+		if !strings.Contains(argValue, "=") && len(parsedLine) >= 3 {
+			argValue = fmt.Sprintf("%s=%s", argValue, parsedLine[2])
+		}
+		splittedArgValue := strings.Split(argValue, "=")
+		if len(splittedArgValue) < 2 {
+			// ENV without value
+			return "", nil
+		} else {
+			return splittedArgValue[1], nil
+		}
+	}
+	return "", fmt.Errorf("Value not found in line")
+}

--- a/pkg/plugins/resources/dockerfile/simpletextparser/keywords/env_test.go
+++ b/pkg/plugins/resources/dockerfile/simpletextparser/keywords/env_test.go
@@ -155,3 +155,91 @@ func TestEnv_IsLineMatching(t *testing.T) {
 		})
 	}
 }
+
+func TestEnv_GetValue(t *testing.T) {
+	tests := []struct {
+		name         string
+		originalLine string
+		matcher      string
+		want         string
+		wantErr      bool
+	}{
+		{
+			name:         "Match",
+			originalLine: "ENV TERRAFORM_VERSION=0.13.6",
+			matcher:      "TERRAFORM_VERSION",
+			want:         "0.13.6",
+			wantErr:      false,
+		}, {
+			name:         "Match Space (legacy)",
+			originalLine: "ENV TERRAFORM_VERSION 0.13.6",
+			matcher:      "TERRAFORM_VERSION",
+			want:         "0.13.6",
+			wantErr:      false,
+		},
+
+		{
+			name:         "Match (lower case instruction)",
+			originalLine: "env TERRAFORM_VERSION=0.13.6",
+			matcher:      "TERRAFORM_VERSION",
+			want:         "0.13.6",
+			wantErr:      false,
+		},
+		{
+			name:         "Match default value",
+			originalLine: "ENV TERRAFORM_VERSION",
+			matcher:      "TERRAFORM_VERSION",
+			want:         "",
+			wantErr:      false,
+		},
+		{
+			name:         "Match empty value",
+			originalLine: "ENV TERRAFORM_VERSION=",
+			matcher:      "TERRAFORM_VERSION",
+			want:         "",
+			wantErr:      false,
+		},
+		{
+			name:         "No Match at all",
+			originalLine: "ENV GOLANG_VERSION=1.15.7",
+			matcher:      "TERRAFORM_VERSION",
+			want:         "",
+			wantErr:      true,
+		},
+		{
+			name:         "No Match for key but value",
+			originalLine: "ENV GOLANG_VERSION=TERRAFORM_VERSION",
+			matcher:      "TERRAFORM_VERSION",
+			want:         "",
+			wantErr:      true,
+		},
+		{
+			name:         "No Match for lower case key",
+			originalLine: "ENV terraform_version=0.13.6",
+			matcher:      "TERRAFORM_VERSION",
+			want:         "",
+			wantErr:      true,
+		},
+		{
+			name:         "Empty line",
+			originalLine: "",
+			matcher:      "TERRAFORM_VERSION",
+			want:         "",
+			wantErr:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := Env{}
+
+			got, gotErr := a.GetValue(tt.originalLine, tt.matcher)
+			if tt.wantErr {
+				assert.Error(t, gotErr)
+			} else {
+				assert.Equal(t, tt.want, got)
+			}
+
+		})
+	}
+}

--- a/pkg/plugins/resources/dockerfile/simpletextparser/keywords/from.go
+++ b/pkg/plugins/resources/dockerfile/simpletextparser/keywords/from.go
@@ -3,8 +3,6 @@ package keywords
 import (
 	"fmt"
 	"strings"
-
-	"github.com/sirupsen/logrus"
 )
 
 type From struct {
@@ -77,7 +75,7 @@ func (f From) parseTokens(originalLine string) (fromToken, error) {
 	// Whatever remains is the raw image
 	tokens.image = rawImage
 	currentTokenIndex += 1
-	// We may have reach the end of the from directorive
+	// We may have reach the end of the from directive
 	if currentTokenIndex >= lineLength {
 		return tokens, nil
 	}
@@ -154,7 +152,6 @@ func (f From) ReplaceLine(source, originalLine, matcher string) string {
 func (f From) IsLineMatching(originalLine, matcher string) bool {
 	tokens, err := f.parseTokens(originalLine)
 	if err != nil {
-		logrus.Tracef("Skipping dockerfile line due to: %s", err)
 		return false
 	}
 

--- a/pkg/plugins/resources/dockerfile/simpletextparser/keywords/from.go
+++ b/pkg/plugins/resources/dockerfile/simpletextparser/keywords/from.go
@@ -3,56 +3,179 @@ package keywords
 import (
 	"fmt"
 	"strings"
+
+	"github.com/sirupsen/logrus"
 )
 
-type From struct{}
+type From struct {
+}
+type fromToken struct {
+	keyword  string
+	platform string
+	image    string
+	tag      string
+	digest   string
+	alias    string
+	aliasKw  string
+	comment  string
+}
+
+func (ft fromToken) getImageRef() string {
+	// We can now reconstruct the image, we first start with the tag
+	imageWithTagTokens := []string{ft.image}
+	if ft.tag != "" {
+		imageWithTagTokens = append(imageWithTagTokens, ft.tag)
+	}
+	imageWithTag := strings.Join(imageWithTagTokens, ":")
+	// We now try to add the digest
+	imageWithDigestTokens := []string{imageWithTag}
+	if ft.digest != "" {
+		imageWithDigestTokens = append(imageWithDigestTokens, ft.digest)
+	}
+	return strings.Join(imageWithDigestTokens, "@")
+}
+
+func (f From) parseTokens(originalLine string) (fromToken, error) {
+	tokens := fromToken{}
+	parsedLine := strings.Fields(originalLine)
+	lineLength := len(parsedLine)
+	if len(parsedLine) < 2 {
+		// Empty or malformed line
+		return tokens, fmt.Errorf("Got an empty or malformed line")
+	}
+	tokens.keyword = parsedLine[0]
+	if strings.ToLower(tokens.keyword) != "from" {
+		return tokens, fmt.Errorf("Not a FROM line: %q", tokens.keyword)
+	}
+	currentTokenIndex := 1
+
+	// We may have a platform token
+	if strings.HasPrefix(parsedLine[currentTokenIndex], "--platform") {
+		tokens.platform = parsedLine[currentTokenIndex]
+		currentTokenIndex += 1
+	}
+
+	// The next token is always the image, a from line without image is not valid
+	if currentTokenIndex >= lineLength {
+		return tokens, fmt.Errorf("No image in line")
+	}
+	rawImage := parsedLine[currentTokenIndex]
+	// Test for digest
+	imageInfo := strings.Split(rawImage, "@")
+	if len(imageInfo) == 2 {
+		// image as a digest
+		tokens.digest = imageInfo[1]
+		rawImage = imageInfo[0]
+	}
+	// Test for tag
+	imageInfo = strings.Split(rawImage, ":")
+	if len(imageInfo) == 2 {
+		// image as a tag
+		tokens.tag = imageInfo[1]
+		rawImage = imageInfo[0]
+	}
+	// Whatever remains is the raw image
+	tokens.image = rawImage
+	currentTokenIndex += 1
+	// We may have reach the end of the from directorive
+	if currentTokenIndex >= lineLength {
+		return tokens, nil
+	}
+	currentToken := parsedLine[currentTokenIndex]
+	if strings.ToLower(currentToken) == "as" {
+		// We have an alias
+		tokens.aliasKw = currentToken
+		currentTokenIndex += 1
+		if currentTokenIndex >= lineLength {
+			// Invalid alias, missing alias
+			return tokens, fmt.Errorf("Malformed FROM line, AS keyword but no value for it")
+		}
+		tokens.alias = parsedLine[currentTokenIndex]
+		currentTokenIndex += 1
+	}
+	if currentTokenIndex >= lineLength {
+		// We reach the end of a non commented line
+		return tokens, nil
+	}
+	// Whatever remains should be a comment and start with #
+	if !strings.HasPrefix(parsedLine[currentTokenIndex], "#") {
+		return tokens, fmt.Errorf("Remaining token in line that should be a comment but doesn't start with \"#\"")
+	}
+	tokens.comment = strings.Join(parsedLine[currentTokenIndex:], " ")
+
+	return tokens, nil
+
+}
 
 func (f From) ReplaceLine(source, originalLine, matcher string) string {
-
 	if !f.IsLineMatching(originalLine, matcher) {
 		return originalLine
 	}
-
-	// With a FROM instruction, Only the first word following "FROM" has to be processed
-	parsedLine := strings.Fields(originalLine)
-	parsedValue := strings.Split(parsedLine[1], ":")
-
-	if len(parsedValue) == 1 {
-		// Case with no tags specified: append the new tag to the current value
-		parsedLine[1] = fmt.Sprintf("%s:%s", parsedLine[1], source)
-	} else {
-		// Case with a tag already specified: replace only the tag's value
-		parsedLine[1] = fmt.Sprintf("%s:%s", parsedValue[0], source)
+	tokens, err := f.parseTokens(originalLine)
+	if err != nil {
+		// Could not process as a from line, not touching
+		return originalLine
+	}
+	// Let's construct the line back
+	lineTokens := []string{
+		tokens.keyword,
+	}
+	// Add platform if present
+	if tokens.platform != "" {
+		lineTokens = append(lineTokens, tokens.platform)
+	}
+	// Reconstruct the image
+	// And image can be in the form <name>[:<tag>][@<digest>]
+	// Source can be in the form [<tag>][@<digest>]
+	tag := source
+	digest := ""
+	splittedSource := strings.Split(source, "@")
+	if len(splittedSource) == 2 {
+		// We have a digest
+		tag = splittedSource[0]
+		digest = splittedSource[1]
+	}
+	tokens.tag = tag
+	tokens.digest = digest
+	lineTokens = append(lineTokens, tokens.getImageRef())
+	// Add alias if present
+	if tokens.aliasKw != "" {
+		lineTokens = append(lineTokens, tokens.aliasKw, tokens.alias)
+	}
+	// Add comment if present
+	if tokens.comment != "" {
+		lineTokens = append(lineTokens, tokens.comment)
 	}
 
-	return strings.Join(parsedLine, " ")
+	return strings.Join(lineTokens, " ")
 
 }
 
 func (f From) IsLineMatching(originalLine, matcher string) bool {
-	parsedLine := strings.Fields(originalLine)
-	if len(parsedLine) == 0 {
-		// Empty line
+	tokens, err := f.parseTokens(originalLine)
+	if err != nil {
+		logrus.Tracef("Skipping dockerfile line due to: %s", err)
 		return false
 	}
-	found := strings.ToLower(parsedLine[0]) == "from" && strings.HasPrefix(parsedLine[1], matcher)
 
-	return found
+	return strings.HasPrefix(tokens.image, matcher)
 }
 
 func (f From) GetStageName(originalLine string) (string, error) {
-	if f.IsLineMatching(originalLine, "") {
-		parsedLine := strings.Fields(originalLine)
-		if len(parsedLine) < 3 || strings.ToLower(parsedLine[2]) != "as" {
-			// No stage name
-			return "", nil
-		}
-		// At this stage we have a stage name, it will be the 4th token
-		return parsedLine[3], nil
+	tokens, err := f.parseTokens(originalLine)
+	if err != nil {
+		return "", err
 	}
-	return "", fmt.Errorf("Value not found in line")
+	return tokens.alias, nil
 }
 
-func (a From) GetValue(originalLine, matcher string) (string, error) {
-	return "", fmt.Errorf("GetValue not supported for FROM")
+func (f From) GetValue(originalLine, matcher string) (string, error) {
+	tokens, err := f.parseTokens(originalLine)
+	if err != nil {
+		return "", err
+	}
+	if !f.IsLineMatching(originalLine, matcher) {
+		return "", fmt.Errorf("FROM line not matching")
+	}
+	return tokens.getImageRef(), nil
 }

--- a/pkg/plugins/resources/dockerfile/simpletextparser/keywords/from.go
+++ b/pkg/plugins/resources/dockerfile/simpletextparser/keywords/from.go
@@ -127,11 +127,11 @@ func (f From) ReplaceLine(source, originalLine, matcher string) string {
 	// Source can be in the form [<tag>][@<digest>]
 	tag := source
 	digest := ""
-	splittedSource := strings.Split(source, "@")
-	if len(splittedSource) == 2 {
+	splitSource := strings.Split(source, "@")
+	if len(splitSource) == 2 {
 		// We have a digest
-		tag = splittedSource[0]
-		digest = splittedSource[1]
+		tag = splitSource[0]
+		digest = splitSource[1]
 	}
 	tokens.tag = tag
 	tokens.digest = digest

--- a/pkg/plugins/resources/dockerfile/simpletextparser/keywords/from.go
+++ b/pkg/plugins/resources/dockerfile/simpletextparser/keywords/from.go
@@ -39,3 +39,20 @@ func (f From) IsLineMatching(originalLine, matcher string) bool {
 
 	return found
 }
+
+func (f From) GetStageName(originalLine string) (string, error) {
+	if f.IsLineMatching(originalLine, "") {
+		parsedLine := strings.Fields(originalLine)
+		if len(parsedLine) < 3 || strings.ToLower(parsedLine[2]) != "as" {
+			// No stage name
+			return "", nil
+		}
+		// At this stage we have a stage name, it will be the 4th token
+		return parsedLine[3], nil
+	}
+	return "", fmt.Errorf("Value not found in line")
+}
+
+func (a From) GetValue(originalLine, matcher string) (string, error) {
+	return "", fmt.Errorf("GetValue not supported for FROM")
+}

--- a/pkg/plugins/resources/dockerfile/simpletextparser/keywords/from_test.go
+++ b/pkg/plugins/resources/dockerfile/simpletextparser/keywords/from_test.go
@@ -378,7 +378,7 @@ func TestFrom_IsLineMatching(t *testing.T) {
 			want:         true,
 		},
 		{
-			name:         "Match and change with platforming",
+			name:         "Match and change with platform",
 			originalLine: "FROM --platform=linux/amd64 alpine:3.12",
 			matcher:      "alpine",
 			want:         true,

--- a/pkg/plugins/resources/dockerfile/simpletextparser/keywords/from_test.go
+++ b/pkg/plugins/resources/dockerfile/simpletextparser/keywords/from_test.go
@@ -180,3 +180,87 @@ func TestFrom_IsLineMatching(t *testing.T) {
 		})
 	}
 }
+
+func Test_GetStageName(t *testing.T) {
+	tests := []struct {
+		name         string
+		originalLine string
+		want         string
+		wantErr      bool
+	}{
+		{
+			name:         "No stage name",
+			originalLine: "FROM alpine:3.12",
+			want:         "",
+		},
+		{
+			name:         "Non From line",
+			originalLine: "ENV alpine=3.12",
+			wantErr:      true,
+		},
+		{
+			name:         "Empty line",
+			originalLine: "",
+			wantErr:      true,
+		},
+		{
+			name:         "Stage Name",
+			originalLine: "FROM alpine:3.12 AS builder",
+			want:         "builder",
+		},
+		{
+			name:         "Stage Name lowercase",
+			originalLine: "from alpine:3.12 as builder",
+			want:         "builder",
+		},
+
+		{
+			name:         "Stage name and comment",
+			originalLine: "FROM alpine:3.12 AS alpine",
+			want:         "alpine",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := From{}
+
+			got, gotErr := f.GetStageName(tt.originalLine)
+			if tt.wantErr {
+				assert.Error(t, gotErr)
+			} else {
+				assert.Equal(t, tt.want, got)
+			}
+
+		})
+	}
+}
+
+func TestFrom_GetValue(t *testing.T) {
+	tests := []struct {
+		name         string
+		originalLine string
+		matcher      string
+		want         string
+		wantErr      bool
+	}{
+		{
+			name:         "Match",
+			originalLine: "FROM alpine:3.12 AS alpine",
+			matcher:      "TERRAFORM_VERSION",
+			wantErr:      true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := From{}
+
+			got, gotErr := a.GetValue(tt.originalLine, tt.matcher)
+			if tt.wantErr {
+				assert.Error(t, gotErr)
+			} else {
+				assert.Equal(t, tt.want, got)
+			}
+
+		})
+	}
+}

--- a/pkg/plugins/resources/dockerfile/simpletextparser/keywords/from_test.go
+++ b/pkg/plugins/resources/dockerfile/simpletextparser/keywords/from_test.go
@@ -1,10 +1,155 @@
 package keywords
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+func TestFrom_GetToken(t *testing.T) {
+	tests := []struct {
+		name         string
+		originalLine string
+		want         fromToken
+		wantErr      error
+	}{
+		{
+			name:         "Empty line",
+			originalLine: "",
+			wantErr:      fmt.Errorf("Got an empty or malformed line"),
+		},
+		{
+			name:         "Non FROM line",
+			originalLine: "ARG TERRAFORM_VERSION",
+			wantErr:      fmt.Errorf("Not a FROM line: \"ARG\""),
+		},
+		{
+			name:         "Malformed FROM line",
+			originalLine: "FROM",
+			wantErr:      fmt.Errorf("Got an empty or malformed line"),
+		},
+		{
+			name:         "No image in platformed line",
+			originalLine: "FROM --platform=linux/amd64",
+			wantErr:      fmt.Errorf("No image in line"),
+		},
+		{
+			name:         "Malformed alias",
+			originalLine: "FROM alpine AS",
+			wantErr:      fmt.Errorf("Malformed FROM line, AS keyword but no value for it"),
+		},
+		{
+			name:         "Malformed comment",
+			originalLine: "FROM alpine malformed comment",
+			wantErr:      fmt.Errorf("Remaining token in line that should be a comment but doesn't start with \"#\""),
+		},
+		{
+			name:         "Correct comment",
+			originalLine: "FROM alpine # correct comment",
+			want:         fromToken{keyword: "FROM", image: "alpine", comment: "# correct comment"},
+		},
+		{
+			name:         "Match Spec with platform no tag no digest with alias",
+			originalLine: "FROM --platform=linux/amd64 alpine AS builder",
+			want:         fromToken{keyword: "FROM", platform: "--platform=linux/amd64", image: "alpine", alias: "builder", aliasKw: "AS"},
+		},
+		{
+			name:         "Match Spec with platform no tag no digest with alias lowercase",
+			originalLine: "from --platform=linux/amd64 alpine as builder",
+			want:         fromToken{keyword: "from", platform: "--platform=linux/amd64", image: "alpine", alias: "builder", aliasKw: "as"},
+		},
+		{
+			name:         "Match Spec with platform no tag no digest no alias",
+			originalLine: "FROM --platform=linux/amd64 alpine",
+			want:         fromToken{keyword: "FROM", platform: "--platform=linux/amd64", image: "alpine"},
+		},
+		{
+			name:         "Match Spec no platform no tag no digest with alias",
+			originalLine: "FROM alpine AS builder",
+			want:         fromToken{keyword: "FROM", image: "alpine", alias: "builder", aliasKw: "AS"},
+		},
+		{
+			name:         "Match Spec no platform no tag no digest no alias",
+			originalLine: "FROM alpine",
+			want:         fromToken{keyword: "FROM", image: "alpine"},
+		},
+		{
+			name:         "Match Spec with platform with tag no digest with alias",
+			originalLine: "FROM --platform=linux/amd64 alpine:3.12 AS builder",
+			want:         fromToken{keyword: "FROM", platform: "--platform=linux/amd64", image: "alpine", tag: "3.12", alias: "builder", aliasKw: "AS"},
+		},
+		{
+			name:         "Match Spec with platform with tag no digest no alias",
+			originalLine: "FROM --platform=linux/amd64 alpine:3.12",
+			want:         fromToken{keyword: "FROM", platform: "--platform=linux/amd64", image: "alpine", tag: "3.12"},
+		},
+		{
+			name:         "Match Spec no platform with tag no digest no alias",
+			originalLine: "FROM alpine:3.12 AS builder",
+			want:         fromToken{keyword: "FROM", image: "alpine", tag: "3.12", alias: "builder", aliasKw: "AS"},
+		},
+		{
+			name:         "Match Spec no platform with tag no digest no alias",
+			originalLine: "FROM alpine:3.12",
+			want:         fromToken{keyword: "FROM", image: "alpine", tag: "3.12"},
+		},
+		{
+			name:         "Match Spec with platform no tag with digest with alias",
+			originalLine: "FROM --platform=linux/amd64 alpine@sha256:732 AS builder",
+			want:         fromToken{keyword: "FROM", platform: "--platform=linux/amd64", image: "alpine", digest: "sha256:732", alias: "builder", aliasKw: "AS"},
+		},
+		{
+			name:         "Match Spec with platform no tag with digest no alias",
+			originalLine: "FROM --platform=linux/amd64 alpine@sha256:732",
+			want:         fromToken{keyword: "FROM", platform: "--platform=linux/amd64", image: "alpine", digest: "sha256:732"},
+		},
+		{
+			name:         "Match Spec no platform no tag with digest with alias",
+			originalLine: "FROM alpine@sha256:732 AS builder",
+			want:         fromToken{keyword: "FROM", image: "alpine", digest: "sha256:732", alias: "builder", aliasKw: "AS"},
+		},
+		{
+			name:         "Match Spec no platform no tag with digest no alias",
+			originalLine: "FROM alpine@sha256:732",
+			want:         fromToken{keyword: "FROM", image: "alpine", digest: "sha256:732"},
+		},
+		{
+			name:         "Match Spec with platform with tag with digest with alias",
+			originalLine: "FROM --platform=linux/amd64 alpine:3.12@sha256:732 AS builder",
+			want:         fromToken{keyword: "FROM", platform: "--platform=linux/amd64", image: "alpine", tag: "3.12", digest: "sha256:732", alias: "builder", aliasKw: "AS"},
+		},
+		{
+			name:         "Match Spec with platform with tag with digest no alias",
+			originalLine: "FROM --platform=linux/amd64 alpine:3.12@sha256:732",
+			want:         fromToken{keyword: "FROM", platform: "--platform=linux/amd64", image: "alpine", tag: "3.12", digest: "sha256:732"},
+		},
+		{
+			name:         "Match Spec no platform with tag with digest with alias",
+			originalLine: "FROM alpine:3.12@sha256:732 AS builder",
+			want:         fromToken{keyword: "FROM", image: "alpine", tag: "3.12", digest: "sha256:732", alias: "builder", aliasKw: "AS"},
+		},
+		{
+			name:         "Match Spec no platform with tag with digest no alias",
+			originalLine: "FROM alpine:3.12@sha256:732",
+			want:         fromToken{keyword: "FROM", image: "alpine", tag: "3.12", digest: "sha256:732"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := From{}
+
+			got, gotErr := f.parseTokens(tt.originalLine)
+			if tt.wantErr != nil {
+				assert.Error(t, gotErr)
+				assert.Equal(t, tt.wantErr, gotErr)
+				return
+			}
+			assert.Equal(t, tt.want, got)
+
+		})
+	}
+}
 
 func TestFrom_ReplaceLine(t *testing.T) {
 	tests := []struct {
@@ -84,6 +229,111 @@ func TestFrom_ReplaceLine(t *testing.T) {
 			matcher:      "alpine",
 			want:         "FROM ALPINE:3.12",
 		},
+		{
+			name:         "No Match for upper case key and platform",
+			source:       "3.14",
+			originalLine: "FROM --platform=linux/amd64 ALPINE:3.12",
+			matcher:      "alpine",
+			want:         "FROM --platform=linux/amd64 ALPINE:3.12",
+		},
+		{
+			name:         "Comment",
+			source:       "3.14",
+			originalLine: "FROM --platform=linux/amd64 alpine:3.12 # Base amd64 image",
+			matcher:      "alpine",
+			want:         "FROM --platform=linux/amd64 alpine:3.14 # Base amd64 image",
+		},
+		{
+			name:         "Match Spec with platform no tag no digest with alias",
+			source:       "3.14",
+			originalLine: "FROM --platform=linux/amd64 alpine AS builder",
+			matcher:      "alpine",
+			want:         "FROM --platform=linux/amd64 alpine:3.14 AS builder",
+		},
+		{
+			name:         "Match Spec with platform no tag no digest no alias",
+			source:       "3.14",
+			originalLine: "FROM --platform=linux/amd64 alpine",
+			matcher:      "alpine",
+			want:         "FROM --platform=linux/amd64 alpine:3.14",
+		},
+		{
+			name:         "Match Spec no platform no tag no digest with alias",
+			source:       "3.14",
+			originalLine: "FROM alpine AS builder",
+			matcher:      "alpine",
+			want:         "FROM alpine:3.14 AS builder",
+		},
+		{
+			name:         "Match Spec no platform no tag no digest no alias",
+			source:       "3.14",
+			originalLine: "FROM alpine",
+			matcher:      "alpine",
+			want:         "FROM alpine:3.14",
+		},
+		{
+			name:         "Match Spec with platform with tag no digest with alias",
+			source:       "3.14",
+			originalLine: "FROM --platform=linux/amd64 alpine:3.12 AS builder",
+			matcher:      "alpine",
+			want:         "FROM --platform=linux/amd64 alpine:3.14 AS builder",
+		},
+		{
+			name:         "Match Spec with platform with tag no digest no alias",
+			source:       "3.14",
+			originalLine: "FROM --platform=linux/amd64 alpine:3.12",
+			matcher:      "alpine",
+			want:         "FROM --platform=linux/amd64 alpine:3.14",
+		},
+		{
+			name:         "Match Spec no platform with tag no digest no alias",
+			source:       "3.14",
+			originalLine: "FROM alpine:3.12 AS builder",
+			matcher:      "alpine",
+			want:         "FROM alpine:3.14 AS builder",
+		},
+		{
+			name:         "Match Spec no platform with tag no digest no alias",
+			source:       "3.14",
+			originalLine: "FROM alpine:3.12",
+			matcher:      "alpine",
+			want:         "FROM alpine:3.14",
+		},
+		{
+			name:         "Match Spec with platform no tag with digest with alias",
+			source:       "@sha256:734",
+			originalLine: "FROM --platform=linux/amd64 alpine@sha256:732 AS builder",
+			matcher:      "alpine",
+			want:         "FROM --platform=linux/amd64 alpine@sha256:734 AS builder",
+		},
+		{
+			name:         "Match Spec with platform with tag with digest with alias",
+			source:       "3.14@sha256:734",
+			originalLine: "FROM --platform=linux/amd64 alpine:3.12@sha256:732 AS builder",
+			matcher:      "alpine",
+			want:         "FROM --platform=linux/amd64 alpine:3.14@sha256:734 AS builder",
+		},
+		{
+			name:         "Match Spec with platform no tag with digest no alias",
+			source:       "@sha256:734",
+			originalLine: "FROM --platform=linux/amd64 alpine@sha256:732",
+			matcher:      "alpine",
+			want:         "FROM --platform=linux/amd64 alpine@sha256:734",
+		},
+		{
+			name:         "Match Spec no platform no tag with digest with alias",
+			source:       "@sha256:734",
+			originalLine: "FROM alpine@sha256:732 AS builder",
+			matcher:      "alpine",
+			want:         "FROM alpine@sha256:734 AS builder",
+		},
+		{
+			name:         "Match Spec no platform no tag with digest no alias",
+			source:       "@sha256:734",
+			originalLine: "FROM alpine@sha256:732",
+			matcher:      "alpine",
+			want:         "FROM alpine@sha256:734",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -124,6 +374,12 @@ func TestFrom_IsLineMatching(t *testing.T) {
 		{
 			name:         "Match and change with same name in alias",
 			originalLine: "FROM alpine:3.12 AS alpine",
+			matcher:      "alpine",
+			want:         true,
+		},
+		{
+			name:         "Match and change with platforming",
+			originalLine: "FROM --platform=linux/amd64 alpine:3.12",
 			matcher:      "alpine",
 			want:         true,
 		},
@@ -240,14 +496,43 @@ func TestFrom_GetValue(t *testing.T) {
 		name         string
 		originalLine string
 		matcher      string
+		stage        string
 		want         string
 		wantErr      bool
 	}{
+
 		{
 			name:         "Match",
-			originalLine: "FROM alpine:3.12 AS alpine",
-			matcher:      "TERRAFORM_VERSION",
+			originalLine: "FROM alpine:3.12 AS builder",
+			want:         "alpine:3.12",
+			wantErr:      false,
+		},
+		{
+			name:         "Lowercase Match",
+			originalLine: "from alpine:3.12 as builder",
+			want:         "alpine:3.12",
+			wantErr:      false,
+		},
+		{
+			name:         "Empty line",
+			originalLine: "",
+			matcher:      "alpine",
+			want:         "",
 			wantErr:      true,
+		},
+		{
+			name:         "Special Characters",
+			originalLine: "from eclipse-temurin:${JAVA_VERSION}-jdk-jammy AS jdk",
+			matcher:      "eclipse-temurin",
+			want:         "eclipse-temurin:${JAVA_VERSION}-jdk-jammy",
+			wantErr:      false,
+		},
+		{
+			name:         "Platform",
+			originalLine: "FROM --platform=linux/amd64 eclipse-mosquito:2.0",
+			matcher:      "eclipse-mosquito",
+			want:         "eclipse-mosquito:2.0",
+			wantErr:      false,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/plugins/resources/dockerfile/simpletextparser/keywords/label.go
+++ b/pkg/plugins/resources/dockerfile/simpletextparser/keywords/label.go
@@ -35,12 +35,12 @@ func (a Label) GetValue(originalLine, matcher string) (string, error) {
 	if a.IsLineMatching(originalLine, matcher) {
 		// With an ARG instruction, we just need the rest of the 2nd "word"
 		parsedLine := strings.Fields(originalLine)
-		splittedArgValue := strings.Split(parsedLine[1], "=")
-		if len(splittedArgValue) < 2 {
+		splitArgValue := strings.Split(parsedLine[1], "=")
+		if len(splitArgValue) < 2 {
 			// ARG without value
 			return "", nil
 		} else {
-			return splittedArgValue[1], nil
+			return splitArgValue[1], nil
 		}
 	}
 	return "", fmt.Errorf("Value not found in line")

--- a/pkg/plugins/resources/dockerfile/simpletextparser/keywords/label.go
+++ b/pkg/plugins/resources/dockerfile/simpletextparser/keywords/label.go
@@ -1,0 +1,47 @@
+package keywords
+
+import (
+	"fmt"
+	"strings"
+)
+
+type Label struct{}
+
+func (a Label) ReplaceLine(source, originalLine, matcher string) string {
+
+	if !a.IsLineMatching(originalLine, matcher) {
+		return originalLine
+	}
+
+	// With an ARG instruction, we only need to use the 2nd "word"
+	parsedLine := strings.Fields(originalLine)
+
+	parsedLine[1] = matcher + "=" + source
+	return strings.Join(parsedLine, " ")
+}
+
+func (a Label) IsLineMatching(originalLine, matcher string) bool {
+	parsedLine := strings.Fields(originalLine)
+	if len(parsedLine) == 0 {
+		// Empty line
+		return false
+	}
+	found := strings.ToLower(parsedLine[0]) == "label" && strings.HasPrefix(parsedLine[1], matcher)
+
+	return found
+}
+
+func (a Label) GetValue(originalLine, matcher string) (string, error) {
+	if a.IsLineMatching(originalLine, matcher) {
+		// With an ARG instruction, we just need the rest of the 2nd "word"
+		parsedLine := strings.Fields(originalLine)
+		splittedArgValue := strings.Split(parsedLine[1], "=")
+		if len(splittedArgValue) < 2 {
+			// ARG without value
+			return "", nil
+		} else {
+			return splittedArgValue[1], nil
+		}
+	}
+	return "", fmt.Errorf("Value not found in line")
+}

--- a/pkg/plugins/resources/dockerfile/simpletextparser/keywords/label.go
+++ b/pkg/plugins/resources/dockerfile/simpletextparser/keywords/label.go
@@ -13,7 +13,7 @@ func (a Label) ReplaceLine(source, originalLine, matcher string) string {
 		return originalLine
 	}
 
-	// With an ARG instruction, we only need to use the 2nd "word"
+	// With an LABEL instruction, we only need to use the 2nd "word"
 	parsedLine := strings.Fields(originalLine)
 
 	parsedLine[1] = matcher + "=" + source
@@ -33,11 +33,11 @@ func (a Label) IsLineMatching(originalLine, matcher string) bool {
 
 func (a Label) GetValue(originalLine, matcher string) (string, error) {
 	if a.IsLineMatching(originalLine, matcher) {
-		// With an ARG instruction, we just need the rest of the 2nd "word"
+		// With an LABEL instruction, we just need the rest of the 2nd "word"
 		parsedLine := strings.Fields(originalLine)
 		splitArgValue := strings.Split(parsedLine[1], "=")
 		if len(splitArgValue) < 2 {
-			// ARG without value
+			// LABEL without value
 			return "", nil
 		} else {
 			return splitArgValue[1], nil

--- a/pkg/plugins/resources/dockerfile/simpletextparser/keywords/label_test.go
+++ b/pkg/plugins/resources/dockerfile/simpletextparser/keywords/label_test.go
@@ -1,0 +1,217 @@
+package keywords
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLabel_ReplaceLine(t *testing.T) {
+	tests := []struct {
+		name         string
+		source       string
+		originalLine string
+		matcher      string
+		want         string
+	}{
+		{
+			name:         "Match and change",
+			source:       "0.14.6",
+			originalLine: "LABEL org.opencontainers.image.version=0.13.6",
+			matcher:      "org.opencontainers.image.version",
+			want:         "LABEL org.opencontainers.image.version=0.14.6",
+		},
+		{
+			name:         "Match and change (lower case instruction)",
+			source:       "0.14.6",
+			originalLine: "label org.opencontainers.image.version=0.13.6",
+			matcher:      "org.opencontainers.image.version",
+			want:         "label org.opencontainers.image.version=0.14.6",
+		},
+		{
+			name:         "Match default value and change",
+			source:       "0.14.6",
+			originalLine: "LABEL org.opencontainers.image.version",
+			matcher:      "org.opencontainers.image.version",
+			want:         "LABEL org.opencontainers.image.version=0.14.6",
+		},
+		{
+			name:         "Match empty value and change",
+			source:       "0.14.6",
+			originalLine: "LABEL org.opencontainers.image.version=",
+			matcher:      "org.opencontainers.image.version",
+			want:         "LABEL org.opencontainers.image.version=0.14.6",
+		},
+		{
+			name:         "Match but no change",
+			source:       "0.14.6",
+			originalLine: "LABEL org.opencontainers.image.version=0.14.6",
+			matcher:      "org.opencontainers.image.version",
+			want:         "LABEL org.opencontainers.image.version=0.14.6",
+		},
+		{
+			name:         "No Match at all",
+			source:       "0.14.6",
+			originalLine: "LABEL org.opencontainers.image.url=https://github.com/updatecli/updatecli",
+			matcher:      "org.opencontainers.image.version",
+			want:         "LABEL org.opencontainers.image.url=https://github.com/updatecli/updatecli",
+		},
+		{
+			name:         "No Match for key but value, no change",
+			source:       "0.14.6",
+			originalLine: "LABEL org.opencontainers.image.base.image_version=TERRAFORM_VERSION",
+			matcher:      "TERRAFORM_VERSION",
+			want:         "LABEL org.opencontainers.image.base.image_version=TERRAFORM_VERSION",
+		},
+		{
+			name:         "No Match for upper case key",
+			source:       "0.14.6",
+			originalLine: "LABEL org.opencontainers.image.version=0.13.6",
+			matcher:      "ORG.OPENCONTAINERS.IMAGE.VERSION",
+			want:         "LABEL org.opencontainers.image.version=0.13.6",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := Label{}
+
+			got := a.ReplaceLine(tt.source, tt.originalLine, tt.matcher)
+			assert.Equal(t, tt.want, got)
+
+		})
+	}
+}
+
+func TestLabel_IsLineMatching(t *testing.T) {
+	tests := []struct {
+		name         string
+		originalLine string
+		matcher      string
+		want         bool
+	}{
+		{
+			name:         "Match",
+			originalLine: "LABEL org.opencontainers.image.version=0.13.6",
+			matcher:      "org.opencontainers.image.version",
+			want:         true,
+		},
+		{
+			name:         "Match (lower case instruction)",
+			originalLine: "label org.opencontainers.image.version=0.13.6",
+			matcher:      "org.opencontainers.image.version",
+			want:         true,
+		},
+		{
+			name:         "Match empty value",
+			originalLine: "LABEL org.opencontainers.image.version=",
+			matcher:      "org.opencontainers.image.version",
+			want:         true,
+		},
+		{
+			name:         "No Match at all",
+			originalLine: "LABEL org.opencontainers.image.url=https://github.com/updatecli/updatecli",
+			matcher:      "org.opencontainers.image.version",
+			want:         false,
+		},
+		{
+			name:         "No Match for key but value",
+			originalLine: "LABEL org.opencontainers.image.base.image_version=TERRAFORM_VERSION",
+			matcher:      "TERRAFORM_VERSION",
+			want:         false,
+		},
+		{
+			name:         "No Match for lower case key",
+			originalLine: "LABEL org.opencontainers.image.version=0.13.6",
+			matcher:      "ORG.OPENCONTAINERS.IMAGE.VERSION",
+			want:         false,
+		},
+		{
+			name:         "Empty line",
+			originalLine: "",
+			matcher:      "org.opencontainers.image.version",
+			want:         false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := Label{}
+
+			got := a.IsLineMatching(tt.originalLine, tt.matcher)
+			assert.Equal(t, tt.want, got)
+
+		})
+	}
+}
+
+func TestLabel_GetValue(t *testing.T) {
+	tests := []struct {
+		name         string
+		originalLine string
+		matcher      string
+		want         string
+		wantErr      bool
+	}{
+		{
+			name:         "Match",
+			originalLine: "LABEL org.opencontainers.image.version=0.13.6",
+			matcher:      "org.opencontainers.image.version",
+			want:         "0.13.6",
+			wantErr:      false,
+		},
+		{
+			name:         "Match (lower case instruction)",
+			originalLine: "label org.opencontainers.image.version=0.13.6",
+			matcher:      "org.opencontainers.image.version",
+			want:         "0.13.6",
+			wantErr:      false,
+		},
+		{
+			name:         "Match empty value",
+			originalLine: "LABEL org.opencontainers.image.version=",
+			matcher:      "org.opencontainers.image.version",
+			want:         "",
+			wantErr:      false,
+		},
+		{
+			name:         "No Match at all",
+			originalLine: "LABEL org.opencontainers.image.url=https://github.com/updatecli/updatecli",
+			matcher:      "org.opencontainers.image.version",
+			want:         "",
+			wantErr:      true,
+		},
+		{
+			name:         "No Match for key but value",
+			originalLine: "LABEL org.opencontainers.image.base.image_version=TERRAFORM_VERSION",
+			matcher:      "TERRAFORM_VERSION",
+			want:         "",
+			wantErr:      true,
+		},
+		{
+			name:         "No Match for lower case key",
+			originalLine: "LABEL org.opencontainers.image.version=0.13.6",
+			matcher:      "ORG.OPENCONTAINERS.IMAGE.VERSION",
+			want:         "",
+			wantErr:      true,
+		},
+		{
+			name:         "Empty line",
+			originalLine: "",
+			matcher:      "org.opencontainers.image.version",
+			want:         "",
+			wantErr:      true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := Label{}
+
+			got, gotErr := a.GetValue(tt.originalLine, tt.matcher)
+			if tt.wantErr {
+				assert.Error(t, gotErr)
+			} else {
+				assert.Equal(t, tt.want, got)
+			}
+
+		})
+	}
+}

--- a/pkg/plugins/resources/dockerfile/simpletextparser/keywords/main.go
+++ b/pkg/plugins/resources/dockerfile/simpletextparser/keywords/main.go
@@ -3,4 +3,5 @@ package keywords
 type Logic interface {
 	IsLineMatching(originalLine, matcher string) bool
 	ReplaceLine(source, originalLine, matcher string) string
+	GetValue(originalLine, matcher string) (string, error)
 }

--- a/pkg/plugins/resources/dockerfile/simpletextparser/main.go
+++ b/pkg/plugins/resources/dockerfile/simpletextparser/main.go
@@ -15,11 +15,12 @@ import (
 type SimpleTextDockerfileParser struct {
 	Keyword      string `yaml:"keyword,omitempty"`
 	Matcher      string `yaml:"matcher,omitempty"`
+	Stage        string `yaml:"stage,omitempty"`
 	KeywordLogic keywords.Logic
 }
 
-func (s SimpleTextDockerfileParser) FindInstruction(dockerfileContent []byte) bool {
-	if found, originalLine := s.hasMatch(dockerfileContent); found {
+func (s SimpleTextDockerfileParser) FindInstruction(dockerfileContent []byte, stage string) bool {
+	if found, originalLine := s.hasMatch(dockerfileContent, stage); found {
 		logrus.Infof("%s Line %q found, matching the keyword %q and the matcher %q.", result.SUCCESS, originalLine, s.Keyword, s.Matcher)
 		return true
 	}
@@ -28,13 +29,21 @@ func (s SimpleTextDockerfileParser) FindInstruction(dockerfileContent []byte) bo
 	return false
 }
 
-func (s SimpleTextDockerfileParser) hasMatch(dockerfileContent []byte) (bool, string) {
+func (s SimpleTextDockerfileParser) hasMatch(dockerfileContent []byte, stage string) (bool, string) {
 	scanner := bufio.NewScanner(bytes.NewReader(dockerfileContent))
 
 	// For each line of the dockerfile
+	// Make sure we handle the stage
+	currentStageName := ""
+	stageScanner := keywords.From{}
 	for scanner.Scan() {
 		originalLine := scanner.Text()
-
+		if stageName, err := stageScanner.GetStageName(originalLine); err == nil {
+			currentStageName = stageName
+		}
+		if stage != "" && currentStageName != stage {
+			continue
+		}
 		if s.KeywordLogic.IsLineMatching(originalLine, s.Matcher) {
 			// Immediately returns if there is match: the result of a condition is the same with one or multiple matches
 			return true, originalLine
@@ -44,11 +53,11 @@ func (s SimpleTextDockerfileParser) hasMatch(dockerfileContent []byte) (bool, st
 	return false, ""
 }
 
-func (s SimpleTextDockerfileParser) ReplaceInstructions(dockerfileContent []byte, sourceValue string) ([]byte, types.ChangedLines, error) {
+func (s SimpleTextDockerfileParser) ReplaceInstructions(dockerfileContent []byte, sourceValue, stage string) ([]byte, types.ChangedLines, error) {
 
 	changedLines := make(types.ChangedLines)
 
-	if found, _ := s.hasMatch(dockerfileContent); !found {
+	if found, _ := s.hasMatch(dockerfileContent, stage); !found {
 		return dockerfileContent, changedLines, fmt.Errorf("%s No line found matching the keyword %q and the matcher %q.", result.FAILURE, s.Keyword, s.Matcher)
 	}
 
@@ -56,13 +65,20 @@ func (s SimpleTextDockerfileParser) ReplaceInstructions(dockerfileContent []byte
 	scanner := bufio.NewScanner(bytes.NewReader(dockerfileContent))
 	linePosition := 0
 
+	// Make sure we handle the stage
+	currentStageName := ""
+	stageScanner := keywords.From{}
 	// For each line of the dockerfile
 	for scanner.Scan() {
 		originalLine := scanner.Text()
 		newLine := originalLine
 		linePosition += 1
 
-		if s.KeywordLogic.IsLineMatching(originalLine, s.Matcher) {
+		if stageName, err := stageScanner.GetStageName(originalLine); err == nil {
+			currentStageName = stageName
+		}
+
+		if ((stage != "" && stage == currentStageName) || stage == "") && s.KeywordLogic.IsLineMatching(originalLine, s.Matcher) {
 			// if strings.HasPrefix(strings.ToLower(originalLine), strings.ToLower(d.spec.Instruction.Keyword)) {
 			newLine = s.KeywordLogic.ReplaceLine(sourceValue, originalLine, s.Matcher)
 
@@ -93,8 +109,12 @@ func (s SimpleTextDockerfileParser) ReplaceInstructions(dockerfileContent []byte
 	return newDockerfile.Bytes(), changedLines, nil
 }
 
-func (s SimpleTextDockerfileParser) GetInstruction(dockerfileContent []byte) []types.StageInstructionValue {
-	var stagesInstruction []types.StageInstructionValue
+func (s SimpleTextDockerfileParser) GetInstruction(dockerfileContent []byte, stage string) string {
+	type stageValue struct {
+		StageName string
+		Value     string
+	}
+	var stagesInstruction []stageValue
 	scanner := bufio.NewScanner(bytes.NewReader(dockerfileContent))
 	stageCounter := -1
 	currentStageName := ""
@@ -104,14 +124,18 @@ func (s SimpleTextDockerfileParser) GetInstruction(dockerfileContent []byte) []t
 		if stageName, err := stageScanner.GetStageName(originalLine); err == nil {
 			currentStageName = stageName
 			stageCounter += 1
-		} else if s.KeywordLogic.IsLineMatching(originalLine, s.Matcher) {
+		}
+		if stage != "" && stage != currentStageName {
+			continue
+		}
+		if s.KeywordLogic.IsLineMatching(originalLine, s.Matcher) {
 			stageName := currentStageName
 			if stageName == "" {
 				// Use stage counter
 				stageName = fmt.Sprintf("%d", stageCounter)
 			}
 			if value, err := s.KeywordLogic.GetValue(originalLine, s.Matcher); err == nil {
-				stageValue := types.StageInstructionValue{
+				stageValue := stageValue{
 					StageName: stageName,
 					Value:     value,
 				}
@@ -124,8 +148,22 @@ func (s SimpleTextDockerfileParser) GetInstruction(dockerfileContent []byte) []t
 		}
 
 	}
-
-	return stagesInstruction
+	var instruction string
+	if len(stagesInstruction) == 0 {
+		// Found nothing
+		return ""
+	}
+	if stage == "" {
+		// No Stage selected, return info for last one
+		return stagesInstruction[len(stagesInstruction)-1].Value
+	}
+	// We have a stage name, let's try to find it
+	for _, currentStage := range stagesInstruction {
+		if currentStage.StageName == stage {
+			instruction = currentStage.Value
+		}
+	}
+	return instruction
 }
 
 func NewSimpleTextDockerfileParser(input map[string]string) (SimpleTextDockerfileParser, error) {

--- a/pkg/plugins/resources/dockerfile/simpletextparser/main_test.go
+++ b/pkg/plugins/resources/dockerfile/simpletextparser/main_test.go
@@ -343,9 +343,9 @@ func TestSimpleTextDockerfileParser_GetInstruction(t *testing.T) {
 				"matcher": "HELM_VERSION",
 			},
 			expectedResult: []types.StageInstructionValue{
-				types.StageInstructionValue{StageName: "builder", Value: "3.0.0"},
-				types.StageInstructionValue{StageName: "tester", Value: "3.0.0"},
-				types.StageInstructionValue{StageName: "reporter", Value: ""},
+				{StageName: "builder", Value: "3.0.0"},
+				{StageName: "tester", Value: "3.0.0"},
+				{StageName: "reporter", Value: ""},
 			},
 		},
 		{
@@ -356,8 +356,8 @@ func TestSimpleTextDockerfileParser_GetInstruction(t *testing.T) {
 				"matcher": "helm_version",
 			},
 			expectedResult: []types.StageInstructionValue{
-				types.StageInstructionValue{StageName: "base", Value: ""},
-				types.StageInstructionValue{StageName: "6", Value: ""},
+				{StageName: "base", Value: ""},
+				{StageName: "6", Value: ""},
 			},
 		},
 		{
@@ -368,10 +368,10 @@ func TestSimpleTextDockerfileParser_GetInstruction(t *testing.T) {
 				"matcher": "TERRAFORM_VERSION",
 			},
 			expectedResult: []types.StageInstructionValue{
-				types.StageInstructionValue{StageName: "normal-upper-case-equal", Value: "0.14.0"},
-				types.StageInstructionValue{StageName: "normal-upper-case-space", Value: "\"0.14.0\""},
-				types.StageInstructionValue{StageName: "normal-lower-case-equal", Value: "0.14.0"},
-				types.StageInstructionValue{StageName: "default-multi-instructions-first", Value: "0.14.0"},
+				{StageName: "normal-upper-case-equal", Value: "0.14.0"},
+				{StageName: "normal-upper-case-space", Value: "\"0.14.0\""},
+				{StageName: "normal-lower-case-equal", Value: "0.14.0"},
+				{StageName: "default-multi-instructions-first", Value: "0.14.0"},
 			},
 		},
 		{
@@ -382,10 +382,10 @@ func TestSimpleTextDockerfileParser_GetInstruction(t *testing.T) {
 				"matcher": "org.opencontainers.image.version",
 			},
 			expectedResult: []types.StageInstructionValue{
-				types.StageInstructionValue{StageName: "builder", Value: "0.14.0"},
-				types.StageInstructionValue{StageName: "tester", Value: "0.14.0"},
-				types.StageInstructionValue{StageName: "reporter", Value: ""},
-				types.StageInstructionValue{StageName: "base", Value: "0.14.0"},
+				{StageName: "builder", Value: "0.14.0"},
+				{StageName: "tester", Value: "0.14.0"},
+				{StageName: "reporter", Value: ""},
+				{StageName: "base", Value: "0.14.0"},
 			},
 		},
 		{

--- a/pkg/plugins/resources/dockerfile/simpletextparser/test_fixtures/ARG.Dockerfile
+++ b/pkg/plugins/resources/dockerfile/simpletextparser/test_fixtures/ARG.Dockerfile
@@ -40,7 +40,7 @@ FROM ubuntu AS golang
 
 FROM ubuntu:20.04
 
-arg helm_version
+arg helm_version # here
 
 LABEL maintainer="Olblak <me@olblak.com>"
 

--- a/pkg/plugins/resources/dockerfile/simpletextparser/test_fixtures/LABEL.Dockerfile
+++ b/pkg/plugins/resources/dockerfile/simpletextparser/test_fixtures/LABEL.Dockerfile
@@ -1,0 +1,22 @@
+FROM golang:1.15 AS builder
+
+LABEL org.opencontainers.image.version=0.14.0
+
+FROM golang:1.15 as tester
+
+label org.opencontainers.image.version=0.14.0
+
+FROM golang AS reporter
+
+LABEL org.opencontainers.image.version
+
+FROM golang
+
+RUN echo OK
+
+FROM ubuntu AS base
+
+LABEL org.opencontainers.image.version
+label org.opencontainers.image.version=0.14.0
+
+FROM ubuntu AS golang

--- a/pkg/plugins/resources/dockerfile/source.go
+++ b/pkg/plugins/resources/dockerfile/source.go
@@ -1,11 +1,90 @@
 package dockerfile
 
 import (
+	"errors"
 	"fmt"
+	"os"
 
+	"path/filepath"
+
+	"github.com/sirupsen/logrus"
 	"github.com/updatecli/updatecli/pkg/core/result"
+	"github.com/updatecli/updatecli/pkg/plugins/resources/dockerfile/types"
 )
 
 func (df *Dockerfile) Source(workingDir string, resultSource *result.Source) error {
+	// By the default workingdir is set to the current working directory
+	// it would be better to have it empty by default but it must be changed in the
+	// source core codebase.
+	currentWorkingDirectory, err := os.Getwd()
+	if err != nil {
+		return errors.New("fail getting current working directory")
+	}
+
+	switch len(df.files) {
+	case 1:
+		//
+	case 0:
+		return fmt.Errorf("no dockerfile specified")
+	default:
+		return fmt.Errorf("validation error in sources of type 'dockerfile': the attributes `spec.files` can't contain more than one element for sources")
+	}
+
+	if workingDir == currentWorkingDirectory {
+		workingDir = ""
+	}
+
+	// loop over the only file
+	for _, file := range df.files {
+		if workingDir != "" {
+			file = filepath.Join(workingDir, file)
+		}
+
+		if !df.contentRetriever.FileExists(file) {
+			return fmt.Errorf("the file %s does not exist", file)
+		}
+
+		dockerfileContent, err := df.contentRetriever.ReadAll(file)
+		if err != nil {
+			return fmt.Errorf("reading dockerfile: %w", err)
+		}
+
+		logrus.Debugf("\n🐋 On (Docker)file %q:\n\n", file)
+
+		stageValues := df.parser.GetInstruction([]byte(dockerfileContent))
+		stageName := "last stage"
+		if len(stageValues) == 0 {
+			return fmt.Errorf("could not get source value %q for %s in the dockerfile %q",
+				resultSource.Name,
+				stageName,
+				file,
+			)
+		}
+		var value *types.StageInstructionValue
+		if df.spec.Stage != "" {
+			for _, stageInstruction := range stageValues {
+				if stageInstruction.StageName == df.spec.Stage {
+					value = &stageInstruction
+				}
+				break
+			}
+			stageName := fmt.Sprintf("stage %q", df.spec.Stage)
+			if value == nil {
+				return fmt.Errorf("could not find %s in %q", stageName, file)
+			}
+		} else {
+			// No Stage name provider, using last
+			value = &stageValues[len(stageValues)-1]
+		}
+		resultSource.Result = result.SUCCESS
+		resultSource.Information = value.Value
+		resultSource.Description = fmt.Sprintf("value %q found for %s in the dockerfile file %q",
+			value.Value,
+			stageName,
+			file,
+		)
+		return nil
+
+	}
 	return fmt.Errorf("Source is not supported for the plugin 'dockerfile'")
 }

--- a/pkg/plugins/resources/dockerfile/source.go
+++ b/pkg/plugins/resources/dockerfile/source.go
@@ -4,12 +4,10 @@ import (
 	"errors"
 	"fmt"
 	"os"
-
 	"path/filepath"
 
 	"github.com/sirupsen/logrus"
 	"github.com/updatecli/updatecli/pkg/core/result"
-	"github.com/updatecli/updatecli/pkg/plugins/resources/dockerfile/types"
 )
 
 func (df *Dockerfile) Source(workingDir string, resultSource *result.Source) error {
@@ -51,36 +49,16 @@ func (df *Dockerfile) Source(workingDir string, resultSource *result.Source) err
 
 		logrus.Debugf("\n🐋 On (Docker)file %q:\n\n", file)
 
-		stageValues := df.parser.GetInstruction([]byte(dockerfileContent))
-		stageName := "last stage"
-		if len(stageValues) == 0 {
-			return fmt.Errorf("could not get source value %q for %s in the dockerfile %q",
-				resultSource.Name,
-				stageName,
-				file,
-			)
-		}
-		var value *types.StageInstructionValue
+		value := df.parser.GetInstruction([]byte(dockerfileContent), df.spec.Stage)
+		stageInfo := "last stage"
 		if df.spec.Stage != "" {
-			for _, stageInstruction := range stageValues {
-				if stageInstruction.StageName == df.spec.Stage {
-					value = &stageInstruction
-				}
-				break
-			}
-			stageName := fmt.Sprintf("stage %q", df.spec.Stage)
-			if value == nil {
-				return fmt.Errorf("could not find %s in %q", stageName, file)
-			}
-		} else {
-			// No Stage name provider, using last
-			value = &stageValues[len(stageValues)-1]
+			stageInfo = fmt.Sprintf("stage %q", df.spec.Stage)
 		}
 		resultSource.Result = result.SUCCESS
-		resultSource.Information = value.Value
+		resultSource.Information = value
 		resultSource.Description = fmt.Sprintf("value %q found for %s in the dockerfile file %q",
-			value.Value,
-			stageName,
+			value,
+			stageInfo,
 			file,
 		)
 		return nil

--- a/pkg/plugins/resources/dockerfile/source_test.go
+++ b/pkg/plugins/resources/dockerfile/source_test.go
@@ -37,6 +37,23 @@ func TestDockerfile_Source(t *testing.T) {
 			files: []string{"SOURCE.Dockerfile"},
 		},
 		{
+			name: "FROM Uppercase",
+			spec: Spec{
+				Stage: "builder",
+				Instruction: map[string]interface{}{
+					"keyword": "FROM",
+					"matcher": "golang",
+				},
+			},
+			expectedResult: "golang:1.15",
+			mockFile: text.MockTextRetriever{
+				Contents: map[string]string{
+					"SOURCE.Dockerfile": dockerfileFixture,
+				},
+			},
+			files: []string{"SOURCE.Dockerfile"},
+		},
+		{
 			name: "LABEL lowercase",
 			spec: Spec{
 				Instruction: map[string]interface{}{
@@ -77,7 +94,7 @@ func TestDockerfile_Source(t *testing.T) {
 					"matcher": "org.opencontainers.image.source",
 				},
 			},
-			wantErr: fmt.Errorf("could not get source value \"\" for last stage in the dockerfile \"SOURCE.Dockerfile\""),
+			expectedResult: "",
 			mockFile: text.MockTextRetriever{
 				Contents: map[string]string{
 					"SOURCE.Dockerfile": dockerfileFixture,
@@ -162,7 +179,7 @@ LABEL org.opencontainers.image.version=1.0.0
 					"matcher": "org.opencontainers.image.version",
 				},
 			},
-			wantErr: fmt.Errorf("could not find stage \"tester\" in \"SOURCE.Dockerfile\""),
+			expectedResult: "",
 			mockFile: text.MockTextRetriever{
 				Contents: map[string]string{
 					"SOURCE.Dockerfile": `FROM golang:1.15 AS builder

--- a/pkg/plugins/resources/dockerfile/source_test.go
+++ b/pkg/plugins/resources/dockerfile/source_test.go
@@ -102,7 +102,7 @@ func TestDockerfile_Source(t *testing.T) {
 			},
 			files: []string{"SOURCE.Dockerfile", "LABEL2.Dockerfile"},
 		}, {
-			name: "Inexistant files",
+			name: "No files specified",
 			spec: Spec{
 				Instruction: map[string]interface{}{
 					"keyword": "LABEL",
@@ -154,7 +154,7 @@ LABEL org.opencontainers.image.version=1.0.0
 			files: []string{"SOURCE.Dockerfile"},
 		},
 		{
-			name: "MultiStage inexisting stage",
+			name: "Non existing stage",
 			spec: Spec{
 				Stage: "tester",
 				Instruction: map[string]interface{}{

--- a/pkg/plugins/resources/dockerfile/source_test.go
+++ b/pkg/plugins/resources/dockerfile/source_test.go
@@ -1,0 +1,208 @@
+package dockerfile
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/updatecli/updatecli/pkg/core/result"
+	"github.com/updatecli/updatecli/pkg/core/text"
+)
+
+func TestDockerfile_Source(t *testing.T) {
+	tests := []struct {
+		name           string
+		spec           Spec
+		expectedResult string
+		mockFile       text.MockTextRetriever
+		wantErr        error
+		parserErr      bool
+		files          []string
+	}{
+		{
+			name: "LABEL Uppercase",
+			spec: Spec{
+				Instruction: map[string]interface{}{
+					"keyword": "LABEL",
+					"matcher": "org.opencontainers.image.version",
+				},
+			},
+			expectedResult: "1.0.0",
+			mockFile: text.MockTextRetriever{
+				Contents: map[string]string{
+					"SOURCE.Dockerfile": dockerfileFixture,
+				},
+			},
+			files: []string{"SOURCE.Dockerfile"},
+		},
+		{
+			name: "LABEL lowercase",
+			spec: Spec{
+				Instruction: map[string]interface{}{
+					"keyword": "label",
+					"matcher": "org.opencontainers.image.version",
+				},
+			},
+			expectedResult: "1.0.0",
+			mockFile: text.MockTextRetriever{
+				Contents: map[string]string{
+					"SOURCE.Dockerfile": dockerfileFixture,
+				},
+			},
+			files: []string{"SOURCE.Dockerfile"},
+		},
+		{
+			name: "Unsupported instruction",
+			spec: Spec{
+				Instruction: map[string]interface{}{
+					"keyword": "quack",
+					"matcher": "org.opencontainers.image.version",
+				},
+			},
+			parserErr: true,
+			wantErr:   fmt.Errorf("✗ Unknown keyword \"quack\" provided for Dockerfile's instruction."),
+			mockFile: text.MockTextRetriever{
+				Contents: map[string]string{
+					"SOURCE.Dockerfile": dockerfileFixture,
+				},
+			},
+			files: []string{"SOURCE.Dockerfile"},
+		},
+		{
+			name: "Missing instruction",
+			spec: Spec{
+				Instruction: map[string]interface{}{
+					"keyword": "LABEL",
+					"matcher": "org.opencontainers.image.source",
+				},
+			},
+			wantErr: fmt.Errorf("could not get source value \"\" for last stage in the dockerfile \"SOURCE.Dockerfile\""),
+			mockFile: text.MockTextRetriever{
+				Contents: map[string]string{
+					"SOURCE.Dockerfile": dockerfileFixture,
+				},
+			},
+			files: []string{"SOURCE.Dockerfile"},
+		},
+		{
+			name: "More than one files",
+			spec: Spec{
+				Instruction: map[string]interface{}{
+					"keyword": "LABEL",
+					"matcher": "org.opencontainers.image.source",
+				},
+			},
+			wantErr: fmt.Errorf("validation error in sources of type 'dockerfile': the attributes `spec.files` can't contain more than one element for sources"),
+			mockFile: text.MockTextRetriever{
+				Contents: map[string]string{
+					"SOURCE.Dockerfile": dockerfileFixture,
+					"LABEL2.Dockerfile": dockerfileFixture,
+				},
+			},
+			files: []string{"SOURCE.Dockerfile", "LABEL2.Dockerfile"},
+		}, {
+			name: "Inexistant files",
+			spec: Spec{
+				Instruction: map[string]interface{}{
+					"keyword": "LABEL",
+					"matcher": "org.opencontainers.image.source",
+				},
+			},
+			wantErr: fmt.Errorf("no dockerfile specified"),
+			mockFile: text.MockTextRetriever{
+				Contents: map[string]string{
+					"SOURCE.Dockerfile": dockerfileFixture,
+				},
+			},
+			files: []string{},
+		}, {
+			name: "Bad Path",
+			spec: Spec{
+				Instruction: map[string]interface{}{
+					"keyword": "LABEL",
+					"matcher": "org.opencontainers.image.source",
+				},
+			},
+			wantErr: fmt.Errorf("the file LABEL2.Dockerfile does not exist"),
+			mockFile: text.MockTextRetriever{
+				Contents: map[string]string{
+					"SOURCE.Dockerfile": dockerfileFixture,
+				},
+			},
+			files: []string{"LABEL2.Dockerfile"},
+		},
+		{
+			name: "MultiStage",
+			spec: Spec{
+				Stage: "builder",
+				Instruction: map[string]interface{}{
+					"keyword": "LABEL",
+					"matcher": "org.opencontainers.image.version",
+				},
+			},
+			expectedResult: "0.1.0",
+			mockFile: text.MockTextRetriever{
+				Contents: map[string]string{
+					"SOURCE.Dockerfile": `FROM golang:1.15 AS builder
+LABEL org.opencontainers.image.version=0.1.0
+FROM golang
+LABEL org.opencontainers.image.version=1.0.0
+`,
+				},
+			},
+			files: []string{"SOURCE.Dockerfile"},
+		},
+		{
+			name: "MultiStage inexisting stage",
+			spec: Spec{
+				Stage: "tester",
+				Instruction: map[string]interface{}{
+					"keyword": "LABEL",
+					"matcher": "org.opencontainers.image.version",
+				},
+			},
+			wantErr: fmt.Errorf("could not find stage \"tester\" in \"SOURCE.Dockerfile\""),
+			mockFile: text.MockTextRetriever{
+				Contents: map[string]string{
+					"SOURCE.Dockerfile": `FROM golang:1.15 AS builder
+LABEL org.opencontainers.image.version=0.1.0
+FROM golang
+LABEL org.opencontainers.image.version=1.0.0
+`,
+				},
+			},
+			files: []string{"SOURCE.Dockerfile"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockFile := tt.mockFile
+			newParser, gotErr := getParser(tt.spec)
+			if tt.parserErr {
+				assert.Error(t, gotErr)
+				assert.Equal(t, tt.wantErr, gotErr)
+				return
+			} else {
+				require.NoError(t, gotErr)
+			}
+			d := &Dockerfile{
+				spec:             tt.spec,
+				contentRetriever: &mockFile,
+				parser:           newParser,
+				files:            tt.files,
+			}
+			gotResult := result.Source{}
+			gotErr = d.Source("", &gotResult)
+
+			if tt.wantErr != nil {
+				assert.Error(t, gotErr)
+				assert.Equal(t, tt.wantErr, gotErr)
+			} else {
+				require.NoError(t, gotErr)
+			}
+
+			assert.Equal(t, tt.expectedResult, gotResult.Information)
+		})
+	}
+}

--- a/pkg/plugins/resources/dockerfile/target.go
+++ b/pkg/plugins/resources/dockerfile/target.go
@@ -35,7 +35,7 @@ func (d *Dockerfile) Target(source string, scm scm.ScmHandler, dryRun bool, resu
 
 		logrus.Debugf("\n🐋 On (Docker)file %q:\n\n", file)
 
-		newDockerfileContent, changedLines, err := d.parser.ReplaceInstructions([]byte(dockerfileContent), source)
+		newDockerfileContent, changedLines, err := d.parser.ReplaceInstructions([]byte(dockerfileContent), source, d.spec.Stage)
 		if err != nil {
 			return err
 		}

--- a/pkg/plugins/resources/dockerfile/target_test.go
+++ b/pkg/plugins/resources/dockerfile/target_test.go
@@ -158,6 +158,47 @@ CMD ["--help:golang"]
 				},
 			},
 		},
+		{
+			name:             "FROM with text parser and stage selection",
+			inputSourceValue: "1.16",
+			spec: Spec{
+				Stage: "builder",
+				Instruction: map[string]interface{}{
+					"keyword": "FROM",
+					"matcher": "golang",
+				},
+			},
+			mockFile: text.MockTextRetriever{
+				Contents: map[string]string{
+					"FROM.Dockerfile": dockerfileFixture,
+				},
+			},
+			files:       []string{"FROM.Dockerfile"},
+			wantChanged: true,
+			wantMockState: text.MockTextRetriever{
+				Contents: map[string]string{
+					"FROM.Dockerfile": `FROM golang:1.16 AS builder
+ARG golang=3.0.0
+LABEL org.opencontainers.image.version=1.0.0
+COPY ./golang .
+RUN go get -d -v ./... && echo golang
+FROM golang
+WORKDIR /go/src/app
+FROM ubuntu:20.04 AS golang
+RUN apt-get update
+FROM ubuntu:20.04
+RUN apt-get update
+LABEL golang="${GOLANG_VERSION}"
+VOLUME /tmp / golang
+USER golang
+WORKDIR /home/updatecli
+COPY --from=golang --chown=updatecli:golang /go/src/app/dist/updatecli /usr/bin/golang
+ENTRYPOINT [ "/usr/bin/golang" ]
+CMD ["--help:golang"]
+`,
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/plugins/resources/dockerfile/target_test.go
+++ b/pkg/plugins/resources/dockerfile/target_test.go
@@ -92,23 +92,24 @@ func TestDockerfile_Target(t *testing.T) {
 			wantMockState: text.MockTextRetriever{
 				Contents: map[string]string{
 					"FROM.Dockerfile": `FROM golang:1.16 AS builder
-		ARG golang=3.0.0
-		COPY ./golang .
-		RUN go get -d -v ./... && echo golang
-		FROM golang:1.16
-		WORKDIR /go/src/app
-		FROM ubuntu:20.04 AS golang
-		RUN apt-get update
-		FROM ubuntu:20.04
-		RUN apt-get update
-		LABEL golang="${GOLANG_VERSION}"
-		VOLUME /tmp / golang
-		USER golang
-		WORKDIR /home/updatecli
-		COPY --from=golang --chown=updatecli:golang /go/src/app/dist/updatecli /usr/bin/golang
-		ENTRYPOINT [ "/usr/bin/golang" ]
-		CMD ["--help:golang"]
-		`,
+ARG golang=3.0.0
+LABEL org.opencontainers.image.version=1.0.0
+COPY ./golang .
+RUN go get -d -v ./... && echo golang
+FROM golang:1.16
+WORKDIR /go/src/app
+FROM ubuntu:20.04 AS golang
+RUN apt-get update
+FROM ubuntu:20.04
+RUN apt-get update
+LABEL golang="${GOLANG_VERSION}"
+VOLUME /tmp / golang
+USER golang
+WORKDIR /home/updatecli
+COPY --from=golang --chown=updatecli:golang /go/src/app/dist/updatecli /usr/bin/golang
+ENTRYPOINT [ "/usr/bin/golang" ]
+CMD ["--help:golang"]
+`,
 				},
 			},
 		},
@@ -181,7 +182,10 @@ func TestDockerfile_Target(t *testing.T) {
 
 			require.NoError(t, gotErr)
 			assert.Equal(t, tt.wantChanged, gotResult.Changed)
-			assert.Equal(t, tt.wantMockState.Contents[tt.spec.File], mockFile.Contents[tt.spec.File])
+			assert.Equal(t, len(tt.files), len(gotResult.Files))
+			for _, file := range tt.files {
+				assert.Equal(t, tt.wantMockState.Contents[file], mockFile.Contents[file])
+			}
 		})
 	}
 }

--- a/pkg/plugins/resources/dockerfile/types/main.go
+++ b/pkg/plugins/resources/dockerfile/types/main.go
@@ -3,6 +3,7 @@ package types
 // DockerfileParser is an interface that any updatecli's Dockerfile parser must verifies to be used
 type DockerfileParser interface {
 	FindInstruction(dockerfileContent []byte) bool
+	GetInstruction(dockerfileContent []byte) []StageInstructionValue
 	ReplaceInstructions(dockerfileContent []byte, sourceValue string) ([]byte, ChangedLines, error)
 }
 
@@ -15,3 +16,9 @@ type LineDiff struct {
 }
 
 type Instruction interface{}
+
+// StagesInstruction is struct to store instruction value for each Dockerfile stages
+type StageInstructionValue struct {
+	StageName string
+	Value     string
+}

--- a/pkg/plugins/resources/dockerfile/types/main.go
+++ b/pkg/plugins/resources/dockerfile/types/main.go
@@ -2,9 +2,9 @@ package types
 
 // DockerfileParser is an interface that any updatecli's Dockerfile parser must verifies to be used
 type DockerfileParser interface {
-	FindInstruction(dockerfileContent []byte) bool
-	GetInstruction(dockerfileContent []byte) []StageInstructionValue
-	ReplaceInstructions(dockerfileContent []byte, sourceValue string) ([]byte, ChangedLines, error)
+	FindInstruction(dockerfileContent []byte, stage string) bool
+	GetInstruction(dockerfileContent []byte, stage string) string
+	ReplaceInstructions(dockerfileContent []byte, sourceValue, stage string) ([]byte, ChangedLines, error)
 }
 
 // ChangedLine is struct to store a single (Dockerfile-)line change's information
@@ -16,9 +16,3 @@ type LineDiff struct {
 }
 
 type Instruction interface{}
-
-// StagesInstruction is struct to store instruction value for each Dockerfile stages
-type StageInstructionValue struct {
-	StageName string
-	Value     string
-}


### PR DESCRIPTION
Fix #2022
Fix #2275 


`dockerfile` improvements

## Test

To test this pull request, you can run the following commands:

```shell
cd pkgs/plugins/dockerfile
go test
```

## Additional Information

This PR brings 4 changes to the dockerfile resources:
- Addition of the `stage` param for the Spec:
The default value (omit/empty) does not change the behaviour of the `condition` and `target`, all stages are considered for condition/targetting. But if a stage is specified, only that stage will be taken into account
- #2275 Creation of the `source`: `dockerfile now support a source attribute. Here the `stage` works a bit differently, if none is specified, then only the last stage of the dockerfile will be taken into account, otherwise we use the provided stage name. In the vast mojority of cases (non multi-stage dockerfile) this means that the argument can be safely disregarderd. 
- #2022 Refactoring of the `SimpleTextParser` to accomodate for the whole spec of the `FROM` keyword.

### Tradeoff
- The changes where only implemented to the `SimpleTextParser`, this means that the `moby` parser remains unchanged, no `source` and no `stage`
- As a docker image ref can be specified as `<image>[:<tag>][@<digest>]` we can have a situation where a dockerfile is defined with a ref such as `alpine@sha256...`. If a user uses the `dockertag` resource to update it, the image ref would become `alpine:3.1.4`. Maybe we should add a warning that the user is switching from digest specification of the ref to tag only.


