### PR TITLE
feat: set oauth2 as default github username when username is not provided.

### DIFF
--- a/pkg/plugins/scms/github/main.go
+++ b/pkg/plugins/scms/github/main.go
@@ -217,6 +217,10 @@ func New(s Spec, pipelineID string) (*Github, error) {
 		s.URL = "https://" + s.URL
 	}
 
+	if s.Username == "" {
+		s.Username = "oauth2"
+	}
+
 	// Initialize github client
 	src := oauth2.StaticTokenSource(
 		&oauth2.Token{AccessToken: s.Token},

--- a/pkg/plugins/scms/github/main_test.go
+++ b/pkg/plugins/scms/github/main_test.go
@@ -190,6 +190,29 @@ func TestNew(t *testing.T) {
 			},
 		},
 		{
+			name:       "No Username provided",
+			pipelineID: "12345",
+			spec: Spec{
+				Branch:     "main",
+				Repository: "updatecli",
+				Owner:      "updatecli",
+				Token:      "superSecretTOkenOfJoe",
+				Directory:  "/home/updatecli",
+				URL:        "github.com",
+			},
+			want: Github{
+				Spec: Spec{
+					Branch:     "main",
+					Repository: "updatecli",
+					Owner:      "updatecli",
+					Username:   "oauth2",
+					Token:      "superSecretTOkenOfJoe",
+					URL:        "https://github.com",
+					Directory:  "/home/updatecli",
+				},
+			},
+		},
+		{
 			name:       "Validation Error (missing token)",
 			pipelineID: "12345",
 			spec: Spec{


### PR DESCRIPTION
Fix #3800 

Sets a default `oauth2` username for GitHub scm plugin in case no username is provided.

## Test

Added a test spec