### PR TITLE
Support maven mirror in autodiscovery

### DIFF
--- a/pkg/plugins/autodiscovery/maven/main.go
+++ b/pkg/plugins/autodiscovery/maven/main.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/mitchellh/mapstructure"
 	"github.com/sirupsen/logrus"
+	"github.com/updatecli/updatecli/pkg/plugins/resources/maven"
 	"github.com/updatecli/updatecli/pkg/plugins/utils/version"
 )
 
@@ -42,6 +43,7 @@ type Spec struct {
 		and its type like regex, semver, or just latest.
 	*/
 	VersionFilter version.Filter `yaml:",omitempty"`
+	Mirror        string         `yaml:",omotempty"`
 }
 
 // Maven hold all information needed to generate helm manifest.
@@ -63,6 +65,10 @@ func New(spec interface{}, rootDir, scmID string) (Maven, error) {
 	err := mapstructure.Decode(spec, &s)
 	if err != nil {
 		return Maven{}, err
+	}
+
+	if s.Mirror != "" {
+		maven.MavenCentralRepository = s.Mirror
 	}
 
 	dir := rootDir


### PR DESCRIPTION
Allow the maven autodiscovery crawler to be configured to use a mirror instead of upstream maven central.

Fix #3053 

<!-- Describe the changes introduced by this pull request -->

## Test

I have not yet provided a test.

## Additional Information

### Tradeoff

The `maven` crawler now needs access to the `maven` plugin in order to set a default `MavenCentralRepository`.

### Potential improvement

Parse and understand the standard maven `settings.xml` file to identify any mirrors.