### PR TITLE
fix: use latest when tag is not set in autodiscover

### DIFF
--- a/pkg/plugins/autodiscovery/helm/container.go
+++ b/pkg/plugins/autodiscovery/helm/container.go
@@ -92,6 +92,11 @@ func (h Helm) discoverHelmContainerManifests() ([][]byte, error) {
 				}
 			}
 
+			if tag == "" {
+				logrus.Debugf("No tag set for image %q using 'latest' as default", repository)
+				tag = "latest"
+			}
+
 			if repository == "" {
 				return
 			}
@@ -106,7 +111,7 @@ func (h Helm) discoverHelmContainerManifests() ([][]byte, error) {
 			})
 		}
 
-		if values.Image.Tag != "" && values.Image.Repository != "" {
+		if values.Image.Repository != "" {
 			appendImages(
 				values.Image.Registry,
 				values.Image.Repository,

--- a/pkg/plugins/autodiscovery/helm/main_test.go
+++ b/pkg/plugins/autodiscovery/helm/main_test.go
@@ -348,6 +348,108 @@ targets:
 			rootDir:           "testdata-4/chart",
 			expectedPipelines: []string{},
 		},
+		{
+			name:    "Test latest tag when empty string",
+			rootDir: "testdata-6/chart",
+			digest:  true,
+			expectedPipelines: []string{`name: 'deps(helm): bump image "nginx" digest for chart "test-tag-01"'
+sources:
+  nginx-digest:
+    name: 'get latest image "nginx" digest'
+    kind: 'dockerdigest'
+    spec:
+      image: 'nginx'
+      tag: 'latest'
+conditions:
+  nginx-repository:
+    disablesourceinput: true
+    name: 'Ensure container repository "nginx" is specified'
+    kind: 'yaml'
+    spec:
+      file: 'test-tag-01/values.yaml'
+      key: '$.image.repository'
+      value: 'nginx'
+targets:
+  nginx:
+    name: 'deps(helm): bump image "nginx" digest'
+    kind: 'helmchart'
+    spec:
+      file: 'values.yaml'
+      name: 'test-tag-01'
+      key: '$.image.tag'
+      skippackaging: false
+      versionincrement: ''
+    sourceid: 'nginx-digest'
+`},
+		},
+		{
+			name:    "Test latest tag",
+			rootDir: "testdata-6/chart",
+			digest:  true,
+			expectedPipelines: []string{`name: 'deps(helm): bump image "nginx" digest for chart "test-tag-01"'
+sources:
+  nginx-digest:
+    name: 'get latest image "nginx" digest'
+    kind: 'dockerdigest'
+    spec:
+      image: 'nginx'
+      tag: 'latest'
+conditions:
+  nginx-repository:
+    disablesourceinput: true
+    name: 'Ensure container repository "nginx" is specified'
+    kind: 'yaml'
+    spec:
+      file: 'test-tag-01/values.yaml'
+      key: '$.image.repository'
+      value: 'nginx'
+targets:
+  nginx:
+    name: 'deps(helm): bump image "nginx" digest'
+    kind: 'helmchart'
+    spec:
+      file: 'values.yaml'
+      name: 'test-tag-01'
+      key: '$.image.tag'
+      skippackaging: false
+      versionincrement: ''
+    sourceid: 'nginx-digest'
+`},
+		},
+		{
+			name:    "Test latest tag when tag not defined",
+			rootDir: "testdata-6/chart",
+			digest:  true,
+			expectedPipelines: []string{`name: 'deps(helm): bump image "nginx" digest for chart "test-tag-01"'
+sources:
+  nginx-digest:
+    name: 'get latest image "nginx" digest'
+    kind: 'dockerdigest'
+    spec:
+      image: 'nginx'
+      tag: 'latest'
+conditions:
+  nginx-repository:
+    disablesourceinput: true
+    name: 'Ensure container repository "nginx" is specified'
+    kind: 'yaml'
+    spec:
+      file: 'test-tag-01/values.yaml'
+      key: '$.image.repository'
+      value: 'nginx'
+targets:
+  nginx:
+    name: 'deps(helm): bump image "nginx" digest'
+    kind: 'helmchart'
+    spec:
+      file: 'values.yaml'
+      name: 'test-tag-01'
+      key: '$.image.tag'
+      skippackaging: false
+      versionincrement: ''
+    sourceid: 'nginx-digest'
+`},
+		},
 	}
 
 	for _, tt := range testdata {
@@ -364,7 +466,6 @@ targets:
 			var pipelines []string
 			bytesPipelines, err := helm.DiscoverManifests()
 			require.NoError(t, err)
-
 			assert.Equal(t, len(tt.expectedPipelines), len(bytesPipelines))
 
 			stringPipelines := []string{}

--- a/pkg/plugins/autodiscovery/helm/testdata-6/chart/test-tag-01/Chart.yaml
+++ b/pkg/plugins/autodiscovery/helm/testdata-6/chart/test-tag-01/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: test-tag-01
+description: Test tag empty string
+type: application
+version: 0.1.0
+appVersion: "1.16.0"

--- a/pkg/plugins/autodiscovery/helm/testdata-6/chart/test-tag-01/values.yaml
+++ b/pkg/plugins/autodiscovery/helm/testdata-6/chart/test-tag-01/values.yaml
@@ -1,0 +1,3 @@
+image:
+  repository: nginx
+  tag: ""

--- a/pkg/plugins/autodiscovery/helm/testdata-7/chart/test-tag-02/Chart.yaml
+++ b/pkg/plugins/autodiscovery/helm/testdata-7/chart/test-tag-02/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: test-tag-02
+description: test tag latest
+type: application
+version: 0.1.0
+appVersion: "1.16.0"

--- a/pkg/plugins/autodiscovery/helm/testdata-7/chart/test-tag-02/values.yaml
+++ b/pkg/plugins/autodiscovery/helm/testdata-7/chart/test-tag-02/values.yaml
@@ -1,0 +1,3 @@
+image:
+  repository: nginx
+  tag: "latest"

--- a/pkg/plugins/autodiscovery/helm/testdata-8/chart/test-tag-03/Chart.yaml
+++ b/pkg/plugins/autodiscovery/helm/testdata-8/chart/test-tag-03/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: test-tag-03
+description: Test no tag set
+type: application
+version: 0.1.0
+appVersion: "1.16.0"

--- a/pkg/plugins/autodiscovery/helm/testdata-8/chart/test-tag-03/values.yaml
+++ b/pkg/plugins/autodiscovery/helm/testdata-8/chart/test-tag-03/values.yaml
@@ -1,0 +1,2 @@
+image:
+  repository: nginx


### PR DESCRIPTION
Fix #3368

<!-- Describe the changes introduced by this pull request -->
When the Helm Chart manifest does not have `tag` set, updatecli will use `latest` as tag. If the digest option is set to true this will update the tags to the latest digest of the image.

## Test

To test this pull request, you can run the following commands:

```shell
gh repo clone https://github.com/updatecli/updatecli.git
cd updatecli
gh co https://github.com/updatecli/updatecli/pull/3369
go test -run ^TestDiscoverManifests/Test_latest_tag*$ github.com/updatecli/updatecli/pkg/plugins/autodiscovery/helm
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

The following configuration will throw an error because the update `kind: helmfile` will not create new fields.

```yaml

ERROR: something went wrong in "target#nginx" : something went wrong in target "nginx" : "unable to update chart new-helm-template/helm-charts/test-tag-03: updating yaml file: couldn't find key \"$.image.tag\" from file \"new-helm-template/helm-charts/test-tag-03/values.yaml\""

Pipeline "deps(helm): bump image \"nginx\" digest for chart \"test-tag-03\"" failed
Skipping due to:
	something went wrong during target execution

```



### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->

It could be nice to add options to all YAML targets to create new fields
