### PR TITLE
refactor: git error messages

### DIFF
--- a/pkg/plugins/utils/gitgeneric/file.go
+++ b/pkg/plugins/utils/gitgeneric/file.go
@@ -34,12 +34,12 @@ func ReadFileFromRevision(repoPath, revision, filePath string) ([]byte, error) {
 
 	blob, err := resolve(obj, filePath)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("resolve %q: %w", filePath, err)
 	}
 
 	r, err := blob.Reader()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("open reader: %w", err)
 	}
 
 	defer func() {
@@ -48,7 +48,7 @@ func ReadFileFromRevision(repoPath, revision, filePath string) ([]byte, error) {
 
 	content, err := io.ReadAll(r)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("read content: %w", err)
 	}
 
 	return content, nil
@@ -60,19 +60,19 @@ func resolve(obj object.Object, path string) (*object.Blob, error) {
 	case *object.Commit:
 		t, err := o.Tree()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("get tree: %w", err)
 		}
 		return resolve(t, path)
 	case *object.Tag:
 		target, err := o.Object()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("get object: %w", err)
 		}
 		return resolve(target, path)
 	case *object.Tree:
 		file, err := o.File(path)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("get file %q: %w", path, err)
 		}
 		return &file.Blob, nil
 	case *object.Blob:


### PR DESCRIPTION
Refactor git error messages, this pull request shouldn't affect core functionalities 

Fix #3396 

Before
```
SCM repository retrieved: 1
ERROR: failed cloning GitHub repository "https://github.com/olblak/fleet-lab.git"
ERROR: err - authentication required
```

After
```
SCM repository retrieved: 1
ERROR: failed cloning GitHub repository "https://github.com/olblak/fleet-lab.git"
ERROR: err - cloning: authentication required: Repository not found.
	It appears that a password has been specified without a username, could it be related?
```

Fix #1014 

Before
```
ERROR: something went wrong in "target#contributing-doc" : something went wrong in target "contributing-doc" : "reference not found"
```

After
```
ERROR: something went wrong in "target#contributing-doc" : something went wrong in target "contributing-doc" : "checking out branch \"donotexist22222222\" - reference not found"
```
<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
cd <to_package_directory>
go test
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
