### PR TITLE
feat(temurin): introduces condition to check for Adoptium releases existence

### DIFF
--- a/e2e/updatecli.d/success.d/temurin/conditions.yaml
+++ b/e2e/updatecli.d/success.d/temurin/conditions.yaml
@@ -1,0 +1,52 @@
+name: "Test Adoptium Temurin Versions Conditions"
+pipelineid: e2e/temurin/conditions
+
+sources:
+  getLastGA17Version:
+    kind: temurin
+    spec:
+      releaseline: feature
+      releasetype: ga
+      featureversion: 17
+
+conditions:
+  checkLatestTemurin:
+    name: Temurin Check
+    kind: temurin
+    disablesourceinput: true
+  checkLatestTemurinGA17LinuxArm64:
+    name: Temurin Check
+    kind: temurin
+    disablesourceinput: true
+    spec:
+      releaseline: feature
+      releasetype: ga
+      featureversion: 17
+      architecture: aarch64
+      operatingsystem: linux
+  checkFromSpecifiedVersion:
+    name: Temurin Check
+    kind: temurin
+    disablesourceinput: true
+    spec:
+      specificversion: '{{ source "getLastGA17Version" }}'
+  checkListOfPlatforms:
+    name: Temurin Check
+    kind: temurin
+    disablesourceinput: true
+    spec:
+      specificversion: 17.0.13+11 # Known to provide all existing platform specified below
+      platforms:
+        - linux/x64
+        - linux/aarch64
+        - linux/s390x
+        - alpine-linux/x64
+        - windows/x64
+  checkPlatformForSourceInput:
+    name: Temurin Check
+    kind: temurin
+    sourceid: getLastGA17Version
+    spec:
+      platforms:
+        - linux/x64
+        - linux/aarch64

--- a/e2e/updatecli.d/success.d/temurin/sources.yaml
+++ b/e2e/updatecli.d/success.d/temurin/sources.yaml
@@ -1,5 +1,5 @@
-name: "Test Adoptium Temurin Versions Resource"
-pipelineid: e2e/adoptium
+name: "Test Adoptium Temurin Versions Sources"
+pipelineid: e2e/temurin/sources
 
 sources:
   ## Returns last LTS (implicit default)

--- a/pkg/plugins/resources/temurin/api.go
+++ b/pkg/plugins/resources/temurin/api.go
@@ -27,8 +27,7 @@ func (t Temurin) apiPerformHttpReq(endpoint string, webClient httpclient.HTTPCli
 
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
-		logrus.Errorf("something went wrong while performing a request to %q :\n%q\n", url, err)
-		return []byte{}, "", err
+		return []byte{}, "", fmt.Errorf("something went wrong while performing a request to %q:\n%s\n", url, err)
 	}
 
 	req.Header.Set("User-Agent", httputils.UserAgent)
@@ -37,8 +36,7 @@ func (t Temurin) apiPerformHttpReq(endpoint string, webClient httpclient.HTTPCli
 
 	res, err := webClient.Do(req)
 	if err != nil {
-		logrus.Errorf("something went wrong while performing a request to %q :\n%q\n", url, err)
-		return []byte{}, "", err
+		return []byte{}, "", fmt.Errorf("something went wrong while performing a request to %q:\n%s\n", url, err)
 	}
 	defer res.Body.Close()
 
@@ -46,7 +44,7 @@ func (t Temurin) apiPerformHttpReq(endpoint string, webClient httpclient.HTTPCli
 
 	if res.StatusCode >= 400 {
 		_, _ = httputil.DumpResponse(res, false)
-		return []byte{}, "", fmt.Errorf("[temurin] Caught HTTP error %d from the API.\n", res.StatusCode)
+		return []byte{}, "", fmt.Errorf("Got an HTTP error %d from the API.\n", res.StatusCode)
 	}
 
 	locationHeader = res.Header.Get("Location")
@@ -54,8 +52,7 @@ func (t Temurin) apiPerformHttpReq(endpoint string, webClient httpclient.HTTPCli
 
 	body, err = io.ReadAll(res.Body)
 	if err != nil {
-		logrus.Errorf("something went wrong while performing a request to %q :\n%q\n", url, err)
-		return []byte{}, "", err
+		return []byte{}, "", fmt.Errorf("something went wrong while decoding the answer of the request %q:\n%s\n", url, err)
 	}
 
 	return body, locationHeader, nil
@@ -142,13 +139,11 @@ func (t Temurin) apiParseVersion(version string) (result parsedVersion, err erro
 
 	body, err := t.apiGetBody(apiEndpoint)
 	if err != nil {
-		logrus.Errorf("something went wrong while parsing the version %q with the Temurin API available operating systems %q\n", version, err)
-		return result, err
+		return result, fmt.Errorf("the version %q is not a valid Temurin version.\nAPI response was: %q", version, err)
 	}
 
 	err = json.Unmarshal(body, &result)
 	if err != nil {
-		logrus.Errorf("something went wrong while decoding response from Temurin API %q\n", err)
 		return result, err
 	}
 

--- a/pkg/plugins/resources/temurin/api.go
+++ b/pkg/plugins/resources/temurin/api.go
@@ -155,14 +155,14 @@ func (t Temurin) apiParseVersion(version string) (result parsedVersion, err erro
 	return result, nil
 }
 
-func (t Temurin) apiGetReleaseName() (result string, err error) {
+func (t Temurin) apiGetReleaseNames() (result []string, err error) {
 	var versionRange string
 
 	// If user specified a custom version, we have to normalize and validate it
 	if t.spec.SpecificVersion != "" {
 		parsedVersion, err := t.apiParseVersion(t.spec.SpecificVersion)
 		if err != nil {
-			return "", err
+			return []string{}, err
 		}
 
 		versionRange = fmt.Sprintf("(%d.%d.%d, %d.%d.%d]",
@@ -179,7 +179,7 @@ func (t Temurin) apiGetReleaseName() (result string, err error) {
 		if featureVersion == 0 {
 			featureVersion, err = t.apiGetLastFeatureRelease()
 			if err != nil {
-				return "", err
+				return []string{}, err
 			}
 		}
 
@@ -213,13 +213,8 @@ func (t Temurin) apiGetReleaseName() (result string, err error) {
 		return result, fmt.Errorf("[temurin] No release found matching provided criteria. Use '--debug' to get details.")
 	}
 
-	if len(apiResult.Releases) == 0 {
-		logrus.Debug("[temurin] empty response for 'release_names'.")
-		return result, fmt.Errorf("[temurin] No release found matching provided criteria. Use '--debug' to get details.")
-	}
-
 	// Return only the most recent, e.g. the first one (sort is DESC in the URL)
-	return apiResult.Releases[0], nil
+	return apiResult.Releases, nil
 }
 
 func (t Temurin) apiGetInstallerUrl(releaseName string) (result string, err error) {

--- a/pkg/plugins/resources/temurin/condition.go
+++ b/pkg/plugins/resources/temurin/condition.go
@@ -2,8 +2,11 @@ package temurin
 
 import (
 	"fmt"
+	"strings"
 
+	"github.com/sirupsen/logrus"
 	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
+	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
 /*
@@ -11,6 +14,64 @@ Condition tests if the response of the specified HTTP request meets assertion.
 If no assertion is specified, it only checks for successful HTTP response code (HTTP/1xx, HTTP/2xx or HTTP/3xx).
 */
 func (t *Temurin) Condition(source string, scm scm.ScmHandler) (pass bool, message string, err error) {
-	message = "Condition not supported for resource of kind 'temurin'"
-	return false, message, fmt.Errorf(message)
+	if len(source) > 0 {
+		logrus.Infof("[temurin] using specific version (`spec.SpecificVersion`) from source value %q. Set `disablesourceinput` to true to avoid this behavior.", source)
+		if t.spec.SpecificVersion != "" {
+			logrus.Warning("[temurin] Overriding specified version (`spec.SpecificVersion`) with the source input value", source)
+		}
+		t.spec.SpecificVersion = source
+	}
+
+	if len(t.spec.Platforms) > 0 {
+		pass = true
+		for _, platform := range t.spec.Platforms {
+			t.spec.OperatingSystem = strings.Split(platform, "/")[0]
+			t.spec.Architecture = strings.Split(platform, "/")[1]
+
+			found, message, err := t.checkRelease()
+			if err != nil {
+				return false, "", err
+			}
+
+			if found {
+				logrus.Infof(result.SUCCESS+" (Platform %q) "+message, platform)
+			} else {
+				logrus.Infof(result.FAILURE+" (Platform %q) "+message, platform)
+			}
+
+			pass = pass && found
+		}
+
+		if pass {
+			message = "All releases found."
+		} else {
+			message = "Some releases were not found."
+		}
+
+		return pass, message, nil
+	}
+
+	return t.checkRelease()
+}
+
+func (t *Temurin) checkRelease() (pass bool, message string, err error) {
+	foundReleases, err := t.apiGetReleaseNames()
+	if err != nil {
+		return false, "", err
+	}
+
+	if len(foundReleases) == 0 {
+		return false, "No release found with specified attributes.", nil
+	}
+
+	if t.spec.SpecificVersion != "" {
+		for _, foundRelease := range foundReleases {
+			if strings.Contains(foundRelease, t.spec.SpecificVersion) {
+				return true, fmt.Sprintf("Found release %q which maps specified %q version.", foundRelease, t.spec.SpecificVersion), nil
+			}
+		}
+		return false, fmt.Sprintf("Release %q (either specified or from source input) not found with specified attributes.", t.spec.SpecificVersion), nil
+	}
+
+	return true, "Release exists.", nil
 }

--- a/pkg/plugins/resources/temurin/condition_test.go
+++ b/pkg/plugins/resources/temurin/condition_test.go
@@ -1,1 +1,178 @@
 package temurin
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/updatecli/updatecli/pkg/core/httpclient"
+	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
+)
+
+func TestCondition(t *testing.T) {
+	tests := []struct {
+		name                 string
+		spec                 Spec
+		source               string
+		scm                  scm.ScmHandler
+		mockedHTTPStatusCode map[string]int
+		mockedReleases       []string
+		mockedLocationHeader string
+		mockedParsedVersion  parsedVersion
+		mockedHttpError      error
+		want                 bool
+		wantErr              string
+	}{
+		{
+			name:           "Normal case with latest LTS and defaults",
+			mockedReleases: []string{"jdk-21.0.4+7", "jdk-21.0.3+8", "jdk-21.0.2+4"},
+			spec:           Spec{},
+			want:           true,
+		},
+		{
+			name:           "Normal case with user specified version",
+			mockedReleases: []string{"jdk-17.0.3+12", "jdk-17.0.2+9", "jdk-17.0.1+8"},
+			mockedParsedVersion: parsedVersion{
+				Major:    17,
+				Minor:    0,
+				Security: 2,
+			},
+			spec: Spec{
+				SpecificVersion: "jdk-17.0.2+9",
+			},
+			want: true,
+		},
+		{
+			name:           "Normal case with latest LTS, defaults and a source input",
+			mockedReleases: []string{"jdk-21.0.4+7", "jdk-21.0.3+8", "jdk-21.0.2+4"},
+			source:         "jdk-21.0.4+7",
+			spec:           Spec{},
+			want:           true,
+		},
+		{
+			name:           "Normal case with latest LTS, list of platforms and a source input",
+			mockedReleases: []string{"jdk-21.0.4+7", "jdk-21.0.3+8", "jdk-21.0.2+4"},
+			source:         "jdk-21.0.4+7",
+			spec: Spec{
+				Platforms: []string{"linux/x64", "windows/x64"},
+			},
+			want: true,
+		},
+		{
+			name:           "Failing case with no release found matching user provided Spec",
+			mockedReleases: []string{},
+			spec:           Spec{},
+			want:           false,
+		},
+		{
+			name:           "Failing case with user specified version not existing",
+			mockedReleases: []string{"jdk-17.0.2+9", "jdk-21.0.4+7", "jdk-21.0.3+8", "jdk-21.0.2+4"},
+			mockedParsedVersion: parsedVersion{
+				Major:    17,
+				Minor:    1,
+				Security: 9,
+			},
+			spec: Spec{
+				SpecificVersion: "17.1.9",
+			},
+			want: false,
+		},
+		{
+			name:            "Failure when HTTP request error",
+			mockedHttpError: fmt.Errorf("Connection Error"),
+			spec:            Spec{},
+			wantErr:         "Connection Error",
+		},
+		{
+			name:                 "Failure when HTTP/500 from the 'available_releases' endpoint",
+			mockedHTTPStatusCode: map[string]int{availableReleasesEndpoint: http.StatusInternalServerError},
+			spec:                 Spec{},
+			wantErr:              fmt.Sprintf("[temurin] Caught HTTP error %d from the API.\n", http.StatusInternalServerError),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sut, sutErr := New(tt.spec)
+			require.NoError(t, sutErr)
+
+			var mockedHttpClient = &httpclient.MockClient{
+				DoFunc: func(req *http.Request) (*http.Response, error) {
+
+					mockedResponse := &http.Response{
+						StatusCode: http.StatusOK,
+					}
+					mockedBody := []byte{}
+
+					requestedEndpoint := req.URL.String()
+					switch true {
+					case strings.HasPrefix(requestedEndpoint, temurinApiUrl+availableReleasesEndpoint):
+						mockedBody, _ = json.Marshal(apiInfoReleases{
+							MostRecentLTS:            21,
+							AvailableLTSReleases:     []int{21, 17, 11},
+							MostRecentFeatureRelease: 23,
+							AvailableReleases:        []int{23, 22, 21, 17, 11, 8},
+						})
+						mockedResponse.StatusCode = tt.mockedHTTPStatusCode[availableReleasesEndpoint]
+
+					case strings.HasPrefix(requestedEndpoint, temurinApiUrl+releaseNamesEndpoint):
+						mockedBody, _ = json.Marshal(releaseInformation{tt.mockedReleases})
+						mockedResponse.StatusCode = tt.mockedHTTPStatusCode[releaseNamesEndpoint]
+
+					case strings.HasPrefix(requestedEndpoint, temurinApiUrl+installersEndpoint):
+						mockedResponse.Header = map[string][]string{
+							"Location": {tt.mockedLocationHeader},
+						}
+						mockedResponse.StatusCode = tt.mockedHTTPStatusCode[installersEndpoint]
+
+					case strings.HasPrefix(requestedEndpoint, temurinApiUrl+architecturesEndpoint):
+						mockedResponse.StatusCode = tt.mockedHTTPStatusCode[architecturesEndpoint]
+
+					case strings.HasPrefix(requestedEndpoint, temurinApiUrl+osEndpoints):
+						mockedResponse.StatusCode = tt.mockedHTTPStatusCode[osEndpoints]
+
+					case strings.HasPrefix(requestedEndpoint, temurinApiUrl+checksumsEndpoint):
+						mockedResponse.Header = map[string][]string{
+							"Location": {tt.mockedLocationHeader},
+						}
+						mockedResponse.StatusCode = tt.mockedHTTPStatusCode[checksumsEndpoint]
+
+					case strings.HasPrefix(requestedEndpoint, temurinApiUrl+signaturesEndpoint):
+						mockedResponse.Header = map[string][]string{
+							"Location": {tt.mockedLocationHeader},
+						}
+						mockedResponse.StatusCode = tt.mockedHTTPStatusCode[signaturesEndpoint]
+
+					case strings.HasPrefix(requestedEndpoint, temurinApiUrl+parseVersionEndpoint):
+						mockedBody, _ = json.Marshal(tt.mockedParsedVersion)
+						mockedResponse.StatusCode = tt.mockedHTTPStatusCode[parseVersionEndpoint]
+					}
+
+					mockedResponse.Body = io.NopCloser(bytes.NewReader(mockedBody))
+
+					return mockedResponse, tt.mockedHttpError
+				},
+			}
+
+			sut.apiWebClient = mockedHttpClient
+			sut.apiWebRedirectionClient = mockedHttpClient
+
+			gotResult, _, gotErr := sut.Condition(tt.source, tt.scm)
+
+			if tt.wantErr != "" {
+				require.Error(t, gotErr)
+				assert.Equal(t, tt.wantErr, gotErr.Error())
+				return
+			}
+
+			require.NoError(t, gotErr)
+			assert.Equal(t, tt.want, gotResult)
+		})
+	}
+}

--- a/pkg/plugins/resources/temurin/condition_test.go
+++ b/pkg/plugins/resources/temurin/condition_test.go
@@ -87,13 +87,13 @@ func TestCondition(t *testing.T) {
 			name:            "Failure when HTTP request error",
 			mockedHttpError: fmt.Errorf("Connection Error"),
 			spec:            Spec{},
-			wantErr:         "Connection Error",
+			wantErr:         "something went wrong while performing a request to \"https://api.adoptium.net/v3/info/available_releases\":\nConnection Error\n",
 		},
 		{
 			name:                 "Failure when HTTP/500 from the 'available_releases' endpoint",
 			mockedHTTPStatusCode: map[string]int{availableReleasesEndpoint: http.StatusInternalServerError},
 			spec:                 Spec{},
-			wantErr:              fmt.Sprintf("[temurin] Caught HTTP error %d from the API.\n", http.StatusInternalServerError),
+			wantErr:              fmt.Sprintf("Got an HTTP error %d from the API.\n", http.StatusInternalServerError),
 		},
 	}
 

--- a/pkg/plugins/resources/temurin/main_test.go
+++ b/pkg/plugins/resources/temurin/main_test.go
@@ -31,21 +31,65 @@ func TestNew(t *testing.T) {
 			spec: Spec{
 				Architecture: "apple-silicon",
 			},
-			wantErr: "[temurin] Specified architecture \"apple-silicon\" is not a valid Temurin architecture ([x64 x32 ppc64 ppc64le s390x aarch64 arm sparcv9 riscv64])",
+			wantErr: "[temurin] Specified architecture \"apple-silicon\" is not a valid Temurin architecture (check https://api.adoptium.net/q/swagger-ui/#/Types for valid list)",
 		},
 		{
 			name: "Failing case with invalid Temurin os",
 			spec: Spec{
 				OperatingSystem: "archlinux",
 			},
-			wantErr: "[temurin] Specified operating system ('os') \"archlinux\" is not a valid Temurin architecture ([linux windows mac solaris aix alpine-linux])",
+			wantErr: "[temurin] Specified operating system \"archlinux\" is not a valid Temurin architecture (check https://api.adoptium.net/q/swagger-ui/#/Types for valid list)",
 		},
 		{
 			name: "Failing case with invalid Temurin release type",
 			spec: Spec{
 				OperatingSystem: "foo",
 			},
-			wantErr: "[temurin] Specified operating system ('os') \"foo\" is not a valid Temurin architecture ([linux windows mac solaris aix alpine-linux])",
+			wantErr: "[temurin] Specified operating system \"foo\" is not a valid Temurin architecture (check https://api.adoptium.net/q/swagger-ui/#/Types for valid list)",
+		},
+		{
+			name: "Failing case with invalid platform type (1)",
+			spec: Spec{
+				Platforms: []string{"linux/x64", "aarch64/windows"},
+			},
+			wantErr: "[temurin] Specified platform \"aarch64/windows\" is not a valid Temurin platform: \"aarch64\" is not a valid Operating System (check https://api.adoptium.net/q/swagger-ui/#/Types for valid list).",
+		},
+		{
+			name: "Failing case with invalid platform type (2)",
+			spec: Spec{
+				Platforms: []string{"linux"},
+			},
+			wantErr: "[temurin] Specified platform \"linux\" is not a valid Temurin platform: it misses a CPU architecture.",
+		},
+		{
+			name: "Failing case with invalid platform type (3)",
+			spec: Spec{
+				Platforms: []string{"linux/x64/aarch64"},
+			},
+			wantErr: "[temurin] Specified platform \"linux/x64/aarch64\" is not a valid Temurin platform: too much items specified.",
+		},
+		{
+			name: "Failing case with invalid platform type (4)",
+			spec: Spec{
+				Platforms: []string{"linux/foo"},
+			},
+			wantErr: "[temurin] Specified platform \"linux/foo\" is not a valid Temurin platform: \"foo\" is not a valid Architecture (check https://api.adoptium.net/q/swagger-ui/#/Types for valid list).",
+		},
+		{
+			name: "Failing case with both platforms and OS specified",
+			spec: Spec{
+				OperatingSystem: "linux",
+				Platforms:       []string{"linux/x64"},
+			},
+			wantErr: "[temurin] `spec.platform` and `spec.operatingsystem` are mutually exclusive.",
+		},
+		{
+			name: "Failing case with both platforms and Architecture specified",
+			spec: Spec{
+				Architecture: "x64",
+				Platforms:    []string{"linux/x64"},
+			},
+			wantErr: "[temurin] `spec.platform` and `spec.architecture` are mutually exclusive.",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/plugins/resources/temurin/source.go
+++ b/pkg/plugins/resources/temurin/source.go
@@ -3,56 +3,64 @@ package temurin
 import (
 	"fmt"
 
+	"github.com/sirupsen/logrus"
 	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
 func (t *Temurin) Source(workingDir string, resultSource *result.Source) error {
 	// Start by getting the version (required in any case)
-	releaseName, err := t.apiGetReleaseName()
+	releaseNames, err := t.apiGetReleaseNames()
 	if err != nil {
 		resultSource.Result = result.FAILURE
 		return err
 	}
 
-	t.foundVersion = releaseName
+	if len(releaseNames) == 0 {
+		logrus.Debug("[temurin] empty response for 'release_names'.")
+		resultSource.Result = result.FAILURE
+		return fmt.Errorf("[temurin] No release found matching provided criteria. Use '--debug' to get details.")
+	}
+
+	// Only get the most recent, e.g. the first one (DESC order)
+	t.foundVersion = releaseNames[0]
 
 	switch t.spec.Result {
 	case "version":
 		resultSource.Result = result.SUCCESS
-		resultSource.Description = fmt.Sprintf("[temurin] found version %q", releaseName)
-		resultSource.Information = releaseName
+		resultSource.Description = fmt.Sprintf("[temurin] found version %q", t.foundVersion)
+		resultSource.Information = t.foundVersion
 		return nil
 
 	case "installer_url":
-		installerUrl, err := t.apiGetInstallerUrl(releaseName)
+		installerUrl, err := t.apiGetInstallerUrl(t.foundVersion)
 		if err != nil {
 			resultSource.Result = result.FAILURE
 			return err
 		}
 		resultSource.Result = result.SUCCESS
-		resultSource.Description = fmt.Sprintf("[temurin] found installer URL %q (version %q)", installerUrl, releaseName)
+		resultSource.Description = fmt.Sprintf("[temurin] found installer URL %q (version %q)", installerUrl, t.foundVersion)
 		resultSource.Information = installerUrl
 		return nil
 
 	case "checksum_url":
-		installerChecksumUrl, err := t.apiGetChecksumUrl(releaseName)
+		installerChecksumUrl, err := t.apiGetChecksumUrl(t.foundVersion)
 		if err != nil {
 			resultSource.Result = result.FAILURE
 			return err
 		}
 		resultSource.Result = result.SUCCESS
-		resultSource.Description = fmt.Sprintf("[temurin] found installer checksum URL %q (version %q)", installerChecksumUrl, releaseName)
+		resultSource.Description = fmt.Sprintf("[temurin] found installer checksum URL %q (version %q)", installerChecksumUrl, t.foundVersion)
 		resultSource.Information = installerChecksumUrl
 		return nil
 
 	case "signature_url":
-		signatureUrl, err := t.apiGetSignatureUrl(releaseName)
+		signatureUrl, err := t.apiGetSignatureUrl(t.foundVersion)
 		if err != nil {
 			resultSource.Result = result.FAILURE
 			return err
 		}
 		resultSource.Result = result.SUCCESS
-		resultSource.Description = fmt.Sprintf("[temurin] found installer signature URL %q (version %q)", signatureUrl, releaseName)
+		resultSource.Description = fmt.Sprintf("[temurin] found installer signature URL %q (version %q)", signatureUrl, t.foundVersion)
 		resultSource.Information = signatureUrl
 		return nil
 

--- a/pkg/plugins/resources/temurin/source_test.go
+++ b/pkg/plugins/resources/temurin/source_test.go
@@ -95,21 +95,21 @@ func TestSource(t *testing.T) {
 			mockedHttpError: fmt.Errorf("Connection Error"),
 			spec:            Spec{},
 			wantStatus:      result.FAILURE,
-			wantErr:         "Connection Error",
+			wantErr:         "something went wrong while performing a request to \"https://api.adoptium.net/v3/info/available_releases\":\nConnection Error\n",
 		},
 		{
 			name:                 "Failure when HTTP/500 from the 'available_releases' endpoint",
 			mockedHTTPStatusCode: map[string]int{availableReleasesEndpoint: http.StatusInternalServerError},
 			spec:                 Spec{},
 			wantStatus:           result.FAILURE,
-			wantErr:              fmt.Sprintf("[temurin] Caught HTTP error %d from the API.\n", http.StatusInternalServerError),
+			wantErr:              fmt.Sprintf("Got an HTTP error %d from the API.\n", http.StatusInternalServerError),
 		},
 		{
 			name:                 "Failure when HTTP/500 from the 'release_names' endpoint",
 			mockedHTTPStatusCode: map[string]int{releaseNamesEndpoint: http.StatusInternalServerError},
 			spec:                 Spec{},
 			wantStatus:           result.FAILURE,
-			wantErr:              fmt.Sprintf("[temurin] Caught HTTP error %d from the API.\n", http.StatusInternalServerError),
+			wantErr:              fmt.Sprintf("Got an HTTP error %d from the API.\n", http.StatusInternalServerError),
 		},
 		{
 			name:                 "Failure when HTTP/500 from the '" + installersEndpoint + "' endpoint",
@@ -119,7 +119,7 @@ func TestSource(t *testing.T) {
 				Result: "installer_url",
 			},
 			wantStatus: result.FAILURE,
-			wantErr:    fmt.Sprintf("[temurin] Caught HTTP error %d from the API.\n", http.StatusInternalServerError),
+			wantErr:    fmt.Sprintf("Got an HTTP error %d from the API.\n", http.StatusInternalServerError),
 		},
 		{
 			name: "Failure when HTTP/500 from the '/version' endpoint",
@@ -129,7 +129,7 @@ func TestSource(t *testing.T) {
 				SpecificVersion: "17.0.2",
 			},
 			wantStatus: result.FAILURE,
-			wantErr:    fmt.Sprintf("[temurin] Caught HTTP error %d from the API.\n", http.StatusInternalServerError),
+			wantErr:    "the version \"17.0.2\" is not a valid Temurin version.\nAPI response was: \"Got an HTTP error 500 from the API.\\n\"",
 		},
 		{
 			name:                 "Failure when HTTP/500 from the 'checksum/version' endpoint",
@@ -139,7 +139,7 @@ func TestSource(t *testing.T) {
 				Result: "checksum_url",
 			},
 			wantStatus: result.FAILURE,
-			wantErr:    fmt.Sprintf("[temurin] Caught HTTP error %d from the API.\n", http.StatusInternalServerError),
+			wantErr:    fmt.Sprintf("Got an HTTP error %d from the API.\n", http.StatusInternalServerError),
 		},
 		{
 			name:                 "Failure when HTTP/500 from the 'signature/version' endpoint",
@@ -149,7 +149,7 @@ func TestSource(t *testing.T) {
 				Result: "signature_url",
 			},
 			wantStatus: result.FAILURE,
-			wantErr:    fmt.Sprintf("[temurin] Caught HTTP error %d from the API.\n", http.StatusInternalServerError),
+			wantErr:    fmt.Sprintf("Got an HTTP error %d from the API.\n", http.StatusInternalServerError),
 		},
 		{
 			name:           "Failure when 'release_names' provides empty results",

--- a/pkg/plugins/resources/temurin/spec.go
+++ b/pkg/plugins/resources/temurin/spec.go
@@ -33,7 +33,8 @@ type Spec struct {
 	// * "checksum_url" (HTTP URL to the checksum file)
 	// * "signature_url" (HTTP URL to the signature file)
 	Result string `yaml:",omitempty"`
-	// Architecture specifies the CPU architecture to filter the Temurin release to retrieve.
+	// Architecture specifies the CPU architecture (as defined by the Temurin API - https://api.adoptium.net/q/swagger-ui/#/Types)
+	// to filter the Temurin release to retrieve.
 	//
 	// default: "x64"
 	//
@@ -61,7 +62,8 @@ type Spec struct {
 	// * "source
 	// * "sbom"
 	ImageType string `yaml:",omitempty"`
-	// OperatingSystem specifies the Operating System to filter the Temurin release to retrieve.
+	// OperatingSystem specifies the Operating System (as defined by the Temurin API - https://api.adoptium.net/q/swagger-ui/#/Types)
+	// to filter the Temurin release to retrieve.
 	//
 	// default: "linux"
 	//
@@ -78,7 +80,7 @@ type Spec struct {
 	//
 	// default: undefined
 	//
-	// Allowed values: string (can be a semantic version, a JDK version or a temurin release name)
+	// Allowed values: string (can be a semantic version, a JDK version or a Temurin release name)
 	SpecificVersion string `yaml:",omitempty"`
 	// Project specifies the project to filter the Temurin release to retrieve.
 	//
@@ -91,4 +93,17 @@ type Spec struct {
 	// * "jfr"
 	// * "shenandoah"
 	Project string `yaml:",omitempty"`
+	// Platforms is only valid within conditions. It specifies a collection of platforms as a filter for Temurin releases.
+	// Each platform must be a combination of an Operating System and a CPU architecture separated by the slash (`/`) character.
+	//
+	// default: empty list (e.g. no filtering per platform).
+	//
+	// Allowed values: Any combination of Operating System and Architecture as defined by the Temurin API (https://api.adoptium.net/q/swagger-ui/#/Types):
+	// * `linux/x64`
+	// * `linux/aarch64`
+	// * `linux/s390x`
+	// * `alpine-linux/x64`
+	// * `windows/x64`
+	// ...
+	Platforms []string `yaml:",omitempty"`
 }


### PR DESCRIPTION
Fix #2915

This PR introduces a new condition for the resource type `temurin`

- Supports specific version through source input or `spec`
- Introduces a condition-only keyword: `platforms` to check for multiple combinations of CPU Architecture and Operating Systems.

Associated documentation PR: https://github.com/updatecli/website/pull/1874

## Test

To test this pull request, you can run the following commands:

```shell
cd pkg/plugins/resources/temurin/
go test
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
