### PR TITLE
feat: get helm changelog from annotations and github release

### DIFF
--- a/pkg/plugins/changelog/github/v3/api.go
+++ b/pkg/plugins/changelog/github/v3/api.go
@@ -15,7 +15,7 @@ func getReleasesFromAPI(client *github.Client, owner, repository string) (allRel
 	ctx := context.Background()
 
 	opt := github.ListOptions{
-		PerPage: 10,
+		PerPage: 100,
 	}
 
 	for {

--- a/pkg/plugins/resources/helm/changelog.go
+++ b/pkg/plugins/resources/helm/changelog.go
@@ -188,7 +188,13 @@ func (c Chart) getLongVersion(version string) string {
 
 func (c Chart) getChangelogsFromArtifactHubAnnotations(index repo.IndexFile, from string, to string) result.Changelogs {
 	var changelogs result.Changelogs
+	// versionAdded map is used to prevent duplicate changelog entries being
+	// generated from index files that contain duplicate items with same version
+	versionAdded := make(map[string]bool)
 	for _, version := range index.Entries[c.spec.Name] {
+		if _, ok := versionAdded[version.Version]; ok {
+			continue
+		}
 		versionObj, err := semver.NewVersion(version.Version)
 		if err != nil {
 			continue
@@ -215,6 +221,7 @@ func (c Chart) getChangelogsFromArtifactHubAnnotations(index repo.IndexFile, fro
 					Body:        parseChangeAnnotation(changesAnnotation),
 					PublishedAt: version.Created.String(),
 				})
+				versionAdded[version.Version] = true
 			}
 		}
 	}

--- a/pkg/plugins/resources/helm/changelog.go
+++ b/pkg/plugins/resources/helm/changelog.go
@@ -2,14 +2,25 @@ package helm
 
 import (
 	"bytes"
+	"fmt"
 	"html/template"
+	"maps"
+	"slices"
+	"strings"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/sirupsen/logrus"
 	"github.com/updatecli/updatecli/pkg/core/result"
+	githubChangelog "github.com/updatecli/updatecli/pkg/plugins/changelog/github/v3"
+	"gopkg.in/yaml.v2"
+	"helm.sh/helm/v3/pkg/repo"
 )
 
 const (
-	// CHANGELOGTEMPLATE contains helm chart changelog information
+	artifactHubChangesAnnotation = "artifacthub.io/changes"
+	artifactHubLinksAnnotation   = "artifacthub.io/links"
+
+	// CHANGELOGTEMPLATE contains helm chart changelog fallback template
 	CHANGELOGTEMPLATE string = `
 Remark: We couldn't identify a way to automatically retrieve changelog information.
 Please use following information to take informed decision
@@ -49,42 +60,225 @@ func (c Chart) Changelog(from, to string) *result.Changelogs {
 		return nil
 	}
 
-	t := template.Must(template.New("changelog").Parse(CHANGELOGTEMPLATE))
+	index.SortEntries()
 
-	buffer := new(bytes.Buffer)
+	changelogs := c.getChangelogsFromArtifactHubAnnotations(index, from, to)
 
-	type params struct {
-		Name        string
-		Description string
-		Home        string
-		KubeVersion string
-		Created     string
-		URLs        []string `json:"url"`
-		Sources     []string
+	if len(changelogs) > 0 {
+		return &changelogs
+	} else {
+		logrus.Debugf("no changelog found in %s annotation for versions between %s and %s", artifactHubChangesAnnotation, from, to)
+
+		changelogs = c.getChangelogsFromGithubReleases(index, from, to)
+		if len(changelogs) > 0 {
+			return &changelogs
+		}
+
+		t := template.Must(template.New("changelog").Parse(CHANGELOGTEMPLATE))
+		buffer := new(bytes.Buffer)
+
+		type params struct {
+			Name        string
+			Description string
+			Home        string
+			KubeVersion string
+			Created     string
+			URLs        []string `json:"url"`
+			Sources     []string
+		}
+
+		err = t.Execute(buffer, params{
+			Name:        e.Name,
+			Description: e.Description,
+			Home:        e.Home,
+			KubeVersion: e.KubeVersion,
+			Created:     e.Created.String(),
+			URLs:        e.URLs,
+			Sources:     e.Sources})
+
+		if err != nil {
+			logrus.Debugf("failed to render helm chart information: %s", err)
+			return nil
+		}
+
+		changelog := buffer.String()
+		return &result.Changelogs{
+			{
+				Title:       from,
+				Body:        changelog,
+				PublishedAt: e.Created.String(),
+			},
+		}
 	}
+}
 
-	err = t.Execute(buffer, params{
-		Name:        e.Name,
-		Description: e.Description,
-		Home:        e.Home,
-		KubeVersion: e.KubeVersion,
-		Created:     e.Created.String(),
-		URLs:        e.URLs,
-		Sources:     e.Sources})
+func (c Chart) getChangelogsFromGithubReleases(index repo.IndexFile, from string, to string) result.Changelogs {
 
+	chartVersion, err := index.Get(c.spec.Name, from)
 	if err != nil {
-		logrus.Debugf("failed to render helm chart information: %s", err)
+		logrus.Debugf("failed to get helm chart information: %s", err)
 		return nil
 	}
 
-	changelog := buffer.String()
-
-	return &result.Changelogs{
-		{
-			Title:       from,
-			Body:        changelog,
-			PublishedAt: e.Created.String(),
-		},
+	linksAnnotation, ok := chartVersion.Annotations[artifactHubLinksAnnotation]
+	if !ok {
+		logrus.Debugf("no %s annotation found in %s", artifactHubLinksAnnotation, from)
+		return nil
+	}
+	type link struct {
+		URL  string `yaml:"url"`
+		Name string `yaml:"name"`
+	}
+	var links []link
+	err = yaml.Unmarshal([]byte(linksAnnotation), &links)
+	if err != nil {
+		logrus.Debugf("failed to unmarshal %s annotation: %s", artifactHubLinksAnnotation, err)
+		return nil
 	}
 
+	linkIndex := slices.IndexFunc(links, func(l link) bool {
+		return l.Name == "Chart Source"
+	})
+	if linkIndex == -1 {
+		logrus.Debugf("no chart source link found in %s annotation", artifactHubLinksAnnotation)
+		return nil
+	}
+
+	chartSourceLink := links[linkIndex].URL
+	logrus.Debugf("chart source link: %s", chartSourceLink)
+	if !strings.HasPrefix(chartSourceLink, "https://github.com/") {
+		logrus.Debugf("chart source link is not a github link: %s", chartSourceLink)
+		return nil
+	}
+
+	changelog := c.getChangelogFromGitHub(chartSourceLink, from, to)
+	return changelog
+}
+
+func (c Chart) getChangelogFromGitHub(chartSourceLink, from, to string) result.Changelogs {
+	parsedRepo := strings.Split(strings.TrimPrefix(chartSourceLink, "https://github.com/"), "/")
+	if len(parsedRepo) < 2 {
+		logrus.Debugf("invalid chart source link: %s", chartSourceLink)
+		return nil
+	}
+
+	changelog := githubChangelog.Changelog{
+		Owner:      parsedRepo[0],
+		Repository: parsedRepo[1],
+	}
+
+	fromLongVersion := c.getLongVersion(from)
+	toLongVersion := c.getLongVersion(to)
+	releases, err := changelog.Search(fromLongVersion, toLongVersion)
+	if err != nil {
+		logrus.Debugf("failed to search github releases: %s", err)
+	}
+
+	// exclude fromVersion from releases
+	releases = slices.DeleteFunc(releases, func(c result.Changelog) bool {
+		return c.Title == fromLongVersion
+	})
+
+	return releases
+}
+
+func (c Chart) getLongVersion(version string) string {
+	return fmt.Sprintf("%s-%s", c.spec.Name, version)
+}
+
+func (c Chart) getChangelogsFromArtifactHubAnnotations(index repo.IndexFile, from string, to string) result.Changelogs {
+	var changelogs result.Changelogs
+	for _, version := range index.Entries[c.spec.Name] {
+		versionObj, err := semver.NewVersion(version.Version)
+		if err != nil {
+			continue
+		}
+
+		fromVersion, err := semver.NewVersion(from)
+		if err != nil {
+			continue
+		}
+
+		var toVersion *semver.Version
+		if to != "" {
+			toVersion, err = semver.NewVersion(to)
+			if err != nil {
+				continue
+			}
+		}
+
+		if versionObj.GreaterThan(fromVersion) && (toVersion == nil || versionObj.LessThanEqual(toVersion)) {
+			changesAnnotation, ok := version.Annotations[artifactHubChangesAnnotation]
+			if ok {
+				changelogs = append(changelogs, result.Changelog{
+					Title:       version.Version,
+					Body:        parseChangeAnnotation(changesAnnotation),
+					PublishedAt: version.Created.String(),
+				})
+			}
+		}
+	}
+
+	return changelogs
+}
+
+type change struct {
+	Kind        string `yaml:"kind,omitempty"`
+	Description string `yaml:"description,omitempty"`
+}
+
+func parseChangeAnnotation(changesAnnotation string) string {
+
+	var changes []change
+	var yamlData = []byte(changesAnnotation)
+	// Try to unmarshal as a list of changes first
+	err := yaml.Unmarshal(yamlData, &changes)
+	if err != nil {
+		// If that fails, try to unmarshal as a list of strings
+		var simpleList []string
+		err = yaml.Unmarshal(yamlData, &simpleList)
+		if err != nil {
+			logrus.Debugf("failed to unmarshal %s annotation: %s", artifactHubChangesAnnotation, err)
+			return changesAnnotation
+		}
+		return renderSimpleList(simpleList)
+	}
+
+	return renderChanges(changes)
+}
+
+func renderSimpleList(list []string) string {
+	var renderedList string
+	for _, item := range list {
+		renderedList += fmt.Sprintf("* %s\n", item)
+	}
+	return renderedList
+}
+
+func renderChanges(changes []change) string {
+	var renderedChanges string
+	changesByKind := make(map[string][]change)
+	for _, ch := range changes {
+
+		if _, ok := changesByKind[ch.Kind]; !ok {
+			changesByKind[ch.Kind] = make([]change, 0)
+		}
+		changesByKind[ch.Kind] = append(changesByKind[ch.Kind], ch)
+	}
+
+	sortedKinds := slices.Sorted(maps.Keys(changesByKind))
+
+	// Render changes in alphabetical order by kind
+	for _, kind := range sortedKinds {
+		renderedChanges += fmt.Sprintf("## %s\n\n", capitalize(kind))
+		for _, ch := range changesByKind[kind] {
+			renderedChanges += fmt.Sprintf("* %s\n", ch.Description)
+		}
+		renderedChanges += "\n"
+	}
+	return renderedChanges
+}
+
+func capitalize(s string) string {
+	return strings.ToUpper(s[:1]) + s[1:]
 }

--- a/pkg/plugins/resources/helm/changelog.go
+++ b/pkg/plugins/resources/helm/changelog.go
@@ -248,7 +248,7 @@ func parseChangeAnnotation(changesAnnotation string) string {
 }
 
 func renderSimpleList(list []string) string {
-	var renderedList string
+	var renderedList = "\n"
 	for _, item := range list {
 		renderedList += fmt.Sprintf("* %s\n", item)
 	}
@@ -270,11 +270,10 @@ func renderChanges(changes []change) string {
 
 	// Render changes in alphabetical order by kind
 	for _, kind := range sortedKinds {
-		renderedChanges += fmt.Sprintf("## %s\n\n", capitalize(kind))
+		renderedChanges += fmt.Sprintf("\n## %s\n\n", capitalize(kind))
 		for _, ch := range changesByKind[kind] {
 			renderedChanges += fmt.Sprintf("* %s\n", ch.Description)
 		}
-		renderedChanges += "\n"
 	}
 	return renderedChanges
 }

--- a/pkg/plugins/resources/helm/changelog_test.go
+++ b/pkg/plugins/resources/helm/changelog_test.go
@@ -52,6 +52,33 @@ func TestChangelog(t *testing.T) {
 			},
 		},
 		{
+			name: "Another valid chart with multiple changelog information in artifacthub.io/changes annotation",
+			spec: Spec{
+				URL:     "https://kubernetes.github.io/ingress-nginx",
+				Name:    "ingress-nginx",
+				Version: "4.11.3",
+			},
+			from: "4.11.3",
+			to:   "4.12.0",
+			expected: &result.Changelogs{
+				{
+					Title:       "4.12.0",
+					Body:        "\n* CI: Fix chart testing. (#12258)\n* Update Ingress-Nginx version controller-v1.12.0\n",
+					PublishedAt: "2024-12-30 17:42:14.794948649 +0000 UTC",
+				},
+				{
+					Title:       "4.12.0-beta.0",
+					Body:        "\n* Update Ingress-Nginx version controller-v1.12.0-beta.0\n",
+					PublishedAt: "2024-10-15 09:49:01.496212197 +0000 UTC",
+				},
+				{
+					Title:       "4.11.4",
+					Body:        "\n* CI: Fix chart testing. (#12259)\n* Update Ingress-Nginx version controller-v1.11.4\n",
+					PublishedAt: "2024-12-30 17:36:51.265913014 +0000 UTC",
+				},
+			},
+		},
+		{
 			name: "Valid chart with rich changelog string in annotation",
 			spec: Spec{
 				URL:     "https://kyverno.github.io/kyverno/",

--- a/pkg/plugins/resources/helm/changelog_test.go
+++ b/pkg/plugins/resources/helm/changelog_test.go
@@ -1,0 +1,150 @@
+package helm
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/updatecli/updatecli/pkg/core/result"
+)
+
+func TestChangelog(t *testing.T) {
+	tests := []struct {
+		name                string
+		from                string
+		to                  string
+		spec                Spec
+		requiresGithubToken bool
+		expected            *result.Changelogs
+	}{
+		{
+			name: "Valid chart with single changelog information in artifacthub.io/changes annotation",
+			spec: Spec{
+				URL:     "https://charts.jenkins.io",
+				Name:    "jenkins",
+				Version: "5.8.0",
+			},
+			from: "5.8.15",
+			to:   "5.8.16",
+			expected: &result.Changelogs{
+				{
+					Title:       "5.8.16",
+					Body:        "* Update `docker.io/kiwigrid/k8s-sidecar` to version `1.30.1`\n",
+					PublishedAt: "2025-02-21 19:29:15.858414421 +0000 UTC",
+				},
+			},
+		},
+		{
+			name: "Another valid chart with single changelog information in artifacthub.io/changes annotation",
+			spec: Spec{
+				URL:     "https://kubernetes.github.io/ingress-nginx",
+				Name:    "ingress-nginx",
+				Version: "4.11.3",
+			},
+			from: "4.11.3",
+			to:   "4.11.4",
+			expected: &result.Changelogs{
+				{
+					Title:       "4.11.4",
+					Body:        "* CI: Fix chart testing. (#12259)\n* Update Ingress-Nginx version controller-v1.11.4\n",
+					PublishedAt: "2024-12-30 17:36:51.265913014 +0000 UTC",
+				},
+			},
+		},
+		{
+			name: "Valid chart with rich changelog string in annotation",
+			spec: Spec{
+				URL:     "https://kyverno.github.io/kyverno/",
+				Name:    "kyverno",
+				Version: "3.3.4",
+			},
+			from: "3.3.4",
+			to:   "3.3.5",
+			expected: &result.Changelogs{
+				{
+					Title:       "3.3.5",
+					PublishedAt: "2025-02-06 11:06:30.639777967 +0000 UTC",
+					Body:        "## Added\n\n* added a new option .reportsController.sanityChecks to disable checks for policy reports crds\n\n## Fixed\n\n* fix validation error in validate.yaml\n* fixed global image registry config by introducing *.image.defaultRegistry.\n\n",
+				},
+			},
+		},
+		{
+			name: "Valid chart with multiple changelog information in artifacthub.io/changes annotation",
+			spec: Spec{
+				URL:     "https://charts.jenkins.io",
+				Name:    "jenkins",
+				Version: "5.8.0",
+			},
+			from: "5.8.14",
+			to:   "5.8.16",
+			expected: &result.Changelogs{
+				{
+					Title:       "5.8.16",
+					Body:        "* Update `docker.io/kiwigrid/k8s-sidecar` to version `1.30.1`\n",
+					PublishedAt: "2025-02-21 19:29:15.858414421 +0000 UTC",
+				},
+				{
+					Title:       "5.8.15",
+					Body:        "* Update `kubernetes` to version `4313.va_9b_4fe2a_0e34`\n",
+					PublishedAt: "2025-02-20 08:48:55.363415299 +0000 UTC",
+				},
+			},
+		},
+		{
+			name: "Chart with changelog information in github releases and artifacthub.io/links annotation",
+			spec: Spec{
+				URL:     "https://prometheus-community.github.io/helm-charts",
+				Name:    "kube-prometheus-stack",
+				Version: "69.7.0",
+			},
+			from: "69.7.0",
+			to:   "69.7.1",
+			expected: &result.Changelogs{
+				{
+					Title:       "kube-prometheus-stack-69.7.1",
+					Body:        "kube-prometheus-stack collects Kubernetes manifests, Grafana dashboards, and Prometheus rules combined with documentation and scripts to provide easy to operate end-to-end Kubernetes cluster monitoring with Prometheus using the Prometheus Operator.\n\n## What's Changed\n* [kube-prometheus-stack] Fix indentation for the nameValidationScheme field in Prometheus CR by @sviatlo in https://github.com/prometheus-community/helm-charts/pull/5400\n\n\n**Full Changelog**: https://github.com/prometheus-community/helm-charts/compare/prometheus-pingdom-exporter-3.0.2...kube-prometheus-stack-69.7.1",
+					PublishedAt: "2025-03-03 10:56:56 +0000 UTC",
+					URL:         "https://github.com/prometheus-community/helm-charts/releases/tag/kube-prometheus-stack-69.7.1",
+				},
+			},
+			requiresGithubToken: true,
+		},
+		{
+			name: "Chart without changes annotation",
+			spec: Spec{
+				URL:     "https://kubernetes.github.io/autoscaler",
+				Name:    "cluster-autoscaler",
+				Version: "9.46.1",
+			},
+			from: "9.46.1",
+			to:   "9.46.2",
+			expected: &result.Changelogs{
+				{
+					Title:       "9.46.1",
+					Body:        "\nRemark: We couldn't identify a way to automatically retrieve changelog information.\nPlease use following information to take informed decision\n\nHelm Chart: cluster-autoscaler\nScales Kubernetes worker nodes within autoscaling groups.\nProject Home: https://github.com/kubernetes/autoscaler\n\nVersion created on the 2025-02-25 01:26:59.960231386 &#43;0000 UTC\n\nSources:\n\n* https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler\n\n\n\nURL:\n\n* https://github.com/kubernetes/autoscaler/releases/download/cluster-autoscaler-chart-9.46.2/cluster-autoscaler-9.46.2.tgz\n\n\n",
+					PublishedAt: "2025-02-25 01:26:59.960231386 +0000 UTC",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.requiresGithubToken {
+				if os.Getenv("GITHUB_TOKEN") == "" || os.Getenv("UPDATECLI_GITHUB_TOKEN") == "" {
+					t.Skip("Skipping test because GITHUB_TOKEN is not set")
+				}
+			}
+			chart, err := New(tt.spec)
+			assert.NoError(t, err)
+
+			changelog := chart.Changelog(tt.from, tt.to)
+			if tt.expected == nil && changelog == nil {
+				return
+			}
+
+			assert.EqualExportedValues(t, tt.expected, changelog)
+
+		})
+	}
+}

--- a/pkg/plugins/resources/helm/changelog_test.go
+++ b/pkg/plugins/resources/helm/changelog_test.go
@@ -29,7 +29,7 @@ func TestChangelog(t *testing.T) {
 			expected: &result.Changelogs{
 				{
 					Title:       "5.8.16",
-					Body:        "* Update `docker.io/kiwigrid/k8s-sidecar` to version `1.30.1`\n",
+					Body:        "\n* Update `docker.io/kiwigrid/k8s-sidecar` to version `1.30.1`\n",
 					PublishedAt: "2025-02-21 19:29:15.858414421 +0000 UTC",
 				},
 			},
@@ -46,7 +46,7 @@ func TestChangelog(t *testing.T) {
 			expected: &result.Changelogs{
 				{
 					Title:       "4.11.4",
-					Body:        "* CI: Fix chart testing. (#12259)\n* Update Ingress-Nginx version controller-v1.11.4\n",
+					Body:        "\n* CI: Fix chart testing. (#12259)\n* Update Ingress-Nginx version controller-v1.11.4\n",
 					PublishedAt: "2024-12-30 17:36:51.265913014 +0000 UTC",
 				},
 			},
@@ -64,7 +64,7 @@ func TestChangelog(t *testing.T) {
 				{
 					Title:       "3.3.5",
 					PublishedAt: "2025-02-06 11:06:30.639777967 +0000 UTC",
-					Body:        "## Added\n\n* added a new option .reportsController.sanityChecks to disable checks for policy reports crds\n\n## Fixed\n\n* fix validation error in validate.yaml\n* fixed global image registry config by introducing *.image.defaultRegistry.\n\n",
+					Body:        "\n## Added\n\n* added a new option .reportsController.sanityChecks to disable checks for policy reports crds\n\n## Fixed\n\n* fix validation error in validate.yaml\n* fixed global image registry config by introducing *.image.defaultRegistry.\n",
 				},
 			},
 		},
@@ -80,12 +80,12 @@ func TestChangelog(t *testing.T) {
 			expected: &result.Changelogs{
 				{
 					Title:       "5.8.16",
-					Body:        "* Update `docker.io/kiwigrid/k8s-sidecar` to version `1.30.1`\n",
+					Body:        "\n* Update `docker.io/kiwigrid/k8s-sidecar` to version `1.30.1`\n",
 					PublishedAt: "2025-02-21 19:29:15.858414421 +0000 UTC",
 				},
 				{
 					Title:       "5.8.15",
-					Body:        "* Update `kubernetes` to version `4313.va_9b_4fe2a_0e34`\n",
+					Body:        "\n* Update `kubernetes` to version `4313.va_9b_4fe2a_0e34`\n",
 					PublishedAt: "2025-02-20 08:48:55.363415299 +0000 UTC",
 				},
 			},
@@ -102,7 +102,7 @@ func TestChangelog(t *testing.T) {
 			expected: &result.Changelogs{
 				{
 					Title:       "kube-prometheus-stack-69.7.1",
-					Body:        "kube-prometheus-stack collects Kubernetes manifests, Grafana dashboards, and Prometheus rules combined with documentation and scripts to provide easy to operate end-to-end Kubernetes cluster monitoring with Prometheus using the Prometheus Operator.\n\n## What's Changed\n* [kube-prometheus-stack] Fix indentation for the nameValidationScheme field in Prometheus CR by @sviatlo in https://github.com/prometheus-community/helm-charts/pull/5400\n\n\n**Full Changelog**: https://github.com/prometheus-community/helm-charts/compare/prometheus-pingdom-exporter-3.0.2...kube-prometheus-stack-69.7.1",
+					Body:        "\nkube-prometheus-stack collects Kubernetes manifests, Grafana dashboards, and Prometheus rules combined with documentation and scripts to provide easy to operate end-to-end Kubernetes cluster monitoring with Prometheus using the Prometheus Operator.\n\n## What's Changed\n* [kube-prometheus-stack] Fix indentation for the nameValidationScheme field in Prometheus CR by @sviatlo in https://github.com/prometheus-community/helm-charts/pull/5400\n\n\n**Full Changelog**: https://github.com/prometheus-community/helm-charts/compare/prometheus-pingdom-exporter-3.0.2...kube-prometheus-stack-69.7.1",
 					PublishedAt: "2025-03-03 10:56:56 +0000 UTC",
 					URL:         "https://github.com/prometheus-community/helm-charts/releases/tag/kube-prometheus-stack-69.7.1",
 				},


### PR DESCRIPTION
Partially resolves #1836
Resolves #4041

This pull request introduces enhancement in changelog generation for helm charts:
- If there are `artifacthub.io/changes` in repository index, then use them to generate changelog
- Else if there is `Chart Source` link to GitHub repo in `artifacthub.io/links` annotation, then get changelog from github releases
- Otherwise use unchanged fallback

Additionally, I've updated pagination options for `getReleasesFromAPI` method. Otherwise, in repositories with tons of releases it takes too long to filter them.

## Test

To test this pull request, you can run the following commands:

```shell
cd pkg/plugins/resources/helm
export GITHUB_TOKEN="set your token" # needed for gathering github releases info
go test
```

## Additional Information

### Potential improvement

There [were other suggestion](https://github.com/updatecli/updatecli/issues/1836#issuecomment-1851419334) on how to gather changelog but they require more complex logic and some strict assumptions need to be made about metadata we have in repository index.
