### PR TITLE
chore(gha): update check-spelling to 0.0.22

### DIFF
--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -91,7 +91,7 @@ jobs:
     steps:
       - name: check-spelling
         id: spelling
-        uses: check-spelling/check-spelling@v0.0.21
+        uses: check-spelling/check-spelling@v0.0.22
         with:
           suppress_push_for_open_pull_request: 1
           checkout: true


### PR DESCRIPTION
Let's see if updating the GHA will resolve it failing on `-latest` (it wrongly detects it as `atest` cf #2758)

Changelog: https://github.com/check-spelling/check-spelling/releases/tag/v0.0.22

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
cd <to_package_directory>
go test
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
