### PR TITLE
feat: by default create github commit via API

### DIFF
--- a/pkg/plugins/scms/git/sign/main.go
+++ b/pkg/plugins/scms/git/sign/main.go
@@ -39,3 +39,8 @@ func GetCommitSignKey(armoredKeyRing string, keyPassphrase string) (*openpgp.Ent
 
 	return key, nil
 }
+
+// IsZero returns true if the GPGSpec is empty
+func (g GPGSpec) IsZero() bool {
+	return g.SigningKey == "" && g.Passphrase == ""
+}

--- a/pkg/plugins/scms/github/main.go
+++ b/pkg/plugins/scms/github/main.go
@@ -243,7 +243,7 @@ func New(s Spec, pipelineID string) (*Github, error) {
 		force = *s.Force
 	}
 
-	commitUsingApi := false
+	commitUsingApi := true
 	if s.CommitUsingAPI != nil {
 		commitUsingApi = *s.CommitUsingAPI
 	}

--- a/pkg/plugins/scms/github/main.go
+++ b/pkg/plugins/scms/github/main.go
@@ -245,7 +245,12 @@ func New(s Spec, pipelineID string) (*Github, error) {
 
 	commitUsingApi := true
 	if s.CommitUsingAPI != nil {
-		commitUsingApi = *s.CommitUsingAPI
+		if !s.GPG.IsZero() {
+			logrus.Warningf("GPG key is set, but commitUsingApi is set to true, commitusingapi key will be ignored")
+			logrus.Warningf("a gpg key can't be used to sign a commit created by the GitHub API")
+		} else {
+			commitUsingApi = *s.CommitUsingAPI
+		}
 	}
 
 	if force {

--- a/pkg/plugins/scms/github/main.go
+++ b/pkg/plugins/scms/github/main.go
@@ -244,13 +244,15 @@ func New(s Spec, pipelineID string) (*Github, error) {
 	}
 
 	commitUsingApi := true
+
 	if s.CommitUsingAPI != nil {
-		if !s.GPG.IsZero() {
-			logrus.Warningf("GPG key is set, but commitUsingApi is set to true, commitusingapi key will be ignored")
-			logrus.Warningf("a gpg key can't be used to sign a commit created by the GitHub API")
-		} else {
-			commitUsingApi = *s.CommitUsingAPI
-		}
+		commitUsingApi = *s.CommitUsingAPI
+	}
+
+	if commitUsingApi && !s.GPG.IsZero() {
+		logrus.Warningf("GPG key is set, and commitUsingApi is set to true, commitusingapi key will be ignored")
+		logrus.Warningf("a gpg key can't be used to sign a commit created by the GitHub API")
+		logrus.Warningf("Please set commitusingapi to false to hide this message if you want to sign commits with a GPG key")
 	}
 
 	if force {


### PR DESCRIPTION
No breaking changes should be introduced by this pullrequest, but pipeline using gpg key will now show the warning.
The warning can be removed by setting `commitusingapi`: false

By default, the GitHub SCM now creates commits using the GitHub API, so commits are signed by GitHub if Updatecli is executed from GitHub action using the token GITHUB_TOKEN.

While the purpose of this change is to increase security, this behavior can be disabled by setting the parameter `commitusingapi: false` such as:

```
scms:
  default:
    kind: github
    spec:
      owner: git_repo_owner
     repository: git_repo_name
     commitusingapi: false
```

When set to false, Updatecli creates commit in a more traditional way by running git command.
As a reminder, Updatecli also allow sign commits using a gpg key using the parameter `gpg`
with an example on  https://www.updatecli.io/docs/core/scm/ but this behavior is not compatible with commit over API

<!-- Describe the changes introduced by this pull request -->

## Test

Nothing to test, as this feature is used in production for over 6 months
## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
