### PR TITLE
githubaction autodiscovery should allow for pinning version to commit hash 

### DIFF
--- a/e2e/updatecli.d/success.d/gitBranch.yaml
+++ b/e2e/updatecli.d/success.d/gitBranch.yaml
@@ -26,6 +26,12 @@ sources:
     kind: gitbranch
     spec:
       url: https://github.com/olblak/nocode.git
+  hash:
+    name: Get Latest committed branch
+    kind: gitbranch
+    scmid: default
+    spec:
+      key: hash
 
 conditions:
   default:

--- a/e2e/updatecli.d/success.d/githubRelease.yaml
+++ b/e2e/updatecli.d/success.d/githubRelease.yaml
@@ -29,6 +29,15 @@ sources:
       username: '{{ requiredEnv "GITHUB_ACTOR" }}'
       typefilter:
         release: true
+  hash:
+    name: Default Get Latest github action Release Hash
+    kind: githubrelease
+    spec:
+      owner: updatecli
+      repository: updatecli-action
+      token: '{{ requiredEnv "GITHUB_TOKEN" }}'
+      username: '{{ requiredEnv "GITHUB_ACTOR" }}'
+      key: hash
 conditions:
   default:
     name: Default Get Latest GitHub action Release

--- a/pkg/plugins/autodiscovery/githubaction/main.go
+++ b/pkg/plugins/autodiscovery/githubaction/main.go
@@ -90,6 +90,8 @@ type Spec struct {
 	//             token: '{{ requiredEnv "GITHUB_TOKEN" }}'
 	// ```
 	Credentials map[string]gitProviderToken `yaml:",omitempty"`
+	// Digest provides parameters to specify if the generated manifest should use a digest instead of the branch or tag.
+	Digest *bool `yaml:",omitempty"`
 }
 
 // GitHubAction holds all information needed to generate GitHubAction manifest.
@@ -108,6 +110,8 @@ type GitHubAction struct {
 	versionFilter version.Filter
 	// workflowFiles is a list of HelmRelease files found
 	workflowFiles []string
+	// digest holds the value of the digest parameter
+	digest bool
 }
 
 type gitProviderToken struct {
@@ -163,6 +167,10 @@ func New(spec interface{}, rootDir, scmID string) (GitHubAction, error) {
 		newFilter.Kind = defaultVersionFilterKind
 		newFilter.Pattern = defaultVersionFilterPattern
 	}
+	digest := false
+	if s.Digest != nil {
+		digest = *s.Digest
+	}
 
 	return GitHubAction{
 		credentials:   s.Credentials,
@@ -171,6 +179,7 @@ func New(spec interface{}, rootDir, scmID string) (GitHubAction, error) {
 		rootDir:       dir,
 		scmID:         scmID,
 		versionFilter: newFilter,
+		digest:        digest,
 	}, nil
 
 }

--- a/pkg/plugins/autodiscovery/githubaction/main_test.go
+++ b/pkg/plugins/autodiscovery/githubaction/main_test.go
@@ -279,7 +279,7 @@ targets:
       file: '.github/workflows/updatecli.yaml'
       key: '$.jobs.updatecli.steps[0].uses'
       engine: 'yamlpath'
-      comment: 'pinned from {{ source "release" }} by updatecli (do-not-remove-comment)'
+      comment: '{{ source "release" }}'
 
   tag:
     dependson:
@@ -294,7 +294,7 @@ targets:
       file: '.github/workflows/updatecli.yaml'
       key: '$.jobs.updatecli.steps[0].uses'
       engine: 'yamlpath'
-      comment: 'pinned from {{ source "tag" }} by updatecli (do-not-remove-comment)'
+      comment: '{{ source "tag" }}'
 
   branch:
     dependson:
@@ -309,7 +309,7 @@ targets:
       file: '.github/workflows/updatecli.yaml'
       key: '$.jobs.updatecli.steps[0].uses'
       engine: 'yamlpath'
-      comment: 'pinned from {{ source "branch" }} by updatecli (do-not-remove-comment)'
+      comment: '{{ source "branch" }}'
 `, `name: 'deps: bump actions/checkout GitHub workflow'
 
 sources:
@@ -438,7 +438,7 @@ targets:
       file: '.github/workflows/updatecli.yaml'
       key: '$.jobs.updatecli.steps[1].uses'
       engine: 'yamlpath'
-      comment: 'pinned from {{ source "release" }} by updatecli (do-not-remove-comment)'
+      comment: '{{ source "release" }}'
 
   tag:
     dependson:
@@ -453,7 +453,7 @@ targets:
       file: '.github/workflows/updatecli.yaml'
       key: '$.jobs.updatecli.steps[1].uses'
       engine: 'yamlpath'
-      comment: 'pinned from {{ source "tag" }} by updatecli (do-not-remove-comment)'
+      comment: '{{ source "tag" }}'
 
   branch:
     dependson:
@@ -468,7 +468,7 @@ targets:
       file: '.github/workflows/updatecli.yaml'
       key: '$.jobs.updatecli.steps[1].uses'
       engine: 'yamlpath'
-      comment: 'pinned from {{ source "branch" }} by updatecli (do-not-remove-comment)'
+      comment: '{{ source "branch" }}'
 `},
 		},
 		{

--- a/pkg/plugins/autodiscovery/githubaction/main_test.go
+++ b/pkg/plugins/autodiscovery/githubaction/main_test.go
@@ -143,7 +143,7 @@ targets:
 		},
 		{
 			name:    "Scenario - GitHub Action with a single workflow file and digest",
-			rootDir: "testdata/updatecli",
+			rootDir: "testdata/digest",
 			credentials: map[string]gitProviderToken{
 				"github.com": {
 					Kind:  "github",
@@ -155,6 +155,20 @@ targets:
 
 sources:
   release:
+    dependson:
+      - 'condition#release:and'
+    name: 'Get latest GitHub Release for actions/checkout'
+    kind: 'githubrelease'
+    spec:
+      owner: 'actions'
+      repository: 'checkout'
+      url: 'https://github.com'
+      token: 'xxx'
+      versionfilter:
+        kind: 'semver'
+        pattern: '*'
+
+  release_digest:
     dependson:
       - 'condition#release:and'
     name: 'Get latest GitHub Release for actions/checkout'
@@ -177,12 +191,36 @@ sources:
     spec:
       url: "https://github.com/actions/checkout.git"
       password: 'xxx'
+      versionfilter:
+        kind: 'semver'
+        pattern: '*'
+
+  tag_digest:
+    dependson:
+      - 'condition#tag:and'
+    name: 'Get latest tag for actions/checkout'
+    kind: 'gittag'
+    spec:
+      url: "https://github.com/actions/checkout.git"
+      password: 'xxx'
       key: 'hash'
       versionfilter:
         kind: 'semver'
         pattern: '*'
 
   branch:
+    dependson:
+      - 'condition#branch:and'
+    name: 'Get latest branch for actions/checkout'
+    kind: 'gitbranch'
+    spec:
+      url: "https://github.com/actions/checkout.git"
+      password: 'xxx'
+      versionfilter:
+        kind: 'semver'
+        pattern: '*'
+
+  branch_digest:
     dependson:
       - 'condition#branch:and'
     name: 'Get latest branch for actions/checkout'
@@ -232,12 +270,13 @@ targets:
     dependson:
       - 'condition#release:and'
     disableconditions: true
-    name: 'deps(github): bump Action release for actions/checkout from v4 to {{ source "release" }}'
+    name: 'deps(github): bump Action release for actions/checkout from v4 to {{ source "release_digest" }} (Pinned from {{ source "release" }})'
     kind: 'yaml'
-    sourceid: 'release'
+    sourceid: 'release_digest'
     transformers:
       - addprefix: '"actions/checkout@'
       - addsuffix: '"'
+      - addsuffix: '  # pinned from {{ source "release" }} by updatecli (do-not-remove-comment)'
     spec:
       file: '.github/workflows/updatecli.yaml'
       key: '$.jobs.updatecli.steps[0].uses'
@@ -246,12 +285,13 @@ targets:
     dependson:
       - 'condition#tag:and'
     disableconditions: true
-    name: 'deps(github): bump Action tag for actions/checkout from v4 to {{ source "tag" }}'
+    name: 'deps(github): bump Action tag for actions/checkout from v4 to {{ source "tag_digest" }} (Pinned from {{ source "tag" }})'
     kind: 'yaml'
-    sourceid: 'tag'
+    sourceid: 'tag_digest'
     transformers:
       - addprefix: '"actions/checkout@'
       - addsuffix: '"'
+      - addsuffix: '  # pinned from {{ source "tag" }} by updatecli (do-not-remove-comment)'
     spec:
       file: '.github/workflows/updatecli.yaml'
       key: '$.jobs.updatecli.steps[0].uses'
@@ -260,15 +300,175 @@ targets:
     dependson:
       - 'condition#branch:and'
     disableconditions: true
-    name: 'deps(github): bump Action branch for actions/checkout from v4 to {{ source "branch" }}'
+    name: 'deps(github): bump Action branch for actions/checkout from v4 to {{ source "branch_digest" }} (Pinned from {{ source "branch" }})'
     kind: yaml
-    sourceid: branch
+    sourceid: branch_digest
     transformers:
       - addprefix: '"actions/checkout@'
       - addsuffix: '"'
+      - addsuffix: '  # pinned from {{ source "branch" }} by updatecli (do-not-remove-comment)'
     spec:
       file: '.github/workflows/updatecli.yaml'
       key: '$.jobs.updatecli.steps[0].uses'
+`, `name: 'deps: bump actions/checkout GitHub workflow'
+
+sources:
+  release:
+    dependson:
+      - 'condition#release:and'
+    name: 'Get latest GitHub Release for actions/checkout'
+    kind: 'githubrelease'
+    spec:
+      owner: 'actions'
+      repository: 'checkout'
+      url: 'https://github.com'
+      token: 'xxx'
+      versionfilter:
+        kind: 'semver'
+        pattern: '*'
+
+  release_digest:
+    dependson:
+      - 'condition#release:and'
+    name: 'Get latest GitHub Release for actions/checkout'
+    kind: 'githubrelease'
+    spec:
+      owner: 'actions'
+      repository: 'checkout'
+      url: 'https://github.com'
+      token: 'xxx'
+      key: 'hash'
+      versionfilter:
+        kind: 'semver'
+        pattern: '*'
+
+  tag:
+    dependson:
+      - 'condition#tag:and'
+    name: 'Get latest tag for actions/checkout'
+    kind: 'gittag'
+    spec:
+      url: "https://github.com/actions/checkout.git"
+      password: 'xxx'
+      versionfilter:
+        kind: 'semver'
+        pattern: '*'
+
+  tag_digest:
+    dependson:
+      - 'condition#tag:and'
+    name: 'Get latest tag for actions/checkout'
+    kind: 'gittag'
+    spec:
+      url: "https://github.com/actions/checkout.git"
+      password: 'xxx'
+      key: 'hash'
+      versionfilter:
+        kind: 'semver'
+        pattern: '*'
+
+  branch:
+    dependson:
+      - 'condition#branch:and'
+    name: 'Get latest branch for actions/checkout'
+    kind: 'gitbranch'
+    spec:
+      url: "https://github.com/actions/checkout.git"
+      password: 'xxx'
+      versionfilter:
+        kind: 'semver'
+        pattern: '*'
+
+  branch_digest:
+    dependson:
+      - 'condition#branch:and'
+    name: 'Get latest branch for actions/checkout'
+    kind: 'gitbranch'
+    spec:
+      url: "https://github.com/actions/checkout.git"
+      password: 'xxx'
+      key: 'hash'
+      versionfilter:
+        kind: 'semver'
+        pattern: '*'
+
+conditions:
+  release:
+    name: 'Check if actions/checkout@v4.2.2 is a GitHub release'
+    kind: 'githubrelease'
+    disablesourceinput: true
+    spec:
+      owner: 'actions'
+      repository: 'checkout'
+      url: 'https://github.com'
+      token: 'xxx'
+      tag: 'v4.2.2'
+
+  tag:
+    name: 'Check if actions/checkout@v4.2.2 is a tag'
+    kind: 'gittag'
+    disablesourceinput: true
+    spec:
+      url: "https://github.com/actions/checkout.git"
+      password: 'xxx'
+      versionfilter:
+        kind: 'regex'
+        pattern: '^v4.2.2$'
+
+  branch:
+    name: 'Check if actions/checkout@v4.2.2 is a branch'
+    kind: 'gitbranch'
+    disablesourceinput: true
+    spec:
+      branch: 'v4.2.2'
+      url: "https://github.com/actions/checkout.git"
+      password: 'xxx'
+
+targets:
+  release:
+    dependson:
+      - 'condition#release:and'
+    disableconditions: true
+    name: 'deps(github): bump Action release for actions/checkout from 11bd71901bbe5b1630ceea73d27597364c9af683 to {{ source "release_digest" }} (Pinned from {{ source "release" }})'
+    kind: 'yaml'
+    sourceid: 'release_digest'
+    transformers:
+      - addprefix: '"actions/checkout@'
+      - addsuffix: '"'
+      - addsuffix: '  # pinned from {{ source "release" }} by updatecli (do-not-remove-comment)'
+    spec:
+      file: '.github/workflows/updatecli.yaml'
+      key: '$.jobs.updatecli.steps[1].uses'
+
+  tag:
+    dependson:
+      - 'condition#tag:and'
+    disableconditions: true
+    name: 'deps(github): bump Action tag for actions/checkout from 11bd71901bbe5b1630ceea73d27597364c9af683 to {{ source "tag_digest" }} (Pinned from {{ source "tag" }})'
+    kind: 'yaml'
+    sourceid: 'tag_digest'
+    transformers:
+      - addprefix: '"actions/checkout@'
+      - addsuffix: '"'
+      - addsuffix: '  # pinned from {{ source "tag" }} by updatecli (do-not-remove-comment)'
+    spec:
+      file: '.github/workflows/updatecli.yaml'
+      key: '$.jobs.updatecli.steps[1].uses'
+
+  branch:
+    dependson:
+      - 'condition#branch:and'
+    disableconditions: true
+    name: 'deps(github): bump Action branch for actions/checkout from 11bd71901bbe5b1630ceea73d27597364c9af683 to {{ source "branch_digest" }} (Pinned from {{ source "branch" }})'
+    kind: yaml
+    sourceid: branch_digest
+    transformers:
+      - addprefix: '"actions/checkout@'
+      - addsuffix: '"'
+      - addsuffix: '  # pinned from {{ source "branch" }} by updatecli (do-not-remove-comment)'
+    spec:
+      file: '.github/workflows/updatecli.yaml'
+      key: '$.jobs.updatecli.steps[1].uses'
 `},
 		},
 		{

--- a/pkg/plugins/autodiscovery/githubaction/main_test.go
+++ b/pkg/plugins/autodiscovery/githubaction/main_test.go
@@ -106,11 +106,11 @@ targets:
     kind: 'yaml'
     sourceid: 'release'
     transformers:
-      - addprefix: '"actions/checkout@'
-      - addsuffix: '"'
+      - addprefix: 'actions/checkout@'
     spec:
       file: '.github/workflows/updatecli.yaml'
       key: '$.jobs.updatecli.steps[0].uses'
+      engine: 'yamlpath'
 
   tag:
     dependson:
@@ -120,11 +120,11 @@ targets:
     kind: 'yaml'
     sourceid: 'tag'
     transformers:
-      - addprefix: '"actions/checkout@'
-      - addsuffix: '"'
+      - addprefix: 'actions/checkout@'
     spec:
       file: '.github/workflows/updatecli.yaml'
       key: '$.jobs.updatecli.steps[0].uses'
+      engine: 'yamlpath'
 
   branch:
     dependson:
@@ -134,11 +134,11 @@ targets:
     kind: yaml
     sourceid: branch
     transformers:
-      - addprefix: '"actions/checkout@'
-      - addsuffix: '"'
+      - addprefix: 'actions/checkout@'
     spec:
       file: '.github/workflows/updatecli.yaml'
       key: '$.jobs.updatecli.steps[0].uses'
+      engine: 'yamlpath'
 `},
 		},
 		{
@@ -274,12 +274,12 @@ targets:
     kind: 'yaml'
     sourceid: 'release_digest'
     transformers:
-      - addprefix: '"actions/checkout@'
-      - addsuffix: '"'
-      - addsuffix: '  # pinned from {{ source "release" }} by updatecli (do-not-remove-comment)'
+      - addprefix: 'actions/checkout@'
     spec:
       file: '.github/workflows/updatecli.yaml'
       key: '$.jobs.updatecli.steps[0].uses'
+      engine: 'yamlpath'
+      comment: 'pinned from {{ source "release" }} by updatecli (do-not-remove-comment)'
 
   tag:
     dependson:
@@ -289,12 +289,12 @@ targets:
     kind: 'yaml'
     sourceid: 'tag_digest'
     transformers:
-      - addprefix: '"actions/checkout@'
-      - addsuffix: '"'
-      - addsuffix: '  # pinned from {{ source "tag" }} by updatecli (do-not-remove-comment)'
+      - addprefix: 'actions/checkout@'
     spec:
       file: '.github/workflows/updatecli.yaml'
       key: '$.jobs.updatecli.steps[0].uses'
+      engine: 'yamlpath'
+      comment: 'pinned from {{ source "tag" }} by updatecli (do-not-remove-comment)'
 
   branch:
     dependson:
@@ -304,12 +304,12 @@ targets:
     kind: yaml
     sourceid: branch_digest
     transformers:
-      - addprefix: '"actions/checkout@'
-      - addsuffix: '"'
-      - addsuffix: '  # pinned from {{ source "branch" }} by updatecli (do-not-remove-comment)'
+      - addprefix: 'actions/checkout@'
     spec:
       file: '.github/workflows/updatecli.yaml'
       key: '$.jobs.updatecli.steps[0].uses'
+      engine: 'yamlpath'
+      comment: 'pinned from {{ source "branch" }} by updatecli (do-not-remove-comment)'
 `, `name: 'deps: bump actions/checkout GitHub workflow'
 
 sources:
@@ -433,12 +433,12 @@ targets:
     kind: 'yaml'
     sourceid: 'release_digest'
     transformers:
-      - addprefix: '"actions/checkout@'
-      - addsuffix: '"'
-      - addsuffix: '  # pinned from {{ source "release" }} by updatecli (do-not-remove-comment)'
+      - addprefix: 'actions/checkout@'
     spec:
       file: '.github/workflows/updatecli.yaml'
       key: '$.jobs.updatecli.steps[1].uses'
+      engine: 'yamlpath'
+      comment: 'pinned from {{ source "release" }} by updatecli (do-not-remove-comment)'
 
   tag:
     dependson:
@@ -448,12 +448,12 @@ targets:
     kind: 'yaml'
     sourceid: 'tag_digest'
     transformers:
-      - addprefix: '"actions/checkout@'
-      - addsuffix: '"'
-      - addsuffix: '  # pinned from {{ source "tag" }} by updatecli (do-not-remove-comment)'
+      - addprefix: 'actions/checkout@'
     spec:
       file: '.github/workflows/updatecli.yaml'
       key: '$.jobs.updatecli.steps[1].uses'
+      engine: 'yamlpath'
+      comment: 'pinned from {{ source "tag" }} by updatecli (do-not-remove-comment)'
 
   branch:
     dependson:
@@ -463,12 +463,12 @@ targets:
     kind: yaml
     sourceid: branch_digest
     transformers:
-      - addprefix: '"actions/checkout@'
-      - addsuffix: '"'
-      - addsuffix: '  # pinned from {{ source "branch" }} by updatecli (do-not-remove-comment)'
+      - addprefix: 'actions/checkout@'
     spec:
       file: '.github/workflows/updatecli.yaml'
       key: '$.jobs.updatecli.steps[1].uses'
+      engine: 'yamlpath'
+      comment: 'pinned from {{ source "branch" }} by updatecli (do-not-remove-comment)'
 `},
 		},
 		{
@@ -563,11 +563,11 @@ targets:
     kind: 'yaml'
     sourceid: 'release'
     transformers:
-      - addprefix: '"https://gitea.com/actions/checkout@'
-      - addsuffix: '"'
+      - addprefix: 'https://gitea.com/actions/checkout@'
     spec:
       file: '.gitea/workflows/updatecli.yaml'
       key: '$.jobs.updatecli.steps[0].uses'
+      engine: 'yamlpath'
 
   tag:
     dependson:
@@ -577,11 +577,11 @@ targets:
     kind: 'yaml'
     sourceid: 'tag'
     transformers:
-      - addprefix: '"https://gitea.com/actions/checkout@'
-      - addsuffix: '"'
+      - addprefix: 'https://gitea.com/actions/checkout@'
     spec:
       file: '.gitea/workflows/updatecli.yaml'
       key: '$.jobs.updatecli.steps[0].uses'
+      engine: 'yamlpath'
 
   branch:
     dependson:
@@ -591,11 +591,11 @@ targets:
     kind: yaml
     sourceid: branch
     transformers:
-      - addprefix: '"https://gitea.com/actions/checkout@'
-      - addsuffix: '"'
+      - addprefix: 'https://gitea.com/actions/checkout@'
     spec:
       file: '.gitea/workflows/updatecli.yaml'
       key: '$.jobs.updatecli.steps[0].uses'
+      engine: 'yamlpath'
 `},
 		},
 		{
@@ -689,11 +689,11 @@ targets:
     kind: 'yaml'
     sourceid: 'release'
     transformers:
-      - addprefix: '"tibdex/github-app-token@'
-      - addsuffix: '"'
+      - addprefix: 'tibdex/github-app-token@'
     spec:
       file: '.github/workflows/updatecli.yaml'
       key: '$.jobs.updatecli.steps[0].uses'
+      engine: 'yamlpath'
 
   tag:
     dependson:
@@ -703,11 +703,11 @@ targets:
     kind: 'yaml'
     sourceid: 'tag'
     transformers:
-      - addprefix: '"tibdex/github-app-token@'
-      - addsuffix: '"'
+      - addprefix: 'tibdex/github-app-token@'
     spec:
       file: '.github/workflows/updatecli.yaml'
       key: '$.jobs.updatecli.steps[0].uses'
+      engine: 'yamlpath'
 
   branch:
     dependson:
@@ -717,11 +717,11 @@ targets:
     kind: yaml
     sourceid: branch
     transformers:
-      - addprefix: '"tibdex/github-app-token@'
-      - addsuffix: '"'
+      - addprefix: 'tibdex/github-app-token@'
     spec:
       file: '.github/workflows/updatecli.yaml'
       key: '$.jobs.updatecli.steps[0].uses'
+      engine: 'yamlpath'
 `, `name: 'deps: bump tibdex/github-app-token GitHub workflow'
 
 sources:
@@ -804,11 +804,11 @@ targets:
     kind: 'yaml'
     sourceid: 'release'
     transformers:
-      - addprefix: '"tibdex/github-app-token@'
-      - addsuffix: '"'
+      - addprefix: 'tibdex/github-app-token@'
     spec:
       file: '.github/workflows/updatecli.yaml'
       key: '$.jobs.updatecli.steps[1].uses'
+      engine: 'yamlpath'
 
   tag:
     dependson:
@@ -818,11 +818,11 @@ targets:
     kind: 'yaml'
     sourceid: 'tag'
     transformers:
-      - addprefix: '"tibdex/github-app-token@'
-      - addsuffix: '"'
+      - addprefix: 'tibdex/github-app-token@'
     spec:
       file: '.github/workflows/updatecli.yaml'
       key: '$.jobs.updatecli.steps[1].uses'
+      engine: 'yamlpath'
 
   branch:
     dependson:
@@ -832,11 +832,11 @@ targets:
     kind: yaml
     sourceid: branch
     transformers:
-      - addprefix: '"tibdex/github-app-token@'
-      - addsuffix: '"'
+      - addprefix: 'tibdex/github-app-token@'
     spec:
       file: '.github/workflows/updatecli.yaml'
       key: '$.jobs.updatecli.steps[1].uses'
+      engine: 'yamlpath'
 `, `name: 'deps: bump actions/checkout GitHub workflow'
 
 sources:
@@ -919,11 +919,11 @@ targets:
     kind: 'yaml'
     sourceid: 'release'
     transformers:
-      - addprefix: '"actions/checkout@'
-      - addsuffix: '"'
+      - addprefix: 'actions/checkout@'
     spec:
       file: '.github/workflows/updatecli.yaml'
       key: '$.jobs.updatecli.steps[2].uses'
+      engine: 'yamlpath'
 
   tag:
     dependson:
@@ -933,11 +933,11 @@ targets:
     kind: 'yaml'
     sourceid: 'tag'
     transformers:
-      - addprefix: '"actions/checkout@'
-      - addsuffix: '"'
+      - addprefix: 'actions/checkout@'
     spec:
       file: '.github/workflows/updatecli.yaml'
       key: '$.jobs.updatecli.steps[2].uses'
+      engine: 'yamlpath'
 
   branch:
     dependson:
@@ -947,11 +947,11 @@ targets:
     kind: yaml
     sourceid: branch
     transformers:
-      - addprefix: '"actions/checkout@'
-      - addsuffix: '"'
+      - addprefix: 'actions/checkout@'
     spec:
       file: '.github/workflows/updatecli.yaml'
       key: '$.jobs.updatecli.steps[2].uses'
+      engine: 'yamlpath'
 `, `name: 'deps: bump updatecli/updatecli-action GitHub workflow'
 
 sources:
@@ -1034,11 +1034,11 @@ targets:
     kind: 'yaml'
     sourceid: 'release'
     transformers:
-      - addprefix: '"updatecli/updatecli-action@'
-      - addsuffix: '"'
+      - addprefix: 'updatecli/updatecli-action@'
     spec:
       file: '.github/workflows/updatecli.yaml'
       key: '$.jobs.updatecli.steps[3].uses'
+      engine: 'yamlpath'
 
   tag:
     dependson:
@@ -1048,11 +1048,11 @@ targets:
     kind: 'yaml'
     sourceid: 'tag'
     transformers:
-      - addprefix: '"updatecli/updatecli-action@'
-      - addsuffix: '"'
+      - addprefix: 'updatecli/updatecli-action@'
     spec:
       file: '.github/workflows/updatecli.yaml'
       key: '$.jobs.updatecli.steps[3].uses'
+      engine: 'yamlpath'
 
   branch:
     dependson:
@@ -1062,11 +1062,11 @@ targets:
     kind: yaml
     sourceid: branch
     transformers:
-      - addprefix: '"updatecli/updatecli-action@'
-      - addsuffix: '"'
+      - addprefix: 'updatecli/updatecli-action@'
     spec:
       file: '.github/workflows/updatecli.yaml'
       key: '$.jobs.updatecli.steps[3].uses'
+      engine: 'yamlpath'
 `},
 		},
 	}

--- a/pkg/plugins/autodiscovery/githubaction/main_test.go
+++ b/pkg/plugins/autodiscovery/githubaction/main_test.go
@@ -180,8 +180,8 @@ sources:
       token: 'xxx'
       key: 'hash'
       versionfilter:
-        kind: 'semver'
-        pattern: '*'
+        kind: 'regex'
+        pattern: '{{ source "release" }}'
 
   tag:
     dependson:
@@ -205,8 +205,8 @@ sources:
       password: 'xxx'
       key: 'hash'
       versionfilter:
-        kind: 'semver'
-        pattern: '*'
+        kind: 'regex'
+        pattern: '{{ source "tag" }}'
 
   branch:
     dependson:
@@ -230,8 +230,8 @@ sources:
       password: 'xxx'
       key: 'hash'
       versionfilter:
-        kind: 'semver'
-        pattern: '*'
+        kind: 'regex'
+        pattern: '{{ source "branch" }}'
 
 conditions:
   release:
@@ -339,8 +339,8 @@ sources:
       token: 'xxx'
       key: 'hash'
       versionfilter:
-        kind: 'semver'
-        pattern: '*'
+        kind: 'regex'
+        pattern: '{{ source "release" }}'
 
   tag:
     dependson:
@@ -364,8 +364,8 @@ sources:
       password: 'xxx'
       key: 'hash'
       versionfilter:
-        kind: 'semver'
-        pattern: '*'
+        kind: 'regex'
+        pattern: '{{ source "tag" }}'
 
   branch:
     dependson:
@@ -389,8 +389,8 @@ sources:
       password: 'xxx'
       key: 'hash'
       versionfilter:
-        kind: 'semver'
-        pattern: '*'
+        kind: 'regex'
+        pattern: '{{ source "branch" }}'
 
 conditions:
   release:

--- a/pkg/plugins/autodiscovery/githubaction/testdata/digest/.github/workflows/updatecli.yaml
+++ b/pkg/plugins/autodiscovery/githubaction/testdata/digest/.github/workflows/updatecli.yaml
@@ -23,4 +23,4 @@ jobs:
       - name: "Checkout"
         uses: "actions/checkout@v4"
       - name: "Checkout"
-        uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683"  # pinned from v4.2.2 by updatecli (do-not-remove-comment)
+        uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683"  # v4.2.2

--- a/pkg/plugins/autodiscovery/githubaction/testdata/digest/.github/workflows/updatecli.yaml
+++ b/pkg/plugins/autodiscovery/githubaction/testdata/digest/.github/workflows/updatecli.yaml
@@ -1,0 +1,26 @@
+name: updatecli
+on:
+  release:
+  workflow_dispatch:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    # Run at 12:00 on Friday.”
+    - cron: "0 12 * * 5"
+
+permissions: {}
+
+jobs:
+  updatecli:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v4"
+      - name: "Checkout"
+        uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683"  # pinned from v4.2.2 by updatecli (do-not-remove-comment)

--- a/pkg/plugins/autodiscovery/githubaction/utils.go
+++ b/pkg/plugins/autodiscovery/githubaction/utils.go
@@ -124,19 +124,12 @@ func parseActionName(input string) (URL, owner, repository, directory, reference
 // parseActionDigestComment will parse the action comment from the input string.
 // and then try to identify if we already tried to derive a digest
 func parseActionDigestComment(input string) (digestReference string) {
-	// Check if the input contains the "pinned from" prefix
-	const prefix = "pinned from "
-	const suffix = " by updatecli (do-not-remove-comment)"
-
-	if strings.HasPrefix(input, prefix) && strings.HasSuffix(input, " by updatecli (do-not-remove-comment)") {
-		// Extract the substring between the prefix and suffix
-		sanitized := strings.TrimPrefix(input, prefix)
-		sanitized = strings.TrimSuffix(sanitized, suffix)
-		return strings.TrimSpace(sanitized)
+	trimmed := strings.TrimSpace(input)
+	words := strings.Fields(trimmed)
+	if len(words) > 0 {
+		return words[0]
 	}
-
-	// Return empty if it doesn't match the expected format
-	return ""
+	return "" // Return an empty string if no words are found
 }
 
 func (ga *GitHubAction) getGitProviderKind(URL string) (kind, token string, err error) {

--- a/pkg/plugins/autodiscovery/githubaction/utils.go
+++ b/pkg/plugins/autodiscovery/githubaction/utils.go
@@ -121,6 +121,24 @@ func parseActionName(input string) (URL, owner, repository, directory, reference
 	}
 }
 
+// parseActionDigestComment will parse the action comment from the input string.
+// and then try to identify if we already tried to derive a digest
+func parseActionDigestComment(input string) (digestReference string) {
+	// Check if the input contains the "pinned from" prefix
+	const prefix = "pinned from "
+	const suffix = " by updatecli (do-not-remove-comment)"
+
+	if strings.HasPrefix(input, prefix) && strings.HasSuffix(input, " by updatecli (do-not-remove-comment)") {
+		// Extract the substring between the prefix and suffix
+		sanitized := strings.TrimPrefix(input, prefix)
+		sanitized = strings.TrimSuffix(sanitized, suffix)
+		return strings.TrimSpace(sanitized)
+	}
+
+	// Return empty if it doesn't match the expected format
+	return ""
+}
+
 func (ga *GitHubAction) getGitProviderKind(URL string) (kind, token string, err error) {
 	if URL == "" {
 		URL = defaultGitProviderURL

--- a/pkg/plugins/autodiscovery/githubaction/utils_test.go
+++ b/pkg/plugins/autodiscovery/githubaction/utils_test.go
@@ -21,6 +21,7 @@ func TestSearchWorkflowFiles(t *testing.T) {
 	}
 
 	expectedWorkflowFiles := []string{
+		"testdata/digest/.github/workflows/updatecli.yaml",
 		"testdata/duplicate_steps/.github/workflows/updatecli.yaml",
 		"testdata/gitea/.gitea/workflows/updatecli.yaml",
 		"testdata/updatecli/.github/workflows/updatecli.yaml",
@@ -105,6 +106,52 @@ func TestParseActionName(t *testing.T) {
 			assert.Equal(t, tt.expectedRepository, gotRepository)
 			assert.Equal(t, tt.expectedReference, gotReference)
 			assert.Equal(t, tt.expectedDirectory, gotDirectory)
+		})
+	}
+}
+
+func TestParseActionDigestComment(t *testing.T) {
+	tests := []struct {
+		name                    string
+		input                   string
+		expectedDigestReference string
+	}{
+		{
+			name:                    "complete digest commit comment",
+			input:                   "pinned from 8f4b7f84864484a7bf31766abe9204da3cbe65b3 by updatecli (do-not-remove-comment)",
+			expectedDigestReference: "8f4b7f84864484a7bf31766abe9204da3cbe65b3",
+		},
+		{
+			name:                    "complete digest tag comment",
+			input:                   "pinned from v4.3.2 by updatecli (do-not-remove-comment)",
+			expectedDigestReference: "v4.3.2",
+		},
+		{
+			name:                    "complete digest branch comment",
+			input:                   "pinned from main by updatecli (do-not-remove-comment)",
+			expectedDigestReference: "main",
+		},
+		{
+			name:                    "incomplete digest comment",
+			input:                   "main by updatecli (do-not-remove-comment)",
+			expectedDigestReference: "",
+		},
+		{
+			name:                    "incomplete digest comment end",
+			input:                   "pinned from main by updatecli",
+			expectedDigestReference: "",
+		},
+		{
+			name:                    "empty digest comment",
+			input:                   "",
+			expectedDigestReference: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotDigestReference := parseActionDigestComment(tt.input)
+			assert.Equal(t, tt.expectedDigestReference, gotDigestReference)
 		})
 	}
 }

--- a/pkg/plugins/autodiscovery/githubaction/utils_test.go
+++ b/pkg/plugins/autodiscovery/githubaction/utils_test.go
@@ -118,28 +118,18 @@ func TestParseActionDigestComment(t *testing.T) {
 	}{
 		{
 			name:                    "complete digest commit comment",
-			input:                   "pinned from 8f4b7f84864484a7bf31766abe9204da3cbe65b3 by updatecli (do-not-remove-comment)",
+			input:                   "8f4b7f84864484a7bf31766abe9204da3cbe65b3",
 			expectedDigestReference: "8f4b7f84864484a7bf31766abe9204da3cbe65b3",
 		},
 		{
 			name:                    "complete digest tag comment",
-			input:                   "pinned from v4.3.2 by updatecli (do-not-remove-comment)",
+			input:                   "v4.3.2 by",
 			expectedDigestReference: "v4.3.2",
 		},
 		{
-			name:                    "complete digest branch comment",
-			input:                   "pinned from main by updatecli (do-not-remove-comment)",
-			expectedDigestReference: "main",
-		},
-		{
-			name:                    "incomplete digest comment",
-			input:                   "main by updatecli (do-not-remove-comment)",
-			expectedDigestReference: "",
-		},
-		{
-			name:                    "incomplete digest comment end",
-			input:                   "pinned from main by updatecli",
-			expectedDigestReference: "",
+			name:                    "irrelevant comment",
+			input:                   "This is a comment irrelevant",
+			expectedDigestReference: "This",
 		},
 		{
 			name:                    "empty digest comment",

--- a/pkg/plugins/autodiscovery/githubaction/workflow.go
+++ b/pkg/plugins/autodiscovery/githubaction/workflow.go
@@ -3,39 +3,92 @@ package githubaction
 import (
 	"fmt"
 	"os"
+	"strings"
 
-	"sigs.k8s.io/yaml"
+	"gopkg.in/yaml.v3"
 )
 
 // https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsuses
 
 type Workflow struct {
-	// Name of the workflow
-	Name string         `yaml:"name, omitempty"`
-	Jobs map[string]Job `yaml:"jobs, omitempty"`
+	Name string         `yaml:"name,omitempty"`
+	Jobs map[string]Job `yaml:"jobs,omitempty"`
 }
 
 type Job struct {
-	Steps []Step `yaml:"steps, omitempty"`
+	Steps []Step `yaml:"steps,omitempty"`
 }
 
 type Step struct {
-	Name string `yaml:"name, omitempty"`
-	Uses string `yaml:"uses, omitempty"`
+	Name          string `yaml:"name,omitempty"`
+	Uses          string `yaml:"uses,omitempty"`
+	CommentDigest string // Captured comment for the 'uses' field
 }
 
 func loadGitHubActionWorkflow(filename string) (*Workflow, error) {
-
 	data, err := os.ReadFile(filename)
 	if err != nil {
-		return nil, fmt.Errorf("opening file %s:%s", filename, err)
+		return nil, fmt.Errorf("error opening file %s: %w", filename, err)
 	}
 
-	w := Workflow{}
-	err = yaml.Unmarshal(data, &w)
+	var root yaml.Node
+	err = yaml.Unmarshal(data, &root)
 	if err != nil {
-		return nil, fmt.Errorf("unmarshalling GitHub action workflow file %s: %s", filename, err)
+		return nil, fmt.Errorf("error unmarshalling YAML file %s: %w", filename, err)
 	}
 
-	return &w, nil
+	var workflow Workflow
+	parseWorkflowNode(&root, &workflow)
+	return &workflow, nil
+}
+
+// parseWorkflowNode extracts the Workflow structure and captures comments.
+func parseWorkflowNode(root *yaml.Node, workflow *Workflow) {
+	workflow.Jobs = make(map[string]Job)
+	for _, jobNode := range root.Content {
+		if jobNode.Kind == yaml.MappingNode {
+			for i, keyNode := range jobNode.Content {
+				if keyNode.Value == "jobs" {
+					jobsNode := jobNode.Content[i+1]
+					for j := 0; j < len(jobsNode.Content); j += 2 {
+						jobKey := jobsNode.Content[j]
+						jobValue := jobsNode.Content[j+1]
+						jobName := jobKey.Value
+						if _, exists := workflow.Jobs[jobName]; !exists {
+							workflow.Jobs[jobName] = Job{}
+						}
+
+						for k, stepKey := range jobValue.Content {
+							if stepKey.Value == "steps" {
+								stepsNode := jobValue.Content[k+1]
+								for l := 0; l < len(stepsNode.Content); l++ {
+									stepNode := stepsNode.Content[l]
+									if stepNode.Kind == yaml.MappingNode {
+										var step Step
+
+										for m := 0; m < len(stepNode.Content); m += 2 {
+											stepField := stepNode.Content[m]
+											stepValue := stepNode.Content[m+1]
+
+											switch stepField.Value {
+											case "name":
+												step.Name = stepValue.Value
+											case "uses":
+												step.Uses = stepValue.Value
+												step.CommentDigest = strings.TrimSpace(strings.TrimPrefix(stepValue.LineComment, "#"))
+											}
+										}
+
+										job := workflow.Jobs[jobName]
+										job.Steps = append(job.Steps, step)
+										workflow.Jobs[jobName] = job
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
 }

--- a/pkg/plugins/autodiscovery/githubaction/workflowManifestGitHubTemplate.go
+++ b/pkg/plugins/autodiscovery/githubaction/workflowManifestGitHubTemplate.go
@@ -146,7 +146,7 @@ targets:
       key: '$.jobs.{{ .JobID }}.steps[{{ .StepID }}].uses'
       engine: 'yamlpath'
 {{- if .Digest }}
-      comment: 'pinned from {{ "{{" }} source "release" {{ "}}" }} by updatecli (do-not-remove-comment)'
+      comment: '{{ "{{" }} source "release" {{ "}}" }}'
 {{- end }}
 
   tag:
@@ -166,7 +166,7 @@ targets:
       key: '$.jobs.{{ .JobID }}.steps[{{ .StepID }}].uses'
       engine: 'yamlpath'
 {{- if .Digest }}
-      comment: 'pinned from {{ "{{" }} source "tag" {{ "}}" }} by updatecli (do-not-remove-comment)'
+      comment: '{{ "{{" }} source "tag" {{ "}}" }}'
 {{- end }}
 
   branch:
@@ -186,7 +186,7 @@ targets:
       key: '$.jobs.{{ .JobID }}.steps[{{ .StepID }}].uses'
       engine: 'yamlpath'
 {{- if .Digest }}
-      comment: 'pinned from {{ "{{" }} source "branch" {{ "}}" }} by updatecli (do-not-remove-comment)'
+      comment: '{{ "{{" }} source "branch" {{ "}}" }}'
 {{- end }}
 `
 )

--- a/pkg/plugins/autodiscovery/githubaction/workflowManifestGitHubTemplate.go
+++ b/pkg/plugins/autodiscovery/githubaction/workflowManifestGitHubTemplate.go
@@ -15,12 +15,28 @@ sources:
       repository: '{{ .Repository }}'
       url: '{{ .URL }}'
       token: '{{ .Token }}'
-{{- if .Digest }}
-      key: 'hash'
-{{- end }}
       versionfilter:
         kind: '{{ .VersionFilterKind }}'
         pattern: '{{ .VersionFilterPattern }}'
+
+{{- if .Digest }}
+
+  release_digest:
+    dependson:
+      - 'condition#release:and'
+    name: 'Get latest GitHub Release for {{ .ActionName }}'
+    kind: 'githubrelease'
+    spec:
+      owner: '{{ .Owner }}'
+      repository: '{{ .Repository }}'
+      url: '{{ .URL }}'
+      token: '{{ .Token }}'
+      key: 'hash'
+      versionfilter:
+        kind: '{{ .VersionFilterKind }}'
+        pattern: '{{ .VersionFilterPattern }}'
+
+{{- end }}
 
   tag:
     dependson:
@@ -30,12 +46,26 @@ sources:
     spec:
       url: "{{ .URL }}/{{ .Owner }}/{{ .Repository }}.git"
       password: '{{ .Token }}'
-{{- if .Digest }}
-      key: 'hash'
-{{- end }}
       versionfilter:
         kind: '{{ .VersionFilterKind }}'
         pattern: '{{ .VersionFilterPattern }}'
+
+{{- if .Digest }}
+
+  tag_digest:
+    dependson:
+      - 'condition#tag:and'
+    name: 'Get latest tag for {{ .ActionName }}'
+    kind: 'gittag'
+    spec:
+      url: "{{ .URL }}/{{ .Owner }}/{{ .Repository }}.git"
+      password: '{{ .Token }}'
+      key: 'hash'
+      versionfilter:
+        kind: '{{ .VersionFilterKind }}'
+        pattern: '{{ .VersionFilterPattern }}'
+
+{{- end }}
 
   branch:
     dependson:
@@ -45,16 +75,30 @@ sources:
     spec:
       url: "{{ .URL }}/{{ .Owner }}/{{ .Repository }}.git"
       password: '{{ .Token }}'
-{{- if .Digest }}
-      key: 'hash'
-{{- end }}
       versionfilter:
         kind: '{{ .VersionFilterKind }}'
         pattern: '{{ .VersionFilterPattern }}'
 
+{{- if .Digest }}
+
+  branch_digest:
+    dependson:
+      - 'condition#branch:and'
+    name: 'Get latest branch for {{ .ActionName }}'
+    kind: 'gitbranch'
+    spec:
+      url: "{{ .URL }}/{{ .Owner }}/{{ .Repository }}.git"
+      password: '{{ .Token }}'
+      key: 'hash'
+      versionfilter:
+        kind: '{{ .VersionFilterKind }}'
+        pattern: '{{ .VersionFilterPattern }}'
+
+{{- end }}
+
 conditions:
   release:
-    name: 'Check if {{ .ActionName }}@{{ .Reference }} is a GitHub release'
+    name: 'Check if {{ .ActionName }}@{{ if .Digest }}{{ .PinReference }}{{ else }}{{ .Reference }}{{ end }} is a GitHub release'
     kind: 'githubrelease'
     disablesourceinput: true
     spec:
@@ -62,10 +106,10 @@ conditions:
       repository: '{{ .Repository }}'
       url: '{{ .URL }}'
       token: '{{ .Token }}'
-      tag: '{{ .Reference }}'
+      tag: '{{ if .Digest }}{{ .PinReference }}{{ else }}{{ .Reference }}{{ end }}'
 
   tag:
-    name: 'Check if {{ .ActionName }}@{{ .Reference }} is a tag'
+    name: 'Check if {{ .ActionName }}@{{ if .Digest }}{{ .PinReference }}{{ else }}{{ .Reference }}{{ end }} is a tag'
     kind: 'gittag'
     disablesourceinput: true
     spec:
@@ -73,14 +117,14 @@ conditions:
       password: '{{ .Token }}'
       versionfilter:
         kind: 'regex'
-        pattern: '^{{ .Reference }}$'
+        pattern: '^{{ if .Digest }}{{ .PinReference }}{{ else }}{{ .Reference }}{{ end }}$'
 
   branch:
-    name: 'Check if {{ .ActionName }}@{{ .Reference }} is a branch'
+    name: 'Check if {{ .ActionName }}@{{ if .Digest }}{{ .PinReference }}{{ else }}{{ .Reference }}{{ end }} is a branch'
     kind: 'gitbranch'
     disablesourceinput: true
     spec:
-      branch: '{{ .Reference }}'
+      branch: '{{ if .Digest }}{{ .PinReference }}{{ else }}{{ .Reference }}{{ end }}'
       url: "{{ .URL }}/{{ .Owner }}/{{ .Repository }}.git"
       password: '{{ .Token }}'
 
@@ -89,12 +133,15 @@ targets:
     dependson:
       - 'condition#release:and'
     disableconditions: true
-    name: 'deps(github): bump Action release for {{ .ActionName }} from {{ .Reference }} to {{ "{{" }} source "release" {{ "}}" }}'
+    name: 'deps(github): bump Action release for {{ .ActionName }} from {{ .Reference }} to {{ "{{" }} source "release{{if .Digest}}_digest{{end}}" {{ "}}" }}{{ if .Digest }} (Pinned from {{ "{{" }} source "release" {{ "}}" }}){{ end }}'
     kind: 'yaml'
-    sourceid: 'release'
+    sourceid: 'release{{if .Digest}}_digest{{end}}'
     transformers:
       - addprefix: '"{{ .ActionName }}@'
       - addsuffix: '"'
+{{- if .Digest }}
+      - addsuffix: '  # pinned from {{ "{{" }} source "release" {{ "}}" }} by updatecli (do-not-remove-comment)'
+{{- end }}
 {{- if .ScmID }}
     scmid: '{{ .ScmID }}'
 {{ end }}
@@ -106,12 +153,15 @@ targets:
     dependson:
       - 'condition#tag:and'
     disableconditions: true
-    name: 'deps(github): bump Action tag for {{ .ActionName }} from {{ .Reference }} to {{ "{{" }} source "tag" {{ "}}" }}'
+    name: 'deps(github): bump Action tag for {{ .ActionName }} from {{ .Reference }} to {{ "{{" }} source "tag{{if .Digest}}_digest{{end}}" {{ "}}" }}{{ if .Digest }} (Pinned from {{ "{{" }} source "tag" {{ "}}" }}){{ end }}'
     kind: 'yaml'
-    sourceid: 'tag'
+    sourceid: 'tag{{if .Digest}}_digest{{end}}'
     transformers:
       - addprefix: '"{{ .ActionName }}@'
       - addsuffix: '"'
+{{- if .Digest }}
+      - addsuffix: '  # pinned from {{ "{{" }} source "tag" {{ "}}" }} by updatecli (do-not-remove-comment)'
+{{- end }}
 {{- if .ScmID }}
     scmid: '{{ .ScmID }}'
 {{ end }}
@@ -123,12 +173,15 @@ targets:
     dependson:
       - 'condition#branch:and'
     disableconditions: true
-    name: 'deps(github): bump Action branch for {{ .ActionName }} from {{ .Reference }} to {{ "{{" }} source "branch" {{ "}}" }}'
+    name: 'deps(github): bump Action branch for {{ .ActionName }} from {{ .Reference }} to {{ "{{" }} source "branch{{if .Digest}}_digest{{end}}" {{ "}}" }}{{ if .Digest }} (Pinned from {{ "{{" }} source "branch" {{ "}}" }}){{ end }}'
     kind: yaml
-    sourceid: branch
+    sourceid: branch{{if .Digest}}_digest{{end}}
     transformers:
       - addprefix: '"{{ .ActionName }}@'
       - addsuffix: '"'
+{{- if .Digest }}
+      - addsuffix: '  # pinned from {{ "{{" }} source "branch" {{ "}}" }} by updatecli (do-not-remove-comment)'
+{{- end }}
 {{- if .ScmID }}
     scmid: '{{ .ScmID }}'
 {{ end }}

--- a/pkg/plugins/autodiscovery/githubaction/workflowManifestGitHubTemplate.go
+++ b/pkg/plugins/autodiscovery/githubaction/workflowManifestGitHubTemplate.go
@@ -137,17 +137,17 @@ targets:
     kind: 'yaml'
     sourceid: 'release{{if .Digest}}_digest{{end}}'
     transformers:
-      - addprefix: '"{{ .ActionName }}@'
-      - addsuffix: '"'
-{{- if .Digest }}
-      - addsuffix: '  # pinned from {{ "{{" }} source "release" {{ "}}" }} by updatecli (do-not-remove-comment)'
-{{- end }}
+      - addprefix: '{{ .ActionName }}@'
 {{- if .ScmID }}
     scmid: '{{ .ScmID }}'
 {{ end }}
     spec:
       file: '{{ .File }}'
       key: '$.jobs.{{ .JobID }}.steps[{{ .StepID }}].uses'
+      engine: 'yamlpath'
+{{- if .Digest }}
+      comment: 'pinned from {{ "{{" }} source "release" {{ "}}" }} by updatecli (do-not-remove-comment)'
+{{- end }}
 
   tag:
     dependson:
@@ -157,17 +157,17 @@ targets:
     kind: 'yaml'
     sourceid: 'tag{{if .Digest}}_digest{{end}}'
     transformers:
-      - addprefix: '"{{ .ActionName }}@'
-      - addsuffix: '"'
-{{- if .Digest }}
-      - addsuffix: '  # pinned from {{ "{{" }} source "tag" {{ "}}" }} by updatecli (do-not-remove-comment)'
-{{- end }}
+      - addprefix: '{{ .ActionName }}@'
 {{- if .ScmID }}
     scmid: '{{ .ScmID }}'
 {{ end }}
     spec:
       file: '{{ .File }}'
       key: '$.jobs.{{ .JobID }}.steps[{{ .StepID }}].uses'
+      engine: 'yamlpath'
+{{- if .Digest }}
+      comment: 'pinned from {{ "{{" }} source "tag" {{ "}}" }} by updatecli (do-not-remove-comment)'
+{{- end }}
 
   branch:
     dependson:
@@ -177,16 +177,16 @@ targets:
     kind: yaml
     sourceid: branch{{if .Digest}}_digest{{end}}
     transformers:
-      - addprefix: '"{{ .ActionName }}@'
-      - addsuffix: '"'
-{{- if .Digest }}
-      - addsuffix: '  # pinned from {{ "{{" }} source "branch" {{ "}}" }} by updatecli (do-not-remove-comment)'
-{{- end }}
+      - addprefix: '{{ .ActionName }}@'
 {{- if .ScmID }}
     scmid: '{{ .ScmID }}'
 {{ end }}
     spec:
       file: '{{ .File }}'
       key: '$.jobs.{{ .JobID }}.steps[{{ .StepID }}].uses'
+      engine: 'yamlpath'
+{{- if .Digest }}
+      comment: 'pinned from {{ "{{" }} source "branch" {{ "}}" }} by updatecli (do-not-remove-comment)'
+{{- end }}
 `
 )

--- a/pkg/plugins/autodiscovery/githubaction/workflowManifestGitHubTemplate.go
+++ b/pkg/plugins/autodiscovery/githubaction/workflowManifestGitHubTemplate.go
@@ -33,8 +33,8 @@ sources:
       token: '{{ .Token }}'
       key: 'hash'
       versionfilter:
-        kind: '{{ .VersionFilterKind }}'
-        pattern: '{{ .VersionFilterPattern }}'
+        kind: 'regex'
+        pattern: '{{ "{{" }} source "release" {{ "}}" }}'
 
 {{- end }}
 
@@ -62,8 +62,8 @@ sources:
       password: '{{ .Token }}'
       key: 'hash'
       versionfilter:
-        kind: '{{ .VersionFilterKind }}'
-        pattern: '{{ .VersionFilterPattern }}'
+        kind: 'regex'
+        pattern: '{{ "{{" }} source "tag" {{ "}}" }}'
 
 {{- end }}
 
@@ -91,8 +91,8 @@ sources:
       password: '{{ .Token }}'
       key: 'hash'
       versionfilter:
-        kind: '{{ .VersionFilterKind }}'
-        pattern: '{{ .VersionFilterPattern }}'
+        kind: 'regex'
+        pattern: '{{ "{{" }} source "branch" {{ "}}" }}'
 
 {{- end }}
 

--- a/pkg/plugins/autodiscovery/githubaction/workflowManifestGitHubTemplate.go
+++ b/pkg/plugins/autodiscovery/githubaction/workflowManifestGitHubTemplate.go
@@ -15,6 +15,9 @@ sources:
       repository: '{{ .Repository }}'
       url: '{{ .URL }}'
       token: '{{ .Token }}'
+{{- if .Digest }}
+      key: 'hash'
+{{- end }}
       versionfilter:
         kind: '{{ .VersionFilterKind }}'
         pattern: '{{ .VersionFilterPattern }}'
@@ -27,6 +30,9 @@ sources:
     spec:
       url: "{{ .URL }}/{{ .Owner }}/{{ .Repository }}.git"
       password: '{{ .Token }}'
+{{- if .Digest }}
+      key: 'hash'
+{{- end }}
       versionfilter:
         kind: '{{ .VersionFilterKind }}'
         pattern: '{{ .VersionFilterPattern }}'
@@ -39,6 +45,9 @@ sources:
     spec:
       url: "{{ .URL }}/{{ .Owner }}/{{ .Repository }}.git"
       password: '{{ .Token }}'
+{{- if .Digest }}
+      key: 'hash'
+{{- end }}
       versionfilter:
         kind: '{{ .VersionFilterKind }}'
         pattern: '{{ .VersionFilterPattern }}'

--- a/pkg/plugins/autodiscovery/githubaction/workflowManifestGiteaTemplate.go
+++ b/pkg/plugins/autodiscovery/githubaction/workflowManifestGiteaTemplate.go
@@ -84,14 +84,14 @@ targets:
     kind: 'yaml'
     sourceid: 'release'
     transformers:
-      - addprefix: '"{{ .ActionName }}@'
-      - addsuffix: '"'
+      - addprefix: '{{ .ActionName }}@'
 {{- if .ScmID }}
     scmid: '{{ .ScmID }}'
 {{ end }}
     spec:
       file: '{{ .File }}'
       key: '$.jobs.{{ .JobID }}.steps[{{ .StepID }}].uses'
+      engine: 'yamlpath'
 
   tag:
     dependson:
@@ -101,14 +101,14 @@ targets:
     kind: 'yaml'
     sourceid: 'tag'
     transformers:
-      - addprefix: '"{{ .ActionName }}@'
-      - addsuffix: '"'
+      - addprefix: '{{ .ActionName }}@'
 {{- if .ScmID }}
     scmid: '{{ .ScmID }}'
 {{ end }}
     spec:
       file: '{{ .File }}'
       key: '$.jobs.{{ .JobID }}.steps[{{ .StepID }}].uses'
+      engine: 'yamlpath'
 
   branch:
     dependson:
@@ -118,13 +118,13 @@ targets:
     kind: yaml
     sourceid: branch
     transformers:
-      - addprefix: '"{{ .ActionName }}@'
-      - addsuffix: '"'
+      - addprefix: '{{ .ActionName }}@'
 {{- if .ScmID }}
     scmid: '{{ .ScmID }}'
 {{ end }}
     spec:
       file: '{{ .File }}'
       key: '$.jobs.{{ .JobID }}.steps[{{ .StepID }}].uses'
+      engine: 'yamlpath'
 `
 )

--- a/pkg/plugins/autodiscovery/githubaction/workflowManifests.go
+++ b/pkg/plugins/autodiscovery/githubaction/workflowManifests.go
@@ -133,6 +133,7 @@ func (g GitHubAction) discoverWorkflowManifests() [][]byte {
 					StepID               int
 					ScmID                string
 					Token                string
+					Digest               bool
 				}{
 					ActionName:           actionName,
 					Reference:            reference,
@@ -146,6 +147,7 @@ func (g GitHubAction) discoverWorkflowManifests() [][]byte {
 					ScmID:                g.scmID,
 					StepID:               stepID,
 					Token:                token,
+					Digest:               g.digest,
 				}
 
 				manifest := bytes.Buffer{}

--- a/pkg/plugins/autodiscovery/githubaction/workflowManifests.go
+++ b/pkg/plugins/autodiscovery/githubaction/workflowManifests.go
@@ -39,6 +39,13 @@ func (g GitHubAction) discoverWorkflowManifests() [][]byte {
 		for jobID, job := range data.Jobs {
 			for stepID, step := range job.Steps {
 				URL, owner, repository, directory, reference := parseActionName(step.Uses)
+				pinReference := parseActionDigestComment(step.CommentDigest)
+				if g.digest {
+					if pinReference == "" {
+						// First time we pin a ref
+						pinReference = reference
+					}
+				}
 				switch reference {
 				case "":
 					continue
@@ -90,13 +97,18 @@ func (g GitHubAction) discoverWorkflowManifests() [][]byte {
 					continue
 				}
 
-				versionFilterKind, versionFilterPattern := detectVersionFilter(reference)
+				versionFilterRef := reference
+				if g.digest {
+					versionFilterRef = pinReference
+				}
+
+				versionFilterKind, versionFilterPattern := detectVersionFilter(versionFilterRef)
 				if !g.spec.VersionFilter.IsZero() {
 					versionFilterKind = g.versionFilter.Kind
-					versionFilterPattern, err = g.versionFilter.GreaterThanPattern(reference)
+					versionFilterPattern, err = g.versionFilter.GreaterThanPattern(versionFilterRef)
 					if err != nil {
 						logrus.Debugf("building version filter pattern: %s", err)
-						versionFilterPattern = reference
+						versionFilterPattern = versionFilterRef
 					}
 				}
 
@@ -122,6 +134,7 @@ func (g GitHubAction) discoverWorkflowManifests() [][]byte {
 				params := struct {
 					ActionName           string
 					Reference            string
+					PinReference         string
 					File                 string
 					ImageName            string
 					JobID                string
@@ -137,6 +150,7 @@ func (g GitHubAction) discoverWorkflowManifests() [][]byte {
 				}{
 					ActionName:           actionName,
 					Reference:            reference,
+					PinReference:         pinReference,
 					File:                 relateFoundFile,
 					JobID:                jobID,
 					URL:                  URL,

--- a/pkg/plugins/autodiscovery/githubaction/workflow_test.go
+++ b/pkg/plugins/autodiscovery/githubaction/workflow_test.go
@@ -1,0 +1,163 @@
+package githubaction
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadGitHubActionWorkflow(t *testing.T) {
+	testdata := []struct {
+		name                  string
+		stepName              string
+		stepUses              string
+		expectedStepName      string
+		expectedStepUses      string
+		expectedCommentDigest string
+	}{
+		{
+			name:                  "Reference specific commit",
+			stepName:              "Checkout",
+			stepUses:              "actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3",
+			expectedStepName:      "Checkout",
+			expectedStepUses:      "actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3",
+			expectedCommentDigest: "",
+		},
+		{
+			name:                  "Reference specific commit with pinned digest",
+			stepName:              "Checkout",
+			stepUses:              "actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3  # pinned from 8f4b7f84864484a7bf31766abe9204da3cbe65b3 by updatecli (do-not-remove-comment)",
+			expectedStepName:      "Checkout",
+			expectedStepUses:      "actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3",
+			expectedCommentDigest: "pinned from 8f4b7f84864484a7bf31766abe9204da3cbe65b3 by updatecli (do-not-remove-comment)",
+		},
+		{
+			name:                  "Reference major version",
+			stepName:              "Checkout",
+			stepUses:              "actions/checkout@v4",
+			expectedStepName:      "Checkout",
+			expectedStepUses:      "actions/checkout@v4",
+			expectedCommentDigest: "",
+		},
+		{
+			name:                  "Reference major version with pinned digest",
+			stepName:              "Checkout",
+			stepUses:              "actions/checkout@v4  # pinned from v4 by updatecli (do-not-remove-comment)",
+			expectedStepName:      "Checkout",
+			expectedStepUses:      "actions/checkout@v4",
+			expectedCommentDigest: "pinned from v4 by updatecli (do-not-remove-comment)",
+		},
+		{
+			name:                  "Reference specific version",
+			stepName:              "Checkout",
+			stepUses:              "actions/checkout@v4.2.0",
+			expectedStepName:      "Checkout",
+			expectedStepUses:      "actions/checkout@v4.2.0",
+			expectedCommentDigest: "",
+		},
+		{
+			name:                  "Reference specific version with pinned digest",
+			stepName:              "Checkout",
+			stepUses:              "actions/checkout@v4.2.0  # pinned from v4.2.0 by updatecli (do-not-remove-comment)",
+			expectedStepName:      "Checkout",
+			expectedStepUses:      "actions/checkout@v4.2.0",
+			expectedCommentDigest: "pinned from v4.2.0 by updatecli (do-not-remove-comment)",
+		},
+		{
+			name:                  "Reference branch",
+			stepName:              "Checkout",
+			stepUses:              "actions/checkout@main",
+			expectedStepName:      "Checkout",
+			expectedStepUses:      "actions/checkout@main",
+			expectedCommentDigest: "",
+		},
+		{
+			name:                  "Reference branch with pinned digest",
+			stepName:              "Checkout",
+			stepUses:              "actions/checkout@main  # pinned from main by updatecli (do-not-remove-comment)",
+			expectedStepName:      "Checkout",
+			expectedStepUses:      "actions/checkout@main",
+			expectedCommentDigest: "pinned from main by updatecli (do-not-remove-comment)",
+		},
+		{
+			name:                  "Reference subdirectory in a GitHub repository",
+			stepName:              "AWS EC2 Action",
+			stepUses:              "actions/aws/ec2@main",
+			expectedStepName:      "AWS EC2 Action",
+			expectedStepUses:      "actions/aws/ec2@main",
+			expectedCommentDigest: "",
+		},
+		{
+			name:                  "Reference subdirectory in a GitHub repository with pinned digest",
+			stepName:              "AWS EC2 Action",
+			stepUses:              "actions/aws/ec2@main  # pinned from main by updatecli (do-not-remove-comment)",
+			expectedStepName:      "AWS EC2 Action",
+			expectedStepUses:      "actions/aws/ec2@main",
+			expectedCommentDigest: "pinned from main by updatecli (do-not-remove-comment)",
+		},
+		{
+			name:                  "Reference local action",
+			stepName:              "Local Action",
+			stepUses:              "./.github/actions/my-action",
+			expectedStepName:      "Local Action",
+			expectedStepUses:      "./.github/actions/my-action",
+			expectedCommentDigest: "",
+		},
+		{
+			name:                  "Reference Docker public registry action",
+			stepName:              "Docker Gradle Action",
+			stepUses:              "docker://gcr.io/cloud-builders/gradle",
+			expectedStepName:      "Docker Gradle Action",
+			expectedStepUses:      "docker://gcr.io/cloud-builders/gradle",
+			expectedCommentDigest: "",
+		},
+		{
+			name:                  "Reference Docker Hub image",
+			stepName:              "Alpine Docker Image",
+			stepUses:              "docker://alpine:3.8",
+			expectedStepName:      "Alpine Docker Image",
+			expectedStepUses:      "docker://alpine:3.8",
+			expectedCommentDigest: "",
+		},
+	}
+
+	for _, tt := range testdata {
+		t.Run(tt.name, func(t *testing.T) {
+			workflowContent := fmt.Sprintf(`name: Test Workflow
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: %s
+        uses: %s`, tt.stepName, tt.stepUses)
+
+			// Create a temp file to pass to the function
+			tempFile, err := os.CreateTemp("", "workflow-*.yaml")
+			require.NoError(t, err)
+			defer os.Remove(tempFile.Name())
+
+			_, err = tempFile.WriteString(workflowContent)
+			require.NoError(t, err)
+			tempFile.Close()
+
+			// Load the workflow
+			w, err := loadGitHubActionWorkflow(tempFile.Name())
+			require.NoError(t, err)
+
+			// Validate the step
+			s := w.Jobs["build"].Steps[0]
+			assert.Equal(t, tt.expectedStepName, s.Name)
+			assert.Equal(t, tt.expectedStepUses, s.Uses)
+			assert.Equal(t, tt.expectedCommentDigest, s.CommentDigest)
+		})
+	}
+}

--- a/pkg/plugins/autodiscovery/githubaction/workflow_test.go
+++ b/pkg/plugins/autodiscovery/githubaction/workflow_test.go
@@ -35,6 +35,14 @@ func TestLoadGitHubActionWorkflow(t *testing.T) {
 			expectedCommentDigest: "pinned from 8f4b7f84864484a7bf31766abe9204da3cbe65b3 by updatecli (do-not-remove-comment)",
 		},
 		{
+			name:                  "Reference specific commit with pinned digest",
+			stepName:              "Checkout",
+			stepUses:              "\"actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3\"  # pinned from 8f4b7f84864484a7bf31766abe9204da3cbe65b3 by updatecli (do-not-remove-comment)",
+			expectedStepName:      "Checkout",
+			expectedStepUses:      "actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3",
+			expectedCommentDigest: "pinned from 8f4b7f84864484a7bf31766abe9204da3cbe65b3 by updatecli (do-not-remove-comment)",
+		},
+		{
 			name:                  "Reference major version",
 			stepName:              "Checkout",
 			stepUses:              "actions/checkout@v4",

--- a/pkg/plugins/resources/gitbranch/source.go
+++ b/pkg/plugins/resources/gitbranch/source.go
@@ -33,13 +33,7 @@ func (gb *GitBranch) Source(workingDir string, resultSource *result.Source) erro
 
 	values := []string{}
 	for _, ref := range refs {
-		var value string
-		if gb.spec.Key == "hash" {
-			value = ref.Hash
-		} else {
-			value = ref.Name
-		}
-		values = append(values, value)
+		values = append(values, ref.Name)
 	}
 	gb.foundVersion, err = gb.versionFilter.Search(values)
 	if err != nil {
@@ -49,6 +43,14 @@ func (gb *GitBranch) Source(workingDir string, resultSource *result.Source) erro
 
 	if len(value) == 0 {
 		return fmt.Errorf("no Git Branch found matching pattern %q", gb.versionFilter.Pattern)
+	}
+
+	if gb.spec.Key == "hash" {
+		for i := range refs {
+			if refs[i].Name == value {
+				value = refs[i].Hash
+			}
+		}
 	}
 
 	resultSource.Result = result.SUCCESS

--- a/pkg/plugins/resources/gitbranch/source.go
+++ b/pkg/plugins/resources/gitbranch/source.go
@@ -25,13 +25,23 @@ func (gb *GitBranch) Source(workingDir string, resultSource *result.Source) erro
 		return fmt.Errorf("Unknown Git working directory. Did you specify one of `spec.URL`, `scmid` or a `spec.path`?")
 	}
 
-	tags, err := gb.nativeGitHandler.Branches(gb.directory)
+	refs, err := gb.nativeGitHandler.BranchRefs(gb.directory)
 
 	if err != nil {
 		return fmt.Errorf("retrieving branches: %w", err)
 	}
 
-	gb.foundVersion, err = gb.versionFilter.Search(tags)
+	values := []string{}
+	for _, ref := range refs {
+		var value string
+		if gb.spec.Key == "hash" {
+			value = ref.Hash
+		} else {
+			value = ref.Name
+		}
+		values = append(values, value)
+	}
+	gb.foundVersion, err = gb.versionFilter.Search(values)
 	if err != nil {
 		return fmt.Errorf("filtering branches: %w", err)
 	}

--- a/pkg/plugins/resources/githubrelease/condition.go
+++ b/pkg/plugins/resources/githubrelease/condition.go
@@ -19,7 +19,12 @@ func (gr GitHubRelease) Condition(source string, scm scm.ScmHandler) (pass bool,
 		expectedValue = gr.spec.Tag
 	}
 
-	versions, err := gr.ghHandler.SearchReleases(gr.typeFilter)
+	var versions []string
+	if gr.spec.Key == KeyHash {
+		versions, err = gr.ghHandler.SearchReleasesByTagHash(gr.typeFilter)
+	} else {
+		versions, err = gr.ghHandler.SearchReleasesByTagName(gr.typeFilter)
+	}
 	if err != nil {
 		return false, "", fmt.Errorf("searching GitHub release: %w", err)
 	}

--- a/pkg/plugins/resources/githubrelease/main_test.go
+++ b/pkg/plugins/resources/githubrelease/main_test.go
@@ -96,6 +96,18 @@ func TestNew(t *testing.T) {
 			},
 		},
 		{
+			name: "Validation error (bad key)",
+			spec: Spec{
+				Repository: "updatecli",
+				Owner:      "updatecli",
+				Username:   "joe",
+				Token:      "superSecretTOkenOfJoe",
+				URL:        "github.com",
+				Key:        "commit",
+			},
+			wantErr: true,
+		},
+		{
 			name: "Validation Error (missing token)",
 			spec: Spec{
 				Repository: "updatecli",

--- a/pkg/plugins/resources/githubrelease/source.go
+++ b/pkg/plugins/resources/githubrelease/source.go
@@ -10,7 +10,13 @@ import (
 // Source retrieves a specific version tag from GitHub Releases.
 func (gr *GitHubRelease) Source(workingDir string, resultSource *result.Source) error {
 
-	versions, err := gr.ghHandler.SearchReleases(gr.typeFilter)
+	var versions []string
+	var err error
+	if gr.spec.Key == KeyHash {
+		versions, err = gr.ghHandler.SearchReleasesByTagHash(gr.typeFilter)
+	} else {
+		versions, err = gr.ghHandler.SearchReleasesByTagName(gr.typeFilter)
+	}
 	if err != nil {
 		return fmt.Errorf("searching GitHub release: %w", err)
 	}

--- a/pkg/plugins/resources/yaml/main.go
+++ b/pkg/plugins/resources/yaml/main.go
@@ -126,6 +126,16 @@ type Spec struct {
 
 	*/
 	SearchPattern bool `yaml:",omitempty"`
+	/*
+				"comment" defines a comment to add after the value.
+
+				compatible:
+					* target
+
+		   remarks:
+		            * require engine set to yamlpath
+	*/
+	Comment string `yaml:",omitempty"`
 }
 
 // Yaml defines a resource of kind "yaml"

--- a/pkg/plugins/resources/yaml/target.go
+++ b/pkg/plugins/resources/yaml/target.go
@@ -282,6 +282,9 @@ func (y *Yaml) goYamlPathTarget(valueToWrite string, resultTarget *result.Target
 			}
 
 			node.Value = valueToWrite
+			if y.spec.Comment != "" {
+				node.LineComment = y.spec.Comment
+			}
 		}
 
 		if notChangedNode == len(nodes) {

--- a/pkg/plugins/resources/yaml/target_test.go
+++ b/pkg/plugins/resources/yaml/target_test.go
@@ -277,6 +277,37 @@ github:
 			wantedResult: false,
 			wantedError:  true,
 		},
+		{
+			name: "Passing case with a comment that is added",
+			spec: Spec{
+				File:    "test.yaml",
+				Key:     "github.owner",
+				Value:   "obiwankenobi",
+				Comment: "comment that should be added",
+				Engine:  "yamlpath",
+			},
+			files: map[string]file{
+				"test.yaml": {
+					filePath:         "test.yaml",
+					originalFilePath: "test.yaml",
+				},
+			},
+			inputSourceValue: "olblak",
+			mockedContents: map[string]string{
+				"test.yaml": `---
+github:
+  owner: olblak
+`,
+			},
+			// Note: the re-encoded file doesn't contain any separator anymore
+			wantedContents: map[string]string{
+				"test.yaml": `---
+github:
+  owner: obiwankenobi # comment that should be added
+`,
+			},
+			wantedResult: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/plugins/scms/github/client.go
+++ b/pkg/plugins/scms/github/client.go
@@ -15,7 +15,8 @@ type GitHubClient interface {
 
 // GithubHandler must be implemented by any GitHub module
 type GithubHandler interface {
-	SearchReleases(releaseType ReleaseType) (releases []string, err error)
+	SearchReleasesByTagName(releaseType ReleaseType) (releases []string, err error)
+	SearchReleasesByTagHash(releaseType ReleaseType) (releases []string, err error)
 	SearchTags() (tags []string, err error)
 	Changelog(version.Version) (string, error)
 }

--- a/pkg/plugins/scms/github/client.go
+++ b/pkg/plugins/scms/github/client.go
@@ -15,6 +15,7 @@ type GitHubClient interface {
 
 // GithubHandler must be implemented by any GitHub module
 type GithubHandler interface {
+	SearchReleases(releaseType ReleaseType) (releases []ReleaseNode, err error)
 	SearchReleasesByTagName(releaseType ReleaseType) (releases []string, err error)
 	SearchReleasesByTagHash(releaseType ReleaseType) (releases []string, err error)
 	SearchTags() (tags []string, err error)

--- a/pkg/plugins/scms/github/release.go
+++ b/pkg/plugins/scms/github/release.go
@@ -57,12 +57,12 @@ type releasesQuery struct {
 type ReleaseNode struct {
 	Name         string
 	TagName      string
-	TagCommit    tagCommit
+	TagCommit    TagCommit
 	IsDraft      bool
 	IsLatest     bool
 	IsPrerelease bool
 }
-type tagCommit struct {
+type TagCommit struct {
 	Oid string
 }
 type releaseEdge struct {

--- a/pkg/plugins/scms/github/release.go
+++ b/pkg/plugins/scms/github/release.go
@@ -11,53 +11,63 @@ import (
 /*
 https://developer.github.com/v4/explorer/
 # Query
-query getLatestRelease($owner: String!, $repository: String!){
-	rateLimit {
-		cost
-		remaining
-		resetAt
-	}
-	repository(owner: $owner, name: $repository){
-		releases(last:100, before: $before, orderBy:$orderBy){
-			totalCount
-			pageInfo {
-				hasNextPage
-				endCursor
-			}
-			edges {
-				node {
-							name
-					tagName
-				isDraft
-				isPrerelease
-				}
-				cursor
-			}
-		}
-	}
-}
-# Variables
+query getLatestRelease($owner: String!, $repository: String!, $before: String, $orderBy: ReleaseOrder) {
+  rateLimit {
+    cost
+    remaining
+    resetAt
+  }
+  repository(owner: $owner, name: $repository) {
+    releases(last: 100, before: $before, orderBy: $orderBy) {
+      totalCount
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      edges {
+        node {
+          name
+          tagName
+          tagCommit {
+            oid
+          }
+          isDraft
+          isPrerelease
+        }
+        cursor
+      }
+    }
+  }
+}# Variables
 {
-	"owner": "updatecli",
-	"repository": "updatecli"
-}
-*/
+  "owner": "updatecli",
+  "repository": "updatecli",
+  "before": null,
+  "orderBy": {
+    "field": "CREATED_AT",
+    "direction": "DESC"
+  }
+}*/
 type releasesQuery struct {
 	RateLimit  RateLimit
 	Repository struct {
 		Releases repositoryRelease `graphql:"releases(last: 100, before: $before, orderBy: $orderBy)"`
 	} `graphql:"repository(owner: $owner, name: $repository)"`
 }
-type releaseNode struct {
+type ReleaseNode struct {
 	Name         string
 	TagName      string
+	TagCommit    tagCommit
 	IsDraft      bool
 	IsLatest     bool
 	IsPrerelease bool
 }
+type tagCommit struct {
+	Oid string
+}
 type releaseEdge struct {
 	Cursor string
-	Node   releaseNode
+	Node   ReleaseNode
 }
 type repositoryRelease struct {
 	TotalCount int
@@ -65,10 +75,10 @@ type repositoryRelease struct {
 	Edges      []releaseEdge
 }
 
-// SearchReleases return every releases from the github api
+// SearchReleases return every releaseNode from the github api
 // ordered by reverse order of created time.
 // Draft and pre-releases are filtered out.
-func (g *Github) SearchReleases(releaseType ReleaseType) (releases []string, err error) {
+func (g *Github) SearchReleases(releaseType ReleaseType) (releases []ReleaseNode, err error) {
 	var query releasesQuery
 
 	variables := map[string]interface{}{
@@ -97,7 +107,7 @@ func (g *Github) SearchReleases(releaseType ReleaseType) (releases []string, err
 			// we only care about identifying the latest release
 			if releaseType.Latest {
 				if node.Node.IsLatest {
-					releases = append(releases, node.Node.TagName)
+					releases = append(releases, node.Node)
 					break
 				}
 				// Check if the next release is of type "latest"
@@ -106,15 +116,15 @@ func (g *Github) SearchReleases(releaseType ReleaseType) (releases []string, err
 
 			if node.Node.IsDraft {
 				if releaseType.Draft {
-					releases = append(releases, node.Node.TagName)
+					releases = append(releases, node.Node)
 				}
 			} else if node.Node.IsPrerelease {
 				if releaseType.PreRelease {
-					releases = append(releases, node.Node.TagName)
+					releases = append(releases, node.Node)
 				}
 			} else {
 				if releaseType.Release {
-					releases = append(releases, node.Node.TagName)
+					releases = append(releases, node.Node)
 				}
 			}
 		}
@@ -128,5 +138,36 @@ func (g *Github) SearchReleases(releaseType ReleaseType) (releases []string, err
 
 	logrus.Debugf("%d releases found", len(releases))
 	return releases, nil
+}
 
+// SearchReleasesByTagName return every releases tag name from the github api
+// ordered by reverse order of created time.
+// Draft and pre-releases are filtered out.
+func (g *Github) SearchReleasesByTagName(releaseType ReleaseType) (releases []string, err error) {
+	releaseNodes, err := g.SearchReleases(releaseType)
+	if err != nil {
+		logrus.Errorf("\t%s", err)
+		return releases, err
+	}
+
+	for _, release := range releaseNodes {
+		releases = append(releases, release.TagName)
+	}
+	return releases, nil
+}
+
+// SearchReleasesByTagHash return every releases tag hash from the github api
+// ordered by reverse order of created time.
+// Draft and pre-releases are filtered out.
+func (g *Github) SearchReleasesByTagHash(releaseType ReleaseType) (releases []string, err error) {
+	releaseNodes, err := g.SearchReleases(releaseType)
+	if err != nil {
+		logrus.Errorf("\t%s", err)
+		return releases, err
+	}
+
+	for _, release := range releaseNodes {
+		releases = append(releases, release.TagCommit.Oid)
+	}
+	return releases, nil
 }

--- a/pkg/plugins/scms/github/release_test.go
+++ b/pkg/plugins/scms/github/release_test.go
@@ -47,7 +47,7 @@ func TestSearchReleases(t *testing.T) {
 								Node: ReleaseNode{
 									Name:    "v0.18.4 🌈",
 									TagName: "v0.18.4",
-									TagCommit: tagCommit{
+									TagCommit: TagCommit{
 										Oid: "11111111",
 									},
 									IsDraft: true,
@@ -58,7 +58,7 @@ func TestSearchReleases(t *testing.T) {
 								Node: ReleaseNode{
 									Name:    "v0.18.3",
 									TagName: "v0.18.3",
-									TagCommit: tagCommit{
+									TagCommit: TagCommit{
 										Oid: "2222222",
 									},
 									IsLatest: true,
@@ -69,7 +69,7 @@ func TestSearchReleases(t *testing.T) {
 								Node: ReleaseNode{
 									Name:    "v1.0.0",
 									TagName: "v1.0.0",
-									TagCommit: tagCommit{
+									TagCommit: TagCommit{
 										Oid: "33333333",
 									},
 									IsPrerelease: true,
@@ -80,7 +80,7 @@ func TestSearchReleases(t *testing.T) {
 								Node: ReleaseNode{
 									Name:    "v0.0.1",
 									TagName: "v0.0.1",
-									TagCommit: tagCommit{
+									TagCommit: TagCommit{
 										Oid: "44444444",
 									},
 								},
@@ -121,7 +121,7 @@ func TestSearchReleases(t *testing.T) {
 								Node: ReleaseNode{
 									Name:    "v0.18.4 🌈",
 									TagName: "v0.18.4",
-									TagCommit: tagCommit{
+									TagCommit: TagCommit{
 										Oid: "11111111",
 									},
 									IsDraft: true,
@@ -132,7 +132,7 @@ func TestSearchReleases(t *testing.T) {
 								Node: ReleaseNode{
 									Name:    "v0.18.3",
 									TagName: "v0.18.3",
-									TagCommit: tagCommit{
+									TagCommit: TagCommit{
 										Oid: "2222222",
 									},
 									IsLatest: true,
@@ -143,7 +143,7 @@ func TestSearchReleases(t *testing.T) {
 								Node: ReleaseNode{
 									Name:    "v1.0.0",
 									TagName: "v1.0.0",
-									TagCommit: tagCommit{
+									TagCommit: TagCommit{
 										Oid: "33333333",
 									},
 									IsPrerelease: true,
@@ -154,7 +154,7 @@ func TestSearchReleases(t *testing.T) {
 								Node: ReleaseNode{
 									Name:    "v0.0.1",
 									TagName: "v0.0.1",
-									TagCommit: tagCommit{
+									TagCommit: TagCommit{
 										Oid: "44444444",
 									},
 								},
@@ -198,7 +198,7 @@ func TestSearchReleases(t *testing.T) {
 								Node: ReleaseNode{
 									Name:    "v0.18.4 🌈",
 									TagName: "v0.18.4",
-									TagCommit: tagCommit{
+									TagCommit: TagCommit{
 										Oid: "11111111",
 									},
 									IsDraft: true,
@@ -209,7 +209,7 @@ func TestSearchReleases(t *testing.T) {
 								Node: ReleaseNode{
 									Name:    "v0.18.3",
 									TagName: "v0.18.3",
-									TagCommit: tagCommit{
+									TagCommit: TagCommit{
 										Oid: "2222222",
 									},
 									IsLatest: true,
@@ -220,7 +220,7 @@ func TestSearchReleases(t *testing.T) {
 								Node: ReleaseNode{
 									Name:    "v1.0.0",
 									TagName: "v1.0.0",
-									TagCommit: tagCommit{
+									TagCommit: TagCommit{
 										Oid: "33333333",
 									},
 									IsPrerelease: true,
@@ -231,7 +231,7 @@ func TestSearchReleases(t *testing.T) {
 								Node: ReleaseNode{
 									Name:    "v0.0.1",
 									TagName: "v0.0.1",
-									TagCommit: tagCommit{
+									TagCommit: TagCommit{
 										Oid: "44444444",
 									},
 								},
@@ -273,7 +273,7 @@ func TestSearchReleases(t *testing.T) {
 								Node: ReleaseNode{
 									Name:    "v0.18.4 🌈",
 									TagName: "v0.18.4",
-									TagCommit: tagCommit{
+									TagCommit: TagCommit{
 										Oid: "11111111",
 									},
 									IsDraft: true,
@@ -284,7 +284,7 @@ func TestSearchReleases(t *testing.T) {
 								Node: ReleaseNode{
 									Name:    "v0.18.3",
 									TagName: "v0.18.3",
-									TagCommit: tagCommit{
+									TagCommit: TagCommit{
 										Oid: "2222222",
 									},
 									IsLatest: true,
@@ -295,7 +295,7 @@ func TestSearchReleases(t *testing.T) {
 								Node: ReleaseNode{
 									Name:    "v1.0.0",
 									TagName: "v1.0.0",
-									TagCommit: tagCommit{
+									TagCommit: TagCommit{
 										Oid: "33333333",
 									},
 									IsPrerelease: true,
@@ -306,7 +306,7 @@ func TestSearchReleases(t *testing.T) {
 								Node: ReleaseNode{
 									Name:    "v0.0.1",
 									TagName: "v0.0.1",
-									TagCommit: tagCommit{
+									TagCommit: TagCommit{
 										Oid: "44444444",
 									},
 								},
@@ -345,7 +345,7 @@ func TestSearchReleases(t *testing.T) {
 								Node: ReleaseNode{
 									Name:    "v0.18.4 🌈",
 									TagName: "v0.18.4",
-									TagCommit: tagCommit{
+									TagCommit: TagCommit{
 										Oid: "11111111",
 									},
 									IsDraft:      true,
@@ -357,7 +357,7 @@ func TestSearchReleases(t *testing.T) {
 								Node: ReleaseNode{
 									Name:    "v0.18.3",
 									TagName: "v0.18.3",
-									TagCommit: tagCommit{
+									TagCommit: TagCommit{
 										Oid: "2222222",
 									},
 									IsDraft:      false,
@@ -369,7 +369,7 @@ func TestSearchReleases(t *testing.T) {
 								Node: ReleaseNode{
 									Name:    "v1.0.0",
 									TagName: "v1.0.0",
-									TagCommit: tagCommit{
+									TagCommit: TagCommit{
 										Oid: "33333333",
 									},
 									IsDraft:      false,
@@ -381,7 +381,7 @@ func TestSearchReleases(t *testing.T) {
 								Node: ReleaseNode{
 									Name:    "v0.0.1",
 									TagName: "v0.0.1",
-									TagCommit: tagCommit{
+									TagCommit: TagCommit{
 										Oid: "44444444",
 									},
 									IsDraft:      false,

--- a/pkg/plugins/scms/github/release_test.go
+++ b/pkg/plugins/scms/github/release_test.go
@@ -13,6 +13,7 @@ func TestSearchReleases(t *testing.T) {
 		name         string
 		spec         Spec
 		releaseType  ReleaseType
+		searchKey    string
 		mockedQuery  *releasesQuery
 		mockedError  error
 		wantReleases []string
@@ -43,33 +44,45 @@ func TestSearchReleases(t *testing.T) {
 						Edges: []releaseEdge{
 							{
 								Cursor: "Y3Vyc29yOnYyOpK5MjAyMi0wMS0xOFQxOTo0Nzo1MyswMTowMM4Da8vn",
-								Node: releaseNode{
+								Node: ReleaseNode{
 									Name:    "v0.18.4 🌈",
 									TagName: "v0.18.4",
+									TagCommit: tagCommit{
+										Oid: "11111111",
+									},
 									IsDraft: true,
 								},
 							},
 							{
 								Cursor: "Y3Vyc29yOnYyOpK5MjAyMi0wMS0xOFQxOTo0Nzo1MyswMTowMM4Da8vn",
-								Node: releaseNode{
-									Name:     "v0.18.3",
-									TagName:  "v0.18.3",
+								Node: ReleaseNode{
+									Name:    "v0.18.3",
+									TagName: "v0.18.3",
+									TagCommit: tagCommit{
+										Oid: "2222222",
+									},
 									IsLatest: true,
 								},
 							},
 							{
 								Cursor: "Y3Vyc29yOnYyOpK5MjAyMS0xMS0xM1QxMjozNzoxMiswMTowMM4DK66W",
-								Node: releaseNode{
-									Name:         "v1.0.0",
-									TagName:      "v1.0.0",
+								Node: ReleaseNode{
+									Name:    "v1.0.0",
+									TagName: "v1.0.0",
+									TagCommit: tagCommit{
+										Oid: "33333333",
+									},
 									IsPrerelease: true,
 								},
 							},
 							{
 								Cursor: "Y3Vyc29yOnYyOpK5MjAyMC0wMi0xOVQyMTozMDoxMyswMTowMM4BYOFb",
-								Node: releaseNode{
+								Node: ReleaseNode{
 									Name:    "v0.0.1",
 									TagName: "v0.0.1",
+									TagCommit: tagCommit{
+										Oid: "44444444",
+									},
 								},
 							},
 						},
@@ -77,6 +90,80 @@ func TestSearchReleases(t *testing.T) {
 				},
 			},
 			wantReleases: []string{"v0.0.1", "v0.18.3"},
+		},
+
+		{
+			name: "Case with a mix of releases (draft, prerelease, release) and default ReleaseType filter and hash",
+			spec: Spec{
+				Owner:      "updatecli",
+				Repository: "updatecli",
+				Token:      "superSecretTokenForJoe",
+				Username:   "joe",
+			},
+			searchKey: "hash",
+			mockedQuery: &releasesQuery{
+				RateLimit: RateLimit{
+					Cost:      1,
+					Remaining: 5000,
+				},
+				Repository: struct {
+					Releases repositoryRelease `graphql:"releases(last: 100, before: $before, orderBy: $orderBy)"`
+				}{
+					Releases: repositoryRelease{
+						TotalCount: 4,
+						PageInfo: PageInfo{
+							HasNextPage: false,
+							EndCursor:   "Y3Vyc29yOnYyOpK5MjAyMC0wMi0xOVQyMTozMDoxMyswMTowMM4BYOFb",
+						},
+						Edges: []releaseEdge{
+							{
+								Cursor: "Y3Vyc29yOnYyOpK5MjAyMi0wMS0xOFQxOTo0Nzo1MyswMTowMM4Da8vn",
+								Node: ReleaseNode{
+									Name:    "v0.18.4 🌈",
+									TagName: "v0.18.4",
+									TagCommit: tagCommit{
+										Oid: "11111111",
+									},
+									IsDraft: true,
+								},
+							},
+							{
+								Cursor: "Y3Vyc29yOnYyOpK5MjAyMi0wMS0xOFQxOTo0Nzo1MyswMTowMM4Da8vn",
+								Node: ReleaseNode{
+									Name:    "v0.18.3",
+									TagName: "v0.18.3",
+									TagCommit: tagCommit{
+										Oid: "2222222",
+									},
+									IsLatest: true,
+								},
+							},
+							{
+								Cursor: "Y3Vyc29yOnYyOpK5MjAyMS0xMS0xM1QxMjozNzoxMiswMTowMM4DK66W",
+								Node: ReleaseNode{
+									Name:    "v1.0.0",
+									TagName: "v1.0.0",
+									TagCommit: tagCommit{
+										Oid: "33333333",
+									},
+									IsPrerelease: true,
+								},
+							},
+							{
+								Cursor: "Y3Vyc29yOnYyOpK5MjAyMC0wMi0xOVQyMTozMDoxMyswMTowMM4BYOFb",
+								Node: ReleaseNode{
+									Name:    "v0.0.1",
+									TagName: "v0.0.1",
+									TagCommit: tagCommit{
+										Oid: "44444444",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantReleases: []string{"44444444", "2222222"},
 		},
 		{
 			name: "Case with a mix of releases (draft, prerelease, release) and a ReleaseType with draft, prerelease and releases",
@@ -108,33 +195,45 @@ func TestSearchReleases(t *testing.T) {
 						Edges: []releaseEdge{
 							{
 								Cursor: "Y3Vyc29yOnYyOpK5MjAyMi0wMS0xOFQxOTo0Nzo1MyswMTowMM4Da8vn",
-								Node: releaseNode{
+								Node: ReleaseNode{
 									Name:    "v0.18.4 🌈",
 									TagName: "v0.18.4",
+									TagCommit: tagCommit{
+										Oid: "11111111",
+									},
 									IsDraft: true,
 								},
 							},
 							{
 								Cursor: "Y3Vyc29yOnYyOpK5MjAyMi0wMS0xOFQxOTo0Nzo1MyswMTowMM4Da8vn",
-								Node: releaseNode{
-									Name:     "v0.18.3",
-									TagName:  "v0.18.3",
+								Node: ReleaseNode{
+									Name:    "v0.18.3",
+									TagName: "v0.18.3",
+									TagCommit: tagCommit{
+										Oid: "2222222",
+									},
 									IsLatest: true,
 								},
 							},
 							{
 								Cursor: "Y3Vyc29yOnYyOpK5MjAyMS0xMS0xM1QxMjozNzoxMiswMTowMM4DK66W",
-								Node: releaseNode{
-									Name:         "v1.0.0",
-									TagName:      "v1.0.0",
+								Node: ReleaseNode{
+									Name:    "v1.0.0",
+									TagName: "v1.0.0",
+									TagCommit: tagCommit{
+										Oid: "33333333",
+									},
 									IsPrerelease: true,
 								},
 							},
 							{
 								Cursor: "Y3Vyc29yOnYyOpK5MjAyMC0wMi0xOVQyMTozMDoxMyswMTowMM4BYOFb",
-								Node: releaseNode{
+								Node: ReleaseNode{
 									Name:    "v0.0.1",
 									TagName: "v0.0.1",
+									TagCommit: tagCommit{
+										Oid: "44444444",
+									},
 								},
 							},
 						},
@@ -171,33 +270,45 @@ func TestSearchReleases(t *testing.T) {
 						Edges: []releaseEdge{
 							{
 								Cursor: "Y3Vyc29yOnYyOpK5MjAyMi0wMS0xOFQxOTo0Nzo1MyswMTowMM4Da8vn",
-								Node: releaseNode{
+								Node: ReleaseNode{
 									Name:    "v0.18.4 🌈",
 									TagName: "v0.18.4",
+									TagCommit: tagCommit{
+										Oid: "11111111",
+									},
 									IsDraft: true,
 								},
 							},
 							{
 								Cursor: "Y3Vyc29yOnYyOpK5MjAyMi0wMS0xOFQxOTo0Nzo1MyswMTowMM4Da8vn",
-								Node: releaseNode{
-									Name:     "v0.18.3",
-									TagName:  "v0.18.3",
+								Node: ReleaseNode{
+									Name:    "v0.18.3",
+									TagName: "v0.18.3",
+									TagCommit: tagCommit{
+										Oid: "2222222",
+									},
 									IsLatest: true,
 								},
 							},
 							{
 								Cursor: "Y3Vyc29yOnYyOpK5MjAyMS0xMS0xM1QxMjozNzoxMiswMTowMM4DK66W",
-								Node: releaseNode{
-									Name:         "v1.0.0",
-									TagName:      "v1.0.0",
+								Node: ReleaseNode{
+									Name:    "v1.0.0",
+									TagName: "v1.0.0",
+									TagCommit: tagCommit{
+										Oid: "33333333",
+									},
 									IsPrerelease: true,
 								},
 							},
 							{
 								Cursor: "Y3Vyc29yOnYyOpK5MjAyMC0wMi0xOVQyMTozMDoxMyswMTowMM4BYOFb",
-								Node: releaseNode{
+								Node: ReleaseNode{
 									Name:    "v0.0.1",
 									TagName: "v0.0.1",
+									TagCommit: tagCommit{
+										Oid: "44444444",
+									},
 								},
 							},
 						},
@@ -231,36 +342,48 @@ func TestSearchReleases(t *testing.T) {
 						Edges: []releaseEdge{
 							{
 								Cursor: "Y3Vyc29yOnYyOpK5MjAyMi0wMS0xOFQxOTo0Nzo1MyswMTowMM4Da8vn",
-								Node: releaseNode{
-									Name:         "v0.18.4 🌈",
-									TagName:      "v0.18.4",
+								Node: ReleaseNode{
+									Name:    "v0.18.4 🌈",
+									TagName: "v0.18.4",
+									TagCommit: tagCommit{
+										Oid: "11111111",
+									},
 									IsDraft:      true,
 									IsPrerelease: false,
 								},
 							},
 							{
 								Cursor: "Y3Vyc29yOnYyOpK5MjAyMi0wMS0xOFQxOTo0Nzo1MyswMTowMM4Da8vn",
-								Node: releaseNode{
-									Name:         "v0.18.3",
-									TagName:      "v0.18.3",
+								Node: ReleaseNode{
+									Name:    "v0.18.3",
+									TagName: "v0.18.3",
+									TagCommit: tagCommit{
+										Oid: "2222222",
+									},
 									IsDraft:      false,
 									IsPrerelease: false,
 								},
 							},
 							{
 								Cursor: "Y3Vyc29yOnYyOpK5MjAyMS0xMS0xM1QxMjozNzoxMiswMTowMM4DK66W",
-								Node: releaseNode{
-									Name:         "v1.0.0",
-									TagName:      "v1.0.0",
+								Node: ReleaseNode{
+									Name:    "v1.0.0",
+									TagName: "v1.0.0",
+									TagCommit: tagCommit{
+										Oid: "33333333",
+									},
 									IsDraft:      false,
 									IsPrerelease: true,
 								},
 							},
 							{
 								Cursor: "Y3Vyc29yOnYyOpK5MjAyMC0wMi0xOVQyMTozMDoxMyswMTowMM4BYOFb",
-								Node: releaseNode{
-									Name:         "v0.0.1",
-									TagName:      "v0.0.1",
+								Node: ReleaseNode{
+									Name:    "v0.0.1",
+									TagName: "v0.0.1",
+									TagCommit: tagCommit{
+										Oid: "44444444",
+									},
 									IsDraft:      false,
 									IsPrerelease: false,
 								},
@@ -291,7 +414,14 @@ func TestSearchReleases(t *testing.T) {
 			}
 			tt.releaseType.Init()
 
-			got, err := sut.SearchReleases(tt.releaseType)
+			var got []string
+			var err error
+			if tt.searchKey == "hash" {
+				got, err = sut.SearchReleasesByTagHash(tt.releaseType)
+			} else {
+				got, err = sut.SearchReleasesByTagName(tt.releaseType)
+
+			}
 
 			if tt.wantErr {
 				assert.Error(t, err)

--- a/pkg/plugins/utils/gitgeneric/branch.go
+++ b/pkg/plugins/utils/gitgeneric/branch.go
@@ -13,8 +13,14 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// Tags return a list of git tags ordered by latest commit time
-func (g GoGit) Branches(workingDir string) (branches []string, err error) {
+type DatedBranch struct {
+	When time.Time
+	Name string
+	Hash string
+}
+
+// BranchRefs return a list of git granch ordered by latest commit time
+func (g GoGit) BranchRefs(workingDir string) (branches []DatedBranch, err error) {
 	r, err := git.PlainOpen(workingDir)
 	if err != nil {
 		logrus.Errorf("opening %q git directory: %s", workingDir, err)
@@ -26,12 +32,6 @@ func (g GoGit) Branches(workingDir string) (branches []string, err error) {
 	if err != nil {
 		return branches, fmt.Errorf("listing branches: %s", err)
 	}
-
-	type DatedBranch struct {
-		when time.Time
-		name string
-	}
-	listOfDatedBranches := []DatedBranch{}
 
 	err = branchrefs.ForEach(func(tagRef *plumbing.Reference) error {
 		revision := plumbing.Revision(tagRef.Name().String())
@@ -45,32 +45,49 @@ func (g GoGit) Branches(workingDir string) (branches []string, err error) {
 			return fmt.Errorf("getting commit object for %q: %s", tagRef.Name().Short(), err)
 		}
 
-		listOfDatedBranches = append(
-			listOfDatedBranches,
+		branches = append(
+			branches,
 			DatedBranch{
-				name: tagRef.Name().Short(),
-				when: commit.Committer.When,
+				Name: tagRef.Name().Short(),
+				When: commit.Committer.When,
+				Hash: commit.Hash.String(),
 			},
 		)
 
 		return nil
 	})
 	if err != nil {
-		return branches, fmt.Errorf("listing branches: %s", err)
+		return []DatedBranch{}, fmt.Errorf("listing branches: %s", err)
 	}
 
-	if len(listOfDatedBranches) == 0 {
-		return []string{}, fmt.Errorf(ErrNoBranchFound)
+	if len(branches) == 0 {
+		return []DatedBranch{}, fmt.Errorf(ErrNoBranchFound)
 	}
 
 	// Sort tags by time
-	sort.Slice(listOfDatedBranches, func(i, j int) bool {
-		return listOfDatedBranches[i].when.Before(listOfDatedBranches[j].when)
+	sort.Slice(branches, func(i, j int) bool {
+		return branches[i].When.Before(branches[j].When)
 	})
 
+	logrus.Debugf("got branch refs: %v", branches)
+
+	if len(branches) == 0 {
+		return branches, fmt.Errorf(ErrNoBranchFound)
+	}
+
+	return branches, err
+
+}
+
+// Branches return a list of git branches name ordered by latest commit time
+func (g GoGit) Branches(workingDir string) (branches []string, err error) {
+	branchRefs, err := g.BranchRefs(workingDir)
+	if err != nil {
+		return branches, err
+	}
 	// Extract the list of tags names (ordered by time)
-	for _, datedTag := range listOfDatedBranches {
-		branches = append(branches, datedTag.name)
+	for _, branchRef := range branchRefs {
+		branches = append(branches, branchRef.Name)
 	}
 
 	logrus.Debugf("got branches: %v", branches)

--- a/pkg/plugins/utils/gitgeneric/main.go
+++ b/pkg/plugins/utils/gitgeneric/main.go
@@ -47,6 +47,7 @@ type GitHandler interface {
 	TagHashes(workingDir string) (hashes []string, err error)
 	TagRefs(workingDir string) (refs []DatedTag, err error)
 	Branches(workingDir string) (branches []string, err error)
+	BranchRefs(workingDir string) (branches []DatedBranch, err error)
 }
 
 type GoGit struct {


### PR DESCRIPTION
Fix #3507 
Introduce a `key` argument for github release to get the tag hash instead of the tag name.

## Test

To test this pull request, you can run the following commands:

```shell
cd <to_package_directory>
go test
```

## Additional Information

This pr introduces the following changes:
- `githubrelease` now supports an `key` argument like `gittag` that can either be `name` (default) or `hash`.
- `gitbranch` now supports an `key` argument like `gittag` that can either be `name` (default) or `hash`.
- `yaml` now accept a `comment` arg, when used in a `target` and with the `yamlpath` engine, it can be used to add a comment to a line.
  <details>
    <summary>Yaml comment</summary>
  
  ## Given the following `test.yaml`
  
  ```yaml
  ---
  owner: anakin
  ```
  ## Running `updatecli.yaml`
  
  ```yaml
  ---
  sources:
    default:
      kind: shell
      spec:
        command: echo "obiwan"
    comment:
      kind: shell
      spec:
        command: echo "is the best"
  targets:
    default:
      kind: yaml
      sourceid: default
      spec:
        engine: yamlpath
        key: owner
        file: test.yaml
        comment: '{{ source "comment" }}'
  ``` 
  ## Would yield `test.yaml`
  
  ```yaml
  ---
  owner: obiwan # is the best
  ```
  </details>

- `githubaction` autodiscovery can be setup to resolved `digest`:
```yaml
jobs:
  build:
    steps:
      - uses: "actions/checkout@v4`
```
gets resolved to
```yaml
jobs:
  build:
    steps:
      - uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683"  # pinned from v4.2.2 by updatecli (do-not-remove-comment)`
```

The comment is required to be able to infer the update channel in the following updates, removing it would translate to a pinned version.

