### PR TITLE
feat: add version filter regex/semver

### DIFF
--- a/pkg/plugins/utils/version/filter.go
+++ b/pkg/plugins/utils/version/filter.go
@@ -17,16 +17,17 @@ const (
 	SEMVERVERSIONKIND string = "semver"
 	// LATESTVERSIONKIND specifies that we are looking for the latest version of an array
 	LATESTVERSIONKIND string = "latest"
+	// REGEXSEMVERVERSIONKIND use regex to extract versions and semantic version to find version
+	REGEXSEMVERVERSIONKIND string = "regex/semver"
 )
 
-var (
-	// SupportedKind holds a list of supported version kind
-	SupportedKind []string = []string{
-		REGEXVERSIONKIND,
-		SEMVERVERSIONKIND,
-		LATESTVERSIONKIND,
-	}
-)
+// SupportedKind holds a list of supported version kind
+var SupportedKind []string = []string{
+	REGEXVERSIONKIND,
+	SEMVERVERSIONKIND,
+	LATESTVERSIONKIND,
+	REGEXSEMVERVERSIONKIND,
+}
 
 // Filter defines parameters to apply different kind of version matching based on a list of versions
 type Filter struct {
@@ -36,6 +37,8 @@ type Filter struct {
 	Pattern string `yaml:",omitempty"`
 	// strict enforce strict versioning rule. Only used for semantic versioning at this time
 	Strict bool `yaml:",omitempty"`
+	// specifies the regex pattern, only used for regex/semver. Output of the first capture group will be used.
+	Regex string `yaml:",omitempty"`
 }
 
 // Init returns a new (copy) valid instantiated filter
@@ -75,7 +78,6 @@ func (f Filter) Validate() error {
 
 // Search returns a value matching pattern
 func (f *Filter) Search(versions []string) (Version, error) {
-
 	logrus.Infof("Searching for version matching pattern %q", f.Pattern)
 
 	foundVersion := Version{}
@@ -127,6 +129,35 @@ func (f *Filter) Search(versions []string) (Version, error) {
 		}
 
 		return s.FoundVersion, nil
+	case REGEXSEMVERVERSIONKIND:
+		re, err := regexp.Compile(f.Regex)
+		if err != nil {
+			return foundVersion, err
+		}
+
+		// Create a slice of versions using regex pattern
+		var parsedVersions []string
+		for i := 0; i < len(versions); i++ {
+			v := versions[i]
+			found := re.FindStringSubmatch(v)
+			if len(found) > 1 {
+				parsedVersions = append(parsedVersions, found[1])
+			}
+
+		}
+
+		s := Semver{
+			Constraint: f.Pattern,
+			Strict:     f.Strict,
+		}
+
+		err = s.Search(parsedVersions)
+		if err != nil {
+			return foundVersion, err
+		}
+
+		return s.FoundVersion, nil
+
 	default:
 		return foundVersion, &ErrUnsupportedVersionKindPattern{Pattern: f.Pattern, Kind: f.Kind}
 	}

--- a/pkg/plugins/utils/version/filter_test.go
+++ b/pkg/plugins/utils/version/filter_test.go
@@ -142,6 +142,37 @@ func TestSearch(t *testing.T) {
 			want:     Version{},
 			wantErr:  &ErrNoVersionFoundForPattern{Pattern: "^updatecli-4.(\\d*)$"},
 		},
+		{
+			name: "Passing case with regex/semver",
+			filter: Filter{
+				Kind:  REGEXSEMVERVERSIONKIND,
+				Regex: "^updatecli-(\\d*\\.\\d*\\.\\d*)$",
+			},
+			versions: []string{"updatecli-1.0.0", "updatecli-2.0.0", "updatecli-1.1.0"},
+			want: Version{
+				ParsedVersion:   "2.0.0",
+				OriginalVersion: "2.0.0",
+			},
+		},
+		{
+			name: "Passing case with regex/semver",
+			filter: Filter{
+				Kind:  REGEXSEMVERVERSIONKIND,
+				Regex: "^updatecli-\\d*\\.\\d*\\.\\d*$",
+			},
+			versions: []string{"updatecli-1.0.0", "updatecli-2.0.0", "updatecli-1.1.0"},
+			want:     Version{},
+			wantErr:  errors.New("versions list empty"),
+		},
+		{
+			name: "Passing case with regex/semver",
+			filter: Filter{
+				Kind: REGEXSEMVERVERSIONKIND,
+			},
+			versions: []string{"updatecli-1.0.0", "updatecli-2.0.0", "updatecli-1.1.0"},
+			want:     Version{},
+			wantErr:  errors.New("versions list empty"),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
I've had a couple of cases where i wanted to get latest semantic version, but the versions returned by the resource do not follow the convention.

The idea behind this to extract the version numbers using a regex then pass them on to the semver search.

[yarnpkg/berry](https://github.com/yarnpkg/berry) is a good example, as they do backport releases. Therefore latest of both `regex` and `latest` currently returns a `3.x`.

## Test

To test this pull request, you can run the following commands:

```shell
cd pkg/plugins/utils/version
go test
```

```shell
go build -o bin/updatecli
./bin/updatecli diff --config test.yaml
```

```yaml
sources:
  default:
    name: Get latest version
    kind: githubrelease
    spec:
      owner: yarnpkg
      repository: berry
      token: '{{ requiredEnv "GITHUB_TOKEN" }}'
      versionfilter:
        kind: regex/semver
        regex: "@yarnpkg/cli/(\\d*\\.\\d*\\.\\d*)"
        #pattern: "3.x"
```

## Additional Information

### Tradeoff

Potentially confusing having `regex` parameter.

### Potential improvement

N/A

<!-- Please describe, if any, potential improvement that you are envisioning -->
