### PR TITLE
ci: remove gomnd additional properties from golangci.yaml

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -33,9 +33,6 @@ linters-settings:
       - wrapperFunc
   gocyclo:
     min-complexity: 15
-  gomnd:
-      # don't include the "operation" and "assign"
-    checks: [argument,case,condition,return]
   govet:
     settings:
       shadow:


### PR DESCRIPTION
Fix 
```
Error: Failed to run: Error: Command failed: /home/runner/golangci-lint-1.64.5-linux-amd64/golangci-lint config verify
jsonschema: "linters-settings" does not validate with "/properties/linters-settings/additionalProperties": additional properties 'gomnd' not allowed
Failed executing command with error: the configuration contains invalid elements
```