### PR TITLE
fix: show pipeline as skipped if all target are skipped

### DIFF
--- a/pkg/core/pipeline/main.go
+++ b/pkg/core/pipeline/main.go
@@ -276,7 +276,6 @@ func (p *Pipeline) Run() error {
 	logrus.Infof("# %s #\n", strings.ToTitle(p.Name))
 	logrus.Infof("%s\n", strings.Repeat("#", len(p.Name)+4))
 
-	p.Report.Result = result.SUCCESS
 	resources, err := p.SortedResources()
 	if err != nil {
 		p.Report.Result = result.FAILURE
@@ -305,6 +304,30 @@ func (p *Pipeline) Run() error {
 		p.Report.Result = result.FAILURE
 		return ErrRunTargets
 	}
+
+	// set pipeline report result
+	if len(p.Targets) > 0 {
+		successCounter := 0
+		skippedCounter := 0
+		for id := range p.Targets {
+			switch p.Targets[id].Result.Result {
+			case result.FAILURE:
+				p.Report.Result = result.FAILURE
+				return nil
+			case result.SUCCESS:
+				successCounter++
+			case result.SKIPPED:
+				skippedCounter++
+			}
+		}
+
+		if len(p.Targets) == skippedCounter {
+			p.Report.Result = result.SKIPPED
+			return nil
+		}
+		p.Report.Result = result.SUCCESS
+	}
+
 	return nil
 
 }

--- a/pkg/core/pipeline/target/main.go
+++ b/pkg/core/pipeline/target/main.go
@@ -62,17 +62,22 @@ type Config struct {
 	// default:
 	//   if only one source is defined, then sourceid is set to that sourceid.
 	SourceID string `yaml:",omitempty"`
+	// ! Deprecated - please use DependsOn with `condition#conditionid` keys
+	//
 	// conditionids specifies the list of conditions to be evaluated before running the target.
 	// if at least one condition is not met, the target will be skipped.
 	//
 	// default:
 	//   by default, all conditions are evaluated.
-	// ! Deprecated - please use DependsOn with `condition#conditionid` keys
 	DeprecatedConditionIDs []string `yaml:"conditionids,omitempty"`
-	// disableconditions disables the mechanism to evaluate conditions before running the target.
+	// disableconditions disables the mechanism to evaluate all conditions before running the target.
 	//
 	// default:
 	//   false
+	//
+	// remark:
+	//  It's possible to only monitor specific conditions by setting disableconditions to true
+	//  and using DependsOn with `condition#conditionid` keys
 	DisableConditions bool `yaml:"disableconditions,omitempty"`
 }
 


### PR DESCRIPTION
This pullrequest fix a regression introduced in https://github.com/updatecli/updatecli/pull/2800
Where a pipeline would be displayed as succeeded if all targets are skipped.

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
cd <to_package_directory>
go test
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

We could apply the same logic if all conditions are skipped or all sources are skipped