### PR TITLE
fix!: preserve original version for regex/semver

### DIFF
--- a/pkg/plugins/utils/version/filter.go
+++ b/pkg/plugins/utils/version/filter.go
@@ -137,11 +137,13 @@ func (f *Filter) Search(versions []string) (Version, error) {
 
 		// Create a slice of versions using regex pattern
 		var parsedVersions []string
+		versionLookup := make(map[string]string)
 		for i := 0; i < len(versions); i++ {
 			v := versions[i]
 			found := re.FindStringSubmatch(v)
 			if len(found) > 1 {
 				parsedVersions = append(parsedVersions, found[1])
+				versionLookup[found[1]] = v
 			}
 
 		}
@@ -154,6 +156,10 @@ func (f *Filter) Search(versions []string) (Version, error) {
 		err = s.Search(parsedVersions)
 		if err != nil {
 			return foundVersion, err
+		}
+
+		if originalVersion, ok := versionLookup[s.FoundVersion.OriginalVersion]; ok {
+			s.FoundVersion.OriginalVersion = originalVersion
 		}
 
 		return s.FoundVersion, nil

--- a/pkg/plugins/utils/version/filter_test.go
+++ b/pkg/plugins/utils/version/filter_test.go
@@ -151,7 +151,7 @@ func TestSearch(t *testing.T) {
 			versions: []string{"updatecli-1.0.0", "updatecli-2.0.0", "updatecli-1.1.0"},
 			want: Version{
 				ParsedVersion:   "2.0.0",
-				OriginalVersion: "2.0.0",
+				OriginalVersion: "updatecli-2.0.0",
 			},
 		},
 		{


### PR DESCRIPTION
`regex/semver` was added in #3347, I've had a chance to use it, and it probably isn't quite right compared to other version filters.

This could be considered a feature but it feels more like a bug, but when I've been using this. I didn't get changelogs back from the github release because it was using the regex output version not the original.

```text
16:25:54  ########
16:25:54  # YARN #
16:25:54  ########
16:25:54  
16:25:54  source: source#latestRelease
16:25:54  --------------------
16:25:55  Searching for version matching pattern ""
16:25:55  ✔ GitHub release version "4.6.0" found matching pattern "" of kind "regex/semver"
16:25:55  
16:25:55  
16:25:55  CHANGELOG:
16:25:55  ----------
16:25:55  no GitHub Release found for 4.6.0 on "https://github.com/yarnpkg/berry"
```

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
cd pkg/plugins/utils/version/
go test
```

```yaml
sources:
  default:
    name: Get latest version
    kind: githubrelease
    spec:
      owner: yarnpkg
      repository: berry
      token: '{{ requiredEnv "GITHUB_TOKEN" }}'
      versionfilter:
        kind: regex/semver
        regex: "@yarnpkg/cli/(\\d*\\.\\d*\\.\\d*)"
        #pattern: "3.x"
```

```text
########
# YARN #
########

source: source#latestRelease
--------------------
Searching for version matching pattern ""
✔ GitHub release version "@yarnpkg/cli/4.6.0" found matching pattern "" of kind "regex/semver"


CHANGELOG:
----------

Release published on the 2024-12-29 12:34:29 +0000 UTC at the url https://github.com/yarnpkg/berry/releases/tag/%40yarnpkg/cli/4.6.0

## What's Changed
....
```

## Additional Information

### Tradeoff

Its a breaking change, but its still early in this features life. It does feel more correct though.

Does mean anyone using it will now have to add transformer to preserve the original functionality.

### Potential improvement

N/A
