### PR TITLE
ci(release): Create a token for multiple repositories in the current owner's installation

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -56,6 +56,10 @@ jobs:
         with:
           app-id: ${{ secrets.UPDATECLIBOT_APP_ID }}
           private-key: ${{ secrets.UPDATECLIBOT_APP_PRIVKEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            updatecli
+            homebrew-updatecli
       - name: GoReleaser
         if: success()
         env:


### PR DESCRIPTION
This pull request is an attempt to fix the release pipelines when it comes to update the homebrew information

```
  ⨯ release failed after 18m57s             
    error=
    │ 1 error occurred:
    │ 	* homebrew tap formula: could not update "Formula/updatecli.rb": PUT https://api.github.com/repos/updatecli/homebrew-updatecli/contents/Formula/updatecli.rb: 403 Resource not accessible by integration []
make: *** [Makefile:29: release] Error 1
```

from https://github.com/updatecli/updatecli/actions/runs/13793233484/job/38578302498