### PR TITLE
fix: generated autodiscovery pipeline uses original action id

### DIFF
--- a/pkg/core/engine/autodiscovery.go
+++ b/pkg/core/engine/autodiscovery.go
@@ -197,7 +197,7 @@ func (e *Engine) LoadAutoDiscovery(defaultEnabled bool) error {
 				if err := mergo.Merge(&baseAction, manifestAction); err != nil {
 					fmt.Println("Error:", err)
 				}
-				manifest.Actions[p.Config.Spec.AutoDiscovery.ScmId] = baseAction
+				manifest.Actions[p.Config.Spec.AutoDiscovery.ActionId] = baseAction
 			}
 
 			if manifest.Version != "" {


### PR DESCRIPTION
Fix #4169 

I mistakenly used the scmid instead of the real actionID in the newly generated pipeline.

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

I used the following manifest to test

```
scms:
  github:
    kind: github
    spec:
      owner: epinio
      repository: helm-charts
      branch: main
      token: '{{ requiredEnv "GITHUB_TOKEN" }}'

autodiscovery:
  scmid: github
  actionid: pr
  crawlers:
    helm:
      ignorecontainer: true

actions:
  pr: 
    kind: github/pullrequest
    title: "feat: update helm chart dependencies with updatecli"
    spec:
      labels:
        - updatecli
    scmid: github
```

## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via pull request in [website](https://github.com/updatecli/website) repository.

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
