### PR TITLE
feat: add mermaid graph flavour

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yml
@@ -47,6 +47,19 @@ body:
     required: false
 - type: textarea
   attributes:
+    label: Pipeline Graph
+    description: |
+      Graph output of your pipeline, can be obtained with
+      ```bash
+      updatecli manifest show --graph --graph-flavour mermaid --experimental --config <your-pipeline.yaml>
+      ```
+    value: |
+      ```mermaid
+      ```
+  validations:
+    required: false
+- type: textarea
+  attributes:
     label: Anything else?
     description: |
       Links? References? Screenshots? Anything that will give us more context about the issue you are encountering!

--- a/.github/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yml
@@ -51,7 +51,7 @@ body:
     description: |
       Graph output of your pipeline, can be obtained with
       ```bash
-      updatecli manifest show --graph --graph-flavour mermaid --experimental --config <your-pipeline.yaml>
+      updatecli manifest show --graph --graph-flavor mermaid --experimental --config <your-pipeline.yaml>
       ```
     value: |
       ```mermaid

--- a/cmd/manifest_show.go
+++ b/cmd/manifest_show.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/updatecli/updatecli/pkg/core/config"
 	"github.com/updatecli/updatecli/pkg/core/engine/manifest"
+	"github.com/updatecli/updatecli/pkg/core/pipeline"
 )
 
 var (
@@ -16,7 +17,7 @@ var (
 	manifestShowDisablePrepare    bool
 	manifestShowDisableTemplating bool
 	manifestShowGraph             bool
-	manifestShowGraphFlavour      string
+	manifestShowGraphFlavor       string
 
 	manifestShowCmd = &cobra.Command{
 		Args:  cobra.MatchAll(cobra.MaximumNArgs(1)),
@@ -45,12 +46,13 @@ var (
 					logrus.Warningf("The '--graph' flag requires the flag experimental to work.")
 					os.Exit(1)
 				}
-				e.Options.DisplayFlavour = "graph"
-				if manifestShowGraphFlavour != "dot" && manifestShowGraphFlavour != "mermaid" {
-					logrus.Warningf("The '--graph-flavour' flag should be `dot` or `mermaid`, defaulting to `dot`.")
-					manifestShowGraphFlavour = "dot"
+				e.Options.DisplayFlavor = "graph"
+				err := pipeline.ValidateGraphFlavor(manifestShowGraphFlavor)
+				if err != nil {
+					logrus.Errorf("Invalid graph flavor: %s", err)
+					os.Exit(1)
 				}
-				e.Options.GraphFlavour = manifestShowGraphFlavour
+				e.Options.GraphFlavor = manifestShowGraphFlavor
 			}
 
 			// Showing templating diff may leak sensitive information such as credentials
@@ -74,7 +76,7 @@ func init() {
 	manifestShowCmd.Flags().BoolVar(&manifestShowDisableTemplating, "disable-templating", false, "Disable manifest templating")
 	manifestShowCmd.Flags().BoolVar(&disableTLS, "disable-tls", false, "Disable TLS verification like '--disable-tls=true'")
 	manifestShowCmd.Flags().BoolVar(&manifestShowGraph, "graph", false, "Output in graph format")
-	manifestShowCmd.Flags().StringVar(&manifestShowGraphFlavour, "graph-flavour", "dot", "Flavour of graph format")
+	manifestShowCmd.Flags().StringVar(&manifestShowGraphFlavor, "graph-flavor", "dot", "Flavor of graph format")
 
 	manifestCmd.AddCommand(manifestShowCmd)
 }

--- a/cmd/manifest_show.go
+++ b/cmd/manifest_show.go
@@ -16,6 +16,7 @@ var (
 	manifestShowDisablePrepare    bool
 	manifestShowDisableTemplating bool
 	manifestShowGraph             bool
+	manifestShowGraphFlavour      string
 
 	manifestShowCmd = &cobra.Command{
 		Args:  cobra.MatchAll(cobra.MaximumNArgs(1)),
@@ -45,6 +46,11 @@ var (
 					os.Exit(1)
 				}
 				e.Options.DisplayFlavour = "graph"
+				if manifestShowGraphFlavour != "dot" && manifestShowGraphFlavour != "mermaid" {
+					logrus.Warningf("The '--graph-flavour' flag should be `dot` or `mermaid`, defaulting to `dot`.")
+					manifestShowGraphFlavour = "dot"
+				}
+				e.Options.GraphFlavour = manifestShowGraphFlavour
 			}
 
 			// Showing templating diff may leak sensitive information such as credentials
@@ -68,6 +74,7 @@ func init() {
 	manifestShowCmd.Flags().BoolVar(&manifestShowDisableTemplating, "disable-templating", false, "Disable manifest templating")
 	manifestShowCmd.Flags().BoolVar(&disableTLS, "disable-tls", false, "Disable TLS verification like '--disable-tls=true'")
 	manifestShowCmd.Flags().BoolVar(&manifestShowGraph, "graph", false, "Output in graph format")
+	manifestShowCmd.Flags().StringVar(&manifestShowGraphFlavour, "graph-flavour", "dot", "Flavour of graph format")
 
 	manifestCmd.AddCommand(manifestShowCmd)
 }

--- a/pkg/core/engine/manifest_show.go
+++ b/pkg/core/engine/manifest_show.go
@@ -8,7 +8,7 @@ func (e *Engine) Show() (err error) {
 		PrintTitle(pipeline.Config.Spec.Name)
 
 		if e.Options.DisplayFlavour == "graph" {
-			err = pipeline.Graph()
+			err = pipeline.Graph(e.Options.GraphFlavour)
 		} else {
 			err = pipeline.Config.Display()
 		}

--- a/pkg/core/engine/manifest_show.go
+++ b/pkg/core/engine/manifest_show.go
@@ -7,8 +7,8 @@ func (e *Engine) Show() (err error) {
 
 		PrintTitle(pipeline.Config.Spec.Name)
 
-		if e.Options.DisplayFlavour == "graph" {
-			err = pipeline.Graph(e.Options.GraphFlavour)
+		if e.Options.DisplayFlavor == "graph" {
+			err = pipeline.Graph(e.Options.GraphFlavor)
 		} else {
 			err = pipeline.Config.Display()
 		}

--- a/pkg/core/engine/options.go
+++ b/pkg/core/engine/options.go
@@ -8,9 +8,9 @@ import (
 
 // Options defines application specific behaviors
 type Options struct {
-	Config         config.Option
-	Pipeline       pipeline.Options
-	Manifests      []manifest.Manifest
-	DisplayFlavour string
-	GraphFlavour   string
+	Config        config.Option
+	Pipeline      pipeline.Options
+	Manifests     []manifest.Manifest
+	DisplayFlavor string
+	GraphFlavor   string
 }

--- a/pkg/core/engine/options.go
+++ b/pkg/core/engine/options.go
@@ -12,4 +12,5 @@ type Options struct {
 	Pipeline       pipeline.Options
 	Manifests      []manifest.Manifest
 	DisplayFlavour string
+	GraphFlavour   string
 }


### PR DESCRIPTION
Fix #3161 

Add a new flavour to graph output

Given a pipeline we can now get a graph that can be easily added in a github comment
```bash
updatecli manifest show --graph --graph-flavour mermaid --experimental --config <your-pipeline.yaml>
```

```mermaid
graph TD
    condition#1{"Should be succeeding (shell)"}
    condition#1 --> target#3
    target#3("Should be skipped (shell)")
    condition#1 --> target#1
    target#1("Should be succeeding (shell)")
    target#1 --> target#3
    condition#1 --> target#2
    target#2("Should be succeeding (shell)")
    target#2 --> target#3
    source#1(["Should be succeeding (shell)"])
    source#1 --> target#3
```