### PR TITLE
feat(core): implement retry client for http fetching

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -358,6 +358,7 @@ Successer
 Suse
 sut
 Svqx
+swp
 syft
 systemerr
 systemout

--- a/pkg/core/text/main.go
+++ b/pkg/core/text/main.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -15,6 +14,7 @@ import (
 	"github.com/hexops/gotextdiff/myers"
 	"github.com/hexops/gotextdiff/span"
 	"github.com/sirupsen/logrus"
+	httputils "github.com/updatecli/updatecli/pkg/plugins/utils/http"
 )
 
 type TextRetriever interface {
@@ -29,8 +29,9 @@ type Text struct{}
 
 // readFromURL reads a text content from an http/https url
 func readFromURL(url string, line int) (string, error) {
+	client := httputils.NewRetryClient()
 	// #nosec G107 // url is always "user-defined" so it's tainted by nature
-	resp, err := http.Get(url)
+	resp, err := client.Get(url)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/core/text/main_test.go
+++ b/pkg/core/text/main_test.go
@@ -1,0 +1,85 @@
+package text
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFile_ReadFromUrl(t *testing.T) {
+	tests := []struct {
+		name         string
+		location     string
+		mockRetry    int
+		mockBody     string
+		mockPath     string
+		mockStatus   *int
+		expectedBody string
+		expectedErr  error
+	}{
+		{
+			name:     "Success",
+			location: "https://raw.githubusercontent.com/updatecli/updatecli/v0.81.0/.dockerignore",
+			expectedBody: `bin/
+*zip
+*gz
+*.swp
+`,
+		},
+		{
+			name:         "Mocked Success",
+			mockBody:     "test",
+			expectedBody: "test",
+		},
+		{
+			name:        "404",
+			location:    "http://updatecli.io/notfound",
+			expectedErr: fmt.Errorf("URL \"http://updatecli.io/notfound\" not found or in error"),
+		},
+		{
+			name:         "Success with retry",
+			mockBody:     "test",
+			mockRetry:    1,
+			expectedBody: "test",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			location := tt.location
+			if tt.mockBody != "" {
+				currentRetry := 0
+				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if currentRetry < tt.mockRetry {
+						currentRetry += 1
+						w.WriteHeader(http.StatusGatewayTimeout)
+						return
+					}
+					if tt.mockPath != "" && r.URL.Path != tt.mockPath {
+						w.WriteHeader(http.StatusNotFound)
+						return
+					}
+					status := http.StatusOK
+					if tt.mockStatus != nil {
+						status = *tt.mockStatus
+					}
+					w.WriteHeader(status)
+					_, _ = w.Write([]byte(tt.mockBody))
+				}))
+				defer server.Close()
+				location = fmt.Sprintf("%s/%s", server.URL, tt.location)
+			}
+
+			content, err := readFromURL(location, 0)
+			if tt.expectedErr != nil {
+				assert.Error(t, err)
+				assert.Equal(t, tt.expectedErr, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.expectedBody, content)
+		})
+	}
+}

--- a/pkg/plugins/utils/http/client.go
+++ b/pkg/plugins/utils/http/client.go
@@ -1,0 +1,93 @@
+package http
+
+import (
+	"bytes"
+	"io"
+	"math"
+	"net/http"
+	"time"
+)
+
+const RetryCount = 3
+
+type retryTransport struct {
+	transport http.RoundTripper
+}
+
+func backoff(retries int) time.Duration {
+	return time.Duration(math.Pow(2, float64(retries))) * time.Second
+}
+
+func shouldRetry(err error, resp *http.Response) bool {
+	if err != nil {
+		return true
+	}
+
+	if resp.StatusCode == http.StatusBadGateway ||
+		resp.StatusCode == http.StatusServiceUnavailable ||
+		resp.StatusCode == http.StatusGatewayTimeout ||
+		resp.StatusCode == http.StatusTooManyRequests {
+		return true
+	}
+
+	return false
+}
+
+func drainBody(resp *http.Response) error {
+	if resp.Body != nil {
+		if _, err := io.Copy(io.Discard, resp.Body); err != nil {
+			return err
+		}
+		if err := resp.Body.Close(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (t *retryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Clone the request body
+	var bodyBytes []byte
+	if req.Body != nil {
+		bodyBytes, _ = io.ReadAll(req.Body)
+		req.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+	}
+
+	// Send the request
+	resp, err := t.transport.RoundTrip(req)
+
+	// Retry logic
+	retries := 0
+	for shouldRetry(err, resp) && retries < RetryCount {
+		// Wait for the specified backoff period
+		time.Sleep(backoff(retries))
+
+		// We're going to retry, consume any response to reuse the connection.
+		if err = drainBody(resp); err != nil {
+			return resp, err
+		}
+
+		// Clone the request body again
+		if req.Body != nil {
+			req.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+		}
+
+		// Retry the request
+		resp, err = t.transport.RoundTrip(req)
+
+		retries++
+	}
+
+	// Return the response
+	return resp, err
+}
+
+func NewRetryClient() *http.Client {
+	transport := &retryTransport{
+		transport: &http.Transport{},
+	}
+
+	return &http.Client{
+		Transport: transport,
+	}
+}


### PR DESCRIPTION
Add exponiental retry mechanism for fetching http resource

## Test

To test this pull request, you can run the following commands:

```shell
cd pkg/core/check
go test
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

Use a library like https://github.com/cenkalti/backoff instead of the implemented RetryClient
