### PR TITLE
fix(autodiscovery/helm): correctly handle ignore/only rule

### DIFF
--- a/pkg/plugins/autodiscovery/helm/main_test.go
+++ b/pkg/plugins/autodiscovery/helm/main_test.go
@@ -50,6 +50,7 @@ targets:
       file: 'Chart.yaml'
       key: '$.dependencies[0].version'
       name: 'epinio'
+      skippackaging: false
       versionincrement: ''
     sourceid: 'minio'
 `,
@@ -81,6 +82,7 @@ targets:
       file: 'Chart.yaml'
       key: '$.dependencies[1].version'
       name: 'epinio'
+      skippackaging: false
       versionincrement: ''
     sourceid: 'kubed'
 `,
@@ -112,6 +114,7 @@ targets:
       file: 'Chart.yaml'
       key: '$.dependencies[2].version'
       name: 'epinio'
+      skippackaging: false
       versionincrement: ''
     sourceid: 'epinio-ui'
 `,
@@ -143,6 +146,7 @@ targets:
       file: 'values.yaml'
       name: 'epinio'
       key: '$.image.tag'
+      skippackaging: false
       versionincrement: ''
     sourceid: 'splatform_epinio-server'
 `,
@@ -174,6 +178,7 @@ targets:
       file: 'values.yaml'
       name: 'epinio'
       key: '$.images.ui.tag'
+      skippackaging: false
       versionincrement: ''
     sourceid: 'epinioteam_epinio-ui-qa'
 `},
@@ -218,6 +223,7 @@ targets:
       file: 'values.yaml'
       name: 'sample'
       key: '$.image.tag'
+      skippackaging: false
       versionincrement: ''
     sourceid: 'epinio_epinio-server-digest'
 `,
@@ -257,6 +263,7 @@ targets:
       file: 'values.yaml'
       name: 'sample'
       key: '$.images.ui.tag'
+      skippackaging: false
       versionincrement: ''
     sourceid: 'epinio_epinio-ui-digest'
 `},
@@ -300,6 +307,7 @@ targets:
       file: 'values.yaml'
       name: 'sample'
       key: '$.image.tag'
+      skippackaging: false
       versionincrement: ''
     sourceid: 'ghcr.io_epinio_epinio-server'
 `,
@@ -339,6 +347,7 @@ targets:
       file: 'values.yaml'
       name: 'sample'
       key: '$.images.ui.tag'
+      skippackaging: false
       versionincrement: ''
     sourceid: 'ghcr.io_epinio_epinio-ui'
 `},


### PR DESCRIPTION
Fix #3367 

Correctly handle ignore/only rules in helm autodiscovery plugin.

Also for some reason tests were broken as we were missing a few skippackaging setting

## Test

To test this pull request, you can run the following commands:

```shell
cd pkg/plugins/autodiscovery/helm
go test .
```

## Additional Information

### Checklist

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
