### PR TITLE
fix(prow/e2e): ignore broken image and use updatecli-test

### DIFF
--- a/e2e/updatecli.d/success.d/autodiscovery/prow/prow.yaml
+++ b/e2e/updatecli.d/success.d/autodiscovery/prow/prow.yaml
@@ -3,7 +3,7 @@ scms:
   default:
     kind: git
     spec:
-      url: "https://github.com/knative/infra.git"
+      url: "https://github.com/updatecli-test/knative-infra.git"
       branch: main
 autodiscovery:
   scmid: default
@@ -13,3 +13,6 @@ autodiscovery:
       rootdir: prow/jobs/custom
       files:
         - infra.yaml
+      ignore:
+        - images:
+            - "us-docker.pkg.dev/k8s-infra-prow/images/configurator"


### PR DESCRIPTION
This pullrequest fixes the prow e2e tests by switching to a fork of knative/infra https://github.com/updatecli-test/knative-infra and then ignore failing  docker image

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
go build -o bin/updatecli
./bin/updatecli diff --config e2e/updatecli.d/success.d/autodiscovery/prow/prow.yaml
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
