### PR TITLE
fix: retrieve correct helm chart changelog based on a version

### DIFF
--- a/pkg/plugins/resources/helm/changelog.go
+++ b/pkg/plugins/resources/helm/changelog.go
@@ -41,7 +41,7 @@ func (c Chart) Changelog() string {
 		return ""
 	}
 
-	e, err := index.Get(c.spec.Name, c.spec.Version)
+	e, err := index.Get(c.spec.Name, c.foundVersion.OriginalVersion)
 	if err != nil {
 		return ""
 	}


### PR DESCRIPTION
Fix #2975 

Use the version from the source output instead of the latest one

<!-- Describe the changes introduced by this pull request -->

## Test

No spending more time on testing this change as I am planning to refactor soon this area

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
