### PR TITLE
Fix bug when gitea request fails

### DIFF
--- a/pkg/plugins/resources/gitea/pullrequest/utils.go
+++ b/pkg/plugins/resources/gitea/pullrequest/utils.go
@@ -35,7 +35,7 @@ func (g *Gitea) isPullRequestExist() (bool, error) {
 		)
 
 		if err != nil {
-			logrus.Debugf("RC: %d\nBody:\n%s", resp.Status, resp.Body)
+			logrus.Debugf("RC: %s\n", err)
 			return false, err
 		}
 


### PR DESCRIPTION
fix #2802 

Trying to print out the http status codes
results in a deferencing null when they are not
set. Thus crashing the cmd in case of an error.

As we don't know the error, it's best to just
print the error here.

### Tradeoff

There may be cases in which the body is helpful to have, however that would need to be checked.
I think further down other cases handle HTTP codes so I don't think information is lost

