### PR TITLE
fix(autodiscovery/dockercompose): correctly set arch

### DIFF
--- a/pkg/plugins/autodiscovery/dockercompose/compose.go
+++ b/pkg/plugins/autodiscovery/dockercompose/compose.go
@@ -150,7 +150,7 @@ func (d DockerCompose) discoverDockerComposeImageManifests() ([][]byte, error) {
 			}
 
 			if arch != "" {
-				sourceSpec.Architecture = arch
+				architecture = arch
 			}
 
 			var tmpl *template.Template

--- a/pkg/plugins/autodiscovery/dockercompose/main_test.go
+++ b/pkg/plugins/autodiscovery/dockercompose/main_test.go
@@ -54,6 +54,7 @@ sources:
     name: 'get latest image tag for "jenkinsci/jenkins"'
     kind: 'dockerimage'
     spec:
+      architecture: 'amd64'
       image: 'jenkinsci/jenkins'
       tagfilter: '^\d*(\.\d*){1}-alpine$'
       versionfilter:
@@ -111,6 +112,7 @@ sources:
     name: 'get latest image tag for "jenkinsci/jenkins"'
     kind: 'dockerimage'
     spec:
+      architecture: 'amd64'
       image: 'jenkinsci/jenkins'
       tagfilter: '^\d*(\.\d*){1}-alpine$'
       versionfilter:

--- a/pkg/plugins/autodiscovery/dockercompose/manifestTemplate.go
+++ b/pkg/plugins/autodiscovery/dockercompose/manifestTemplate.go
@@ -10,7 +10,7 @@ sources:
     spec:
 {{- if .ImageArchitecture }}
       architecture: '{{ .ImageArchitecture }}'
-{{ end }}
+{{- end }}
       image: '{{ .ImageName }}'
       tagfilter: '{{ .TagFilter }}'
       versionfilter:
@@ -38,7 +38,7 @@ sources:
     spec:
 {{- if .ImageArchitecture }}
       architecture: '{{ .ImageArchitecture }}'
-{{ end }}
+{{- end }}
       image: '{{ .ImageName }}'
       tagfilter: '{{ .TagFilter }}'
       versionfilter:


### PR DESCRIPTION
Correctly handle platform parameter from docker compose file

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell

cd pkg/plugins/autodiscovery/dockercompose
go test .
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
