### PR TITLE
fix: ArgoCD autodiscovery for OCI registry

### DIFF
--- a/pkg/plugins/autodiscovery/argocd/main_test.go
+++ b/pkg/plugins/autodiscovery/argocd/main_test.go
@@ -100,6 +100,47 @@ targets:
     sourceid: 'sealed-secrets'
 `},
 		},
+		{
+			name:    "ArgoCD manifests discovery with OCI source",
+			rootDir: "testdata/oci-helm-source",
+			expectedPipelines: []string{`name: 'deps(helm): bump Helm chart "nginx" in ArgoCD manifest "manifest.yaml"'
+sources:
+  nginx:
+    name: 'Get latest "nginx" Helm chart version'
+    kind: 'helmchart'
+    spec:
+      name: 'nginx'
+      url: 'oci://registry-1.docker.io/bitnamicharts'
+      versionfilter:
+        kind: 'semver'
+        pattern: '*'
+conditions:
+  nginx-name:
+    name: 'Ensure Helm chart name nginx is specified'
+    kind: 'yaml'
+    disablesourceinput: true
+    spec:
+      file: 'manifest.yaml'
+      key: '$.spec.source.chart'
+      value: 'nginx'
+  nginx-repository:
+    name: 'Ensure Helm chart repository registry-1.docker.io/bitnamicharts is specified'
+    kind: 'yaml'
+    disablesourceinput: true
+    spec:
+      file: 'manifest.yaml'
+      key: '$.spec.source.repoURL'
+      value: 'registry-1.docker.io/bitnamicharts'
+targets:
+  nginx:
+    name: 'deps(helm): bump Helm chart "nginx" in ArgoCD manifest "manifest.yaml"'
+    kind: 'yaml'
+    spec:
+      file: 'manifest.yaml'
+      key: '$.spec.source.targetRevision'
+    sourceid: 'nginx'
+`},
+		},
 	}
 
 	for _, tt := range testdata {

--- a/pkg/plugins/autodiscovery/argocd/manifestTemplate.go
+++ b/pkg/plugins/autodiscovery/argocd/manifestTemplate.go
@@ -9,7 +9,7 @@ sources:
     kind: '{{ .SourceKind }}'
     spec:
       name: '{{ .ChartName }}'
-      url: '{{ .ChartRepository }}'
+      url: '{{ .SourceChartRepository }}'
       versionfilter:
         kind: '{{ .SourceVersionFilterKind }}'
         pattern: '{{ .SourceVersionFilterPattern }}'

--- a/pkg/plugins/autodiscovery/argocd/testdata/oci-helm-source/manifest.yaml
+++ b/pkg/plugins/autodiscovery/argocd/testdata/oci-helm-source/manifest.yaml
@@ -1,0 +1,14 @@
+# Example from documentation: https://argo-cd.readthedocs.io/en/latest/user-guide/helm/
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: nginx
+spec:
+  project: default
+  source:
+    chart: nginx
+    repoURL: registry-1.docker.io/bitnamicharts  # note: the oci:// syntax is not included.
+    targetRevision: 15.9.0
+  destination:
+    name: "in-cluster"
+    namespace: nginx

--- a/pkg/plugins/autodiscovery/argocd/utils_test.go
+++ b/pkg/plugins/autodiscovery/argocd/utils_test.go
@@ -15,6 +15,7 @@ func TestSearchFiles(t *testing.T) {
 	}
 
 	expectedFiles := []string{
+		"testdata/oci-helm-source/manifest.yaml",
 		"testdata/sealed-secrets/manifest.yaml",
 		"testdata/sealed-secrets_sources/manifest.yaml",
 	}


### PR DESCRIPTION
Fix #3459

Added `oci://` prefix for `sources.spec.url` to UpdateCLI manifest if the scheme is not set in ArgoCD Application manifest

## Test

To test this pull request, you can run the following commands:

```shell
cd pkg/plugins/autodiscovery/argocd/
go test
```

## Additional Information

### Checklist

### Tradeoff

### Potential improvement

