### PR TITLE
feat: add versionfilter of kind lexicographical

### DIFF
--- a/pkg/plugins/utils/version/filter.go
+++ b/pkg/plugins/utils/version/filter.go
@@ -3,6 +3,7 @@ package version
 import (
 	"fmt"
 	"regexp"
+	"slices"
 	"strings"
 
 	"github.com/sirupsen/logrus"
@@ -23,6 +24,8 @@ const (
 	REGEXTIMEVERSIONKIND string = "regex/time"
 	// TIMEVERSIONKIND represents versions use date format to identify the version
 	TIMEVERSIONKIND string = "time"
+	// LEXSORTVERSIONKIND uses the go sort package to find the latest version
+	LEXVERSIONKIND string = "lex"
 )
 
 // SupportedKind holds a list of supported version kind
@@ -33,6 +36,7 @@ var SupportedKind []string = []string{
 	REGEXSEMVERVERSIONKIND,
 	REGEXTIMEVERSIONKIND,
 	TIMEVERSIONKIND,
+	LEXVERSIONKIND,
 }
 
 // Filter defines parameters to apply different kind of version matching based on a list of versions
@@ -200,7 +204,6 @@ func (f *Filter) Search(versions []string) (Version, error) {
 		return s.FoundVersion, nil
 
 	case REGEXTIMEVERSIONKIND:
-
 		re, err := regexp.Compile(f.Regex)
 		if err != nil {
 			return foundVersion, err
@@ -228,6 +231,12 @@ func (f *Filter) Search(versions []string) (Version, error) {
 		}
 
 		return d.FoundVersion, nil
+
+	case LEXVERSIONKIND:
+		slices.Sort(versions)
+		foundVersion.ParsedVersion = versions[len(versions)-1]
+		foundVersion.OriginalVersion = foundVersion.ParsedVersion
+		return foundVersion, nil
 
 	default:
 		return foundVersion, &ErrUnsupportedVersionKindPattern{Pattern: f.Pattern, Kind: f.Kind}

--- a/pkg/plugins/utils/version/filter_test.go
+++ b/pkg/plugins/utils/version/filter_test.go
@@ -198,6 +198,28 @@ func TestSearch(t *testing.T) {
 				OriginalVersion: "20232205",
 			},
 		},
+		{
+			name: "Passing case with lex",
+			filter: Filter{
+				Kind: LEXVERSIONKIND,
+			},
+			versions: []string{"main-20241226-57-2242a78", "main-20240910-43-3705031", "main-20240916-49-bc46fdf"},
+			want: Version{
+				ParsedVersion:   "main-20241226-57-2242a78",
+				OriginalVersion: "main-20241226-57-2242a78",
+			},
+		},
+		{
+			name: "Passing case with lex",
+			filter: Filter{
+				Kind: LEXVERSIONKIND,
+			},
+			versions: []string{"v1.1", "v1.10", "v1.2"},
+			want: Version{
+				ParsedVersion:   "v1.2",
+				OriginalVersion: "v1.2",
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
This change implements a `gosort` filter mode. This is intended to start a conversation around picking the "latest" version of a resource that uses the "calendar version" versioning method.

This seems really simple in the implementation (it just uses `slices.Sort()`), but should actually work for many of the calver use cases out there.

Thoughts?

## Test

To test this pull request, you can run the following commands:

```shell
cd <to_package_directory>
go test
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
