### PR TITLE
fix: objuscate username/password from URL in the console output

### DIFF
--- a/pkg/core/text/main.go
+++ b/pkg/core/text/main.go
@@ -110,7 +110,7 @@ func getLine(reader io.Reader, line int) string {
 // "https://", or file url "file://" or filepath (default)
 func (t *Text) ReadAll(location string) (string, error) {
 	if IsURL(location) {
-		logrus.Debugf("URL detected for location %q", location)
+		logrus.Debugf("URL detected for location %q", redact.URL(location))
 		content, err := t.readFromURL(location, 0)
 		if err != nil {
 			return "", err

--- a/pkg/plugins/resources/maven/condition.go
+++ b/pkg/plugins/resources/maven/condition.go
@@ -6,6 +6,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
+	"github.com/updatecli/updatecli/pkg/plugins/utils/redact"
 )
 
 // Condition tests if a specific version exist on the maven repository
@@ -34,7 +35,7 @@ func (m *Maven) Condition(source string, scm scm.ScmHandler) (pass bool, message
 		for _, version := range versions {
 			if version == m.spec.Version {
 				return true, fmt.Sprintf("Version %s is available on the Maven Repository (%s)",
-					m.spec.Version, metadataURL), nil
+					m.spec.Version, redact.URL(metadataURL)), nil
 			}
 		}
 	}

--- a/pkg/plugins/resources/maven/source.go
+++ b/pkg/plugins/resources/maven/source.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/updatecli/updatecli/pkg/core/result"
+	"github.com/updatecli/updatecli/pkg/plugins/utils/redact"
 )
 
 // Source return the latest version
@@ -28,7 +29,7 @@ func (m *Maven) Source(workingDir string, resultSource *result.Source) error {
 			resultSource.Description = fmt.Sprintf(
 				"Latest version is %s on the Maven repository at %s",
 				latestVersion,
-				metadataURL,
+				redact.URL(metadataURL),
 			)
 			return nil
 		}

--- a/pkg/plugins/resources/maven/utils.go
+++ b/pkg/plugins/resources/maven/utils.go
@@ -4,8 +4,6 @@ import (
 	"net/url"
 	"path"
 	"strings"
-
-	"github.com/sirupsen/logrus"
 )
 
 // isRepositoriesContainsMavenCentral return if the repositories list contains the maven central url
@@ -75,8 +73,6 @@ func joinURL(elems []string) (string, error) {
 	remainingElements := elems[1:]
 
 	args := path.Join(remainingElements...)
-
-	logrus.Printf(URL)
 
 	return URL + "/" + args, nil
 }

--- a/pkg/plugins/utils/mavenmetadata/main.go
+++ b/pkg/plugins/utils/mavenmetadata/main.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/updatecli/updatecli/pkg/core/result"
 	"github.com/updatecli/updatecli/pkg/core/text"
+	"github.com/updatecli/updatecli/pkg/plugins/utils/redact"
 	"github.com/updatecli/updatecli/pkg/plugins/utils/version"
 	"golang.org/x/text/encoding/ianaindex"
 )
@@ -69,7 +70,7 @@ func (d *DefaultHandler) GetLatestVersion() (string, error) {
 	switch d.versionFilter.Kind {
 	case "latest", "":
 		if data.Versioning.Latest == "" {
-			return "", fmt.Errorf("%s No latest version found at %s", result.FAILURE, d.metadataURL)
+			return "", fmt.Errorf("%s No latest version found at %s", result.FAILURE, redact.URL(d.metadataURL))
 		}
 		return data.Versioning.Latest, nil
 


### PR DESCRIPTION
Spotted a few places where a URL containing username/password could leak

## Test

Tested manually

## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via pull request in [website](https://github.com/updatecli/website) repository.

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
