### PR TITLE
fix: helm changelog tests

### DIFF
--- a/pkg/plugins/resources/helm/changelog.go
+++ b/pkg/plugins/resources/helm/changelog.go
@@ -66,49 +66,49 @@ func (c Chart) Changelog(from, to string) *result.Changelogs {
 
 	if len(changelogs) > 0 {
 		return &changelogs
-	} else {
-		logrus.Debugf("no changelog found in %s annotation for versions between %s and %s", artifactHubChangesAnnotation, from, to)
+	}
 
-		changelogs = c.getChangelogsFromGithubReleases(index, from, to)
-		if len(changelogs) > 0 {
-			return &changelogs
-		}
+	logrus.Debugf("no changelog found in %s annotation for versions between %s and %s", artifactHubChangesAnnotation, from, to)
 
-		t := template.Must(template.New("changelog").Parse(CHANGELOGTEMPLATE))
-		buffer := new(bytes.Buffer)
+	changelogs = c.getChangelogsFromGithubReleases(index, from, to)
+	if len(changelogs) > 0 {
+		return &changelogs
+	}
 
-		type params struct {
-			Name        string
-			Description string
-			Home        string
-			KubeVersion string
-			Created     string
-			URLs        []string `json:"url"`
-			Sources     []string
-		}
+	t := template.Must(template.New("changelog").Parse(CHANGELOGTEMPLATE))
+	buffer := new(bytes.Buffer)
 
-		err = t.Execute(buffer, params{
-			Name:        e.Name,
-			Description: e.Description,
-			Home:        e.Home,
-			KubeVersion: e.KubeVersion,
-			Created:     e.Created.String(),
-			URLs:        e.URLs,
-			Sources:     e.Sources})
+	type params struct {
+		Name        string
+		Description string
+		Home        string
+		KubeVersion string
+		Created     string
+		URLs        []string `json:"url"`
+		Sources     []string
+	}
 
-		if err != nil {
-			logrus.Debugf("failed to render helm chart information: %s", err)
-			return nil
-		}
+	err = t.Execute(buffer, params{
+		Name:        e.Name,
+		Description: e.Description,
+		Home:        e.Home,
+		KubeVersion: e.KubeVersion,
+		Created:     e.Created.String(),
+		URLs:        e.URLs,
+		Sources:     e.Sources})
 
-		changelog := buffer.String()
-		return &result.Changelogs{
-			{
-				Title:       from,
-				Body:        changelog,
-				PublishedAt: e.Created.String(),
-			},
-		}
+	if err != nil {
+		logrus.Debugf("failed to render helm chart information: %s", err)
+		return nil
+	}
+
+	changelog := buffer.String()
+	return &result.Changelogs{
+		{
+			Title:       from,
+			Body:        changelog,
+			PublishedAt: e.Created.String(),
+		},
 	}
 }
 

--- a/pkg/plugins/resources/helm/changelog_test.go
+++ b/pkg/plugins/resources/helm/changelog_test.go
@@ -20,9 +20,8 @@ func TestChangelog(t *testing.T) {
 		{
 			name: "Valid chart with single changelog information in artifacthub.io/changes annotation",
 			spec: Spec{
-				URL:     "https://charts.jenkins.io",
-				Name:    "jenkins",
-				Version: "5.8.0",
+				URL:  "https://charts.jenkins.io",
+				Name: "jenkins",
 			},
 			from: "5.8.15",
 			to:   "5.8.16",
@@ -37,9 +36,8 @@ func TestChangelog(t *testing.T) {
 		{
 			name: "Another valid chart with single changelog information in artifacthub.io/changes annotation",
 			spec: Spec{
-				URL:     "https://kubernetes.github.io/ingress-nginx",
-				Name:    "ingress-nginx",
-				Version: "4.11.3",
+				URL:  "https://kubernetes.github.io/ingress-nginx",
+				Name: "ingress-nginx",
 			},
 			from: "4.11.3",
 			to:   "4.11.4",
@@ -54,9 +52,8 @@ func TestChangelog(t *testing.T) {
 		{
 			name: "Another valid chart with multiple changelog information in artifacthub.io/changes annotation",
 			spec: Spec{
-				URL:     "https://kubernetes.github.io/ingress-nginx",
-				Name:    "ingress-nginx",
-				Version: "4.11.3",
+				URL:  "https://kubernetes.github.io/ingress-nginx",
+				Name: "ingress-nginx",
 			},
 			from: "4.11.3",
 			to:   "4.12.0",
@@ -81,9 +78,8 @@ func TestChangelog(t *testing.T) {
 		{
 			name: "Valid chart with rich changelog string in annotation",
 			spec: Spec{
-				URL:     "https://kyverno.github.io/kyverno/",
-				Name:    "kyverno",
-				Version: "3.3.4",
+				URL:  "https://kyverno.github.io/kyverno/",
+				Name: "kyverno",
 			},
 			from: "3.3.4",
 			to:   "3.3.5",
@@ -98,9 +94,8 @@ func TestChangelog(t *testing.T) {
 		{
 			name: "Valid chart with multiple changelog information in artifacthub.io/changes annotation",
 			spec: Spec{
-				URL:     "https://charts.jenkins.io",
-				Name:    "jenkins",
-				Version: "5.8.0",
+				URL:  "https://charts.jenkins.io",
+				Name: "jenkins",
 			},
 			from: "5.8.14",
 			to:   "5.8.16",
@@ -120,9 +115,8 @@ func TestChangelog(t *testing.T) {
 		{
 			name: "Chart with changelog information in github releases and artifacthub.io/links annotation",
 			spec: Spec{
-				URL:     "https://prometheus-community.github.io/helm-charts",
-				Name:    "kube-prometheus-stack",
-				Version: "69.7.0",
+				URL:  "https://prometheus-community.github.io/helm-charts",
+				Name: "kube-prometheus-stack",
 			},
 			from: "69.7.0",
 			to:   "69.7.1",
@@ -139,9 +133,8 @@ func TestChangelog(t *testing.T) {
 		{
 			name: "Chart with changelog information in github releases and artifacthub.io/links annotation. Multiple releases",
 			spec: Spec{
-				URL:     "https://prometheus-community.github.io/helm-charts",
-				Name:    "prometheus-operator-crds",
-				Version: "17.0.2",
+				URL:  "https://prometheus-community.github.io/helm-charts",
+				Name: "prometheus-operator-crds",
 			},
 			from: "17.0.2",
 			to:   "18.0.1",
@@ -164,9 +157,8 @@ func TestChangelog(t *testing.T) {
 		{
 			name: "Chart without changes annotation",
 			spec: Spec{
-				URL:     "https://kubernetes.github.io/autoscaler",
-				Name:    "cluster-autoscaler",
-				Version: "9.46.1",
+				URL:  "https://kubernetes.github.io/autoscaler",
+				Name: "cluster-autoscaler",
 			},
 			from: "9.46.1",
 			to:   "9.46.2",
@@ -189,6 +181,9 @@ func TestChangelog(t *testing.T) {
 			}
 			chart, err := New(tt.spec)
 			assert.NoError(t, err)
+
+			// To speed up the process, we don't call the source to get the latest version
+			chart.foundVersion.OriginalVersion = tt.to
 
 			changelog := chart.Changelog(tt.from, tt.to)
 			if tt.expected == nil && changelog == nil {


### PR DESCRIPTION
Fix the helm changelog tests.

The root cause of the problem is that the changelog uses information retrieved from source execution, but in the context of the test we don't execute Helm Source function.
This is an issue for the test named "Chart without changes annotation" as it tries to generate a generic changelog instead of the version specified in the test.

While looking at the code, I also noticed that a else statement could be removed

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
cd pkg/plugins/resources/helm/
go test
```

## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via pull request in [website](https://github.com/updatecli/website) repository.

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
