### PR TITLE
improvement(httpclient): add support for http proxy in retry client

### DIFF
--- a/pkg/core/httpclient/retry.go
+++ b/pkg/core/httpclient/retry.go
@@ -84,7 +84,9 @@ func (t *retryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 
 func NewRetryClient() HTTPClient {
 	transport := &retryTransport{
-		transport: &http.Transport{},
+		transport: &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
+		},
 	}
 
 	client := http.DefaultClient

--- a/pkg/core/udash/publish.go
+++ b/pkg/core/udash/publish.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 
 	"github.com/sirupsen/logrus"
+	"github.com/updatecli/updatecli/pkg/core/httpclient"
 	"github.com/updatecli/updatecli/pkg/core/reports"
 )
 
@@ -79,7 +80,7 @@ func Publish(r *reports.Report) error {
 
 	u := reportApiURL.JoinPath("pipeline", "reports")
 
-	client := &http.Client{}
+	client := httpclient.NewRetryClient()
 
 	req, err := http.NewRequest("POST", u.String(), bodyReader)
 	if err != nil {

--- a/pkg/plugins/resources/bitbucket/client/main.go
+++ b/pkg/plugins/resources/bitbucket/client/main.go
@@ -6,6 +6,7 @@ import (
 	"github.com/drone/go-scm/scm"
 	"github.com/drone/go-scm/scm/driver/bitbucket"
 	"github.com/drone/go-scm/scm/transport"
+	"github.com/updatecli/updatecli/pkg/core/httpclient"
 )
 
 // Spec defines a specification for a Bitbucket Cloud resource
@@ -56,20 +57,20 @@ type Client *scm.Client
 func New(s Spec) (Client, error) {
 	client := bitbucket.NewDefault()
 
+	client.Client = httpclient.NewRetryClient().(*http.Client)
+
 	if (len(s.Username) > 0) && (len(s.Password) > 0) {
-		client.Client = &http.Client{
-			Transport: &transport.BasicAuth{
-				Username: s.Username,
-				Password: s.Password,
-			},
+		client.Client.Transport = &transport.BasicAuth{
+			Username: s.Username,
+			Password: s.Password,
+			Base:     client.Client.Transport,
 		}
 	}
 
 	if len(s.Token) > 0 {
-		client.Client = &http.Client{
-			Transport: &transport.BearerToken{
-				Token: s.Token,
-			},
+		client.Client.Transport = &transport.BearerToken{
+			Token: s.Token,
+			Base:  client.Client.Transport,
 		}
 	}
 

--- a/pkg/plugins/resources/gitea/client/main.go
+++ b/pkg/plugins/resources/gitea/client/main.go
@@ -6,6 +6,7 @@ import (
 	"github.com/drone/go-scm/scm"
 	"github.com/drone/go-scm/scm/driver/gitea"
 	"github.com/drone/go-scm/scm/transport/oauth2"
+	"github.com/updatecli/updatecli/pkg/core/httpclient"
 )
 
 type Client *scm.Client
@@ -18,17 +19,16 @@ func New(s Spec) (Client, error) {
 		return nil, err
 	}
 
-	client.Client = &http.Client{}
+	client.Client = httpclient.NewRetryClient().(*http.Client)
 
 	if len(s.Token) >= 0 {
-		client.Client = &http.Client{
-			Transport: &oauth2.Transport{
-				Source: oauth2.StaticTokenSource(
-					&scm.Token{
-						Token: s.Token,
-					},
-				),
-			},
+		client.Client.Transport = &oauth2.Transport{
+			Source: oauth2.StaticTokenSource(
+				&scm.Token{
+					Token: s.Token,
+				},
+			),
+			Base: client.Client.Transport,
 		}
 	}
 

--- a/pkg/plugins/resources/gitlab/client/main.go
+++ b/pkg/plugins/resources/gitlab/client/main.go
@@ -7,6 +7,7 @@ import (
 	"github.com/drone/go-scm/scm"
 	"github.com/drone/go-scm/scm/driver/gitlab"
 	"github.com/drone/go-scm/scm/transport"
+	"github.com/updatecli/updatecli/pkg/core/httpclient"
 )
 
 const (
@@ -27,16 +28,15 @@ func New(s Spec) (Client, error) {
 		return nil, err
 	}
 
-	client.Client = &http.Client{}
+	client.Client = httpclient.NewRetryClient().(*http.Client)
 
 	if len(s.Token) >= 0 {
 		// provide a custom http.Client with a transport
 		// that injects the private GitLab token through
 		// the PRIVATE_TOKEN header variable.
-		client.Client = &http.Client{
-			Transport: &transport.PrivateToken{
-				Token: s.Token,
-			},
+		client.Client.Transport = &transport.PrivateToken{
+			Token: s.Token,
+			Base:  client.Client.Transport,
 		}
 	}
 

--- a/pkg/plugins/resources/stash/client/main.go
+++ b/pkg/plugins/resources/stash/client/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/drone/go-scm/scm/transport"
 	"github.com/drone/go-scm/scm/transport/oauth2"
 	"github.com/sirupsen/logrus"
+	"github.com/updatecli/updatecli/pkg/core/httpclient"
 )
 
 // Spec defines a specification for a Bitbucket Server resource
@@ -57,23 +58,23 @@ func New(s Spec) (Client, error) {
 		return nil, err
 	}
 
+	client.Client = httpclient.NewRetryClient().(*http.Client)
+
 	if len(s.Token) >= 0 {
 		if len(s.Username) >= 0 {
-			client.Client = &http.Client{
-				Transport: &transport.BasicAuth{
-					Username: s.Username,
-					Password: s.Token,
-				},
+			client.Client.Transport = &transport.BasicAuth{
+				Username: s.Username,
+				Password: s.Token,
+				Base:     client.Client.Transport,
 			}
 		} else {
-			client.Client = &http.Client{
-				Transport: &oauth2.Transport{
-					Source: oauth2.StaticTokenSource(
-						&scm.Token{
-							Token: s.Token,
-						},
-					),
-				},
+			client.Client.Transport = &oauth2.Transport{
+				Source: oauth2.StaticTokenSource(
+					&scm.Token{
+						Token: s.Token,
+					},
+				),
+				Base: client.Client.Transport,
 			}
 		}
 	}

--- a/pkg/plugins/resources/temurin/main.go
+++ b/pkg/plugins/resources/temurin/main.go
@@ -65,13 +65,18 @@ func New(spec interface{}) (*Temurin, error) {
 		return nil, fmt.Errorf("[temurin] resource with both 'specificversion' and 'featureversion' specified which are mutually exclusive.")
 	}
 
+	httpClient := httpclient.NewRetryClient().(*http.Client)
+
 	newResource := &Temurin{
-		spec:         newSpec,
-		apiWebClient: &http.Client{},
+		spec: newSpec,
+		apiWebClient: &http.Client{
+			Transport: httpClient.Transport,
+		},
 		apiWebRedirectionClient: &http.Client{
 			CheckRedirect: func(req *http.Request, via []*http.Request) error {
 				return http.ErrUseLastResponse
 			},
+			Transport: httpClient.Transport,
 		},
 	}
 


### PR DESCRIPTION
The custom retry http client does not current support http proxies. This PR adds support for using proxies variables if set.

Issue: GH-3219

Fix GH-3219
