### PR TITLE
feat(gittag): Add git url param to gittag plugin

### DIFF
--- a/pkg/core/pipeline/main.go
+++ b/pkg/core/pipeline/main.go
@@ -276,7 +276,6 @@ func (p *Pipeline) Run() error {
 	logrus.Infof("# %s #\n", strings.ToTitle(p.Name))
 	logrus.Infof("%s\n", strings.Repeat("#", len(p.Name)+4))
 
-	p.Report.Result = result.SUCCESS
 	resources, err := p.SortedResources()
 	if err != nil {
 		p.Report.Result = result.FAILURE
@@ -305,6 +304,30 @@ func (p *Pipeline) Run() error {
 		p.Report.Result = result.FAILURE
 		return ErrRunTargets
 	}
+
+	// set pipeline report result
+	if len(p.Targets) > 0 {
+		successCounter := 0
+		skippedCounter := 0
+		for id := range p.Targets {
+			switch p.Targets[id].Result.Result {
+			case result.FAILURE:
+				p.Report.Result = result.FAILURE
+				return nil
+			case result.SUCCESS:
+				successCounter++
+			case result.SKIPPED:
+				skippedCounter++
+			}
+		}
+
+		if len(p.Targets) == skippedCounter {
+			p.Report.Result = result.SKIPPED
+			return nil
+		}
+		p.Report.Result = result.SUCCESS
+	}
+
 	return nil
 
 }

--- a/pkg/core/pipeline/target/main.go
+++ b/pkg/core/pipeline/target/main.go
@@ -62,17 +62,22 @@ type Config struct {
 	// default:
 	//   if only one source is defined, then sourceid is set to that sourceid.
 	SourceID string `yaml:",omitempty"`
+	// ! Deprecated - please use DependsOn with `condition#conditionid` keys
+	//
 	// conditionids specifies the list of conditions to be evaluated before running the target.
 	// if at least one condition is not met, the target will be skipped.
 	//
 	// default:
 	//   by default, all conditions are evaluated.
-	// ! Deprecated - please use DependsOn with `condition#conditionid` keys
 	DeprecatedConditionIDs []string `yaml:"conditionids,omitempty"`
-	// disableconditions disables the mechanism to evaluate conditions before running the target.
+	// disableconditions disables the mechanism to evaluate all conditions before running the target.
 	//
 	// default:
 	//   false
+	//
+	// remark:
+	//  It's possible to only monitor specific conditions by setting disableconditions to true
+	//  and using DependsOn with `condition#conditionid` keys
 	DisableConditions bool `yaml:"disableconditions,omitempty"`
 }
 

--- a/pkg/plugins/resources/gitbranch/source.go
+++ b/pkg/plugins/resources/gitbranch/source.go
@@ -7,36 +7,44 @@ import (
 )
 
 // Source returns the latest git tag based on create time
-func (gt *GitBranch) Source(workingDir string, resultSource *result.Source) error {
+func (gb *GitBranch) Source(workingDir string, resultSource *result.Source) error {
+	var err error
 
-	if len(gt.spec.Path) == 0 && len(workingDir) > 0 {
-		gt.spec.Path = workingDir
+	gb.directory = workingDir
+	if gb.spec.URL != "" {
+		gb.directory, err = gb.clone()
+		if err != nil {
+			return err
+		}
+
+	} else if gb.spec.Path != "" {
+		gb.directory = gb.spec.Path
 	}
 
-	err := gt.Validate()
+	err = gb.Validate()
 	if err != nil {
 		return fmt.Errorf("validating git branch: %w", err)
 	}
 
-	tags, err := gt.nativeGitHandler.Branches(workingDir)
+	tags, err := gb.nativeGitHandler.Branches(gb.directory)
 
 	if err != nil {
 		return fmt.Errorf("retrieving branches: %w", err)
 	}
 
-	gt.foundVersion, err = gt.versionFilter.Search(tags)
+	gb.foundVersion, err = gb.versionFilter.Search(tags)
 	if err != nil {
 		return fmt.Errorf("filtering branches: %w", err)
 	}
-	value := gt.foundVersion.GetVersion()
+	value := gb.foundVersion.GetVersion()
 
 	if len(value) == 0 {
-		return fmt.Errorf("no Git Branch found matching pattern %q", gt.versionFilter.Pattern)
+		return fmt.Errorf("no Git Branch found matching pattern %q", gb.versionFilter.Pattern)
 	}
 
 	resultSource.Result = result.SUCCESS
 	resultSource.Information = value
-	resultSource.Description = fmt.Sprintf("git branch %q found matching pattern %q", value, gt.versionFilter.Pattern)
+	resultSource.Description = fmt.Sprintf("git branch %q found matching pattern %q", value, gb.versionFilter.Pattern)
 
 	return nil
 }


### PR DESCRIPTION
Similarly to https://github.com/updatecli/updatecli/pull/2848

This pull request allows using the gitbranch plugin with a URL without having to specify a scmid
Using the scmid comes with the requirement that we need to know what branch the git repository use (master vs main) as Updatecli run git checkout operation before handling a resource, but in the context of the gitbranch all we need is running git clone to retrieve the branch locally.

The gitbranch plugin can now be used in three different ways

    using the scmid to clone the repository
    using the path parameter to analyze an already cloned git repository
    using the url parameter to clone and then analyze the repository, which is more convenient for autodiscovery plugin like 

https://github.com/updatecli/updatecli/pull/1964

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
cd <to_package_directory>
go test
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
