### PR TITLE
Add SkipPackaging option for helm autodiscovery

### DIFF
--- a/pkg/plugins/autodiscovery/helm/container.go
+++ b/pkg/plugins/autodiscovery/helm/container.go
@@ -230,6 +230,7 @@ func (h Helm) discoverHelmContainerManifests() ([][]byte, error) {
 				TargetKey                   string
 				TargetFile                  string
 				TargetChartName             string
+				TargetChartSkipPackaging    bool
 				TargetChartVersionIncrement string
 				File                        string
 				ScmID                       string
@@ -254,6 +255,7 @@ func (h Helm) discoverHelmContainerManifests() ([][]byte, error) {
 				TargetID:                    imageSourceSlug,
 				TargetKey:                   image.yamlTagPath,
 				TargetChartName:             chartRelativeMetadataPath,
+				TargetChartSkipPackaging:    h.spec.SkipPackaging,
 				TargetChartVersionIncrement: h.spec.VersionIncrement,
 				TargetFile:                  filepath.Base(foundValueFile),
 				File:                        relativeFoundValueFile,

--- a/pkg/plugins/autodiscovery/helm/containerManifest.go
+++ b/pkg/plugins/autodiscovery/helm/containerManifest.go
@@ -48,6 +48,7 @@ targets:
       file: '{{ .TargetFile }}'
       name: '{{ .TargetChartName }}'
       key: '{{ .TargetKey }}'
+      skippackaging: {{ .TargetChartSkipPackaging }}
       versionincrement: '{{ .TargetChartVersionIncrement }}'
     sourceid: '{{ .SourceID }}'
 `
@@ -106,6 +107,7 @@ targets:
       file: '{{ .TargetFile }}'
       name: '{{ .TargetChartName }}'
       key: '{{ .TargetKey }}'
+      skippackaging: {{ .TargetChartSkipPackaging }}
       versionincrement: '{{ .TargetChartVersionIncrement }}'
     sourceid: '{{ .SourceID }}-digest'
 `
@@ -153,6 +155,7 @@ targets:
       file: '{{ .TargetFile }}'
       name: '{{ .TargetChartName }}'
       key: '{{ .TargetKey }}'
+      skippackaging: {{ .TargetChartSkipPackaging }}
       versionincrement: '{{ .TargetChartVersionIncrement }}'
     sourceid: '{{ .SourceID }}-digest'
 `

--- a/pkg/plugins/autodiscovery/helm/dependencies.go
+++ b/pkg/plugins/autodiscovery/helm/dependencies.go
@@ -136,6 +136,7 @@ func (h Helm) discoverHelmDependenciesManifests() ([][]byte, error) {
 				TargetID                    string
 				TargetKey                   string
 				TargetChartName             string
+				TargetChartSkipPackaging    bool
 				TargetChartVersionIncrement string
 				TargetFile                  string
 				File                        string
@@ -155,6 +156,7 @@ func (h Helm) discoverHelmDependenciesManifests() ([][]byte, error) {
 				TargetID:                    dependencyNameSlug,
 				TargetKey:                   fmt.Sprintf("$.dependencies[%d].version", i),
 				TargetChartName:             chartRelativeMetadataPath,
+				TargetChartSkipPackaging:    h.spec.SkipPackaging,
 				TargetChartVersionIncrement: h.spec.VersionIncrement,
 				TargetFile:                  filepath.Base(foundChartFile),
 				File:                        relativeFoundChartFile,

--- a/pkg/plugins/autodiscovery/helm/dependencyManifest.go
+++ b/pkg/plugins/autodiscovery/helm/dependencyManifest.go
@@ -37,6 +37,7 @@ targets:
       file: '{{ .TargetFile }}'
       key: '{{ .TargetKey }}'
       name: '{{ .TargetChartName }}'
+      skippackaging: {{ .TargetChartSkipPackaging }}
       versionincrement: '{{ .TargetChartVersionIncrement }}'
     sourceid: '{{ .SourceID }}'
 `

--- a/pkg/plugins/autodiscovery/helm/main.go
+++ b/pkg/plugins/autodiscovery/helm/main.go
@@ -56,6 +56,8 @@ type Spec struct {
 		and its type like regex, semver, or just latest.
 	*/
 	VersionFilter version.Filter `yaml:",omitempty"`
+	// [target] Defines if a Chart should be packaged or not.
+	SkipPackaging bool `yaml:",omitempty"`
 	// [target] Defines if a Chart changes, triggers, or not, a Chart version update, accepted values is a comma separated list of "none,major,minor,patch"
 	VersionIncrement string `yaml:",omitempty"`
 }


### PR DESCRIPTION
SkipPackaging option allows users to bypass `helm dependency update` command during the helmchart target execution. 

For umbrella charts with many dependencies, the helm dependency update command is run repeatedly during dependency checks. This process is not always required and adds unnecessary overhead, especially in large projects.