### PR TITLE
feat: allow to login on Udash without auth enabled

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -220,7 +220,7 @@ func run(command string) error {
 		logrus.Infof("Config file located at %q", configFilePath)
 
 	case "udash/login":
-		err := udash.Login(udashEndpointURL, udashOAuthClientID, udashOAuthIssuer, udashOAuthAudience, udashOAuthAccessToken)
+		err := udash.Login(udashEndpointURL, udashEndpointAPIURL, udashOAuthClientID, udashOAuthIssuer, udashOAuthAudience, udashOAuthAccessToken)
 		if err != nil {
 			logrus.Errorf("%s %s", result.FAILURE, err)
 			return err

--- a/cmd/udash_login.go
+++ b/cmd/udash_login.go
@@ -14,6 +14,7 @@ var (
 	udashOAuthIssuer      string
 	udashOAuthAudience    string
 	udashEndpointURL      string
+	udashEndpointAPIURL   string
 
 	udashLoginCmd = &cobra.Command{
 		Use:     "login url",
@@ -52,6 +53,7 @@ func init() {
 	udashLoginCmd.Flags().StringVar(&udashOAuthIssuer, "oauth-issuer", "", "oauth-issuer defines the Oauth authentication URL")
 	udashLoginCmd.Flags().StringVar(&udashOAuthAudience, "oauth-audience", "", "oauth-audience defines the Oauth audience URL")
 	udashLoginCmd.Flags().StringVar(&udashOAuthAccessToken, "oauth-access-token", "", "oauth-access-token defines the Oauth access token")
+	udashLoginCmd.Flags().StringVar(&udashEndpointAPIURL, "api-url", "", "api-url defines the udash API URL")
 
 	udashCmd.AddCommand(udashLoginCmd)
 }

--- a/pkg/core/udash/config_spec.go
+++ b/pkg/core/udash/config_spec.go
@@ -2,6 +2,7 @@ package udash
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 )
 
@@ -16,11 +17,11 @@ type spec struct {
 // authData defines the structure of the authentication data
 type authData struct {
 	// Token stores the access token
-	Token string
-	// Api stores the api URL
-	Api string
+	Token string `json:"token,omitempty"`
+	// API stores the api URL
+	API string `json:"api,omitempty"`
 	// URL stores the front URL
-	URL string
+	URL string `json:"url,omitempty"`
 }
 
 // readConfigFile reads the config file
@@ -28,22 +29,22 @@ func readConfigFile() (*spec, error) {
 
 	configFile, err := initConfigFile()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("init Updatecli configuration file: %w", err)
 	}
 
 	if _, err := os.Stat(configFile); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("config file %s does not exist: %w", configFile, err)
 	}
 
 	configContent, err := os.ReadFile(configFile)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("read Updatecli configuration file: %w", err)
 	}
 
 	data := spec{}
 
 	if err := json.Unmarshal(configContent, &data); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unmarshal Updatecli configuration file: %w", err)
 	}
 
 	return &data, nil
@@ -51,22 +52,22 @@ func readConfigFile() (*spec, error) {
 
 // writeConfigFile writes the config file
 func writeConfigFile(configFileName string, data *spec) error {
-	d, err := json.Marshal(&data)
+	d, err := json.MarshalIndent(data, "", "  ")
 	if err != nil {
-		return err
+		return fmt.Errorf("marshal Updatecli configuration file: %w", err)
 	}
 
 	// create file
 	f, err := os.Create(configFileName)
 	if err != nil && !os.IsExist(err) {
-		return err
+		return fmt.Errorf("create Updatecli configuration file: %w", err)
 	}
 	defer f.Close()
 
 	// write bytes to the file
 	_, err = f.Write(d)
 	if err != nil {
-		return err
+		return fmt.Errorf("write Updatecli configuration file: %w", err)
 	}
 	return nil
 }
@@ -76,12 +77,12 @@ func updateConfigFile(data authData) error {
 
 	updatecliConfigPath, err := initConfigFile()
 	if err != nil && !os.IsNotExist(err) {
-		return err
+		return fmt.Errorf("init Updatecli configuration file: %w", err)
 	}
 
 	d, err := readConfigFile()
 	if err != nil && !os.IsNotExist(err) {
-		return err
+		return fmt.Errorf("read Updatecli configuration file: %w", err)
 	}
 
 	if d == nil {
@@ -89,16 +90,16 @@ func updateConfigFile(data authData) error {
 		d.Auths = make(map[string]authData)
 	}
 
-	d.Auths[sanitizeTokenID(data.Api)] = authData{
+	d.Auths[sanitizeTokenID(data.API)] = authData{
 		Token: data.Token,
-		Api:   data.Api,
+		API:   data.API,
 		URL:   data.URL,
 	}
-	d.Default = sanitizeTokenID(data.Api)
+	d.Default = sanitizeTokenID(data.API)
 
 	err = writeConfigFile(updatecliConfigPath, d)
 	if err != nil {
-		return err
+		return fmt.Errorf("write Updatecli configuration file: %w", err)
 	}
 
 	return nil
@@ -108,12 +109,12 @@ func updateConfigFile(data authData) error {
 func ConfigFilePath() (string, error) {
 	configFile, err := initConfigFile()
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("init Updatecli configuration file: %w", err)
 	}
 
 	// Testing if configFile exists
 	if _, err = os.Open(configFile); err != nil {
-		return "", err
+		return "", fmt.Errorf("config file %s does not exist: %w", configFile, err)
 	}
 
 	return configFile, nil

--- a/pkg/core/udash/login.go
+++ b/pkg/core/udash/login.go
@@ -1,16 +1,64 @@
 package udash
 
-import "fmt"
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+)
 
 // Login will open a browser to authenticate a user and retrieve an access token
-func Login(serviceURL, clientID, issuer, audience, accessToken string) error {
+func Login(udashEndpoint, udashAPIEndpoint, clientID, issuer, audience, accessToken string) error {
+
+	if udashAPIEndpoint == "" {
+		udashAPIEndpoint = strings.TrimSuffix(udashEndpoint, "/") + "/api"
+	}
+
+	envVariableURL := os.Getenv(DefaultEnvVariableURL)
+	envVariableAccessToken := os.Getenv(DefaultEnvVariableAccessToken)
+	envVariableAPIURL := os.Getenv(DefaultEnvVariableAPIURL)
+
+	setParam := func(flagParam *string, envParam, flagParamName, envParamName string) {
+		if *flagParam != "" && envParam != "" {
+			logrus.Debugf("%s provided via flag and environment variable %q, prioritizing flag", flagParamName, envParamName)
+			return
+		} else if *flagParam == "" && envParam != "" {
+			*flagParam = envParam
+		}
+	}
+
+	isAuthFlagParamEmpty := clientID == "" && issuer == "" && audience == ""
+
+	setParam(&udashAPIEndpoint, envVariableAPIURL, "API URL", DefaultEnvVariableAPIURL)
+	setParam(&accessToken, envVariableAccessToken, "api access token", DefaultEnvVariableAccessToken)
+	setParam(&udashEndpoint, envVariableURL, "URL", DefaultEnvVariableURL)
+
+	if isAuthFlagParamEmpty {
+		logrus.Debugf("Udash api detected via environment variable %q, ignoring config file", DefaultEnvVariableAPIURL)
+		err := updateConfigFile(authData{
+			URL:   udashEndpoint,
+			API:   udashAPIEndpoint,
+			Token: envVariableAccessToken,
+		})
+
+		if err != nil {
+			return fmt.Errorf("update Updatecli config file: %w", err)
+		}
+
+		return nil
+
+	} else if udashEndpoint == "" {
+		return fmt.Errorf("service URL is required")
+	}
+
 	port, err := getAvailablePort()
 	if err != nil {
 		return fmt.Errorf("get available port: %w", err)
 	}
 
 	err = authorizeUser(
-		serviceURL,
+		udashEndpoint,
 		clientID,
 		issuer,
 		audience,

--- a/pkg/core/udash/logout.go
+++ b/pkg/core/udash/logout.go
@@ -11,7 +11,6 @@ func Logout(url string) error {
 
 	updatecliConfigPath, err := initConfigFile()
 	if err != nil {
-		logrus.Errorln(err)
 		return err
 	}
 
@@ -28,7 +27,7 @@ func Logout(url string) error {
 
 	keys := []string{}
 	for i := range data.Auths {
-		if data.Auths[i].URL == url || i == sanitizeTokenID(url) || data.Auths[i].Api == url {
+		if data.Auths[i].URL == url || i == sanitizeTokenID(url) || data.Auths[i].API == url {
 			logrus.Debugf("logout from %q\n", i)
 			delete(data.Auths, i)
 			continue

--- a/pkg/core/udash/main.go
+++ b/pkg/core/udash/main.go
@@ -49,7 +49,7 @@ func authorizeUser(frontURL, clientID, authDomain, audience, redirectURL, access
 		logrus.Infof("Token detected via flag --oauth-access-token, skipping the oauth PKCE flow")
 		err = updateConfigFile(authData{
 			Token: accessToken,
-			Api:   audience,
+			API:   audience,
 			URL:   frontURL,
 		})
 		if err != nil {
@@ -137,11 +137,12 @@ func authorizeUser(frontURL, clientID, authDomain, audience, redirectURL, access
 
 		err = updateConfigFile(authData{
 			Token: accessToken,
-			Api:   audience,
+			API:   audience,
 			URL:   frontURL,
 		})
 		if err != nil {
 			if !os.IsNotExist(err) {
+
 				logrus.Errorln(err)
 				// close the HTTP server and return
 				cleanup(server)

--- a/pkg/core/udash/publish.go
+++ b/pkg/core/udash/publish.go
@@ -24,9 +24,10 @@ func Publish(r *reports.Report) error {
 	// setDefaultParam sets the default value for a parameter
 	setDefaultParam := func(envParam *string, configParam, envParamName, configParamName string) {
 		if *envParam != "" && configParam != "" {
-			logrus.Debugf("%s provided via environment variable %q supersede %q from config file",
+			logrus.Debugf("%s provided via environment variable %q supersede value %q from %q in config file",
 				*envParam,
 				envParamName,
+				configParamName,
 				configParam)
 			return
 		} else if *envParam == "" && configParam != "" {

--- a/pkg/core/udash/publish.go
+++ b/pkg/core/udash/publish.go
@@ -20,14 +20,41 @@ var (
 
 // Publish publish a pipeline report to the updatecli api
 func Publish(r *reports.Report) error {
+
+	// setDefaultParam sets the default value for a parameter
+	setDefaultParam := func(envParam *string, configParam, envParamName, configParamName string) {
+		if *envParam != "" && configParam != "" {
+			logrus.Debugf("%s provided via environment variable %q supersede %q from config file",
+				*envParam,
+				envParamName,
+				configParam)
+			return
+		} else if *envParam == "" && configParam != "" {
+			*envParam = configParam
+		}
+	}
+
 	err := r.UpdateID()
 	if err != nil {
 		return fmt.Errorf("generating report IDs: %w", err)
 	}
 
-	reportURLString, reportApiURLString, bearerToken, err := Token("")
-	if err != nil {
-		return fmt.Errorf("retrieving service access token: %w", err)
+	reportURLString, reportApiURLString, bearerToken := getConfigFromEnv()
+	if reportApiURLString == "" {
+		logrus.Debugf("no Udash API URL detected via environment variables, looking for a configuration file")
+		localReportURLString, localReportApiURLString, localBearerToken, err := getConfigFromFile("")
+		if err != nil {
+			logrus.Debugf("retrieving service access token: %s", err)
+		}
+
+		setDefaultParam(&reportApiURLString, localReportApiURLString, DefaultEnvVariableAPIURL, "api")
+		setDefaultParam(&reportURLString, localReportURLString, DefaultEnvVariableURL, "url")
+		setDefaultParam(&bearerToken, localBearerToken, DefaultEnvVariableAccessToken, "token")
+	}
+
+	if reportApiURLString == "" {
+		logrus.Infof("no Udash endpoint detected, skipping report publication")
+		return nil
 	}
 
 	reportApiURL, err := url.Parse(reportApiURLString)


### PR DESCRIPTION
There are situations where using Udash and Updatecli without authentication makes sense. This commit introduces the following changes

* `udash login` can be used without authentication, just to configure the Updatecli configfile
* `udash login` accepts a new parameter `--api-url` to specify an api url
* Allow to use environment variable if no Updatecli configuration file detect at report publishing time
  * `UPDATECLI_UDASH_API_URL`: defines the api where to publish Updatecli reports.
  * `UPDATECLI_UDASH_ACCESS_TOKEN`: defines the bearer token to use if authentication is required
  * `UPDATECLI_UDASH_URL`: defines the Udash service
* Prettify the updatecli configuration `$HOME/.config/updatecli/udash.json` file by adding indentation.

Worth mentioning, the udash.jon configuration file has bigger priority over environment variable configuration

Fix #XXX

<!-- Describe the changes introduced by this pull request -->

## Test

Manual testing at the moment

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
