### PR TITLE
3507 githubbranch hash

### DIFF
--- a/e2e/updatecli.d/success.d/gitBranch.yaml
+++ b/e2e/updatecli.d/success.d/gitBranch.yaml
@@ -26,6 +26,12 @@ sources:
     kind: gitbranch
     spec:
       url: https://github.com/olblak/nocode.git
+  hash:
+    name: Get Latest committed branch
+    kind: gitbranch
+    scmid: default
+    spec:
+      key: hash
 
 conditions:
   default:

--- a/e2e/updatecli.d/success.d/githubRelease.yaml
+++ b/e2e/updatecli.d/success.d/githubRelease.yaml
@@ -29,6 +29,15 @@ sources:
       username: '{{ requiredEnv "GITHUB_ACTOR" }}'
       typefilter:
         release: true
+  hash:
+    name: Default Get Latest github action Release Hash
+    kind: githubrelease
+    spec:
+      owner: updatecli
+      repository: updatecli-action
+      token: '{{ requiredEnv "GITHUB_TOKEN" }}'
+      username: '{{ requiredEnv "GITHUB_ACTOR" }}'
+      key: hash
 conditions:
   default:
     name: Default Get Latest GitHub action Release

--- a/pkg/plugins/resources/gitbranch/source.go
+++ b/pkg/plugins/resources/gitbranch/source.go
@@ -25,13 +25,23 @@ func (gb *GitBranch) Source(workingDir string, resultSource *result.Source) erro
 		return fmt.Errorf("Unknown Git working directory. Did you specify one of `spec.URL`, `scmid` or a `spec.path`?")
 	}
 
-	tags, err := gb.nativeGitHandler.Branches(gb.directory)
+	refs, err := gb.nativeGitHandler.BranchRefs(gb.directory)
 
 	if err != nil {
 		return fmt.Errorf("retrieving branches: %w", err)
 	}
 
-	gb.foundVersion, err = gb.versionFilter.Search(tags)
+	values := []string{}
+	for _, ref := range refs {
+		var value string
+		if gb.spec.Key == "hash" {
+			value = ref.Hash
+		} else {
+			value = ref.Name
+		}
+		values = append(values, value)
+	}
+	gb.foundVersion, err = gb.versionFilter.Search(values)
 	if err != nil {
 		return fmt.Errorf("filtering branches: %w", err)
 	}

--- a/pkg/plugins/resources/githubrelease/condition.go
+++ b/pkg/plugins/resources/githubrelease/condition.go
@@ -19,7 +19,12 @@ func (gr GitHubRelease) Condition(source string, scm scm.ScmHandler) (pass bool,
 		expectedValue = gr.spec.Tag
 	}
 
-	versions, err := gr.ghHandler.SearchReleases(gr.typeFilter)
+	var versions []string
+	if gr.spec.Key == KeyHash {
+		versions, err = gr.ghHandler.SearchReleasesByTagHash(gr.typeFilter)
+	} else {
+		versions, err = gr.ghHandler.SearchReleasesByTagName(gr.typeFilter)
+	}
 	if err != nil {
 		return false, "", fmt.Errorf("searching GitHub release: %w", err)
 	}

--- a/pkg/plugins/resources/githubrelease/main_test.go
+++ b/pkg/plugins/resources/githubrelease/main_test.go
@@ -96,6 +96,18 @@ func TestNew(t *testing.T) {
 			},
 		},
 		{
+			name: "Validation error (bad key)",
+			spec: Spec{
+				Repository: "updatecli",
+				Owner:      "updatecli",
+				Username:   "joe",
+				Token:      "superSecretTOkenOfJoe",
+				URL:        "github.com",
+				Key:        "commit",
+			},
+			wantErr: true,
+		},
+		{
 			name: "Validation Error (missing token)",
 			spec: Spec{
 				Repository: "updatecli",

--- a/pkg/plugins/resources/githubrelease/source.go
+++ b/pkg/plugins/resources/githubrelease/source.go
@@ -10,7 +10,13 @@ import (
 // Source retrieves a specific version tag from GitHub Releases.
 func (gr *GitHubRelease) Source(workingDir string, resultSource *result.Source) error {
 
-	versions, err := gr.ghHandler.SearchReleases(gr.typeFilter)
+	var versions []string
+	var err error
+	if gr.spec.Key == KeyHash {
+		versions, err = gr.ghHandler.SearchReleasesByTagHash(gr.typeFilter)
+	} else {
+		versions, err = gr.ghHandler.SearchReleasesByTagName(gr.typeFilter)
+	}
 	if err != nil {
 		return fmt.Errorf("searching GitHub release: %w", err)
 	}

--- a/pkg/plugins/scms/github/client.go
+++ b/pkg/plugins/scms/github/client.go
@@ -15,7 +15,8 @@ type GitHubClient interface {
 
 // GithubHandler must be implemented by any GitHub module
 type GithubHandler interface {
-	SearchReleases(releaseType ReleaseType) (releases []string, err error)
+	SearchReleasesByTagName(releaseType ReleaseType) (releases []string, err error)
+	SearchReleasesByTagHash(releaseType ReleaseType) (releases []string, err error)
 	SearchTags() (tags []string, err error)
 	Changelog(version.Version) (string, error)
 }

--- a/pkg/plugins/scms/github/release.go
+++ b/pkg/plugins/scms/github/release.go
@@ -11,53 +11,63 @@ import (
 /*
 https://developer.github.com/v4/explorer/
 # Query
-query getLatestRelease($owner: String!, $repository: String!){
-	rateLimit {
-		cost
-		remaining
-		resetAt
-	}
-	repository(owner: $owner, name: $repository){
-		releases(last:100, before: $before, orderBy:$orderBy){
-			totalCount
-			pageInfo {
-				hasNextPage
-				endCursor
-			}
-			edges {
-				node {
-							name
-					tagName
-				isDraft
-				isPrerelease
-				}
-				cursor
-			}
-		}
-	}
-}
-# Variables
+query getLatestRelease($owner: String!, $repository: String!, $before: String, $orderBy: ReleaseOrder) {
+  rateLimit {
+    cost
+    remaining
+    resetAt
+  }
+  repository(owner: $owner, name: $repository) {
+    releases(last: 100, before: $before, orderBy: $orderBy) {
+      totalCount
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      edges {
+        node {
+          name
+          tagName
+          tagCommit {
+            oid
+          }
+          isDraft
+          isPrerelease
+        }
+        cursor
+      }
+    }
+  }
+}# Variables
 {
-	"owner": "updatecli",
-	"repository": "updatecli"
-}
-*/
+  "owner": "updatecli",
+  "repository": "updatecli",
+  "before": null,
+  "orderBy": {
+    "field": "CREATED_AT",
+    "direction": "DESC"
+  }
+}*/
 type releasesQuery struct {
 	RateLimit  RateLimit
 	Repository struct {
 		Releases repositoryRelease `graphql:"releases(last: 100, before: $before, orderBy: $orderBy)"`
 	} `graphql:"repository(owner: $owner, name: $repository)"`
 }
-type releaseNode struct {
+type ReleaseNode struct {
 	Name         string
 	TagName      string
+	TagCommit    tagCommit
 	IsDraft      bool
 	IsLatest     bool
 	IsPrerelease bool
 }
+type tagCommit struct {
+	Oid string
+}
 type releaseEdge struct {
 	Cursor string
-	Node   releaseNode
+	Node   ReleaseNode
 }
 type repositoryRelease struct {
 	TotalCount int
@@ -65,10 +75,10 @@ type repositoryRelease struct {
 	Edges      []releaseEdge
 }
 
-// SearchReleases return every releases from the github api
+// SearchReleases return every releaseNode from the github api
 // ordered by reverse order of created time.
 // Draft and pre-releases are filtered out.
-func (g *Github) SearchReleases(releaseType ReleaseType) (releases []string, err error) {
+func (g *Github) SearchReleases(releaseType ReleaseType) (releases []ReleaseNode, err error) {
 	var query releasesQuery
 
 	variables := map[string]interface{}{
@@ -97,7 +107,7 @@ func (g *Github) SearchReleases(releaseType ReleaseType) (releases []string, err
 			// we only care about identifying the latest release
 			if releaseType.Latest {
 				if node.Node.IsLatest {
-					releases = append(releases, node.Node.TagName)
+					releases = append(releases, node.Node)
 					break
 				}
 				// Check if the next release is of type "latest"
@@ -106,15 +116,15 @@ func (g *Github) SearchReleases(releaseType ReleaseType) (releases []string, err
 
 			if node.Node.IsDraft {
 				if releaseType.Draft {
-					releases = append(releases, node.Node.TagName)
+					releases = append(releases, node.Node)
 				}
 			} else if node.Node.IsPrerelease {
 				if releaseType.PreRelease {
-					releases = append(releases, node.Node.TagName)
+					releases = append(releases, node.Node)
 				}
 			} else {
 				if releaseType.Release {
-					releases = append(releases, node.Node.TagName)
+					releases = append(releases, node.Node)
 				}
 			}
 		}
@@ -128,5 +138,36 @@ func (g *Github) SearchReleases(releaseType ReleaseType) (releases []string, err
 
 	logrus.Debugf("%d releases found", len(releases))
 	return releases, nil
+}
 
+// SearchReleasesByTagName return every releases tag name from the github api
+// ordered by reverse order of created time.
+// Draft and pre-releases are filtered out.
+func (g *Github) SearchReleasesByTagName(releaseType ReleaseType) (releases []string, err error) {
+	releaseNodes, err := g.SearchReleases(releaseType)
+	if err != nil {
+		logrus.Errorf("\t%s", err)
+		return releases, err
+	}
+
+	for _, release := range releaseNodes {
+		releases = append(releases, release.TagName)
+	}
+	return releases, nil
+}
+
+// SearchReleasesByTagHash return every releases tag hash from the github api
+// ordered by reverse order of created time.
+// Draft and pre-releases are filtered out.
+func (g *Github) SearchReleasesByTagHash(releaseType ReleaseType) (releases []string, err error) {
+	releaseNodes, err := g.SearchReleases(releaseType)
+	if err != nil {
+		logrus.Errorf("\t%s", err)
+		return releases, err
+	}
+
+	for _, release := range releaseNodes {
+		releases = append(releases, release.TagCommit.Oid)
+	}
+	return releases, nil
 }

--- a/pkg/plugins/scms/github/release_test.go
+++ b/pkg/plugins/scms/github/release_test.go
@@ -13,6 +13,7 @@ func TestSearchReleases(t *testing.T) {
 		name         string
 		spec         Spec
 		releaseType  ReleaseType
+		searchKey    string
 		mockedQuery  *releasesQuery
 		mockedError  error
 		wantReleases []string
@@ -43,33 +44,45 @@ func TestSearchReleases(t *testing.T) {
 						Edges: []releaseEdge{
 							{
 								Cursor: "Y3Vyc29yOnYyOpK5MjAyMi0wMS0xOFQxOTo0Nzo1MyswMTowMM4Da8vn",
-								Node: releaseNode{
+								Node: ReleaseNode{
 									Name:    "v0.18.4 🌈",
 									TagName: "v0.18.4",
+									TagCommit: tagCommit{
+										Oid: "11111111",
+									},
 									IsDraft: true,
 								},
 							},
 							{
 								Cursor: "Y3Vyc29yOnYyOpK5MjAyMi0wMS0xOFQxOTo0Nzo1MyswMTowMM4Da8vn",
-								Node: releaseNode{
-									Name:     "v0.18.3",
-									TagName:  "v0.18.3",
+								Node: ReleaseNode{
+									Name:    "v0.18.3",
+									TagName: "v0.18.3",
+									TagCommit: tagCommit{
+										Oid: "2222222",
+									},
 									IsLatest: true,
 								},
 							},
 							{
 								Cursor: "Y3Vyc29yOnYyOpK5MjAyMS0xMS0xM1QxMjozNzoxMiswMTowMM4DK66W",
-								Node: releaseNode{
-									Name:         "v1.0.0",
-									TagName:      "v1.0.0",
+								Node: ReleaseNode{
+									Name:    "v1.0.0",
+									TagName: "v1.0.0",
+									TagCommit: tagCommit{
+										Oid: "33333333",
+									},
 									IsPrerelease: true,
 								},
 							},
 							{
 								Cursor: "Y3Vyc29yOnYyOpK5MjAyMC0wMi0xOVQyMTozMDoxMyswMTowMM4BYOFb",
-								Node: releaseNode{
+								Node: ReleaseNode{
 									Name:    "v0.0.1",
 									TagName: "v0.0.1",
+									TagCommit: tagCommit{
+										Oid: "44444444",
+									},
 								},
 							},
 						},
@@ -77,6 +90,80 @@ func TestSearchReleases(t *testing.T) {
 				},
 			},
 			wantReleases: []string{"v0.0.1", "v0.18.3"},
+		},
+
+		{
+			name: "Case with a mix of releases (draft, prerelease, release) and default ReleaseType filter and hash",
+			spec: Spec{
+				Owner:      "updatecli",
+				Repository: "updatecli",
+				Token:      "superSecretTokenForJoe",
+				Username:   "joe",
+			},
+			searchKey: "hash",
+			mockedQuery: &releasesQuery{
+				RateLimit: RateLimit{
+					Cost:      1,
+					Remaining: 5000,
+				},
+				Repository: struct {
+					Releases repositoryRelease `graphql:"releases(last: 100, before: $before, orderBy: $orderBy)"`
+				}{
+					Releases: repositoryRelease{
+						TotalCount: 4,
+						PageInfo: PageInfo{
+							HasNextPage: false,
+							EndCursor:   "Y3Vyc29yOnYyOpK5MjAyMC0wMi0xOVQyMTozMDoxMyswMTowMM4BYOFb",
+						},
+						Edges: []releaseEdge{
+							{
+								Cursor: "Y3Vyc29yOnYyOpK5MjAyMi0wMS0xOFQxOTo0Nzo1MyswMTowMM4Da8vn",
+								Node: ReleaseNode{
+									Name:    "v0.18.4 🌈",
+									TagName: "v0.18.4",
+									TagCommit: tagCommit{
+										Oid: "11111111",
+									},
+									IsDraft: true,
+								},
+							},
+							{
+								Cursor: "Y3Vyc29yOnYyOpK5MjAyMi0wMS0xOFQxOTo0Nzo1MyswMTowMM4Da8vn",
+								Node: ReleaseNode{
+									Name:    "v0.18.3",
+									TagName: "v0.18.3",
+									TagCommit: tagCommit{
+										Oid: "2222222",
+									},
+									IsLatest: true,
+								},
+							},
+							{
+								Cursor: "Y3Vyc29yOnYyOpK5MjAyMS0xMS0xM1QxMjozNzoxMiswMTowMM4DK66W",
+								Node: ReleaseNode{
+									Name:    "v1.0.0",
+									TagName: "v1.0.0",
+									TagCommit: tagCommit{
+										Oid: "33333333",
+									},
+									IsPrerelease: true,
+								},
+							},
+							{
+								Cursor: "Y3Vyc29yOnYyOpK5MjAyMC0wMi0xOVQyMTozMDoxMyswMTowMM4BYOFb",
+								Node: ReleaseNode{
+									Name:    "v0.0.1",
+									TagName: "v0.0.1",
+									TagCommit: tagCommit{
+										Oid: "44444444",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantReleases: []string{"44444444", "2222222"},
 		},
 		{
 			name: "Case with a mix of releases (draft, prerelease, release) and a ReleaseType with draft, prerelease and releases",
@@ -108,33 +195,45 @@ func TestSearchReleases(t *testing.T) {
 						Edges: []releaseEdge{
 							{
 								Cursor: "Y3Vyc29yOnYyOpK5MjAyMi0wMS0xOFQxOTo0Nzo1MyswMTowMM4Da8vn",
-								Node: releaseNode{
+								Node: ReleaseNode{
 									Name:    "v0.18.4 🌈",
 									TagName: "v0.18.4",
+									TagCommit: tagCommit{
+										Oid: "11111111",
+									},
 									IsDraft: true,
 								},
 							},
 							{
 								Cursor: "Y3Vyc29yOnYyOpK5MjAyMi0wMS0xOFQxOTo0Nzo1MyswMTowMM4Da8vn",
-								Node: releaseNode{
-									Name:     "v0.18.3",
-									TagName:  "v0.18.3",
+								Node: ReleaseNode{
+									Name:    "v0.18.3",
+									TagName: "v0.18.3",
+									TagCommit: tagCommit{
+										Oid: "2222222",
+									},
 									IsLatest: true,
 								},
 							},
 							{
 								Cursor: "Y3Vyc29yOnYyOpK5MjAyMS0xMS0xM1QxMjozNzoxMiswMTowMM4DK66W",
-								Node: releaseNode{
-									Name:         "v1.0.0",
-									TagName:      "v1.0.0",
+								Node: ReleaseNode{
+									Name:    "v1.0.0",
+									TagName: "v1.0.0",
+									TagCommit: tagCommit{
+										Oid: "33333333",
+									},
 									IsPrerelease: true,
 								},
 							},
 							{
 								Cursor: "Y3Vyc29yOnYyOpK5MjAyMC0wMi0xOVQyMTozMDoxMyswMTowMM4BYOFb",
-								Node: releaseNode{
+								Node: ReleaseNode{
 									Name:    "v0.0.1",
 									TagName: "v0.0.1",
+									TagCommit: tagCommit{
+										Oid: "44444444",
+									},
 								},
 							},
 						},
@@ -171,33 +270,45 @@ func TestSearchReleases(t *testing.T) {
 						Edges: []releaseEdge{
 							{
 								Cursor: "Y3Vyc29yOnYyOpK5MjAyMi0wMS0xOFQxOTo0Nzo1MyswMTowMM4Da8vn",
-								Node: releaseNode{
+								Node: ReleaseNode{
 									Name:    "v0.18.4 🌈",
 									TagName: "v0.18.4",
+									TagCommit: tagCommit{
+										Oid: "11111111",
+									},
 									IsDraft: true,
 								},
 							},
 							{
 								Cursor: "Y3Vyc29yOnYyOpK5MjAyMi0wMS0xOFQxOTo0Nzo1MyswMTowMM4Da8vn",
-								Node: releaseNode{
-									Name:     "v0.18.3",
-									TagName:  "v0.18.3",
+								Node: ReleaseNode{
+									Name:    "v0.18.3",
+									TagName: "v0.18.3",
+									TagCommit: tagCommit{
+										Oid: "2222222",
+									},
 									IsLatest: true,
 								},
 							},
 							{
 								Cursor: "Y3Vyc29yOnYyOpK5MjAyMS0xMS0xM1QxMjozNzoxMiswMTowMM4DK66W",
-								Node: releaseNode{
-									Name:         "v1.0.0",
-									TagName:      "v1.0.0",
+								Node: ReleaseNode{
+									Name:    "v1.0.0",
+									TagName: "v1.0.0",
+									TagCommit: tagCommit{
+										Oid: "33333333",
+									},
 									IsPrerelease: true,
 								},
 							},
 							{
 								Cursor: "Y3Vyc29yOnYyOpK5MjAyMC0wMi0xOVQyMTozMDoxMyswMTowMM4BYOFb",
-								Node: releaseNode{
+								Node: ReleaseNode{
 									Name:    "v0.0.1",
 									TagName: "v0.0.1",
+									TagCommit: tagCommit{
+										Oid: "44444444",
+									},
 								},
 							},
 						},
@@ -231,36 +342,48 @@ func TestSearchReleases(t *testing.T) {
 						Edges: []releaseEdge{
 							{
 								Cursor: "Y3Vyc29yOnYyOpK5MjAyMi0wMS0xOFQxOTo0Nzo1MyswMTowMM4Da8vn",
-								Node: releaseNode{
-									Name:         "v0.18.4 🌈",
-									TagName:      "v0.18.4",
+								Node: ReleaseNode{
+									Name:    "v0.18.4 🌈",
+									TagName: "v0.18.4",
+									TagCommit: tagCommit{
+										Oid: "11111111",
+									},
 									IsDraft:      true,
 									IsPrerelease: false,
 								},
 							},
 							{
 								Cursor: "Y3Vyc29yOnYyOpK5MjAyMi0wMS0xOFQxOTo0Nzo1MyswMTowMM4Da8vn",
-								Node: releaseNode{
-									Name:         "v0.18.3",
-									TagName:      "v0.18.3",
+								Node: ReleaseNode{
+									Name:    "v0.18.3",
+									TagName: "v0.18.3",
+									TagCommit: tagCommit{
+										Oid: "2222222",
+									},
 									IsDraft:      false,
 									IsPrerelease: false,
 								},
 							},
 							{
 								Cursor: "Y3Vyc29yOnYyOpK5MjAyMS0xMS0xM1QxMjozNzoxMiswMTowMM4DK66W",
-								Node: releaseNode{
-									Name:         "v1.0.0",
-									TagName:      "v1.0.0",
+								Node: ReleaseNode{
+									Name:    "v1.0.0",
+									TagName: "v1.0.0",
+									TagCommit: tagCommit{
+										Oid: "33333333",
+									},
 									IsDraft:      false,
 									IsPrerelease: true,
 								},
 							},
 							{
 								Cursor: "Y3Vyc29yOnYyOpK5MjAyMC0wMi0xOVQyMTozMDoxMyswMTowMM4BYOFb",
-								Node: releaseNode{
-									Name:         "v0.0.1",
-									TagName:      "v0.0.1",
+								Node: ReleaseNode{
+									Name:    "v0.0.1",
+									TagName: "v0.0.1",
+									TagCommit: tagCommit{
+										Oid: "44444444",
+									},
 									IsDraft:      false,
 									IsPrerelease: false,
 								},
@@ -291,7 +414,14 @@ func TestSearchReleases(t *testing.T) {
 			}
 			tt.releaseType.Init()
 
-			got, err := sut.SearchReleases(tt.releaseType)
+			var got []string
+			var err error
+			if tt.searchKey == "hash" {
+				got, err = sut.SearchReleasesByTagHash(tt.releaseType)
+			} else {
+				got, err = sut.SearchReleasesByTagName(tt.releaseType)
+
+			}
 
 			if tt.wantErr {
 				assert.Error(t, err)

--- a/pkg/plugins/utils/gitgeneric/main.go
+++ b/pkg/plugins/utils/gitgeneric/main.go
@@ -47,6 +47,7 @@ type GitHandler interface {
 	TagHashes(workingDir string) (hashes []string, err error)
 	TagRefs(workingDir string) (refs []DatedTag, err error)
 	Branches(workingDir string) (branches []string, err error)
+	BranchRefs(workingDir string) (branches []DatedBranch, err error)
 }
 
 type GoGit struct {


### PR DESCRIPTION
Fix part of https://github.com/updatecli/updatecli/issues/3507
Introduce a key argument for gitbrnach to get the branch hash instead of the branch name.

## Test

To test this pull request, you can run the following commands:

```shell
cd <to_package_directory>
go test
```

## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via pull request in [website](https://github.com/updatecli/website) repository.

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
