### PR TITLE
lp/loop: implement looping

### DIFF
--- a/e2e/updatecli.d/success.d/loops.yaml
+++ b/e2e/updatecli.d/success.d/loops.yaml
@@ -1,0 +1,48 @@
+name: Loops
+pipelineid: e2e/loops
+
+sources:
+  create_dummy_json:
+    name: Create Fake Json
+    kind: shell
+    spec:
+      command: "echo '{\"o\": [\"0\", \"1\", \"2\"]}'"
+  dummy_json_filepath:
+    name: Create Random uuid
+    kind: shell
+    spec:
+      command: "uuidgen"
+    transformers:
+      - addprefix: "/tmp/update_cli_e2e_loops_"
+      - addsuffix: ".json"
+  read_dummy_json_file:
+    name: Read our fake json
+    kind: json
+    dependson:
+      - target#create_dummy_json_file
+    islist: true
+    spec:
+      file: '{{ source "dummy_json_filepath" }}'
+      query: ".o.[*]"
+targets:
+  create_dummy_json_file:
+    kind: file
+    sourceid: create_dummy_json
+    spec:
+      file: '{{ source "dummy_json_filepath" }}'
+      forcecreate: true
+  delete_dummy_json_file:
+    kind: shell
+    dependson:
+      - source#read_dummy_json_file
+    disablesourceinput: true
+    spec:
+      command: 'rm {{ source "dummy_json_filepath" }}'
+  echo_json_value:
+    kind: shell
+    dependson:
+      - target#delete_dummy_json_file # Only there to ensure we execute after
+    sourceid: read_dummy_json_file
+    iterateonsource: true
+    spec:
+      command: echo

--- a/pkg/core/config/funcsUpdatecli.go
+++ b/pkg/core/config/funcsUpdatecli.go
@@ -77,7 +77,19 @@ func updatecliRuntimeFuncMap(data interface{}) template.FuncMap {
 
 			switch sourceResult {
 			case result.SUCCESS:
-				return getFieldValueByQuery(data, []string{"Sources", s, "Output"})
+				isList, err := getFieldByQuery(data, []string{"Sources", s, "Config", "IsList"})
+				if err != nil {
+					return "", err
+				}
+				query := []string{"Sources", s, "Output", "Value"}
+				if isList.Bool() {
+					query = []string{"Sources", s, "ListOutput", "0", "Value"}
+				}
+				output, err := getFieldValueByQuery(data, query)
+				if err != nil {
+					return "", err
+				}
+				return output, nil
 			case result.FAILURE:
 				return "", fmt.Errorf("parent source %q failed", s)
 			// If the result of the parent source execution is not SUCCESS or FAILURE, then it means it was either skipped or not already run.

--- a/pkg/core/pipeline/actions.go
+++ b/pkg/core/pipeline/actions.go
@@ -88,7 +88,7 @@ func (p *Pipeline) RunActions() error {
 
 			if p.Sources[p.Targets[t].Config.SourceID].Changelog != "" {
 				actionTarget.Changelogs = append(actionTarget.Changelogs, reports.ActionTargetChangelog{
-					Title:       p.Sources[p.Targets[t].Config.SourceID].Output,
+					Title:       p.Sources[p.Targets[t].Config.SourceID].Output.Value,
 					Description: p.Sources[p.Targets[t].Config.SourceID].Changelog,
 				})
 			}

--- a/pkg/core/pipeline/conditions.go
+++ b/pkg/core/pipeline/conditions.go
@@ -11,7 +11,7 @@ func (p *Pipeline) RunCondition(id string) (r string, err error) {
 	condition := p.Conditions[id]
 	condition.Config = p.Config.Spec.Conditions[id]
 	condition.Result.Name = condition.Config.ResourceConfig.Name
-	err = condition.Run(p.Sources[condition.Config.SourceID].Output)
+	err = condition.Run(p.Sources[condition.Config.SourceID].Output.Value)
 	p.Conditions[id] = condition
 	return condition.Result.Result, err
 }

--- a/pkg/core/pipeline/main.go
+++ b/pkg/core/pipeline/main.go
@@ -132,7 +132,9 @@ func (p *Pipeline) Init(config *config.Config, options Options) error {
 			Result: result.Source{
 				Result: result.SKIPPED,
 			},
-			Scm: scmPointer,
+			Output:     result.SourceInformation{},
+			ListOutput: []result.SourceInformation{},
+			Scm:        scmPointer,
 		}
 
 		r := p.Sources[id].Result

--- a/pkg/core/pipeline/main_test.go
+++ b/pkg/core/pipeline/main_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/updatecli/updatecli/pkg/core/config"
 	"github.com/updatecli/updatecli/pkg/core/pipeline/target"
+	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
 /*
@@ -14,11 +15,13 @@ import (
 func TestRun(t *testing.T) {
 
 	testdata := []struct {
-		confPath                 string
-		expectedSourcesResult    map[string]string
-		expectedConditionsResult map[string]string
-		expectedTargetsResult    map[string]string
-		expectedPipelineResult   string
+		confPath                    string
+		expectedSourcesResult       map[string]string
+		expectedSourcesInformations map[string][]result.SourceInformation
+		expectedConditionsResult    map[string]string
+		expectedTargetsResult       map[string]string
+		expectedPipelineResult      string
+		targetDryRun                bool
 	}{
 		{
 			confPath: "../../../e2e/updatecli.d/success.d/command.yaml",
@@ -35,6 +38,7 @@ func TestRun(t *testing.T) {
 				"7": "✔",
 			},
 			expectedPipelineResult: "⚠",
+			targetDryRun:           true,
 		}, {
 			confPath: "../../../e2e/updatecli.d/success.d/dependsonchangeor.yaml",
 			expectedSourcesResult: map[string]string{
@@ -49,17 +53,48 @@ func TestRun(t *testing.T) {
 				"3": "-",
 			},
 			expectedPipelineResult: "✔",
+			targetDryRun:           true,
+		}, {
+			confPath: "../../../e2e/updatecli.d/success.d/loops.yaml",
+			expectedSourcesResult: map[string]string{
+				"create_dummy_json":    result.SUCCESS,
+				"dummy_json_filepath":  result.SUCCESS,
+				"read_dummy_json_file": result.SUCCESS,
+			},
+			expectedSourcesInformations: map[string][]result.SourceInformation{
+				"create_dummy_json": {{
+					Value: "{\"o\": [\"0\", \"1\", \"2\"]}",
+				}},
+				"read_dummy_json_file": {{
+					Key:   "0",
+					Value: "0",
+				}, {
+					Key:   "1",
+					Value: "1",
+				}, {
+					Key:   "2",
+					Value: "2",
+				}},
+			},
+			expectedConditionsResult: map[string]string{},
+			expectedTargetsResult: map[string]string{
+				"create_dummy_json_file": result.ATTENTION,
+				"delete_dummy_json_file": result.SUCCESS,
+				"echo_json_value":        result.ATTENTION,
+			},
+			expectedPipelineResult: result.ATTENTION,
 		},
 	}
 
 	for _, data := range testdata {
-		c, _ := config.New(config.Option{
+		c, err := config.New(config.Option{
 			ManifestFile: data.confPath,
 		})
+		require.NoError(t, err)
 		p := Pipeline{}
 		_ = p.Init(&c[0], Options{
 			Target: target.Options{
-				DryRun: true,
+				DryRun: data.targetDryRun,
 			},
 		})
 		t.Run(p.Config.Spec.Name, func(t *testing.T) {
@@ -72,6 +107,9 @@ func TestRun(t *testing.T) {
 			require.Equal(t, len(data.expectedSourcesResult), len(p.Sources))
 			for id, result := range p.Sources {
 				require.Equal(t, data.expectedSourcesResult[id], result.Result.Result)
+			}
+			for id, expectedSourceInformations := range data.expectedSourcesInformations {
+				require.Equal(t, expectedSourceInformations, p.Sources[id].Result.Information)
 			}
 			require.Equal(t, len(data.expectedConditionsResult), len(p.Conditions))
 			for id, result := range p.Conditions {

--- a/pkg/core/pipeline/resource/main.go
+++ b/pkg/core/pipeline/resource/main.go
@@ -68,6 +68,8 @@ type ResourceConfig struct {
 	DependsOn []string `yaml:",omitempty"`
 	// IsList defines if the output should be stored as a list
 	IsList bool `yaml:",omitempty"`
+	// IterateOnSource defines if we should iterate on the input (a source with islist set to `true`)
+	IterateOnSource bool `yaml:",omitempty"`
 	// name specifies the resource name
 	Name string `yaml:",omitempty"`
 	// kind specifies the resource kind which defines accepted spec value

--- a/pkg/core/pipeline/resource/main.go
+++ b/pkg/core/pipeline/resource/main.go
@@ -257,7 +257,7 @@ func New(rs ResourceConfig) (resource Resource, err error) {
 type Resource interface {
 	Source(workingDir string, sourceResult *result.Source) error
 	Condition(version string, scm scm.ScmHandler) (pass bool, message string, err error)
-	Target(source string, scm scm.ScmHandler, dryRun bool, targetResult *result.Target) (err error)
+	Target(source result.SourceInformation, scm scm.ScmHandler, dryRun bool, targetResult *result.Target) (err error)
 	Changelog() string
 }
 

--- a/pkg/core/pipeline/resource/main.go
+++ b/pkg/core/pipeline/resource/main.go
@@ -66,6 +66,8 @@ type ResourceConfig struct {
 	//   The parameters "sourceid" and "conditionsids" affect the order of resource execution.
 	//   To avoid circular dependencies, the depended resource may need to remove any conditionids or set "disablesourceinput to true".
 	DependsOn []string `yaml:",omitempty"`
+	// IsList defines if the output should be stored as a list
+	IsList bool `yaml:",omitempty"`
 	// name specifies the resource name
 	Name string `yaml:",omitempty"`
 	// kind specifies the resource kind which defines accepted spec value
@@ -185,7 +187,7 @@ func New(rs ResourceConfig) (resource Resource, err error) {
 
 	case "json":
 
-		return json.New(rs.Spec)
+		return json.New(rs.Spec, rs.IsList)
 
 	case "maven":
 

--- a/pkg/core/pipeline/source/main.go
+++ b/pkg/core/pipeline/source/main.go
@@ -36,8 +36,6 @@ type Source struct {
 // Config struct defines a source configuration
 type Config struct {
 	resource.ResourceConfig `yaml:",inline"`
-	// List defines if the output should be stored as a list
-	List bool `yaml:",omitempty"`
 }
 
 var (
@@ -94,7 +92,7 @@ func (s *Source) Run() (err error) {
 
 	err = source.Source(workingDir, &s.Result)
 
-	if s.Config.List {
+	if s.Config.IsList {
 		s.ListOutput = s.Result.Information
 	} else {
 		if len(s.Result.Information) > 1 {
@@ -123,7 +121,7 @@ func (s *Source) Run() (err error) {
 	s.Result.Changelog = s.Changelog
 
 	if len(s.Config.ResourceConfig.Transformers) > 0 {
-		if s.Config.List {
+		if s.Config.IsList {
 			transformedOutputs := []result.SourceInformation{}
 			for _, output := range s.ListOutput {
 				value, err := s.Config.ResourceConfig.Transformers.Apply(output.Value)
@@ -149,7 +147,7 @@ func (s *Source) Run() (err error) {
 	}
 
 	if s.Result.Result == result.SUCCESS {
-		if s.Config.List {
+		if s.Config.IsList {
 			for _, output := range s.ListOutput {
 				if len(output.Value) == 0 {
 					logrus.Debugln("empty source detected")

--- a/pkg/core/pipeline/target/main.go
+++ b/pkg/core/pipeline/target/main.go
@@ -99,7 +99,7 @@ func (t *Target) Check() (bool, error) {
 }
 
 // Run applies a specific target configuration
-func (t *Target) Run(source string, o *Options) (err error) {
+func (t *Target) Run(source result.SourceInformation, o *Options) (err error) {
 	var consoleOutput bytes.Buffer
 	// By default logrus logs to stderr, so I guess we want to keep this behavior...
 	logrus.SetOutput(io.MultiWriter(os.Stdout, &consoleOutput))
@@ -118,7 +118,7 @@ func (t *Target) Run(source string, o *Options) (err error) {
 	}
 
 	if len(t.Config.ResourceConfig.Transformers) > 0 {
-		source, err = t.Config.ResourceConfig.Transformers.Apply(source)
+		source.Value, err = t.Config.ResourceConfig.Transformers.Apply(source.Value) // TODO: switch to use source
 		if err != nil {
 			failTargetRun()
 			return err

--- a/pkg/core/pipeline/targets.go
+++ b/pkg/core/pipeline/targets.go
@@ -38,7 +38,7 @@ func (p *Pipeline) RunTarget(id string) (r string, changed bool, err error) {
 	}
 	if err == nil {
 		for _, output := range sourceOutputs {
-			err = target.Run(output.Value, &p.Options.Target)
+			err = target.Run(output, &p.Options.Target)
 			if err != nil {
 				break
 			}

--- a/pkg/core/pipeline/targets.go
+++ b/pkg/core/pipeline/targets.go
@@ -27,7 +27,7 @@ func (p *Pipeline) RunTarget(id string) (r string, changed bool, err error) {
 	// Ensure the result named contains the up to date target name after templating
 	target.Result.Name = target.Config.ResourceConfig.Name
 	target.Result.DryRun = target.DryRun
-	err = target.Run(p.Sources[target.Config.SourceID].Output, &p.Options.Target)
+	err = target.Run(p.Sources[target.Config.SourceID].Output.Value, &p.Options.Target)
 
 	if err != nil {
 		p.Report.Result = result.FAILURE

--- a/pkg/core/result/source.go
+++ b/pkg/core/result/source.go
@@ -4,6 +4,14 @@ import (
 	"bytes"
 )
 
+// SourceInformation defines the information detected by the source execution such as a version
+type SourceInformation struct {
+	// Key is an identifier for the elem
+	Key string
+	// Value contains the value retrieved from a source
+	Value string
+}
+
 // Source holds source execution result
 type Source struct {
 	// Name holds the source name
@@ -17,7 +25,7 @@ type Source struct {
 	*/
 	Result string
 	// Information stores the information detected by the source execution such as a version
-	Information string
+	Information []SourceInformation
 	// Description stores the source execution description
 	Description string
 	// Scm stores scm information

--- a/pkg/plugins/resources/awsami/source.go
+++ b/pkg/plugins/resources/awsami/source.go
@@ -29,7 +29,10 @@ func (a *AMI) Source(workingDir string, resultSource *result.Source) error {
 	if len(foundAMI) > 0 {
 
 		resultSource.Result = result.SUCCESS
-		resultSource.Information = foundAMI
+		resultSource.Information = []result.SourceInformation{{
+			Key:   resultSource.ID,
+			Value: foundAMI,
+		}}
 		resultSource.Description = fmt.Sprintf("AMI %q found\n", foundAMI)
 		return nil
 	}

--- a/pkg/plugins/resources/awsami/source_test.go
+++ b/pkg/plugins/resources/awsami/source_test.go
@@ -34,7 +34,12 @@ func TestSource(t *testing.T) {
 				id, d.expectedError, err)
 		}
 
-		if strings.Compare(gotResult.Information, d.expectedSource) != 0 {
+		resultSource := ""
+		if len(gotResult.Information) == 1 {
+			resultSource = gotResult.Information[0].Value
+		}
+
+		if strings.Compare(resultSource, d.expectedSource) != 0 {
 			t.Errorf("[%d] Wrong AMI ID returned:\nExpected Result:\t\t%q\nGot:\t\t\t\t\t%q",
 				id,
 				d.expectedSource,

--- a/pkg/plugins/resources/awsami/target.go
+++ b/pkg/plugins/resources/awsami/target.go
@@ -7,6 +7,6 @@ import (
 	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
-func (a *AMI) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
+func (a *AMI) Target(source result.SourceInformation, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
 	return fmt.Errorf("Target not supported for the plugin AWS/AMI")
 }

--- a/pkg/plugins/resources/cargopackage/source.go
+++ b/pkg/plugins/resources/cargopackage/source.go
@@ -25,7 +25,10 @@ func (cp CargoPackage) Source(workingDir string, resultSource *result.Source) er
 	}
 
 	resultSource.Result = result.SUCCESS
-	resultSource.Information = version
+	resultSource.Information = []result.SourceInformation{{
+		Key:   resultSource.ID,
+		Value: version,
+	}}
 	resultSource.Description = fmt.Sprintf("version %q found for cargo package name %q", version, cp.spec.Package)
 	return nil
 }

--- a/pkg/plugins/resources/cargopackage/source_test.go
+++ b/pkg/plugins/resources/cargopackage/source_test.go
@@ -22,7 +22,7 @@ func TestSource(t *testing.T) {
 		name                 string
 		url                  string
 		spec                 Spec
-		expectedResult       string
+		expectedResult       []result.SourceInformation
 		expectedError        bool
 		mockedResponse       bool
 		mockedBody           string
@@ -40,8 +40,10 @@ func TestSource(t *testing.T) {
 					Pattern: "~0.7",
 				},
 			},
-			expectedResult: "0.7.3",
-			expectedError:  false,
+			expectedResult: []result.SourceInformation{{
+				Value: "0.7.3",
+			}},
+			expectedError: false,
 		},
 		{
 			name: "Passing case of retrieving crate-test version from the filesystem index",
@@ -55,8 +57,10 @@ func TestSource(t *testing.T) {
 					Pattern: "~0.1",
 				},
 			},
-			expectedResult: "0.1.0",
-			expectedError:  false,
+			expectedResult: []result.SourceInformation{{
+				Value: "0.1.0",
+			}},
+			expectedError: false,
 		},
 		{
 			name: "Passing case of retrieving nonexistent crate-test from the filesystem index",
@@ -88,7 +92,9 @@ func TestSource(t *testing.T) {
 					Pattern: "~0.1",
 				},
 			},
-			expectedResult:       "0.1.0",
+			expectedResult: []result.SourceInformation{{
+				Value: "0.1.0",
+			}},
 			expectedError:        false,
 			mockedResponse:       true,
 			mockedBody:           existingPackageData,

--- a/pkg/plugins/resources/cargopackage/target.go
+++ b/pkg/plugins/resources/cargopackage/target.go
@@ -7,6 +7,6 @@ import (
 	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
-func (cp *CargoPackage) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
+func (cp *CargoPackage) Target(source result.SourceInformation, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
 	return fmt.Errorf("Target not supported for the plugin Cargo Package")
 }

--- a/pkg/plugins/resources/csv/source.go
+++ b/pkg/plugins/resources/csv/source.go
@@ -68,7 +68,10 @@ func (c *CSV) Source(workingDir string, resultSource *result.Source) error {
 	}
 
 	resultSource.Result = result.SUCCESS
-	resultSource.Information = sourceOutput
+	resultSource.Information = []result.SourceInformation{{
+		Key:   resultSource.ID,
+		Value: sourceOutput,
+	}}
 	resultSource.Description = fmt.Sprintf("csv value %q, found in file %q, for path %q",
 		sourceOutput,
 		content.FilePath,

--- a/pkg/plugins/resources/csv/source_test.go
+++ b/pkg/plugins/resources/csv/source_test.go
@@ -16,7 +16,7 @@ func TestSource(t *testing.T) {
 	testData := []struct {
 		name             string
 		spec             Spec
-		expectedResult   string
+		expectedResult   []result.SourceInformation
 		expectedErrorMsg error
 		wantErr          bool
 	}{
@@ -28,7 +28,9 @@ func TestSource(t *testing.T) {
 				Comma:   ',',
 				Comment: '#',
 			},
-			expectedResult: "John",
+			expectedResult: []result.SourceInformation{{
+				Value: "John",
+			}},
 		},
 		{
 			name: "Regex versionFilter successful workflow",
@@ -40,7 +42,9 @@ func TestSource(t *testing.T) {
 					Pattern: "^Jo",
 				},
 			},
-			expectedResult: "John",
+			expectedResult: []result.SourceInformation{{
+				Value: "John",
+			}},
 		},
 		{
 			name: "Default successful workflow",
@@ -50,7 +54,10 @@ func TestSource(t *testing.T) {
 				Comma:   ';',
 				Comment: '#',
 			},
-			expectedResult: "John",
+			expectedResult: []result.SourceInformation{{
+				Key:   "",
+				Value: "John",
+			}},
 		},
 		{
 			name: "Default successful workflow with empty result",
@@ -58,7 +65,7 @@ func TestSource(t *testing.T) {
 				File: "testdata/data.csv",
 				Key:  ".[0].surname",
 			},
-			expectedResult: "",
+			expectedResult: []result.SourceInformation{{Key: "", Value: ""}},
 		},
 		{
 			name: "Test key do not exist",
@@ -67,7 +74,6 @@ func TestSource(t *testing.T) {
 				Key:   ".doNotExist",
 				Value: "",
 			},
-			expectedResult:   "",
 			wantErr:          true,
 			expectedErrorMsg: errors.New("cannot find value for path \".doNotExist\" from file \"testdata/data.csv\""),
 		},

--- a/pkg/plugins/resources/csv/target.go
+++ b/pkg/plugins/resources/csv/target.go
@@ -9,14 +9,14 @@ import (
 )
 
 // Target updates a scm repository based on the modified yaml file.
-func (c *CSV) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
+func (c *CSV) Target(source result.SourceInformation, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
 
 	rootDir := ""
 	if scm != nil {
 		rootDir = scm.GetDirectory()
 	}
 
-	newValue := source
+	newValue := source.Value
 	if c.spec.Value != "" {
 		newValue = c.spec.Value
 	}

--- a/pkg/plugins/resources/csv/target_test.go
+++ b/pkg/plugins/resources/csv/target_test.go
@@ -70,7 +70,7 @@ func TestTarget(t *testing.T) {
 			require.NoError(t, err)
 
 			gotResult := result.Target{}
-			err = c.Target(tt.sourceInput, nil, true, &gotResult)
+			err = c.Target(result.SourceInformation{Value: tt.sourceInput}, nil, true, &gotResult)
 
 			if tt.wantErr {
 				assert.Equal(t, tt.expectedErrorMsg.Error(), err.Error())

--- a/pkg/plugins/resources/dockerdigest/source.go
+++ b/pkg/plugins/resources/dockerdigest/source.go
@@ -57,7 +57,10 @@ func (ds *DockerDigest) Source(workingDir string, resultSource *result.Source) e
 	}
 
 	resultSource.Result = result.SUCCESS
-	resultSource.Information = finalDigest
+	resultSource.Information = []result.SourceInformation{{
+		Key:   resultSource.ID,
+		Value: finalDigest,
+	}}
 	resultSource.Description = fmt.Sprintf("Docker Image Tag %s resolved to digest %s",
 		ref.String(), imageDigest)
 

--- a/pkg/plugins/resources/dockerdigest/source_test.go
+++ b/pkg/plugins/resources/dockerdigest/source_test.go
@@ -23,7 +23,9 @@ func TestSource(t *testing.T) {
 				Tag:   "v0.64.1",
 			},
 			expectedResult: result.Source{
-				Information: "v0.64.1@sha256:0c7a19c9607b349cb90af92cb0ec98a70074192eb1a3463c3883f10663024ce5",
+				Information: []result.SourceInformation{{
+					Value: "v0.64.1@sha256:0c7a19c9607b349cb90af92cb0ec98a70074192eb1a3463c3883f10663024ce5",
+				}},
 			},
 		},
 		{
@@ -34,7 +36,9 @@ func TestSource(t *testing.T) {
 				Architecture: "arm64",
 			},
 			expectedResult: result.Source{
-				Information: "v0.64.1@sha256:80c8393095062a96e74ac7e23aab35c8b639b890d94f2fe8fbcbbc983993e1de",
+				Information: []result.SourceInformation{{
+					Value: "v0.64.1@sha256:80c8393095062a96e74ac7e23aab35c8b639b890d94f2fe8fbcbbc983993e1de",
+				}},
 			},
 		},
 		{
@@ -45,7 +49,9 @@ func TestSource(t *testing.T) {
 				Architecture: "amd64",
 			},
 			expectedResult: result.Source{
-				Information: "v0.64.1@sha256:4eb444331ca649b24fa8905a98cc1bf922111b7b07292b86a30d3977e5e8f56d",
+				Information: []result.SourceInformation{{
+					Value: "v0.64.1@sha256:4eb444331ca649b24fa8905a98cc1bf922111b7b07292b86a30d3977e5e8f56d",
+				}},
 			},
 		},
 		{
@@ -66,7 +72,9 @@ func TestSource(t *testing.T) {
 				HideTag:      true,
 			},
 			expectedResult: result.Source{
-				Information: "@sha256:6e1833e5240ac52ecf7609623f18ec4536151e0f58b7243b92fd71ecdf3b94df",
+				Information: []result.SourceInformation{{
+					Value: "@sha256:6e1833e5240ac52ecf7609623f18ec4536151e0f58b7243b92fd71ecdf3b94df",
+				}},
 			},
 		},
 		{
@@ -77,7 +85,9 @@ func TestSource(t *testing.T) {
 				Architecture: "amd64",
 			},
 			expectedResult: result.Source{
-				Information: "v0.35.0@sha256:6e1833e5240ac52ecf7609623f18ec4536151e0f58b7243b92fd71ecdf3b94df",
+				Information: []result.SourceInformation{{
+					Value: "v0.35.0@sha256:6e1833e5240ac52ecf7609623f18ec4536151e0f58b7243b92fd71ecdf3b94df",
+				}},
 			},
 		},
 	}

--- a/pkg/plugins/resources/dockerdigest/target.go
+++ b/pkg/plugins/resources/dockerdigest/target.go
@@ -8,6 +8,6 @@ import (
 )
 
 // Target is not supported for the plugin Docker Digest
-func (ds *DockerDigest) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
+func (ds *DockerDigest) Target(source result.SourceInformation, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
 	return fmt.Errorf("Target not supported for the plugin Docker Digest")
 }

--- a/pkg/plugins/resources/dockerfile/source.go
+++ b/pkg/plugins/resources/dockerfile/source.go
@@ -55,7 +55,10 @@ func (df *Dockerfile) Source(workingDir string, resultSource *result.Source) err
 			stageInfo = fmt.Sprintf("stage %q", df.spec.Stage)
 		}
 		resultSource.Result = result.SUCCESS
-		resultSource.Information = value
+		resultSource.Information = []result.SourceInformation{{
+			Key:   resultSource.ID,
+			Value: value,
+		}}
 		resultSource.Description = fmt.Sprintf("value %q found for %s in the dockerfile file %q",
 			value,
 			stageInfo,

--- a/pkg/plugins/resources/dockerfile/source_test.go
+++ b/pkg/plugins/resources/dockerfile/source_test.go
@@ -14,7 +14,7 @@ func TestDockerfile_Source(t *testing.T) {
 	tests := []struct {
 		name           string
 		spec           Spec
-		expectedResult string
+		expectedResult []result.SourceInformation
 		mockFile       text.MockTextRetriever
 		wantErr        error
 		parserErr      bool
@@ -28,7 +28,9 @@ func TestDockerfile_Source(t *testing.T) {
 					"matcher": "org.opencontainers.image.version",
 				},
 			},
-			expectedResult: "1.0.0",
+			expectedResult: []result.SourceInformation{{
+				Value: "1.0.0",
+			}},
 			mockFile: text.MockTextRetriever{
 				Contents: map[string]string{
 					"SOURCE.Dockerfile": dockerfileFixture,
@@ -45,7 +47,9 @@ func TestDockerfile_Source(t *testing.T) {
 					"matcher": "golang",
 				},
 			},
-			expectedResult: "golang:1.15",
+			expectedResult: []result.SourceInformation{{
+				Value: "golang:1.15",
+			}},
 			mockFile: text.MockTextRetriever{
 				Contents: map[string]string{
 					"SOURCE.Dockerfile": dockerfileFixture,
@@ -61,7 +65,9 @@ func TestDockerfile_Source(t *testing.T) {
 					"matcher": "org.opencontainers.image.version",
 				},
 			},
-			expectedResult: "1.0.0",
+			expectedResult: []result.SourceInformation{{
+				Value: "1.0.0",
+			}},
 			mockFile: text.MockTextRetriever{
 				Contents: map[string]string{
 					"SOURCE.Dockerfile": dockerfileFixture,
@@ -94,7 +100,9 @@ func TestDockerfile_Source(t *testing.T) {
 					"matcher": "org.opencontainers.image.source",
 				},
 			},
-			expectedResult: "",
+			expectedResult: []result.SourceInformation{{
+				Value: "",
+			}},
 			mockFile: text.MockTextRetriever{
 				Contents: map[string]string{
 					"SOURCE.Dockerfile": dockerfileFixture,
@@ -158,7 +166,9 @@ func TestDockerfile_Source(t *testing.T) {
 					"matcher": "org.opencontainers.image.version",
 				},
 			},
-			expectedResult: "0.1.0",
+			expectedResult: []result.SourceInformation{{
+				Value: "0.1.0",
+			}},
 			mockFile: text.MockTextRetriever{
 				Contents: map[string]string{
 					"SOURCE.Dockerfile": `FROM golang:1.15 AS builder
@@ -179,7 +189,9 @@ LABEL org.opencontainers.image.version=1.0.0
 					"matcher": "org.opencontainers.image.version",
 				},
 			},
-			expectedResult: "",
+			expectedResult: []result.SourceInformation{{
+				Value: "",
+			}},
 			mockFile: text.MockTextRetriever{
 				Contents: map[string]string{
 					"SOURCE.Dockerfile": `FROM golang:1.15 AS builder

--- a/pkg/plugins/resources/dockerfile/target.go
+++ b/pkg/plugins/resources/dockerfile/target.go
@@ -12,11 +12,11 @@ import (
 )
 
 // Target updates a targeted Dockerfile from source control management system
-func (d *Dockerfile) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) (err error) {
+func (d *Dockerfile) Target(source result.SourceInformation, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) (err error) {
 	// At the moment, this plugin do not return the currently used value
 	// This could be a useful improvement for the source
 	resultTarget.Information = "unknown"
-	resultTarget.NewInformation = source
+	resultTarget.NewInformation = source.Value
 	resultTarget.Changed = false
 	resultTarget.Result = result.SUCCESS
 
@@ -35,7 +35,7 @@ func (d *Dockerfile) Target(source string, scm scm.ScmHandler, dryRun bool, resu
 
 		logrus.Debugf("\n🐋 On (Docker)file %q:\n\n", file)
 
-		newDockerfileContent, changedLines, err := d.parser.ReplaceInstructions([]byte(dockerfileContent), source, d.spec.Stage)
+		newDockerfileContent, changedLines, err := d.parser.ReplaceInstructions([]byte(dockerfileContent), source.Value, d.spec.Stage)
 		if err != nil {
 			return err
 		}

--- a/pkg/plugins/resources/dockerfile/target_test.go
+++ b/pkg/plugins/resources/dockerfile/target_test.go
@@ -215,7 +215,7 @@ CMD ["--help:golang"]
 				parser:           newParser,
 				files:            tt.files,
 			}
-			gotErr := d.Target(tt.inputSourceValue, tt.scm, tt.dryRun, &gotResult)
+			gotErr := d.Target(result.SourceInformation{Value: tt.inputSourceValue}, tt.scm, tt.dryRun, &gotResult)
 			if tt.wantErr != nil {
 				assert.Equal(t, tt.wantErr, gotErr)
 				return

--- a/pkg/plugins/resources/dockerimage/source.go
+++ b/pkg/plugins/resources/dockerimage/source.go
@@ -64,7 +64,10 @@ func (di *DockerImage) Source(workingDir string, resultSource *result.Source) er
 	}
 
 	resultSource.Result = result.SUCCESS
-	resultSource.Information = tag
+	resultSource.Information = []result.SourceInformation{{
+		Key:   resultSource.ID,
+		Value: tag,
+	}}
 	resultSource.Description = fmt.Sprintf("Docker Image Tag %q found matching pattern %q", tag, di.versionFilter.Pattern)
 
 	return nil

--- a/pkg/plugins/resources/dockerimage/source_test.go
+++ b/pkg/plugins/resources/dockerimage/source_test.go
@@ -14,7 +14,7 @@ func TestSource(t *testing.T) {
 		name           string
 		spec           Spec
 		expectedError  bool
-		expectedResult string
+		expectedResult []result.SourceInformation
 	}{
 		{
 			name: "Success",
@@ -26,8 +26,10 @@ func TestSource(t *testing.T) {
 				},
 				Architectures: []string{"amd64"},
 			},
-			expectedResult: "v0.35.0",
-			expectedError:  false,
+			expectedResult: []result.SourceInformation{{
+				Value: "v0.35.0",
+			}},
+			expectedError: false,
 		},
 		{
 			name: "Failure no version found",
@@ -50,8 +52,10 @@ func TestSource(t *testing.T) {
 					Pattern: "v0.35.0",
 				},
 			},
-			expectedResult: "v0.35.0",
-			expectedError:  false,
+			expectedResult: []result.SourceInformation{{
+				Value: "v0.35.0",
+			}},
+			expectedError: false,
 		},
 		{
 			name: "Failure - missing architecture",

--- a/pkg/plugins/resources/dockerimage/target.go
+++ b/pkg/plugins/resources/dockerimage/target.go
@@ -7,6 +7,6 @@ import (
 	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
-func (di *DockerImage) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
+func (di *DockerImage) Target(source result.SourceInformation, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
 	return fmt.Errorf("target not supported for the plugin Docker Image")
 }

--- a/pkg/plugins/resources/file/source.go
+++ b/pkg/plugins/resources/file/source.go
@@ -94,7 +94,10 @@ func (f *File) Source(workingDir string, resultSource *result.Source) error {
 		}
 
 		resultSource.Result = result.SUCCESS
-		resultSource.Information = foundContent
+		resultSource.Information = []result.SourceInformation{{
+			Key:   resultSource.ID,
+			Value: foundContent,
+		}}
 		resultSource.Description = fmt.Sprintf("content: found from file %q:\n%v", filePath, foundContent)
 
 	}

--- a/pkg/plugins/resources/file/source_test.go
+++ b/pkg/plugins/resources/file/source_test.go
@@ -17,7 +17,7 @@ func TestFile_Source(t *testing.T) {
 		files          map[string]fileMetadata
 		mockedContents map[string]string
 		mockedError    error
-		wantedContents map[string]string
+		wantedContents map[string][]result.SourceInformation
 		wantedResult   bool
 		wantedErr      bool
 	}{
@@ -35,8 +35,8 @@ func TestFile_Source(t *testing.T) {
 			mockedContents: map[string]string{
 				"/home/ucli/foo.txt": "Hello World",
 			},
-			wantedContents: map[string]string{
-				"/home/ucli/foo.txt": "Hello World",
+			wantedContents: map[string][]result.SourceInformation{
+				"/home/ucli/foo.txt": []result.SourceInformation{{Value: "Hello World"}},
 			},
 			wantedResult: true,
 		},
@@ -56,8 +56,8 @@ func TestFile_Source(t *testing.T) {
 			mockedContents: map[string]string{
 				"/home/ucli/foo.txt": "Hello World",
 			},
-			wantedContents: map[string]string{
-				"/home/ucli/foo.txt": "Hello World",
+			wantedContents: map[string][]result.SourceInformation{
+				"/home/ucli/foo.txt": []result.SourceInformation{{Value: "Hello World"}},
 			},
 			wantedResult: true,
 		},
@@ -76,8 +76,8 @@ func TestFile_Source(t *testing.T) {
 			mockedContents: map[string]string{
 				"/home/ucli/foo.txt": "Title\r\nGood Bye\r\nThe End",
 			},
-			wantedContents: map[string]string{
-				"/home/ucli/foo.txt": "The End",
+			wantedContents: map[string][]result.SourceInformation{
+				"/home/ucli/foo.txt": []result.SourceInformation{{Value: "The End"}},
 			},
 		},
 		{
@@ -107,8 +107,8 @@ func TestFile_Source(t *testing.T) {
 					f8bf1fca0ef11a33955d225198d1211e15827d43488cc9174dcda14d1a7a1d19  terraform_0.14.5_windows_386.zip
 					5d25f9afc71fc49d5f3e8c7ccc3ccd83a840c56e7a015f55f321fc970a73050b  terraform_0.14.5_windows_amd64.zip`,
 			},
-			wantedContents: map[string]string{
-				"/home/ucli/foo.txt": "					5a3e0c7873faa048f59d563a2a98caf7f04045967cbb5ad6cf05f5991e20b8d1  terraform_0.14.5_freebsd_386.zip",
+			wantedContents: map[string][]result.SourceInformation{
+				"/home/ucli/foo.txt": []result.SourceInformation{{Value: "					5a3e0c7873faa048f59d563a2a98caf7f04045967cbb5ad6cf05f5991e20b8d1  terraform_0.14.5_freebsd_386.zip"}},
 			},
 			wantedResult: true,
 		},
@@ -139,11 +139,11 @@ func TestFile_Source(t *testing.T) {
 					f8bf1fca0ef11a33955d225198d1211e15827d43488cc9174dcda14d1a7a1d19  terraform_0.14.5_windows_386.zip
 					5d25f9afc71fc49d5f3e8c7ccc3ccd83a840c56e7a015f55f321fc970a73050b  terraform_0.14.5_windows_amd64.zip`,
 			},
-			wantedContents: map[string]string{
-				"/home/ucli/foo.txt": `					b262998c85a7cad1c24b90f3d309d592bd349d411167a2939eb482dc2b99702d  terraform_0.14.5_linux_386.zip
+			wantedContents: map[string][]result.SourceInformation{
+				"/home/ucli/foo.txt": []result.SourceInformation{{Value: `					b262998c85a7cad1c24b90f3d309d592bd349d411167a2939eb482dc2b99702d  terraform_0.14.5_linux_386.zip
 					2899f47860b7752e31872e4d57b1c03c99de154f12f0fc84965e231bc50f312f  terraform_0.14.5_linux_amd64.zip
 					a971a5f5da82ea896a2e91fd828c90ea9c28e3de575d03a7ce25a5840ed7ae2b  terraform_0.14.5_linux_arm.zip
-					d3cab7d777eec230b67eb9723f3b271cd43e29c688439e4c67e3398cdaf6406b  terraform_0.14.5_linux_arm64.zip`,
+					d3cab7d777eec230b67eb9723f3b271cd43e29c688439e4c67e3398cdaf6406b  terraform_0.14.5_linux_arm64.zip`}},
 			},
 		},
 		{

--- a/pkg/plugins/resources/file/target.go
+++ b/pkg/plugins/resources/file/target.go
@@ -15,7 +15,7 @@ import (
 
 // Target creates or updates a file from a source control management system.
 // The default content is the value retrieved from source
-func (f *File) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
+func (f *File) Target(source result.SourceInformation, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
 
 	workDir := ""
 	if scm != nil {
@@ -52,7 +52,7 @@ func (f *File) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarg
 	originalContents := make(map[string]string)
 
 	// Unless there is a content specified, the inputContent source value is used to fill the file
-	inputContent := source
+	inputContent := source.Value
 	if len(f.spec.Content) > 0 {
 		inputContent = f.spec.Content
 	}

--- a/pkg/plugins/resources/file/target_test.go
+++ b/pkg/plugins/resources/file/target_test.go
@@ -439,7 +439,7 @@ func TestFile_TargetMultiples(t *testing.T) {
 			}
 
 			gotResultTarget := result.Target{}
-			gotErr := f.Target(tt.inputSourceValue, nil, tt.dryRun, &gotResultTarget)
+			gotErr := f.Target(result.SourceInformation{Value: tt.inputSourceValue}, nil, tt.dryRun, &gotResultTarget)
 
 			if tt.wantedErr {
 				assert.Error(t, gotErr)
@@ -608,7 +608,7 @@ func TestFile_TargetFromSCM(t *testing.T) {
 
 			gotResultTarget := result.Target{}
 
-			gotErr := f.Target(tt.inputSourceValue, tt.scm, tt.dryRun, &gotResultTarget)
+			gotErr := f.Target(result.SourceInformation{Value: tt.inputSourceValue}, tt.scm, tt.dryRun, &gotResultTarget)
 
 			if tt.wantedErr {
 				assert.Error(t, gotErr)

--- a/pkg/plugins/resources/gitbranch/source.go
+++ b/pkg/plugins/resources/gitbranch/source.go
@@ -42,7 +42,10 @@ func (gb *GitBranch) Source(workingDir string, resultSource *result.Source) erro
 	}
 
 	resultSource.Result = result.SUCCESS
-	resultSource.Information = value
+	resultSource.Information = []result.SourceInformation{{
+		Key:   resultSource.ID,
+		Value: value,
+	}}
 	resultSource.Description = fmt.Sprintf("git branch %q found matching pattern %q", value, gb.versionFilter.Pattern)
 
 	return nil

--- a/pkg/plugins/resources/gitbranch/target.go
+++ b/pkg/plugins/resources/gitbranch/target.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Target creates and pushes a git tag based on the SCM configuration
-func (gb *GitBranch) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) (err error) {
+func (gb *GitBranch) Target(source result.SourceInformation, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) (err error) {
 
 	if gb.spec.Path != "" && scm != nil {
 		logrus.Warningf("Path setting value %q is overriding the scm configuration (value %q)",
@@ -42,7 +42,7 @@ func (gb *GitBranch) Target(source string, scm scm.ScmHandler, dryRun bool, resu
 		return fmt.Errorf("source branch is required")
 	}
 
-	gb.branch = source
+	gb.branch = source.Value
 	if gb.spec.Branch != "" {
 		gb.branch = gb.spec.Branch
 	}

--- a/pkg/plugins/resources/gitea/branch/source.go
+++ b/pkg/plugins/resources/gitea/branch/source.go
@@ -39,7 +39,10 @@ func (g *Gitea) Source(workingDir string, resultSource *result.Source) error {
 	}
 
 	resultSource.Result = result.SUCCESS
-	resultSource.Information = value
+	resultSource.Information = []result.SourceInformation{{
+		Key:   resultSource.ID,
+		Value: value,
+	}}
 	resultSource.Description = fmt.Sprintf("Gitea branches %q found matching pattern %q", value, g.versionFilter.Pattern)
 
 	return nil

--- a/pkg/plugins/resources/gitea/branch/source_test.go
+++ b/pkg/plugins/resources/gitea/branch/source_test.go
@@ -20,7 +20,7 @@ func TestSource(t *testing.T) {
 			Repository    string
 			VersionFilter version.Filter
 		}
-		wantResult string
+		wantResult []result.SourceInformation
 		wantErr    bool
 	}{
 		{
@@ -37,8 +37,7 @@ func TestSource(t *testing.T) {
 				Owner:      "updatecli",
 				Repository: "updatecli-nonexistent",
 			},
-			wantResult: "",
-			wantErr:    true,
+			wantErr: true,
 		},
 		{
 			name: "repository should exist with latest branch v3",
@@ -58,8 +57,10 @@ func TestSource(t *testing.T) {
 					Pattern: "v1",
 				},
 			},
-			wantResult: "v1",
-			wantErr:    false,
+			wantResult: []result.SourceInformation{{
+				Value: "v1",
+			}},
+			wantErr: false,
 		},
 	}
 

--- a/pkg/plugins/resources/gitea/branch/target.go
+++ b/pkg/plugins/resources/gitea/branch/target.go
@@ -7,6 +7,6 @@ import (
 	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
-func (g Gitea) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
+func (g Gitea) Target(source result.SourceInformation, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
 	return fmt.Errorf("target not supported for the plugin Gitea branch")
 }

--- a/pkg/plugins/resources/gitea/release/source.go
+++ b/pkg/plugins/resources/gitea/release/source.go
@@ -36,7 +36,10 @@ func (g *Gitea) Source(workingDir string, resultSource *result.Source) error {
 	}
 
 	resultSource.Result = result.SUCCESS
-	resultSource.Information = value
+	resultSource.Information = []result.SourceInformation{{
+		Key:   resultSource.ID,
+		Value: value,
+	}}
 	resultSource.Description = fmt.Sprintf("Gitea Release tag %q found matching pattern %q of kind %q", value, g.versionFilter.Pattern, g.versionFilter.Kind)
 
 	return nil

--- a/pkg/plugins/resources/gitea/release/source_test.go
+++ b/pkg/plugins/resources/gitea/release/source_test.go
@@ -20,7 +20,7 @@ func TestSource(t *testing.T) {
 			Repository    string
 			VersionFilter version.Filter
 		}
-		wantResult string
+		wantResult []result.SourceInformation
 		wantErr    bool
 	}{
 		{
@@ -37,8 +37,7 @@ func TestSource(t *testing.T) {
 				Owner:      "updatecli",
 				Repository: "updatecli-nonexistent",
 			},
-			wantResult: "",
-			wantErr:    true,
+			wantErr: true,
 		},
 		{
 			name: "repository updatecli/demo-terminal should exist but no release",
@@ -54,8 +53,7 @@ func TestSource(t *testing.T) {
 				Owner:      "updatecli",
 				Repository: "demo-terminal",
 			},
-			wantResult: "",
-			wantErr:    true,
+			wantErr: true,
 		},
 		{
 			name: "repository should exist with release 0.0.3",
@@ -75,8 +73,11 @@ func TestSource(t *testing.T) {
 					Pattern: "~2.15",
 				},
 			},
-			wantResult: "v2.15.0",
-			wantErr:    false,
+			wantResult: []result.SourceInformation{{
+				Key:   "",
+				Value: "v2.15.0",
+			}},
+			wantErr: false,
 		},
 	}
 

--- a/pkg/plugins/resources/gitea/release/target.go
+++ b/pkg/plugins/resources/gitea/release/target.go
@@ -13,9 +13,9 @@ import (
 )
 
 // Target ensure that a specific release exist on gitea, otherwise creates it
-func (g Gitea) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
+func (g Gitea) Target(source result.SourceInformation, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
 	if len(g.spec.Tag) == 0 {
-		g.spec.Tag = source
+		g.spec.Tag = source.Value
 	}
 
 	resultTarget.NewInformation = g.spec.Tag

--- a/pkg/plugins/resources/gitea/tag/source.go
+++ b/pkg/plugins/resources/gitea/tag/source.go
@@ -38,7 +38,10 @@ func (g *Gitea) Source(workingDir string, resultSource *result.Source) error {
 	}
 
 	resultSource.Result = result.SUCCESS
-	resultSource.Information = value
+	resultSource.Information = []result.SourceInformation{{
+		Key:   resultSource.ID,
+		Value: value,
+	}}
 	resultSource.Description = fmt.Sprintf("Gitea tags %q found matching pattern %q of kind %q",
 		value,
 		g.versionFilter.Pattern,

--- a/pkg/plugins/resources/gitea/tag/source_test.go
+++ b/pkg/plugins/resources/gitea/tag/source_test.go
@@ -20,7 +20,7 @@ func TestSource(t *testing.T) {
 			Repository    string
 			VersionFilter version.Filter
 		}
-		wantResult string
+		wantResult []result.SourceInformation
 		wantErr    bool
 	}{
 		{
@@ -37,8 +37,7 @@ func TestSource(t *testing.T) {
 				Owner:      "updatecli",
 				Repository: "updatecli-nonexistent",
 			},
-			wantResult: "",
-			wantErr:    true,
+			wantErr: true,
 		},
 		{
 			name: "repository should exist with release 0.0.3",
@@ -58,8 +57,11 @@ func TestSource(t *testing.T) {
 					Pattern: "~1",
 				},
 			},
-			wantResult: "v1.33.0",
-			wantErr:    false,
+			wantResult: []result.SourceInformation{{
+				Key:   "",
+				Value: "v1.33.0",
+			}},
+			wantErr: false,
 		},
 		{
 			name: "repository should exist with no release 1.0.0",
@@ -79,8 +81,7 @@ func TestSource(t *testing.T) {
 					Pattern: "~0",
 				},
 			},
-			wantResult: "",
-			wantErr:    true,
+			wantErr: true,
 		},
 	}
 

--- a/pkg/plugins/resources/gitea/tag/target.go
+++ b/pkg/plugins/resources/gitea/tag/target.go
@@ -8,6 +8,6 @@ import (
 )
 
 // Target ensure that a specific release exist on gitea, otherwise creates it
-func (g Gitea) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
+func (g Gitea) Target(source result.SourceInformation, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
 	return fmt.Errorf("target not supported for the plugin Gitea Tags")
 }

--- a/pkg/plugins/resources/githubrelease/source.go
+++ b/pkg/plugins/resources/githubrelease/source.go
@@ -48,7 +48,10 @@ func (gr *GitHubRelease) Source(workingDir string, resultSource *result.Source) 
 	}
 
 	resultSource.Result = result.SUCCESS
-	resultSource.Information = value
+	resultSource.Information = []result.SourceInformation{{
+		Key:   resultSource.ID,
+		Value: value,
+	}}
 	resultSource.Description = fmt.Sprintf("GitHub release version %q found matching pattern %q of kind %q",
 		value,
 		gr.versionFilter.Pattern,

--- a/pkg/plugins/resources/githubrelease/source_test.go
+++ b/pkg/plugins/resources/githubrelease/source_test.go
@@ -33,7 +33,7 @@ func TestGitHubRelease_Source(t *testing.T) {
 		workingDir      string
 		mockedGhHandler github.GithubHandler
 		versionFilter   version.Filter
-		wantValue       string
+		wantValue       []result.SourceInformation
 		wantErr         bool
 	}{
 		{
@@ -45,7 +45,10 @@ func TestGitHubRelease_Source(t *testing.T) {
 				Kind:    "latest",
 				Pattern: "latest",
 			},
-			wantValue: "3.0.0",
+			wantValue: []result.SourceInformation{{
+				Key:   "",
+				Value: "3.0.0",
+			}},
 		},
 		{
 			name: "0 releases found, 3 tags found, filter with latest",
@@ -56,7 +59,10 @@ func TestGitHubRelease_Source(t *testing.T) {
 				Kind:    "latest",
 				Pattern: "latest",
 			},
-			wantValue: "3.0.0",
+			wantValue: []result.SourceInformation{{
+				Key:   "",
+				Value: "3.0.0",
+			}},
 		},
 		{
 			name:            "Error: 0 releases found, O tags found, filter with latest",

--- a/pkg/plugins/resources/githubrelease/target.go
+++ b/pkg/plugins/resources/githubrelease/target.go
@@ -7,6 +7,6 @@ import (
 	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
-func (ghr GitHubRelease) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
+func (ghr GitHubRelease) Target(source result.SourceInformation, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
 	return fmt.Errorf("target not supported for the plugin GitHub Release")
 }

--- a/pkg/plugins/resources/gitlab/branch/source.go
+++ b/pkg/plugins/resources/gitlab/branch/source.go
@@ -46,7 +46,10 @@ func (g *Gitlab) Source(workingDir string, resultSource *result.Source) error {
 	}
 
 	resultSource.Result = result.SUCCESS
-	resultSource.Information = value
+	resultSource.Information = []result.SourceInformation{{
+		Key:   resultSource.ID,
+		Value: value,
+	}}
 	resultSource.Description = fmt.Sprintf("GitLab branches %q found matching pattern %q of kind %q",
 		value,
 		g.versionFilter.Pattern,

--- a/pkg/plugins/resources/gitlab/branch/source_test.go
+++ b/pkg/plugins/resources/gitlab/branch/source_test.go
@@ -20,7 +20,7 @@ func TestSource(t *testing.T) {
 			Repository    string
 			VersionFilter version.Filter
 		}
-		wantResult string
+		wantResult []result.SourceInformation
 		wantErr    bool
 	}{
 		{
@@ -37,8 +37,7 @@ func TestSource(t *testing.T) {
 				Owner:      "updatecli",
 				Repository: "updatecli-nonexistent",
 			},
-			wantResult: "",
-			wantErr:    true,
+			wantErr: true,
 		},
 		{
 			name: "repository should exist with a branch main",
@@ -57,8 +56,11 @@ func TestSource(t *testing.T) {
 					Pattern: "^main$",
 				},
 			},
-			wantResult: "main",
-			wantErr:    false,
+			wantResult: []result.SourceInformation{{
+				Key:   "",
+				Value: "main",
+			}},
+			wantErr: false,
 		},
 		{
 			name: "repository should not have branch nonexistent",
@@ -78,8 +80,7 @@ func TestSource(t *testing.T) {
 					Pattern: "nonexistent",
 				},
 			},
-			wantResult: "",
-			wantErr:    true,
+			wantErr: true,
 		},
 	}
 

--- a/pkg/plugins/resources/gitlab/branch/target.go
+++ b/pkg/plugins/resources/gitlab/branch/target.go
@@ -8,6 +8,6 @@ import (
 )
 
 // Target ensure that a specific release exist on GitLab, otherwise creates it
-func (g Gitlab) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
+func (g Gitlab) Target(source result.SourceInformation, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
 	return fmt.Errorf("target not supported for the plugin GitLab branch")
 }

--- a/pkg/plugins/resources/gitlab/release/source.go
+++ b/pkg/plugins/resources/gitlab/release/source.go
@@ -32,7 +32,10 @@ func (g *Gitlab) Source(workingDir string, resultSource *result.Source) error {
 		}
 	}
 
-	resultSource.Information = g.foundVersion.GetVersion()
+	resultSource.Information = []result.SourceInformation{{
+		Key:   resultSource.ID,
+		Value: g.foundVersion.GetVersion(),
+	}}
 
 	if len(resultSource.Information) == 0 {
 		return fmt.Errorf("no GitLab Release tag found matching pattern %q of kind %q",

--- a/pkg/plugins/resources/gitlab/release/source_test.go
+++ b/pkg/plugins/resources/gitlab/release/source_test.go
@@ -20,7 +20,7 @@ func TestSource(t *testing.T) {
 			Repository    string
 			VersionFilter version.Filter
 		}
-		wantResult string
+		wantResult []result.SourceInformation
 		wantErr    bool
 	}{
 		{
@@ -37,8 +37,7 @@ func TestSource(t *testing.T) {
 				Owner:      "olblak",
 				Repository: "updatecli-nonexistent",
 			},
-			wantResult: "",
-			wantErr:    true,
+			wantErr: true,
 		},
 		{
 			name: "repository cicd-devroom/FOSDEM22 should exist but no release",
@@ -53,8 +52,7 @@ func TestSource(t *testing.T) {
 				Owner:      "cicd-devroom",
 				Repository: "FOSDEM22",
 			},
-			wantResult: "",
-			wantErr:    true,
+			wantErr: true,
 		},
 		{
 			name: "repository should exist with release 0.46.2",
@@ -74,8 +72,11 @@ func TestSource(t *testing.T) {
 					Pattern: "~0.46.0",
 				},
 			},
-			wantResult: "v0.46.2",
-			wantErr:    false,
+			wantResult: []result.SourceInformation{{
+				Key:   "",
+				Value: "v0.46.2",
+			}},
+			wantErr: false,
 		},
 	}
 

--- a/pkg/plugins/resources/gitlab/release/target.go
+++ b/pkg/plugins/resources/gitlab/release/target.go
@@ -13,9 +13,9 @@ import (
 )
 
 // Target ensure that a specific release exist on GitLab, otherwise creates it
-func (g Gitlab) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
+func (g Gitlab) Target(source result.SourceInformation, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
 	if len(g.spec.Tag) == 0 {
-		g.spec.Tag = source
+		g.spec.Tag = source.Value
 	}
 
 	resultTarget.NewInformation = g.spec.Tag

--- a/pkg/plugins/resources/gitlab/tag/source.go
+++ b/pkg/plugins/resources/gitlab/tag/source.go
@@ -32,7 +32,10 @@ func (g *Gitlab) Source(workingDir string, resultSource *result.Source) error {
 		}
 	}
 
-	resultSource.Information = g.foundVersion.GetVersion()
+	resultSource.Information = []result.SourceInformation{{
+		Key:   resultSource.ID,
+		Value: g.foundVersion.GetVersion(),
+	}}
 
 	if len(resultSource.Information) == 0 {
 		return fmt.Errorf("no GitLab tags found matching pattern %q of kind %q",

--- a/pkg/plugins/resources/gitlab/tag/source_test.go
+++ b/pkg/plugins/resources/gitlab/tag/source_test.go
@@ -20,7 +20,7 @@ func TestSource(t *testing.T) {
 			Repository    string
 			VersionFilter version.Filter
 		}
-		wantResult string
+		wantResult []result.SourceInformation
 		wantErr    bool
 	}{
 		{
@@ -37,8 +37,7 @@ func TestSource(t *testing.T) {
 				Owner:      "olblak",
 				Repository: "updatecli-nonexistent",
 			},
-			wantResult: "",
-			wantErr:    true,
+			wantErr: true,
 		},
 		{
 			name: "repository should exist with tag 0.3.0 without specifying gitlab.com",
@@ -57,8 +56,11 @@ func TestSource(t *testing.T) {
 					Pattern: "0.3.0",
 				},
 			},
-			wantResult: "v0.3.0",
-			wantErr:    false,
+			wantResult: []result.SourceInformation{{
+				Key:   "",
+				Value: "v0.3.0",
+			}},
+			wantErr: false,
 		},
 		{
 			name: "repository should exist with tag 0.3.0",
@@ -78,8 +80,11 @@ func TestSource(t *testing.T) {
 					Pattern: "0.3.0",
 				},
 			},
-			wantResult: "v0.3.0",
-			wantErr:    false,
+			wantResult: []result.SourceInformation{{
+				Key:   "",
+				Value: "v0.3.0",
+			}},
+			wantErr: false,
 		},
 		{
 			name: "repository should exist with no tag 0.3.11",
@@ -99,8 +104,7 @@ func TestSource(t *testing.T) {
 					Pattern: "v0.3.11",
 				},
 			},
-			wantResult: "",
-			wantErr:    true,
+			wantErr: true,
 		},
 	}
 

--- a/pkg/plugins/resources/gitlab/tag/target.go
+++ b/pkg/plugins/resources/gitlab/tag/target.go
@@ -8,6 +8,6 @@ import (
 )
 
 // Target ensure that a specific release exist on GitLab, otherwise creates it
-func (g Gitlab) Target(source string, scm scm.ScmHandler, dryRun bool, releaseTarget *result.Target) error {
+func (g Gitlab) Target(source result.SourceInformation, scm scm.ScmHandler, dryRun bool, releaseTarget *result.Target) error {
 	return fmt.Errorf("target not supported for the plugin GitLab Tags")
 }

--- a/pkg/plugins/resources/gittag/source.go
+++ b/pkg/plugins/resources/gittag/source.go
@@ -58,10 +58,14 @@ func (gt *GitTag) Source(workingDir string, resultSource *result.Source) error {
 			hash = refs[i].Hash
 		}
 	}
-	resultSource.Information = name
+	value := name
 	if gt.spec.Key == "hash" {
-		resultSource.Information = hash
+		value = hash
 	}
+	resultSource.Information = []result.SourceInformation{{
+		Key:   resultSource.ID,
+		Value: value,
+	}}
 
 	if len(resultSource.Information) == 0 {
 		return fmt.Errorf("no git tag found matching pattern %q of kind %q",

--- a/pkg/plugins/resources/gittag/source_test.go
+++ b/pkg/plugins/resources/gittag/source_test.go
@@ -28,7 +28,7 @@ func TestGitTag_Source(t *testing.T) {
 		mockedNativeGitHandler gitgeneric.GitHandler
 		versionFilter          version.Filter
 		spec                   Spec
-		wantValue              string
+		wantValue              []result.SourceInformation
 		wantErr                bool
 	}{
 		{
@@ -54,9 +54,12 @@ func TestGitTag_Source(t *testing.T) {
 				Kind:    "latest",
 				Pattern: "latest",
 			},
-			spec:      Spec{},
-			wantValue: "3.0.0",
-			wantErr:   false,
+			spec: Spec{},
+			wantValue: []result.SourceInformation{{
+				Key:   "",
+				Value: "3.0.0",
+			}},
+			wantErr: false,
 		},
 		{
 			name:                   "Error: O tags found, filter with latest",
@@ -66,9 +69,8 @@ func TestGitTag_Source(t *testing.T) {
 				Kind:    "latest",
 				Pattern: "latest",
 			},
-			spec:      Spec{},
-			wantValue: "",
-			wantErr:   true,
+			spec:    Spec{},
+			wantErr: true,
 		},
 		{
 			name:       "Error: 3 tags found, filter with semver on 2.1.y",
@@ -93,9 +95,8 @@ func TestGitTag_Source(t *testing.T) {
 				Kind:    "semver",
 				Pattern: "~2.1",
 			},
-			spec:      Spec{},
-			wantValue: "",
-			wantErr:   true,
+			spec:    Spec{},
+			wantErr: true,
 		},
 		{
 			name:       "3 tags found, filter with semver on 2.1.y",
@@ -120,9 +121,12 @@ func TestGitTag_Source(t *testing.T) {
 				Kind:    "semver",
 				Pattern: "~2.1",
 			},
-			spec:      Spec{},
-			wantValue: "2.1.1",
-			wantErr:   false,
+			spec: Spec{},
+			wantValue: []result.SourceInformation{{
+				Key:   "",
+				Value: "2.1.1",
+			}},
+			wantErr: false,
 		},
 		{
 			name:       "Error: error while retrieving tags",
@@ -134,9 +138,8 @@ func TestGitTag_Source(t *testing.T) {
 				Kind:    "latest",
 				Pattern: "latest",
 			},
-			spec:      Spec{},
-			wantValue: "",
-			wantErr:   true,
+			spec:    Spec{},
+			wantErr: true,
 		},
 		{
 			name:       "3 tags found, filter with semver on 2.1.y, return hash",
@@ -165,8 +168,11 @@ func TestGitTag_Source(t *testing.T) {
 				Key:  "hash",
 				Path: "github.com/updatecli/updatecli",
 			},
-			wantValue: "ghi789",
-			wantErr:   false,
+			wantValue: []result.SourceInformation{{
+				Key:   "",
+				Value: "ghi789",
+			}},
+			wantErr: false,
 		},
 		{
 			name:       "3 tags found, filter with semver on 2.1.y, return name",
@@ -195,8 +201,11 @@ func TestGitTag_Source(t *testing.T) {
 				Key:  "name",
 				Path: "github.com/updatecli/updatecli",
 			},
-			wantValue: "2.1.1",
-			wantErr:   false,
+			wantValue: []result.SourceInformation{{
+				Key:   "",
+				Value: "2.1.1",
+			}},
+			wantErr: false,
 		},
 		{
 			name:       "5 tags found, filter with regex on 'gopls/', return last tag's name",
@@ -233,8 +242,11 @@ func TestGitTag_Source(t *testing.T) {
 				Key:  "name",
 				Path: "github.com/updatecli/updatecli",
 			},
-			wantValue: "gopls/v3.0.0",
-			wantErr:   false,
+			wantValue: []result.SourceInformation{{
+				Key:   "",
+				Value: "gopls/v3.0.0",
+			}},
+			wantErr: false,
 		},
 		{
 			name:       "5 tags found, filter with regex on 'gopls/', return last tag's hash",
@@ -271,8 +283,11 @@ func TestGitTag_Source(t *testing.T) {
 				Key:  "hash",
 				Path: "github.com/updatecli/updatecli",
 			},
-			wantValue: "mno345",
-			wantErr:   false,
+			wantValue: []result.SourceInformation{{
+				Key:   "",
+				Value: "mno345",
+			}},
+			wantErr: false,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/plugins/resources/gittag/target.go
+++ b/pkg/plugins/resources/gittag/target.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Target creates a tag if needed from a local git repository, without pushing the tag
-func (gt *GitTag) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
+func (gt *GitTag) Target(source result.SourceInformation, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
 	var err error
 
 	if gt.spec.Path != "" && scm != nil {
@@ -46,7 +46,7 @@ func (gt *GitTag) Target(source string, scm scm.ScmHandler, dryRun bool, resultT
 		return fmt.Errorf("Unkownn Git working directory. Did you specify one of `URL`, `scmID`, or `spec.path`?")
 	}
 
-	tagName := source
+	tagName := source.Value
 	if gt.spec.VersionFilter.Pattern != "" {
 		tagName = gt.spec.VersionFilter.Pattern
 	}

--- a/pkg/plugins/resources/go/gomod/source.go
+++ b/pkg/plugins/resources/go/gomod/source.go
@@ -37,7 +37,10 @@ func (g *GoMod) Source(workingDir string, resultSource *result.Source) error {
 		return fmt.Errorf("no version found for module path %q", g.spec.Module)
 	}
 
-	resultSource.Information = g.foundVersion
+	resultSource.Information = []result.SourceInformation{{
+		Key:   resultSource.ID,
+		Value: g.foundVersion,
+	}}
 	resultSource.Result = result.SUCCESS
 
 	switch g.kind {

--- a/pkg/plugins/resources/go/gomod/source_test.go
+++ b/pkg/plugins/resources/go/gomod/source_test.go
@@ -12,7 +12,7 @@ func TestSource(t *testing.T) {
 	tests := []struct {
 		name           string
 		spec           Spec
-		expectedResult string
+		expectedResult []result.SourceInformation
 		expectedError  bool
 	}{
 		{
@@ -21,7 +21,10 @@ func TestSource(t *testing.T) {
 				File:   "testdata/go.mod",
 				Module: "sigs.k8s.io/yaml",
 			},
-			expectedResult: "v1.3.0",
+			expectedResult: []result.SourceInformation{{
+				Key:   "",
+				Value: "v1.3.0",
+			}},
 		},
 		{
 			name: "Test module path do not exist",
@@ -29,8 +32,7 @@ func TestSource(t *testing.T) {
 				File:   "testdata/go.mod",
 				Module: "doNotExist",
 			},
-			expectedResult: "",
-			expectedError:  true,
+			expectedError: true,
 		},
 		{
 			name: "Test retrieving indirect modulepath",
@@ -39,7 +41,10 @@ func TestSource(t *testing.T) {
 				Module:   "github.com/Azure/go-autorest/autorest/azure/auth",
 				Indirect: true,
 			},
-			expectedResult: "v0.5.11",
+			expectedResult: []result.SourceInformation{{
+				Key:   "",
+				Value: "v0.5.11",
+			}},
 		},
 		{
 			name: "Test modulepath not found because it's an indirect dep",
@@ -55,7 +60,10 @@ func TestSource(t *testing.T) {
 				File:   "https://raw.githubusercontent.com/updatecli/updatecli/v0.60.0/go.mod",
 				Module: "github.com/Masterminds/sprig/v3",
 			},
-			expectedResult: "v3.2.3",
+			expectedResult: []result.SourceInformation{{
+				Key:   "",
+				Value: "v3.2.3",
+			}},
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/plugins/resources/go/gomod/target.go
+++ b/pkg/plugins/resources/go/gomod/target.go
@@ -9,9 +9,9 @@ import (
 )
 
 // Target is not supported for the Golang resource
-func (g *GoMod) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) (err error) {
+func (g *GoMod) Target(source result.SourceInformation, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) (err error) {
 
-	version := source
+	version := source.Value
 	if g.spec.Version != "" {
 		version = g.spec.Version
 	}

--- a/pkg/plugins/resources/go/gomod/target_test.go
+++ b/pkg/plugins/resources/go/gomod/target_test.go
@@ -73,7 +73,7 @@ func TestTarget(t *testing.T) {
 			require.NoError(t, err)
 			gotResult := result.Target{}
 
-			err = got.Target("", nil, true, &gotResult)
+			err = got.Target(result.SourceInformation{}, nil, true, &gotResult)
 			if tt.expectedError {
 				assert.Error(t, err)
 				return

--- a/pkg/plugins/resources/go/language/source.go
+++ b/pkg/plugins/resources/go/language/source.go
@@ -13,18 +13,19 @@ func (g *Language) Source(workingDir string, resultSource *result.Source) error 
 		return fmt.Errorf("retrieving golang version: %w", err)
 	}
 
-	resultSource.Information = g.Version.GetVersion()
-
-	if resultSource.Information == "" {
+	version := g.Version.GetVersion()
+	if version == "" {
 		return fmt.Errorf("no Golang version found matching pattern %q",
 			g.Spec.VersionFilter.Pattern,
 		)
 	}
+	resultSource.Information = []result.SourceInformation{{
+		Key:   resultSource.ID,
+		Value: version,
+	}}
 
 	resultSource.Result = result.SUCCESS
-	resultSource.Description = fmt.Sprintf("Golang version %s found",
-		g.Version.GetVersion(),
-	)
+	resultSource.Description = fmt.Sprintf("Golang version %s found", version)
 
 	return nil
 

--- a/pkg/plugins/resources/go/language/source_test.go
+++ b/pkg/plugins/resources/go/language/source_test.go
@@ -13,7 +13,7 @@ func TestSource(t *testing.T) {
 	tests := []struct {
 		name           string
 		spec           Spec
-		expectedResult string
+		expectedResult []result.SourceInformation
 		expectedError  bool
 	}{
 		{
@@ -23,7 +23,10 @@ func TestSource(t *testing.T) {
 					Pattern: "1.13.3",
 				},
 			},
-			expectedResult: "1.13.3",
+			expectedResult: []result.SourceInformation{{
+				Key:   "",
+				Value: "1.13.3",
+			}},
 		},
 		{
 			spec: Spec{
@@ -32,7 +35,10 @@ func TestSource(t *testing.T) {
 					Pattern: "1.17.0",
 				},
 			},
-			expectedResult: "1.17.0",
+			expectedResult: []result.SourceInformation{{
+				Key:   "",
+				Value: "1.17.0",
+			}},
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/plugins/resources/go/language/target.go
+++ b/pkg/plugins/resources/go/language/target.go
@@ -8,6 +8,6 @@ import (
 )
 
 // Target is not supported for the Golang resource
-func (l *Language) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
+func (l *Language) Target(source result.SourceInformation, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
 	return fmt.Errorf("Target not supported for the plugin Go")
 }

--- a/pkg/plugins/resources/go/module/source.go
+++ b/pkg/plugins/resources/go/module/source.go
@@ -20,7 +20,10 @@ func (g *GoModule) Source(workingDir string, resultSource *result.Source) error 
 		return fmt.Errorf("no version found for GO module %q ", g.Spec.Module)
 	}
 
-	resultSource.Information = version
+	resultSource.Information = []result.SourceInformation{{
+		Key:   resultSource.ID,
+		Value: version,
+	}}
 	resultSource.Result = result.SUCCESS
 	resultSource.Description = fmt.Sprintf("version %s found for the GO module %q", version, g.Spec.Module)
 

--- a/pkg/plugins/resources/go/module/source_test.go
+++ b/pkg/plugins/resources/go/module/source_test.go
@@ -13,7 +13,7 @@ func TestSource(t *testing.T) {
 	tests := []struct {
 		name           string
 		spec           Spec
-		expectedResult string
+		expectedResult []result.SourceInformation
 		expectedError  bool
 	}{
 		{
@@ -24,7 +24,9 @@ func TestSource(t *testing.T) {
 					Pattern: "0.47",
 				},
 			},
-			expectedResult: "v0.47.2",
+			expectedResult: []result.SourceInformation{{
+				Value: "v0.47.2",
+			}},
 		},
 		{
 			spec: Spec{
@@ -35,7 +37,9 @@ func TestSource(t *testing.T) {
 					Pattern: "0.47",
 				},
 			},
-			expectedResult: "v0.47.2",
+			expectedResult: []result.SourceInformation{{
+				Value: "v0.47.2",
+			}},
 		},
 		{
 			spec: Spec{
@@ -46,7 +50,9 @@ func TestSource(t *testing.T) {
 					Pattern: "0.47",
 				},
 			},
-			expectedResult: "v0.47.2",
+			expectedResult: []result.SourceInformation{{
+				Value: "v0.47.2",
+			}},
 		},
 		{
 			spec: Spec{
@@ -56,7 +62,9 @@ func TestSource(t *testing.T) {
 					Pattern: "1.0.0",
 				},
 			},
-			expectedResult: "v1.0.0",
+			expectedResult: []result.SourceInformation{{
+				Value: "v1.0.0",
+			}},
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/plugins/resources/go/module/target.go
+++ b/pkg/plugins/resources/go/module/target.go
@@ -8,6 +8,6 @@ import (
 )
 
 // Target is not support for gomodule
-func (g *GoModule) Target(source string, scm scm.ScmHandler, dryRun bool, releaseTarget *result.Target) error {
+func (g *GoModule) Target(source result.SourceInformation, scm scm.ScmHandler, dryRun bool, releaseTarget *result.Target) error {
 	return fmt.Errorf("Target not supported for the plugin GO module")
 }

--- a/pkg/plugins/resources/hcl/source.go
+++ b/pkg/plugins/resources/hcl/source.go
@@ -29,7 +29,10 @@ func (h *Hcl) Source(workingDir string, resultSource *result.Source) error {
 		return err
 	}
 
-	resultSource.Information = sourceOutput
+	resultSource.Information = []result.SourceInformation{{
+		Key:   resultSource.ID,
+		Value: sourceOutput,
+	}}
 	resultSource.Result = result.SUCCESS
 	resultSource.Description = fmt.Sprintf("value %q, found in file %q, for path %q'",
 		sourceOutput,

--- a/pkg/plugins/resources/hcl/source_test.go
+++ b/pkg/plugins/resources/hcl/source_test.go
@@ -13,7 +13,7 @@ func TestSource(t *testing.T) {
 	testData := []struct {
 		name             string
 		spec             Spec
-		expectedResult   string
+		expectedResult   []result.SourceInformation
 		expectedErrorMsg error
 		wantErr          bool
 	}{
@@ -23,7 +23,9 @@ func TestSource(t *testing.T) {
 				File: "testdata/data.hcl",
 				Path: "resource.person.john.first_name",
 			},
-			expectedResult: "John",
+			expectedResult: []result.SourceInformation{{
+				Value: "John",
+			}},
 		},
 		{
 			name: "Success - Query empty value",
@@ -31,7 +33,9 @@ func TestSource(t *testing.T) {
 				File: "testdata/data.hcl",
 				Path: "resource.person.john.middle_name",
 			},
-			expectedResult: "",
+			expectedResult: []result.SourceInformation{{
+				Value: "",
+			}},
 		},
 		{
 			name: "Success - Query integer",
@@ -39,7 +43,9 @@ func TestSource(t *testing.T) {
 				File: "testdata/data.hcl",
 				Path: "resource.person.john.age",
 			},
-			expectedResult: "30",
+			expectedResult: []result.SourceInformation{{
+				Value: "30",
+			}},
 		},
 		{
 			name: "Success - Query nested",
@@ -47,7 +53,9 @@ func TestSource(t *testing.T) {
 				File: "testdata/data.hcl",
 				Path: "resource.person.john.nested.attr1",
 			},
-			expectedResult: "val1",
+			expectedResult: []result.SourceInformation{{
+				Value: "val1",
+			}},
 		},
 		{
 			name: "Success - Query using Files",
@@ -55,7 +63,9 @@ func TestSource(t *testing.T) {
 				Files: []string{"testdata/data.hcl"},
 				Path:  "resource.person.john.first_name",
 			},
-			expectedResult: "John",
+			expectedResult: []result.SourceInformation{{
+				Value: "John",
+			}},
 		},
 		{
 			name: "Failure - File does not exists",

--- a/pkg/plugins/resources/hcl/target.go
+++ b/pkg/plugins/resources/hcl/target.go
@@ -10,7 +10,7 @@ import (
 	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
-func (h *Hcl) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
+func (h *Hcl) Target(source result.SourceInformation, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
 	if scm != nil {
 		h.UpdateAbsoluteFilePath(scm.GetDirectory())
 	}
@@ -31,7 +31,7 @@ func (h *Hcl) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarge
 
 	query := h.spec.Path
 
-	valueToWrite := source
+	valueToWrite := source.Value
 	if h.spec.Value != "" {
 		valueToWrite = h.spec.Value
 		logrus.Debug("Using spec.Value instead of source input value.")

--- a/pkg/plugins/resources/hcl/target_test.go
+++ b/pkg/plugins/resources/hcl/target_test.go
@@ -93,7 +93,7 @@ func TestTarget(t *testing.T) {
 			require.NoError(t, err)
 
 			gotResult := result.Target{}
-			err = j.Target(tt.sourceInput, nil, true, &gotResult)
+			err = j.Target(result.SourceInformation{Value: tt.sourceInput}, nil, true, &gotResult)
 
 			if tt.wantErr {
 				assert.Equal(t, tt.expectedErrorMsg.Error(), err.Error())

--- a/pkg/plugins/resources/helm/source.go
+++ b/pkg/plugins/resources/helm/source.go
@@ -45,15 +45,19 @@ func (c *Chart) Source(workingDir string, resultSource *result.Source) error {
 		return fmt.Errorf("filtering version: %w", err)
 	}
 
-	resultSource.Information = c.foundVersion.GetVersion()
-	if resultSource.Information == "" {
+	version := c.foundVersion.GetVersion()
+	if version == "" {
 		return fmt.Errorf("no Helm Chart version found for %q", c.spec.Name)
 	}
+	resultSource.Information = []result.SourceInformation{{
+		Key:   resultSource.ID,
+		Value: version,
+	}}
 
 	resultSource.Result = result.SUCCESS
 	resultSource.Description = fmt.Sprintf("Helm Chart %q version %q is found from repository %q",
 		c.spec.Name,
-		resultSource.Information,
+		version,
 		c.spec.URL)
 
 	return nil

--- a/pkg/plugins/resources/helm/source_oci.go
+++ b/pkg/plugins/resources/helm/source_oci.go
@@ -38,7 +38,10 @@ func (c *Chart) OCISource(workingDir string, resultSource *result.Source) error 
 		return fmt.Errorf("no OCI Helm chart version found matching pattern %q", c.versionFilter.Pattern)
 	}
 
-	resultSource.Information = version
+	resultSource.Information = []result.SourceInformation{{
+		Key:   resultSource.ID,
+		Value: version,
+	}}
 	resultSource.Description = fmt.Sprintf("OCI version %q found matching pattern %q", version, c.versionFilter.Pattern)
 	resultSource.Result = result.SUCCESS
 

--- a/pkg/plugins/resources/helm/source_test.go
+++ b/pkg/plugins/resources/helm/source_test.go
@@ -15,7 +15,7 @@ func TestSource(t *testing.T) {
 	tests := []struct {
 		name                 string
 		chart                Spec
-		expected             string
+		expected             []result.SourceInformation
 		expectedError        bool
 		expectedErrorMessage error
 	}{
@@ -25,7 +25,9 @@ func TestSource(t *testing.T) {
 				URL:  "https://stenic.github.io/helm-charts",
 				Name: "proxy",
 			},
-			expected: "1.0.3",
+			expected: []result.SourceInformation{{
+				Value: "1.0.3",
+			}},
 		},
 		{
 			name: "Chart not found",
@@ -43,7 +45,6 @@ func TestSource(t *testing.T) {
 				Name:    "jenkins",
 				Version: "999",
 			},
-			expected:             "",
 			expectedError:        true,
 			expectedErrorMessage: errors.New("something went wrong while contacting \"https://example.com/index.yaml\""),
 		},

--- a/pkg/plugins/resources/helm/target.go
+++ b/pkg/plugins/resources/helm/target.go
@@ -13,7 +13,7 @@ import (
 
 // Target updates helm chart, it receives the default source value and a "dry-run" flag
 // then return if it changed something or failed
-func (c *Chart) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
+func (c *Chart) Target(source result.SourceInformation, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
 	var out bytes.Buffer
 	err := c.ValidateTarget()
 	if err != nil {

--- a/pkg/plugins/resources/helm/target_test.go
+++ b/pkg/plugins/resources/helm/target_test.go
@@ -341,7 +341,7 @@ func TestTarget(t *testing.T) {
 			require.NoError(t, err)
 
 			gotResult := result.Target{}
-			err = j.Target(tt.sourceInput, nil, true, &gotResult)
+			err = j.Target(result.SourceInformation{Value: tt.sourceInput}, nil, true, &gotResult)
 
 			if tt.wantErr {
 				assert.Error(t, err)

--- a/pkg/plugins/resources/helm/utils.go
+++ b/pkg/plugins/resources/helm/utils.go
@@ -338,7 +338,7 @@ func (c *Chart) metadataYamlPathUpdate(key string, value string, scm scm.ScmHand
 	}
 
 	metadataResultTarget := result.Target{}
-	if err := yamlResource.Target(value, scm, dryRun, &metadataResultTarget); err != nil {
+	if err := yamlResource.Target(result.SourceInformation{Value: value}, scm, dryRun, &metadataResultTarget); err != nil {
 		return err
 	}
 

--- a/pkg/plugins/resources/jenkins/source.go
+++ b/pkg/plugins/resources/jenkins/source.go
@@ -36,7 +36,10 @@ func (j *Jenkins) Source(workingDir string, resultSource *result.Source) error {
 		return fmt.Errorf("unknown version %s found for the %s release", j.spec.Version, j.spec.Release)
 	}
 
-	resultSource.Information = j.foundVersion
+	resultSource.Information = []result.SourceInformation{{
+		Key:   resultSource.ID,
+		Value: j.foundVersion,
+	}}
 	resultSource.Result = result.SUCCESS
 	resultSource.Description = fmt.Sprintf("version %q found for the Jenkins %s release", j.foundVersion, j.spec.Release)
 

--- a/pkg/plugins/resources/jenkins/source_test.go
+++ b/pkg/plugins/resources/jenkins/source_test.go
@@ -16,7 +16,7 @@ func TestJenkins_Source(t *testing.T) {
 		workingDir            string
 		spec                  Spec
 		mockedMetadataHandler mavenmetadata.Handler
-		want                  string
+		want                  []result.SourceInformation
 		wantErr               bool
 	}{
 		{
@@ -28,7 +28,9 @@ func TestJenkins_Source(t *testing.T) {
 				LatestVersion: "2.331",
 				Versions:      []string{"2.319", "2.319.1", "2.319.2", "2.320", "2.331"},
 			},
-			want: "2.319.2",
+			want: []result.SourceInformation{{
+				Value: "2.319.2",
+			}},
 		},
 		{
 			name: "Normal case with latest weekly version",
@@ -39,7 +41,9 @@ func TestJenkins_Source(t *testing.T) {
 				LatestVersion: "2.331",
 				Versions:      []string{"2.319", "2.319.1", "2.319.2", "2.320", "2.331"},
 			},
-			want: "2.331",
+			want: []result.SourceInformation{{
+				Value: "2.331",
+			}},
 		},
 		{
 			name: "Error case with an error returned by maven meta",

--- a/pkg/plugins/resources/jenkins/target.go
+++ b/pkg/plugins/resources/jenkins/target.go
@@ -7,6 +7,6 @@ import (
 	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
-func (j Jenkins) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
+func (j Jenkins) Target(source result.SourceInformation, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
 	return fmt.Errorf("Target not supported for the plugin Jenkins")
 }

--- a/pkg/plugins/resources/json/condition_test.go
+++ b/pkg/plugins/resources/json/condition_test.go
@@ -81,7 +81,7 @@ func TestCondition(t *testing.T) {
 	for _, tt := range testData {
 
 		t.Run(tt.name, func(t *testing.T) {
-			j, err := New(tt.spec)
+			j, err := New(tt.spec, false)
 
 			require.NoError(t, err)
 

--- a/pkg/plugins/resources/json/main.go
+++ b/pkg/plugins/resources/json/main.go
@@ -12,7 +12,9 @@ import (
 
 // Json stores configuration about the file and the key value which needs to be updated.
 type Json struct {
-	spec     Spec
+	spec Spec
+	// isList control if we should parse all item in the list or just one
+	isList   bool
 	contents []dasel.FileContent
 	// Holds both parsed version and original version (to allow retrieving metadata such as changelog)
 	foundVersion version.Version
@@ -20,7 +22,7 @@ type Json struct {
 	versionFilter version.Filter
 }
 
-func New(spec interface{}) (*Json, error) {
+func New(spec interface{}, isList bool) (*Json, error) {
 
 	newSpec := Spec{}
 
@@ -56,6 +58,7 @@ func New(spec interface{}) (*Json, error) {
 
 	j := Json{
 		spec:          newSpec,
+		isList:        isList,
 		versionFilter: newFilter,
 	}
 

--- a/pkg/plugins/resources/json/source.go
+++ b/pkg/plugins/resources/json/source.go
@@ -67,7 +67,10 @@ func (j *Json) Source(workingDir string, resultSource *result.Source) error {
 		sourceOutput = queryResult.String()
 	}
 
-	resultSource.Information = sourceOutput
+	resultSource.Information = []result.SourceInformation{{
+		Key:   resultSource.ID,
+		Value: sourceOutput,
+	}}
 	resultSource.Result = result.SUCCESS
 	resultSource.Description = fmt.Sprintf("value %q, found in file %q, for key %q",
 		sourceOutput,

--- a/pkg/plugins/resources/json/source_test.go
+++ b/pkg/plugins/resources/json/source_test.go
@@ -14,7 +14,7 @@ func TestSource(t *testing.T) {
 	testData := []struct {
 		name             string
 		spec             Spec
-		expectedResult   string
+		expectedResult   []result.SourceInformation
 		expectedErrorMsg error
 		wantErr          bool
 	}{
@@ -24,7 +24,9 @@ func TestSource(t *testing.T) {
 				File: "testdata/data.json",
 				Key:  ".firstName",
 			},
-			expectedResult: "Jack",
+			expectedResult: []result.SourceInformation{{
+				Value: "Jack",
+			}},
 		},
 		{
 			name: "Default successful workflow with empty result",
@@ -32,7 +34,9 @@ func TestSource(t *testing.T) {
 				File: "testdata/data.json",
 				Key:  ".surname",
 			},
-			expectedResult: "",
+			expectedResult: []result.SourceInformation{{
+				Value: "",
+			}},
 		},
 		{
 			name: "Test key do not exist",
@@ -43,7 +47,6 @@ func TestSource(t *testing.T) {
 			},
 			wantErr:          true,
 			expectedErrorMsg: errors.New("✗ cannot find value for path \".doNotExist\" from file \"testdata/data.json\""),
-			expectedResult:   "",
 		},
 		{
 			name: "Test array exist",
@@ -51,7 +54,9 @@ func TestSource(t *testing.T) {
 				File: "testdata/data.json",
 				Key:  ".children.[1]",
 			},
-			expectedResult: "Thomas",
+			expectedResult: []result.SourceInformation{{
+				Value: "Thomas",
+			}},
 		},
 	}
 

--- a/pkg/plugins/resources/json/source_test.go
+++ b/pkg/plugins/resources/json/source_test.go
@@ -16,6 +16,7 @@ func TestSource(t *testing.T) {
 		spec             Spec
 		expectedResult   []result.SourceInformation
 		expectedErrorMsg error
+		isList           bool
 		wantErr          bool
 	}{
 		{
@@ -58,12 +59,40 @@ func TestSource(t *testing.T) {
 				Value: "Thomas",
 			}},
 		},
+		{
+			name: "Retrieve json source as list with query",
+			spec: Spec{
+				File:  "testdata/data.json",
+				Query: ".children.[*]",
+			},
+			isList: true,
+			expectedResult: []result.SourceInformation{{
+				Key:   "0",
+				Value: "Catherine",
+			}, {
+				Key:   "1",
+				Value: "Thomas",
+			}, {
+				Key:   "2",
+				Value: "Trevor",
+			}},
+		},
+		{
+			name: "Retrieve json source as list with key should error",
+			spec: Spec{
+				File: "testdata/data.json",
+				Key:  ".children.[*]",
+			},
+			isList:           true,
+			wantErr:          true,
+			expectedErrorMsg: errors.New("✗ json source can only be configured as a list with the `query` param."),
+		},
 	}
 
 	for _, tt := range testData {
 
 		t.Run(tt.name, func(t *testing.T) {
-			j, err := New(tt.spec)
+			j, err := New(tt.spec, tt.isList)
 
 			require.NoError(t, err)
 

--- a/pkg/plugins/resources/json/target.go
+++ b/pkg/plugins/resources/json/target.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Target updates a scm repository based on the modified yaml file.
-func (j *Json) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
+func (j *Json) Target(source result.SourceInformation, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
 
 	rootDir := ""
 	if scm != nil {
@@ -18,7 +18,7 @@ func (j *Json) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarg
 	}
 
 	if len(j.spec.Value) == 0 {
-		j.spec.Value = source
+		j.spec.Value = source.Value
 	}
 
 	shouldMessage := ""

--- a/pkg/plugins/resources/json/target_test.go
+++ b/pkg/plugins/resources/json/target_test.go
@@ -50,7 +50,7 @@ func TestTarget(t *testing.T) {
 	for _, tt := range testData {
 
 		t.Run(tt.name, func(t *testing.T) {
-			j, err := New(tt.spec)
+			j, err := New(tt.spec, false)
 
 			require.NoError(t, err)
 

--- a/pkg/plugins/resources/maven/source.go
+++ b/pkg/plugins/resources/maven/source.go
@@ -24,7 +24,10 @@ func (m *Maven) Source(workingDir string, resultSource *result.Source) error {
 
 		if latestVersion != "" {
 			resultSource.Result = result.SUCCESS
-			resultSource.Information = latestVersion
+			resultSource.Information = []result.SourceInformation{{
+				Key:   resultSource.ID,
+				Value: latestVersion,
+			}}
 			resultSource.Description = fmt.Sprintf(
 				"Latest version is %s on the Maven repository at %s",
 				latestVersion,

--- a/pkg/plugins/resources/maven/source_test.go
+++ b/pkg/plugins/resources/maven/source_test.go
@@ -16,7 +16,7 @@ func TestSource(t *testing.T) {
 		workingDir            string
 		spec                  Spec
 		mockedMetadataHandler mavenmetadata.Handler
-		want                  string
+		want                  []result.SourceInformation
 		wantErr               bool
 	}{
 		{
@@ -29,7 +29,9 @@ func TestSource(t *testing.T) {
 			mockedMetadataHandler: &mavenmetadata.MockMetadataHandler{
 				LatestVersion: "1.7.4.v20130429",
 			},
-			want: "1.7.4.v20130429",
+			want: []result.SourceInformation{{
+				Value: "1.7.4.v20130429",
+			}},
 		},
 		{
 			name: "Error case with an error returned by the handler",

--- a/pkg/plugins/resources/maven/target.go
+++ b/pkg/plugins/resources/maven/target.go
@@ -7,6 +7,6 @@ import (
 	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
-func (m Maven) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
+func (m Maven) Target(source result.SourceInformation, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
 	return fmt.Errorf("Target not supported for the plugin Maven")
 }

--- a/pkg/plugins/resources/npm/source.go
+++ b/pkg/plugins/resources/npm/source.go
@@ -17,7 +17,10 @@ func (n Npm) Source(workingDir string, resultSource *result.Source) error {
 		return fmt.Errorf("unknown version %s found for package name %s ", version, n.spec.Name)
 	}
 
-	resultSource.Information = version
+	resultSource.Information = []result.SourceInformation{{
+		Key:   resultSource.ID,
+		Value: version,
+	}}
 	resultSource.Result = result.SUCCESS
 	resultSource.Description = fmt.Sprintf("version %s found for package name %q", version, n.spec.Name)
 

--- a/pkg/plugins/resources/npm/source_test.go
+++ b/pkg/plugins/resources/npm/source_test.go
@@ -21,7 +21,7 @@ func TestSource(t *testing.T) {
 		name                 string
 		url                  string
 		spec                 Spec
-		expectedResult       string
+		expectedResult       []result.SourceInformation
 		expectedError        bool
 		mockedResponse       bool
 		mockedBody           string
@@ -38,8 +38,10 @@ func TestSource(t *testing.T) {
 					Pattern: "~0.27",
 				},
 			},
-			expectedResult: "0.27.2",
-			expectedError:  false,
+			expectedResult: []result.SourceInformation{{
+				Value: "0.27.2",
+			}},
+			expectedError: false,
 		},
 		{
 			name: "Passing case of retrieving latest axios version using private registry",
@@ -57,7 +59,9 @@ func TestSource(t *testing.T) {
 			mockedHTTPStatusCode: 200,
 			mockedToken:          "mytoken",
 			mockedUrl:            "https://mycustomregistry.updatecli.io",
-			expectedResult:       "0.2.0",
+			expectedResult: []result.SourceInformation{{
+				Value: "0.2.0",
+			}},
 		},
 		{
 			name: "Failing case of retrieving latest axios version using private registry but bad token",
@@ -110,7 +114,9 @@ func TestSource(t *testing.T) {
 			mockedHTTPStatusCode: 200,
 			mockedToken:          "mytoken",
 			mockedUrl:            "https://mycustomregistry.updatecli.io",
-			expectedResult:       "0.2.0",
+			expectedResult: []result.SourceInformation{{
+				Value: "0.2.0",
+			}},
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/plugins/resources/npm/target.go
+++ b/pkg/plugins/resources/npm/target.go
@@ -7,6 +7,6 @@ import (
 	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
-func (n Npm) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
+func (n Npm) Target(source result.SourceInformation, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
 	return fmt.Errorf("Target not supported for the plugin Npm")
 }

--- a/pkg/plugins/resources/shell/source_test.go
+++ b/pkg/plugins/resources/shell/source_test.go
@@ -42,17 +42,19 @@ func TestShell_Source(t *testing.T) {
 		command       string
 		shell         string
 		workingDir    string
-		wantSource    string
+		wantSource    []result.SourceInformation
 		wantCommand   string
 		wantErr       bool
 		commandResult commandResult
 	}{
 		{
-			name:        "Get a source from a successful command in working directory",
-			command:     "echo Hello",
-			shell:       bashShell,
-			workingDir:  "/home/ucli",
-			wantSource:  "Hello",
+			name:       "Get a source from a successful command in working directory",
+			command:    "echo Hello",
+			shell:      bashShell,
+			workingDir: "/home/ucli",
+			wantSource: []result.SourceInformation{{
+				Value: "Hello",
+			}},
 			wantCommand: bashShell + " " + wantedScriptFilename(t, "echo Hello"),
 			wantErr:     false,
 			commandResult: commandResult{
@@ -65,7 +67,6 @@ func TestShell_Source(t *testing.T) {
 			command:    "false",
 			shell:      bashShell,
 			workingDir: "/home/ucli",
-			wantSource: "",
 			wantErr:    true,
 			commandResult: commandResult{
 				ExitCode: 1,
@@ -76,7 +77,6 @@ func TestShell_Source(t *testing.T) {
 			command:    "",
 			shell:      bashShell,
 			workingDir: "/home/ucli",
-			wantSource: "",
 			wantErr:    true,
 			commandResult: commandResult{
 				ExitCode: 1,

--- a/pkg/plugins/resources/shell/success/checksum/main.go
+++ b/pkg/plugins/resources/shell/success/checksum/main.go
@@ -124,7 +124,10 @@ func (c *Checksum) SourceResult(resultSource *result.Source) error {
 		return fmt.Errorf("monitored checksum changed")
 	}
 
-	resultSource.Information = *c.output
+	resultSource.Information = []result.SourceInformation{{
+		Key:   resultSource.ID,
+		Value: *c.output,
+	}}
 	resultSource.Result = result.SUCCESS
 	resultSource.Description = "monitored file checksum didn't changed"
 

--- a/pkg/plugins/resources/shell/success/console/main.go
+++ b/pkg/plugins/resources/shell/success/console/main.go
@@ -40,7 +40,10 @@ func (c *Console) PostCommand(workingDir string) error {
 func (c *Console) SourceResult(resultSource *result.Source) error {
 	switch *c.exitCode {
 	case 0:
-		resultSource.Information = *c.output
+		resultSource.Information = []result.SourceInformation{{
+			Key:   resultSource.ID,
+			Value: *c.output,
+		}}
 		resultSource.Result = result.SUCCESS
 		resultSource.Description = "shell command executed successfully"
 

--- a/pkg/plugins/resources/shell/success/console/main_test.go
+++ b/pkg/plugins/resources/shell/success/console/main_test.go
@@ -14,36 +14,38 @@ func TestSourceResult(t *testing.T) {
 		name                       string
 		exitCode                   int
 		stdout                     string
-		expectedResultOutput       string
+		expectedResultOutput       []result.SourceInformation
 		expectedResultErrorMessage error
 		expectedError              bool
 		expectedNewError           bool
 		expectedNewErrorMessage    error
 	}{
 		{
-			name:                 "Test succeeded without command output",
-			exitCode:             0,
-			stdout:               "",
-			expectedResultOutput: "",
+			name:     "Test succeeded without command output",
+			exitCode: 0,
+			stdout:   "",
+			expectedResultOutput: []result.SourceInformation{{
+				Value: "",
+			}},
 		},
 		{
-			name:                 "Test succeeded with command output",
-			exitCode:             0,
-			stdout:               "1.2.3",
-			expectedResultOutput: "1.2.3",
+			name:     "Test succeeded with command output",
+			exitCode: 0,
+			stdout:   "1.2.3",
+			expectedResultOutput: []result.SourceInformation{{
+				Value: "1.2.3",
+			}},
 		},
 		{
-			name:                 "Test failed with no command output",
-			exitCode:             1,
-			stdout:               "",
-			expectedResultOutput: "",
-			expectedError:        false,
+			name:          "Test failed with no command output",
+			exitCode:      1,
+			stdout:        "",
+			expectedError: false,
 		},
 		{
-			name:                 "Test failed with command output",
-			exitCode:             2,
-			stdout:               "1.2.3",
-			expectedResultOutput: "",
+			name:     "Test failed with command output",
+			exitCode: 2,
+			stdout:   "1.2.3",
 		},
 	}
 

--- a/pkg/plugins/resources/shell/success/exitcode/main.go
+++ b/pkg/plugins/resources/shell/success/exitcode/main.go
@@ -85,7 +85,10 @@ func (e *ExitCode) PostCommand(workingDir string) error {
 func (e *ExitCode) SourceResult(resultSource *result.Source) error {
 	switch *e.exitCode {
 	case e.spec.Success:
-		resultSource.Information = *e.output
+		resultSource.Information = []result.SourceInformation{{
+			Key:   resultSource.ID,
+			Value: *e.output,
+		}}
 		resultSource.Result = result.SUCCESS
 		resultSource.Description = "shell command successfully executed"
 

--- a/pkg/plugins/resources/shell/success/exitcode/main_test.go
+++ b/pkg/plugins/resources/shell/success/exitcode/main_test.go
@@ -15,7 +15,7 @@ func TestSourceResult(t *testing.T) {
 		exitCode                   int
 		spec                       Spec
 		stdout                     string
-		expectedResultOutput       string
+		expectedResultOutput       []result.SourceInformation
 		expectedResultErrorMessage string
 		expectedError              bool
 		expectedNewError           bool
@@ -28,21 +28,24 @@ func TestSourceResult(t *testing.T) {
 				Success: 0,
 				Failure: 1,
 			},
-			exitCode:             0,
-			stdout:               "",
-			expectedResultOutput: "",
+			exitCode: 0,
+			stdout:   "",
+			expectedResultOutput: []result.SourceInformation{{
+				Value: "",
+			}},
 		},
 		{
-			name:                 "Test succeeded without specifying spec",
-			exitCode:             0,
-			stdout:               "",
-			expectedResultOutput: "",
+			name:     "Test succeeded without specifying spec",
+			exitCode: 0,
+			stdout:   "",
+			expectedResultOutput: []result.SourceInformation{{
+				Value: "",
+			}},
 		},
 		{
-			name:                 "Test failed without specifying spec",
-			exitCode:             2,
-			stdout:               "",
-			expectedResultOutput: "",
+			name:     "Test failed without specifying spec",
+			exitCode: 2,
+			stdout:   "",
 		},
 		{
 			name: "Test succeeded without command output",
@@ -51,9 +54,11 @@ func TestSourceResult(t *testing.T) {
 				Success: 2,
 				Failure: 1,
 			},
-			exitCode:             2,
-			stdout:               "",
-			expectedResultOutput: "",
+			exitCode: 2,
+			stdout:   "",
+			expectedResultOutput: []result.SourceInformation{{
+				Value: "",
+			}},
 		},
 		{
 			name:     "Test succeeded with command output",
@@ -63,8 +68,10 @@ func TestSourceResult(t *testing.T) {
 				Success: 0,
 				Failure: 1,
 			},
-			stdout:               "1.2.3",
-			expectedResultOutput: "1.2.3",
+			stdout: "1.2.3",
+			expectedResultOutput: []result.SourceInformation{{
+				Value: "1.2.3",
+			}},
 		},
 		{
 			name:     "Test failed with no command output",
@@ -75,7 +82,6 @@ func TestSourceResult(t *testing.T) {
 				Failure: 1,
 			},
 			stdout:                     "",
-			expectedResultOutput:       "",
 			expectedResultErrorMessage: "shell command failed. Expected exit code 0 but got 1",
 			expectedError:              true,
 		},
@@ -88,7 +94,6 @@ func TestSourceResult(t *testing.T) {
 				Failure: 1,
 			},
 			stdout:                     "1.2.3",
-			expectedResultOutput:       "",
 			expectedResultErrorMessage: "shell command failed. Expected exit code 0 but got 2",
 			expectedError:              true,
 		},
@@ -101,7 +106,6 @@ func TestSourceResult(t *testing.T) {
 				Failure: 0,
 			},
 			stdout:                  "1.2.3",
-			expectedResultOutput:    "",
 			expectedError:           true,
 			expectedNewError:        true,
 			expectedNewErrorMessage: errors.New("wrong exit spec"),

--- a/pkg/plugins/resources/shell/target.go
+++ b/pkg/plugins/resources/shell/target.go
@@ -8,7 +8,7 @@ import (
 	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
-func (s *Shell) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
+func (s *Shell) Target(source result.SourceInformation, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
 	getDir := ""
 	if scm != nil {
 		getDir = scm.GetDirectory()
@@ -37,7 +37,7 @@ func (s *Shell) Target(source string, scm scm.ScmHandler, dryRun bool, resultTar
 //   - Any other exit code means "failed command with no change"
 //
 // The environment variable 'DRY_RUN' is set to true or false based on the input parameter (e.g. 'updatecli diff' or 'apply'?)
-func (s *Shell) target(source, workingDir string, dryRun bool, resultTarget *result.Target) error {
+func (s *Shell) target(source result.SourceInformation, workingDir string, dryRun bool, resultTarget *result.Target) error {
 
 	// Ensure environment variable(s) are up to date
 	// either it already has a value specified, or it retrieves
@@ -67,7 +67,7 @@ func (s *Shell) target(source, workingDir string, dryRun bool, resultTarget *res
 		return err
 	}
 
-	scriptFilename, err := newShellScript(s.appendSource(source))
+	scriptFilename, err := newShellScript(s.appendSource(source.Value))
 	if err != nil {
 		return fmt.Errorf("failed initializing source script - %s", err)
 	}
@@ -92,11 +92,11 @@ func (s *Shell) target(source, workingDir string, dryRun bool, resultTarget *res
 		return &ExecutionFailedError{}
 	}
 
-	resultTarget.Description = fmt.Sprintf("ran shell command %q", s.appendSource(source))
+	resultTarget.Description = fmt.Sprintf("ran shell command %q", s.appendSource(source.Value))
 
 	if !resultTarget.Changed {
-		resultTarget.NewInformation = source
-		resultTarget.Information = source
+		resultTarget.NewInformation = source.Value
+		resultTarget.Information = source.Value
 
 		resultTarget.Result = result.SUCCESS
 		logrus.Info("No change detected")

--- a/pkg/plugins/resources/shell/target_test.go
+++ b/pkg/plugins/resources/shell/target_test.go
@@ -84,7 +84,7 @@ func TestShell_Target(t *testing.T) {
 
 			gotResult := result.Target{}
 
-			err = s.Target(tt.source, nil, tt.dryrun, &gotResult)
+			err = s.Target(result.SourceInformation{Value: tt.source}, nil, tt.dryrun, &gotResult)
 
 			if tt.wantErr {
 				assert.Error(t, err)
@@ -159,7 +159,8 @@ func TestShell_TargetFromSCM(t *testing.T) {
 			require.NoError(t, err)
 
 			gotResult := result.Target{}
-			err = s.Target(tt.source, &ms, tt.dryrun, &gotResult)
+			err = s.Target(result.SourceInformation{Value: tt.source}, &ms, tt.dryrun, &gotResult)
+			err = s.Target(result.SourceInformation{Value: tt.source}, nil, tt.dryrun, &gotResult)
 
 			if tt.wantErr {
 				assert.Error(t, err)

--- a/pkg/plugins/resources/stash/branch/source.go
+++ b/pkg/plugins/resources/stash/branch/source.go
@@ -36,7 +36,10 @@ func (g *Stash) Source(workingDir string, resultSource *result.Source) error {
 		return fmt.Errorf("no Bitbucket branches found matching pattern %q", g.versionFilter.Pattern)
 	}
 
-	resultSource.Information = value
+	resultSource.Information = []result.SourceInformation{{
+		Key:   resultSource.ID,
+		Value: value,
+	}}
 	resultSource.Result = result.SUCCESS
 	resultSource.Description = fmt.Sprintf("Bitbucket branches %q found matching pattern %q", value, g.versionFilter.Pattern)
 

--- a/pkg/plugins/resources/stash/branch/target.go
+++ b/pkg/plugins/resources/stash/branch/target.go
@@ -8,6 +8,6 @@ import (
 )
 
 // Target ensure that a specific release exist on Bitbucket Server, otherwise creates it
-func (g Stash) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
+func (g Stash) Target(source result.SourceInformation, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
 	return fmt.Errorf("target not supported for the plugin stash branch")
 }

--- a/pkg/plugins/resources/stash/release/source.go
+++ b/pkg/plugins/resources/stash/release/source.go
@@ -37,7 +37,10 @@ func (g *Stash) Source(workingDir string, resultSource *result.Source) error {
 		return fmt.Errorf("no Bitbucket release tag found matching pattern %q of kind %q", g.versionFilter.Pattern, g.versionFilter.Kind)
 	}
 
-	resultSource.Information = value
+	resultSource.Information = []result.SourceInformation{{
+		Key:   resultSource.ID,
+		Value: value,
+	}}
 	resultSource.Description = fmt.Sprintf("Bitbucket release tag %q found matching pattern %q", value, g.versionFilter.Pattern)
 	resultSource.Result = result.SUCCESS
 

--- a/pkg/plugins/resources/stash/release/target.go
+++ b/pkg/plugins/resources/stash/release/target.go
@@ -12,9 +12,9 @@ import (
 	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
-func (g Stash) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarget result.Target) error {
+func (g Stash) Target(source result.SourceInformation, scm scm.ScmHandler, dryRun bool, resultTarget result.Target) error {
 	if len(g.spec.Tag) == 0 {
-		g.spec.Tag = source
+		g.spec.Tag = source.Value
 	}
 
 	if len(g.spec.Title) == 0 {

--- a/pkg/plugins/resources/stash/tag/source.go
+++ b/pkg/plugins/resources/stash/tag/source.go
@@ -38,7 +38,10 @@ func (g *Stash) Source(workingDir string, resultSource *result.Source) error {
 	}
 
 	resultSource.Result = result.SUCCESS
-	resultSource.Information = value
+	resultSource.Information = []result.SourceInformation{{
+		Key:   resultSource.ID,
+		Value: value,
+	}}
 	resultSource.Description = fmt.Sprintf("Bitbucket tag %q found matching pattern %q", value, g.versionFilter.Pattern)
 
 	return nil

--- a/pkg/plugins/resources/stash/tag/target.go
+++ b/pkg/plugins/resources/stash/tag/target.go
@@ -8,6 +8,6 @@ import (
 )
 
 // Target ensure that a specific release exist on Bitbucket Server, otherwise creates it
-func (g Stash) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
+func (g Stash) Target(source result.SourceInformation, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
 	return fmt.Errorf("target not supported for the plugin Stash Tags")
 }

--- a/pkg/plugins/resources/temurin/source.go
+++ b/pkg/plugins/resources/temurin/source.go
@@ -28,7 +28,10 @@ func (t *Temurin) Source(workingDir string, resultSource *result.Source) error {
 	case "version":
 		resultSource.Result = result.SUCCESS
 		resultSource.Description = fmt.Sprintf("[temurin] found version %q", t.foundVersion)
-		resultSource.Information = t.foundVersion
+		resultSource.Information = []result.SourceInformation{{
+			Key:   resultSource.ID,
+			Value: t.foundVersion,
+		}}
 		return nil
 
 	case "installer_url":
@@ -39,7 +42,10 @@ func (t *Temurin) Source(workingDir string, resultSource *result.Source) error {
 		}
 		resultSource.Result = result.SUCCESS
 		resultSource.Description = fmt.Sprintf("[temurin] found installer URL %q (version %q)", installerUrl, t.foundVersion)
-		resultSource.Information = installerUrl
+		resultSource.Information = []result.SourceInformation{{
+			Key:   resultSource.ID,
+			Value: installerUrl,
+		}}
 		return nil
 
 	case "checksum_url":
@@ -50,7 +56,10 @@ func (t *Temurin) Source(workingDir string, resultSource *result.Source) error {
 		}
 		resultSource.Result = result.SUCCESS
 		resultSource.Description = fmt.Sprintf("[temurin] found installer checksum URL %q (version %q)", installerChecksumUrl, t.foundVersion)
-		resultSource.Information = installerChecksumUrl
+		resultSource.Information = []result.SourceInformation{{
+			Key:   resultSource.ID,
+			Value: installerChecksumUrl,
+		}}
 		return nil
 
 	case "signature_url":
@@ -61,7 +70,10 @@ func (t *Temurin) Source(workingDir string, resultSource *result.Source) error {
 		}
 		resultSource.Result = result.SUCCESS
 		resultSource.Description = fmt.Sprintf("[temurin] found installer signature URL %q (version %q)", signatureUrl, t.foundVersion)
-		resultSource.Information = signatureUrl
+		resultSource.Information = []result.SourceInformation{{
+			Key:   resultSource.ID,
+			Value: signatureUrl,
+		}}
 		return nil
 
 	default:

--- a/pkg/plugins/resources/temurin/source_test.go
+++ b/pkg/plugins/resources/temurin/source_test.go
@@ -25,7 +25,7 @@ func TestSource(t *testing.T) {
 		mockedLocationHeader string
 		mockedParsedVersion  parsedVersion
 		mockedHttpError      error
-		want                 string
+		want                 []result.SourceInformation
 		wantStatus           string
 		wantErr              string
 	}{
@@ -33,8 +33,10 @@ func TestSource(t *testing.T) {
 			name:           "Normal case with latest LTS and default",
 			mockedReleases: []string{"jdk-21.0.4+7", "jdk-21.0.3+8", "jdk-21.0.2+4"},
 			spec:           Spec{},
-			want:           "jdk-21.0.4+7",
-			wantStatus:     result.SUCCESS,
+			want: []result.SourceInformation{{
+				Value: "jdk-21.0.4+7",
+			}},
+			wantStatus: result.SUCCESS,
 		},
 		{
 			name:                 "Normal case with installer_url and defaults",
@@ -43,7 +45,9 @@ func TestSource(t *testing.T) {
 			spec: Spec{
 				Result: "installer_url",
 			},
-			want:       "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.4%2B7/OpenJDK21U-jdk_x64_linux_hotspot_21.0.4_7.tar.gz",
+			want: []result.SourceInformation{{
+				Value: "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.4%2B7/OpenJDK21U-jdk_x64_linux_hotspot_21.0.4_7.tar.gz",
+			}},
 			wantStatus: result.SUCCESS,
 		},
 		{
@@ -53,7 +57,9 @@ func TestSource(t *testing.T) {
 			spec: Spec{
 				Result: "checksum_url",
 			},
-			want:       "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.4%2B7/OpenJDK21U-jdk_x64_linux_hotspot_21.0.4_7.tar.gz.sha256.txt",
+			want: []result.SourceInformation{{
+				Value: "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.4%2B7/OpenJDK21U-jdk_x64_linux_hotspot_21.0.4_7.tar.gz.sha256.txt",
+			}},
 			wantStatus: result.SUCCESS,
 		},
 		{
@@ -63,7 +69,9 @@ func TestSource(t *testing.T) {
 			spec: Spec{
 				Result: "signature_url",
 			},
-			want:       "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.4%2B7/OpenJDK21U-jdk_x64_linux_hotspot_21.0.4_7.tar.gz.sig",
+			want: []result.SourceInformation{{
+				Value: "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.4%2B7/OpenJDK21U-jdk_x64_linux_hotspot_21.0.4_7.tar.gz.sig",
+			}},
 			wantStatus: result.SUCCESS,
 		},
 		{
@@ -73,7 +81,9 @@ func TestSource(t *testing.T) {
 				ReleaseLine: "feature",
 				ReleaseType: "ea",
 			},
-			want:       "jdk-21.0.5+4-ea-beta",
+			want: []result.SourceInformation{{
+				Value: "jdk-21.0.5+4-ea-beta",
+			}},
 			wantStatus: result.SUCCESS,
 		},
 		{
@@ -87,7 +97,9 @@ func TestSource(t *testing.T) {
 			spec: Spec{
 				SpecificVersion: "17.0.2",
 			},
-			want:       "jdk-17.0.2+9",
+			want: []result.SourceInformation{{
+				Value: "jdk-17.0.2+9",
+			}},
 			wantStatus: result.SUCCESS,
 		},
 		{

--- a/pkg/plugins/resources/temurin/target.go
+++ b/pkg/plugins/resources/temurin/target.go
@@ -8,6 +8,6 @@ import (
 )
 
 // Target is not implemented. If you ever feel the need, you can still open a GitHub issue with a valid usecase.
-func (t *Temurin) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
+func (t *Temurin) Target(source result.SourceInformation, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
 	return fmt.Errorf("Target not supported for resource of kind 'temurin'")
 }

--- a/pkg/plugins/resources/terraform/lock/target.go
+++ b/pkg/plugins/resources/terraform/lock/target.go
@@ -11,7 +11,7 @@ import (
 	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
-func (t *TerraformLock) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
+func (t *TerraformLock) Target(source result.SourceInformation, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
 	if scm != nil {
 		t.UpdateAbsoluteFilePath(scm.GetDirectory())
 	}
@@ -30,7 +30,7 @@ func (t *TerraformLock) Target(source string, scm scm.ScmHandler, dryRun bool, r
 
 	address := t.spec.Provider
 
-	valueToWrite := source
+	valueToWrite := source.Value
 	if t.spec.Value != "" {
 		valueToWrite = t.spec.Value
 		logrus.Debug("Using spec.Value instead of source input value.")

--- a/pkg/plugins/resources/terraform/lock/target_test.go
+++ b/pkg/plugins/resources/terraform/lock/target_test.go
@@ -163,7 +163,7 @@ func TestTarget(t *testing.T) {
 			l.lockIndex = lock.NewMockIndex(providerVersions)
 
 			gotResult := result.Target{}
-			err = l.Target(tt.sourceInput, nil, true, &gotResult)
+			err = l.Target(result.SourceInformation{Value: tt.sourceInput}, nil, true, &gotResult)
 			if tt.wantErr {
 				assert.Equal(t, tt.expectedErrorMsg.Error(), err.Error())
 			} else {

--- a/pkg/plugins/resources/terraform/provider/target.go
+++ b/pkg/plugins/resources/terraform/provider/target.go
@@ -10,7 +10,7 @@ import (
 	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
-func (t *TerraformProvider) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
+func (t *TerraformProvider) Target(source result.SourceInformation, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
 	if scm != nil {
 		t.UpdateAbsoluteFilePath(scm.GetDirectory())
 	}
@@ -29,7 +29,7 @@ func (t *TerraformProvider) Target(source string, scm scm.ScmHandler, dryRun boo
 
 	address := t.spec.Provider
 
-	valueToWrite := source
+	valueToWrite := source.Value
 	if t.spec.Value != "" {
 		valueToWrite = t.spec.Value
 		logrus.Debug("Using spec.Value instead of source input value.")

--- a/pkg/plugins/resources/terraform/provider/target_test.go
+++ b/pkg/plugins/resources/terraform/provider/target_test.go
@@ -84,7 +84,7 @@ func TestTarget(t *testing.T) {
 			require.NoError(t, err)
 
 			gotResult := result.Target{}
-			err = l.Target(tt.sourceInput, nil, true, &gotResult)
+			err = l.Target(result.SourceInformation{Value: tt.sourceInput}, nil, true, &gotResult)
 
 			if tt.wantErr {
 				assert.Equal(t, tt.expectedErrorMsg.Error(), err.Error())

--- a/pkg/plugins/resources/terraform/registry/source.go
+++ b/pkg/plugins/resources/terraform/registry/source.go
@@ -13,16 +13,17 @@ func (t *TerraformRegistry) Source(workingDir string, resultSource *result.Sourc
 		return fmt.Errorf("%s retrieving terraform registry version: %w", result.FAILURE, err)
 	}
 
-	resultSource.Information = t.Version.GetVersion()
-
-	if resultSource.Information == "" {
+	version := t.Version.GetVersion()
+	if version == "" {
 		return fmt.Errorf("%s no terraform registry version matching pattern: %q", result.FAILURE, t.Spec.VersionFilter.Pattern)
 	}
+	resultSource.Information = []result.SourceInformation{{
+		Key:   resultSource.ID,
+		Value: version,
+	}}
 
 	resultSource.Result = result.SUCCESS
-	resultSource.Description = fmt.Sprintf("Terraform registry version %s found",
-		t.Version.GetVersion(),
-	)
+	resultSource.Description = fmt.Sprintf("Terraform registry version %s found", version)
 
 	return nil
 }

--- a/pkg/plugins/resources/terraform/registry/source_test.go
+++ b/pkg/plugins/resources/terraform/registry/source_test.go
@@ -16,7 +16,7 @@ func TestSource(t *testing.T) {
 	tests := []struct {
 		name            string
 		spec            Spec
-		expectedResult  string
+		expectedResult  []result.SourceInformation
 		expectedError   bool
 		mockedHttpBody  string
 		mockedHttpError error
@@ -28,7 +28,9 @@ func TestSource(t *testing.T) {
 				Namespace: "hashicorp",
 				Name:      "kubernetes",
 			},
-			expectedResult: "2.23.0",
+			expectedResult: []result.SourceInformation{{
+				Value: "2.23.0",
+			}},
 			mockedHttpBody: `{ "versions" : [{ "version": "2.23.0" }] }`,
 		},
 		{
@@ -39,7 +41,9 @@ func TestSource(t *testing.T) {
 				Name:         "vpc",
 				TargetSystem: "aws",
 			},
-			expectedResult: "5.1.1",
+			expectedResult: []result.SourceInformation{{
+				Value: "5.1.1",
+			}},
 			mockedHttpBody: `{ "modules": [{ "versions" : [{ "version": "5.1.1" }] }] }`,
 		},
 	}

--- a/pkg/plugins/resources/terraform/registry/target.go
+++ b/pkg/plugins/resources/terraform/registry/target.go
@@ -7,6 +7,6 @@ import (
 	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
-func (t *TerraformRegistry) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
+func (t *TerraformRegistry) Target(source result.SourceInformation, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
 	return fmt.Errorf("Target not supported for the plugin terraform/registry")
 }

--- a/pkg/plugins/resources/toml/source.go
+++ b/pkg/plugins/resources/toml/source.go
@@ -66,7 +66,10 @@ func (t *Toml) Source(workingDir string, resultSource *result.Source) error {
 		sourceOutput = queryResult.String()
 	}
 
-	resultSource.Information = sourceOutput
+	resultSource.Information = []result.SourceInformation{{
+		Key:   resultSource.ID,
+		Value: sourceOutput,
+	}}
 	resultSource.Result = result.SUCCESS
 	resultSource.Description = fmt.Sprintf("value %q, found in file %q, for key %q'",
 		sourceOutput,

--- a/pkg/plugins/resources/toml/source_test.go
+++ b/pkg/plugins/resources/toml/source_test.go
@@ -16,7 +16,7 @@ func TestSource(t *testing.T) {
 	testData := []struct {
 		name             string
 		spec             Spec
-		expectedResult   string
+		expectedResult   []result.SourceInformation
 		expectedErrorMsg error
 		wantErr          bool
 	}{
@@ -26,7 +26,9 @@ func TestSource(t *testing.T) {
 				File: "testdata/data.toml",
 				Key:  ".owner.firstName",
 			},
-			expectedResult: "Jack",
+			expectedResult: []result.SourceInformation{{
+				Value: "Jack",
+			}},
 		},
 		{
 			name: "Default successful workflow with empty result",
@@ -34,7 +36,9 @@ func TestSource(t *testing.T) {
 				File: "testdata/data.toml",
 				Key:  ".owner.surname",
 			},
-			expectedResult: "",
+			expectedResult: []result.SourceInformation{{
+				Value: "",
+			}},
 		},
 		{
 			name: "Test key do not exist",
@@ -43,7 +47,6 @@ func TestSource(t *testing.T) {
 				Key:   ".doNotExist",
 				Value: "",
 			},
-			expectedResult:   "",
 			wantErr:          true,
 			expectedErrorMsg: errors.New("cannot find value for path \".doNotExist\" from file \"testdata/data.toml\""),
 		},
@@ -53,7 +56,9 @@ func TestSource(t *testing.T) {
 				File: "testdata/data.toml",
 				Key:  ".database.ports.[1]",
 			},
-			expectedResult: "8001",
+			expectedResult: []result.SourceInformation{{
+				Value: "8001",
+			}},
 		},
 		{
 			name: "Test Query exist",
@@ -65,7 +70,9 @@ func TestSource(t *testing.T) {
 					Pattern: "I(.*)",
 				},
 			},
-			expectedResult: "IC",
+			expectedResult: []result.SourceInformation{{
+				Value: "IC",
+			}},
 		},
 	}
 

--- a/pkg/plugins/resources/toml/target.go
+++ b/pkg/plugins/resources/toml/target.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Target updates a scm repository based on the modified yaml file.
-func (t *Toml) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
+func (t *Toml) Target(source result.SourceInformation, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
 
 	rootDir := ""
 	if scm != nil {
@@ -30,7 +30,7 @@ func (t *Toml) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarg
 		}
 
 		if len(t.spec.Value) == 0 {
-			t.spec.Value = source
+			t.spec.Value = source.Value
 		}
 		resultTarget.NewInformation = t.spec.Value
 
@@ -38,7 +38,7 @@ func (t *Toml) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarg
 
 		// Override value from source if not yet defined
 		if len(t.spec.Value) == 0 {
-			t.spec.Value = source
+			t.spec.Value = source.Value
 		}
 
 		var queryResults []string

--- a/pkg/plugins/resources/toml/target_test.go
+++ b/pkg/plugins/resources/toml/target_test.go
@@ -133,7 +133,7 @@ func TestTarget(t *testing.T) {
 
 			gotResult := result.Target{}
 
-			err = j.Target(tt.sourceInput, nil, true, &gotResult)
+			err = j.Target(result.SourceInformation{Value: tt.sourceInput}, nil, true, &gotResult)
 
 			if tt.wantErr {
 				assert.Equal(t, tt.expectedErrorMsg.Error(), err.Error())

--- a/pkg/plugins/resources/toolversions/source.go
+++ b/pkg/plugins/resources/toolversions/source.go
@@ -25,7 +25,10 @@ func (t *ToolVersions) Source(workingDir string, resultSource *result.Source) er
 		return err
 	}
 
-	resultSource.Information = value
+	resultSource.Information = []result.SourceInformation{{
+		Key:   resultSource.ID,
+		Value: value,
+	}}
 	resultSource.Result = result.SUCCESS
 	resultSource.Description = fmt.Sprintf("value %q, found in file %q, for key %q'",
 		value,

--- a/pkg/plugins/resources/toolversions/source_test.go
+++ b/pkg/plugins/resources/toolversions/source_test.go
@@ -15,7 +15,7 @@ func TestSource(t *testing.T) {
 	testData := []struct {
 		name             string
 		spec             Spec
-		expectedResult   string
+		expectedResult   []result.SourceInformation
 		expectedErrorMsg error
 		wantErr          bool
 	}{
@@ -25,7 +25,9 @@ func TestSource(t *testing.T) {
 				File: "testdata/.tool-versions",
 				Key:  "bats",
 			},
-			expectedResult: "1.0.0",
+			expectedResult: []result.SourceInformation{{
+				Value: "1.0.0",
+			}},
 		},
 		{
 			name: "Default successful workflow with empty result",
@@ -33,7 +35,6 @@ func TestSource(t *testing.T) {
 				File: "testdata/.tool-versions",
 				Key:  "empty",
 			},
-			expectedResult:   "",
 			wantErr:          true,
 			expectedErrorMsg: errors.New("could not find value for key \"empty\" from file \"testdata/.tool-versions\""),
 		},
@@ -44,7 +45,6 @@ func TestSource(t *testing.T) {
 				Key:   "doNotExist",
 				Value: "",
 			},
-			expectedResult:   "",
 			wantErr:          true,
 			expectedErrorMsg: errors.New("could not find value for key \"doNotExist\" from file \"testdata/.tool-versions\""),
 		},

--- a/pkg/plugins/resources/toolversions/target.go
+++ b/pkg/plugins/resources/toolversions/target.go
@@ -8,7 +8,7 @@ import (
 	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
-func (t *ToolVersions) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
+func (t *ToolVersions) Target(source result.SourceInformation, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
 
 	rootDir := ""
 	if scm != nil {
@@ -29,13 +29,13 @@ func (t *ToolVersions) Target(source string, scm scm.ScmHandler, dryRun bool, re
 		}
 
 		if len(t.spec.Value) == 0 {
-			t.spec.Value = source
+			t.spec.Value = source.Value
 		}
 		resultTarget.NewInformation = t.spec.Value
 
 		// Override value from source if not yet defined
 		if len(t.spec.Value) == 0 {
-			t.spec.Value = source
+			t.spec.Value = source.Value
 		}
 
 		queryResult, _ := t.contents[i].Get(t.spec.Key)

--- a/pkg/plugins/resources/toolversions/target_test.go
+++ b/pkg/plugins/resources/toolversions/target_test.go
@@ -82,7 +82,7 @@ func TestTarget(t *testing.T) {
 
 			gotResult := result.Target{}
 
-			err = j.Target(tt.sourceInput, nil, true, &gotResult)
+			err = j.Target(result.SourceInformation{Value: tt.sourceInput}, nil, true, &gotResult)
 
 			if tt.wantErr {
 				assert.Equal(t, tt.expectedErrorMsg.Error(), err.Error())

--- a/pkg/plugins/resources/updateclihttp/source.go
+++ b/pkg/plugins/resources/updateclihttp/source.go
@@ -27,7 +27,10 @@ func (h *Http) Source(workingDir string, resultSource *result.Source) error {
 	resultSource.Description = fmt.Sprintf("[http] response received from %q.", h.spec.Url)
 
 	if h.spec.ReturnResponseHeader != "" {
-		resultSource.Information = httpRes.Header.Get(h.spec.ReturnResponseHeader)
+		resultSource.Information = []result.SourceInformation{{
+			Key:   resultSource.ID,
+			Value: httpRes.Header.Get(h.spec.ReturnResponseHeader),
+		}}
 		logrus.Debugf("[http] source: header %q found with %d characters", h.spec.ReturnResponseHeader, len(resultSource.Information))
 	} else {
 		b, err := io.ReadAll(httpRes.Body)
@@ -38,7 +41,10 @@ func (h *Http) Source(workingDir string, resultSource *result.Source) error {
 
 		logrus.Debugf("[http] source: response body received (with %d characters)", len(bodyContent))
 
-		resultSource.Information = bodyContent
+		resultSource.Information = []result.SourceInformation{{
+			Key:   resultSource.ID,
+			Value: bodyContent,
+		}}
 	}
 
 	return nil

--- a/pkg/plugins/resources/updateclihttp/source_test.go
+++ b/pkg/plugins/resources/updateclihttp/source_test.go
@@ -39,7 +39,7 @@ func TestSource(t *testing.T) {
 		mockedHTTPBody        string
 		mockedHTTPRespHeaders http.Header
 		mockedHttpError       error
-		want                  string
+		want                  []result.SourceInformation
 		wantStatus            string
 		wantErr               error
 	}{
@@ -50,8 +50,10 @@ func TestSource(t *testing.T) {
 			},
 			mockedHTTPStatusCode: http.StatusOK,
 			mockedHTTPBody:       multiLineText,
-			want:                 multiLineText,
-			wantStatus:           result.SUCCESS,
+			want: []result.SourceInformation{{
+				Value: multiLineText,
+			}},
+			wantStatus: result.SUCCESS,
 		},
 		{
 			name: "Normal case with header as result",
@@ -66,7 +68,9 @@ func TestSource(t *testing.T) {
 			mockedHTTPRespHeaders: map[string][]string{
 				"Location": {monoLineText},
 			},
-			want:       monoLineText,
+			want: []result.SourceInformation{{
+				Value: monoLineText,
+			}},
 			wantStatus: result.SUCCESS,
 		},
 		{

--- a/pkg/plugins/resources/updateclihttp/target.go
+++ b/pkg/plugins/resources/updateclihttp/target.go
@@ -8,6 +8,6 @@ import (
 )
 
 // Target is not implemented. If you ever feel the need, you can still open a GitHub issue with a valid usecase.
-func (h *Http) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
+func (h *Http) Target(source result.SourceInformation, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
 	return fmt.Errorf("Target not supported for the plugin http")
 }

--- a/pkg/plugins/resources/xml/source.go
+++ b/pkg/plugins/resources/xml/source.go
@@ -53,7 +53,10 @@ func (x *XML) Source(workingDir string, resultSource *result.Source) error {
 	queryResult := elem.Text()
 
 	resultSource.Result = result.SUCCESS
-	resultSource.Information = queryResult
+	resultSource.Information = []result.SourceInformation{{
+		Key:   resultSource.ID,
+		Value: queryResult,
+	}}
 	resultSource.Description = fmt.Sprintf("value %q found at path %q in the xml file %q",
 		queryResult,
 		x.spec.Path,

--- a/pkg/plugins/resources/xml/source_test.go
+++ b/pkg/plugins/resources/xml/source_test.go
@@ -13,7 +13,7 @@ func TestSource(t *testing.T) {
 	testData := []struct {
 		name             string
 		spec             Spec
-		expectedResult   string
+		expectedResult   []result.SourceInformation
 		wantErr          bool
 		expectedErrorMsg string
 	}{
@@ -23,7 +23,9 @@ func TestSource(t *testing.T) {
 				File: "testdata/data_0.xml",
 				Path: "//name/firstname",
 			},
-			expectedResult: "John",
+			expectedResult: []result.SourceInformation{{
+				Value: "John",
+			}},
 		},
 		{
 			name: "scenario 1.1 - http",
@@ -31,7 +33,9 @@ func TestSource(t *testing.T) {
 				File: "https://raw.githubusercontent.com/updatecli/updatecli/main/pkg/plugins/resources/xml/testdata/data_0.xml",
 				Path: "//name/firstname",
 			},
-			expectedResult: "John",
+			expectedResult: []result.SourceInformation{{
+				Value: "John",
+			}},
 		},
 		{
 			name: "scenario 2",
@@ -39,7 +43,6 @@ func TestSource(t *testing.T) {
 				File: "testdata/data_1.xml",
 				Path: "doNotExist",
 			},
-			expectedResult:   "",
 			wantErr:          true,
 			expectedErrorMsg: "cannot find value for path \"doNotExist\" from file \"testdata/data_1.xml\"",
 		},
@@ -49,7 +52,9 @@ func TestSource(t *testing.T) {
 				File: "testdata/data_1.xml",
 				Path: "//breakfast_menu/food[0]/name",
 			},
-			expectedResult: "Belgian Waffles",
+			expectedResult: []result.SourceInformation{{
+				Value: "Belgian Waffles",
+			}},
 		},
 	}
 

--- a/pkg/plugins/resources/xml/target.go
+++ b/pkg/plugins/resources/xml/target.go
@@ -11,14 +11,14 @@ import (
 )
 
 // Target updates a scm repository based on the modified yaml file.
-func (x *XML) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) (err error) {
+func (x *XML) Target(source result.SourceInformation, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) (err error) {
 
 	if strings.HasPrefix(x.spec.File, "https://") ||
 		strings.HasPrefix(x.spec.File, "http://") {
 		return fmt.Errorf("URL scheme is not supported for XML target: %q", x.spec.File)
 	}
 
-	value := source
+	value := source.Value
 	if x.spec.Value != "" {
 		value = x.spec.Value
 	}

--- a/pkg/plugins/resources/xml/target_test.go
+++ b/pkg/plugins/resources/xml/target_test.go
@@ -97,7 +97,7 @@ func TestTarget(t *testing.T) {
 			require.NoError(t, err)
 
 			gotResult := result.Target{}
-			err = x.Target("", nil, true, &gotResult)
+			err = x.Target(result.SourceInformation{}, nil, true, &gotResult)
 
 			if tt.wantErr {
 				assert.Equal(t, tt.expectedErrorMsg.Error(), err.Error())

--- a/pkg/plugins/resources/yaml/source.go
+++ b/pkg/plugins/resources/yaml/source.go
@@ -127,7 +127,10 @@ func (y *Yaml) Source(workingDir string, resultSource *result.Source) error {
 	if len(results) > 0 {
 		value := results[0]
 		resultSource.Result = result.SUCCESS
-		resultSource.Information = value
+		resultSource.Information = []result.SourceInformation{{
+			Key:   resultSource.ID,
+			Value: value,
+		}}
 		resultSource.Description = fmt.Sprintf("value %q found for key %q in the yaml file %q",
 			value,
 			y.spec.Key,

--- a/pkg/plugins/resources/yaml/source_test.go
+++ b/pkg/plugins/resources/yaml/source_test.go
@@ -17,7 +17,7 @@ func Test_Source(t *testing.T) {
 		files          map[string]file
 		mockedContents map[string]string
 		mockedError    error
-		wantedContents map[string]string
+		wantedContents map[string][]result.SourceInformation
 		isResultWanted bool
 		isErrorWanted  bool
 	}{
@@ -41,8 +41,8 @@ annotations:
   repository: charts
 `,
 			},
-			wantedContents: map[string]string{
-				"test.yaml": "olblak",
+			wantedContents: map[string][]result.SourceInformation{
+				"test.yaml": []result.SourceInformation{{Value: "olblak"}},
 			},
 			isResultWanted: true,
 		},
@@ -65,8 +65,8 @@ github:
   repository: charts
 `,
 			},
-			wantedContents: map[string]string{
-				"test.yaml": "olblak",
+			wantedContents: map[string][]result.SourceInformation{
+				"test.yaml": []result.SourceInformation{{Value: "olblak"}},
 			},
 			isResultWanted: true,
 		},
@@ -91,8 +91,8 @@ github:
   repository: charts
 `,
 			},
-			wantedContents: map[string]string{
-				"test.yaml": "olblak",
+			wantedContents: map[string][]result.SourceInformation{
+				"test.yaml": []result.SourceInformation{{Value: "olblak"}},
 			},
 			isResultWanted: true,
 		},
@@ -138,8 +138,8 @@ github:
   repository: charts
 `,
 			},
-			wantedContents: map[string]string{
-				"test.yaml": "olblak",
+			wantedContents: map[string][]result.SourceInformation{
+				"test.yaml": []result.SourceInformation{{Value: "olblak"}},
 			},
 			isResultWanted: true,
 		},
@@ -224,8 +224,8 @@ repos:
     repository: updatecli
 `,
 			},
-			wantedContents: map[string]string{
-				"test.yaml": "updatecli",
+			wantedContents: map[string][]result.SourceInformation{
+				"test.yaml": []result.SourceInformation{{Value: "updatecli"}},
 			},
 			isResultWanted: true,
 		},

--- a/pkg/plugins/resources/yaml/target.go
+++ b/pkg/plugins/resources/yaml/target.go
@@ -22,7 +22,7 @@ import (
 )
 
 // Target updates a scm repository based on the modified yaml file.
-func (y *Yaml) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
+func (y *Yaml) Target(source result.SourceInformation, scm scm.ScmHandler, dryRun bool, resultTarget *result.Target) error {
 	var err error
 
 	workDir := ""
@@ -47,7 +47,7 @@ func (y *Yaml) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarg
 		return fmt.Errorf("loading yaml file(s): %w", err)
 	}
 
-	valueToWrite := source
+	valueToWrite := source.Value
 	if y.spec.Value != "" {
 		valueToWrite = y.spec.Value
 		logrus.Debug("Using spec.Value instead of source input value.")

--- a/pkg/plugins/resources/yaml/target_test.go
+++ b/pkg/plugins/resources/yaml/target_test.go
@@ -292,7 +292,7 @@ github:
 			assert.NoError(t, err)
 
 			gotResult := result.Target{}
-			gotErr := y.Target(tt.inputSourceValue, nil, tt.dryRun, &gotResult)
+			gotErr := y.Target(result.SourceInformation{Value: tt.inputSourceValue}, nil, tt.dryRun, &gotResult)
 			if tt.wantedError {
 				assert.Error(t, gotErr)
 				return
@@ -426,7 +426,7 @@ github:
 			assert.NoError(t, err)
 
 			gotResult := result.Target{}
-			gotErr := y.Target(tt.inputSourceValue, tt.scm, tt.dryRun, &gotResult)
+			gotErr := y.Target(result.SourceInformation{Value: tt.inputSourceValue}, tt.scm, tt.dryRun, &gotResult)
 			if tt.wantedError {
 				assert.Error(t, gotErr)
 				return


### PR DESCRIPTION
I'm experimenting with the idea of loop

* What if a source could return multiple item?
* What if you could run a target multiple time based on a listed source

This is highly experimental and really an investigation, I'm using the loop.yaml pipeline to test my scenari

```mermaid
graph TD
    source#read_dummy_json_file(["S: Read our fake json (json)*"])
    source#read_dummy_json_file --> target#echo_json_value
    target#echo_json_value("T: echo_json_value (shell)*")
    source#read_dummy_json_file --> target#delete_dummy_json_file
    target#delete_dummy_json_file("T: delete_dummy_json_file (shell)")
    target#delete_dummy_json_file --> target#echo_json_value
    target#create_dummy_json_file("T: create_dummy_json_file (file)")
    target#create_dummy_json_file --> target#echo_json_value
    target#create_dummy_json_file --> target#delete_dummy_json_file
    target#create_dummy_json_file --> source#read_dummy_json_file
    source#dummy_json_filepath(["S: Create Random uuid (shell)"])
    source#dummy_json_filepath --> source#read_dummy_json_file
    source#dummy_json_filepath --> target#create_dummy_json_file
    source#dummy_json_filepath --> target#echo_json_value
    source#dummy_json_filepath --> target#delete_dummy_json_file
    source#create_dummy_json(["S: Create Fake Json (shell)"])
    source#create_dummy_json --> source#read_dummy_json_file
    source#create_dummy_json --> target#echo_json_value
    source#create_dummy_json --> target#create_dummy_json_file
    source#create_dummy_json --> target#delete_dummy_json_file
```