### PR TITLE
fix: use the right action configuration in autodiscovery

### DIFF
--- a/pkg/core/engine/autodiscovery.go
+++ b/pkg/core/engine/autodiscovery.go
@@ -190,12 +190,14 @@ func (e *Engine) LoadAutoDiscovery(defaultEnabled bool) error {
 						actionConfig.Title = defaultActionTitle
 					}
 				}
+
 				manifestAction := manifest.Actions[p.Config.Spec.AutoDiscovery.ScmId]
-				//if err := mergo.Merge(&dstAction, actionConfig); err != nil {
-				if err := mergo.Merge(actionConfig, &manifestAction); err != nil {
+
+				baseAction := *actionConfig
+				if err := mergo.Merge(&baseAction, manifestAction); err != nil {
 					fmt.Println("Error:", err)
 				}
-				manifest.Actions[p.Config.Spec.AutoDiscovery.ScmId] = *actionConfig
+				manifest.Actions[p.Config.Spec.AutoDiscovery.ScmId] = baseAction
 			}
 
 			if manifest.Version != "" {


### PR DESCRIPTION
Fix #3955 

<!-- Describe the changes introduced by this pull request -->

## Test

Tested manually with the following command from this repository 

```
updatecli manifest show --values updatecli/values.d/scm.yaml --values updatecli/values.d/golang_major.yaml ghcr.io/updatecli/policies/autodiscovery/golang:0.10.0@sha256:3b1a2b03b3cd8e33305ca165a8be2ca126a06be4cbdf388bf98e48a568855cdc
```

## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via pull request in [website](https://github.com/updatecli/website) repository.

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
