### PR TITLE
fix: correctly set http headers in http plugin

### DIFF
--- a/pkg/plugins/resources/updateclihttp/main.go
+++ b/pkg/plugins/resources/updateclihttp/main.go
@@ -65,6 +65,12 @@ func New(spec interface{}) (*Http, error) {
 		return nil, err
 	}
 
+	if len(newSpec.Request.Headers) > 0 {
+		for k, v := range newSpec.Request.Headers {
+			httpReq.Header.Set(k, v)
+		}
+	}
+
 	newResource := &Http{
 		spec:       newSpec,
 		httpClient: httpClient,


### PR DESCRIPTION
Fix #4024 

Looking at this plugin, it appears that the headers specified in the Updatecli configuration weren't used

## Test

To test this pull request, you can run the following commands:

```shell
cd pkg/plugins/resources/updateclihttp/
go test .cd <to_package_directory>
```

And using the following Updatecli manifest 

```
name: "test"

sources:
  getWithCustomRequest:
    name: "test"
    kind: http
    spec:
      url: https://api.github.com/repos/owner/repository/releases
      request:
        headers:
          Authorization: 'Bearer {{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}'

conditions:
  getWithCustomRequest:
    name: "test"
    kind: http
    spec:
      url: https://api.github.com/repos/owner/repository/releases
      request:
        headers:
          Authorization: 'Bearer {{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}'
```

## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via pull request in [website](https://github.com/updatecli/website) repository.

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
