### PR TITLE
fix(terragrunt): source block can be nil

### DIFF
--- a/pkg/plugins/autodiscovery/terragrunt/test/testdata/terraform_without_source.hcl
+++ b/pkg/plugins/autodiscovery/terragrunt/test/testdata/terraform_without_source.hcl
@@ -1,0 +1,14 @@
+terraform {}
+
+locals {}
+
+generate "main" {
+  path      = "main.tf"
+  if_exists = "overwrite_terragrunt"
+  contents  = <<EOF
+variable "tags" {
+  type = map(string)
+  default = {}
+}
+EOF
+}

--- a/pkg/plugins/autodiscovery/terragrunt/utils.go
+++ b/pkg/plugins/autodiscovery/terragrunt/utils.go
@@ -64,7 +64,11 @@ func getTerragruntModule(filename string, allowNoVersion bool) (module *terragru
 
 	for _, block := range hclfile.Body().Blocks() {
 		if block.Type() == "terraform" {
-			quotedSource := strings.TrimSpace(string(block.Body().GetAttribute("source").Expr().BuildTokens(nil).Bytes()))
+			sourceBlock := block.Body().GetAttribute("source")
+			if sourceBlock == nil {
+				return nil, nil
+			}
+			quotedSource := strings.TrimSpace(string(sourceBlock.Expr().BuildTokens(nil).Bytes()))
 			source, hclContext, err := evaluateHcl(quotedSource, data, filename)
 			if err != nil {
 				return nil, err

--- a/pkg/plugins/autodiscovery/terragrunt/utils_test.go
+++ b/pkg/plugins/autodiscovery/terragrunt/utils_test.go
@@ -26,6 +26,7 @@ func TestSearchTerragruntFiles(t *testing.T) {
 				"test/testdata/more_complex_localized.hcl",
 				"test/testdata/non_tfr.hcl",
 				"test/testdata/simple_localized.hcl",
+				"test/testdata/terraform_without_source.hcl",
 				"test/testdata/terragrunt.hcl",
 			},
 		},
@@ -155,6 +156,11 @@ func TestGetTerragruntModules(t *testing.T) {
 					sourceType:      SourceTypeGit,
 				},
 			},
+		},
+		{
+			name:           "Terragrunt terraform block without source",
+			file:           "test/testdata/terraform_without_source.hcl",
+			expectedModule: nil,
 		},
 	}
 


### PR DESCRIPTION
Fix #2976 

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
cd pkg/plugins/autodiscovery/terragrunt
go test
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
