### PR TITLE
refactor: improving json error message

### DIFF
--- a/pkg/plugins/resources/json/main.go
+++ b/pkg/plugins/resources/json/main.go
@@ -80,9 +80,5 @@ func New(spec interface{}) (*Json, error) {
 		}
 	}
 
-	if err != nil {
-		return nil, err
-	}
-
 	return &j, err
 }

--- a/pkg/plugins/resources/json/target.go
+++ b/pkg/plugins/resources/json/target.go
@@ -42,7 +42,7 @@ func (j *Json) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarg
 		}
 
 		if err := j.contents[i].Read(rootDir); err != nil {
-			return fmt.Errorf("file %q does not exist", j.contents[i].FilePath)
+			return fmt.Errorf("loading json file %q: %w", filename, err)
 		}
 
 		var queryResults []string
@@ -53,14 +53,14 @@ func (j *Json) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarg
 			queryResults, err = j.contents[i].MultipleQuery(j.spec.Query)
 
 			if err != nil {
-				return err
+				return fmt.Errorf("querying json file %q: %w", filename, err)
 			}
 
 		case false:
 			queryResult, err := j.contents[i].Query(j.spec.Key)
 
 			if err != nil {
-				return err
+				return fmt.Errorf("querying json file %q: %w", filename, err)
 			}
 
 			queryResults = append(queryResults, queryResult)
@@ -115,20 +115,20 @@ func (j *Json) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarg
 			err = j.contents[i].PutMultiple(j.spec.Query, j.spec.Value)
 
 			if err != nil {
-				return err
+				return fmt.Errorf("updating json file %q: %w", filename, err)
 			}
 
 		case false:
 			err = j.contents[i].Put(j.spec.Key, j.spec.Value)
 
 			if err != nil {
-				return err
+				return fmt.Errorf("updating json file %q: %w", filename, err)
 			}
 		}
 
 		err = j.contents[i].Write()
 		if err != nil {
-			return err
+			return fmt.Errorf("writing json file %q: %w", filename, err)
 		}
 	}
 
@@ -159,7 +159,7 @@ func (j *Json) Target(source string, scm scm.ScmHandler, dryRun bool, resultTarg
 		description := "unable to determine the result"
 		resultTarget.Result = result.FAILURE
 		resultTarget.Description = description
-		return fmt.Errorf(description)
+		return fmt.Errorf("%s", description)
 	}
 
 	return nil

--- a/pkg/plugins/resources/yaml/main_test.go
+++ b/pkg/plugins/resources/yaml/main_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/updatecli/updatecli/pkg/core/text"
 )
 
 func Test_Validate(t *testing.T) {
@@ -76,8 +75,7 @@ func Test_Validate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			yaml := Yaml{
-				spec:             tt.spec,
-				contentRetriever: &text.MockTextRetriever{},
+				spec: tt.spec,
 			}
 			gotErr := yaml.spec.Validate()
 			if tt.isErrorWanted {

--- a/pkg/plugins/utils/dasel/read.go
+++ b/pkg/plugins/utils/dasel/read.go
@@ -21,7 +21,7 @@ func (f *FileContent) Read(rootDir string) error {
 		f.FilePath)
 
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to read file %q: %w", f.FilePath, err)
 	}
 
 	var data interface{}
@@ -30,14 +30,14 @@ func (f *FileContent) Read(rootDir string) error {
 	case "json":
 		err = json.Unmarshal([]byte(textContent), &data)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to unmarshal json content: %w", err)
 		}
 
 	case "toml":
 		err := toml.Unmarshal([]byte(textContent), &data)
 
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to unmarshal toml content: %w", err)
 		}
 
 	default:


### PR DESCRIPTION
Refactor json error message to remove misleading message, and provide additional context to others.
Core functionality of the json plugin shouldn't be affected

<!-- Describe the changes introduced by this pull request -->

## Test

/

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
