### PR TITLE
feat(shell): set default shell environments variable

### DIFF
--- a/pkg/plugins/resources/shell/condition.go
+++ b/pkg/plugins/resources/shell/condition.go
@@ -16,7 +16,8 @@ func (s *Shell) Condition(source string, scm scm.ScmHandler) (pass bool, message
 	// Ensure environment variable(s) are up to date
 	// either it already has a value specified, or it retrieves
 	// the value from the Updatecli process
-	err = s.spec.Environments.Load()
+	ignoreEnvironmentsNotFound := s.spec.Environments == nil
+	err = s.environments.Load(ignoreEnvironmentsNotFound)
 	if err != nil {
 		return false, "", err
 	}
@@ -25,7 +26,7 @@ func (s *Shell) Condition(source string, scm scm.ScmHandler) (pass bool, message
 	// It's only purpose is to have at least one environment variable
 	// so we don't fallback to use the current process environment as explained
 	// on https://pkg.go.dev/os/exec#Cmd
-	env := append(s.spec.Environments, Environment{
+	env := append(s.environments, Environment{
 		Name:  CurrentStageVariableName,
 		Value: "condition",
 	})

--- a/pkg/plugins/resources/shell/condition.go
+++ b/pkg/plugins/resources/shell/condition.go
@@ -26,9 +26,10 @@ func (s *Shell) Condition(source string, scm scm.ScmHandler) (pass bool, message
 	// It's only purpose is to have at least one environment variable
 	// so we don't fallback to use the current process environment as explained
 	// on https://pkg.go.dev/os/exec#Cmd
+	conditionStageValue := "condition"
 	env := append(s.environments, Environment{
 		Name:  CurrentStageVariableName,
-		Value: "condition",
+		Value: &conditionStageValue,
 	})
 
 	err = s.success.PreCommand(s.getWorkingDirPath(workingDir))

--- a/pkg/plugins/resources/shell/environment.go
+++ b/pkg/plugins/resources/shell/environment.go
@@ -12,6 +12,30 @@ const (
 	CurrentStageVariableName = "UPDATECLI_PIPELINE_STAGE"
 )
 
+var (
+	// DefaultWinEnvVariables is a list of environment variables that are commonly used on Windows
+	DefaultWinEnvVariables Environments = Environments{
+		{Name: "PATH"},
+		{Name: "PSModulePath"},
+		{Name: "PSModuleAnalysisCachePath"},
+		{Name: "PATHEXT"},
+		{Name: "TEMP"},
+		{Name: "HOME"},
+		{Name: "USERPROFILE"},
+		{Name: "PROFILE"},
+	}
+
+	DefaultUnixEnvVariables Environments = Environments{
+		{Name: "PATH"},
+		{Name: "HOME"},
+		{Name: "USER"},
+		{Name: "LOGNAME"},
+		{Name: "SHELL"},
+		{Name: "LANG"},
+		{Name: "LC_ALL"},
+	}
+)
+
 // Environment is a struct containing information for an environment variable such as its name and its value
 type Environment struct {
 	// Name defines the environment variable name
@@ -25,7 +49,7 @@ func (e Environment) String() string {
 }
 
 // Load updates the environment value based on Updatecli environment variables, if the value is not defined yet
-func (e *Environment) Load() error {
+func (e *Environment) Load(ignoreNotFound bool) error {
 	err := e.Validate()
 	if err != nil {
 		return err
@@ -36,7 +60,7 @@ func (e *Environment) Load() error {
 	if len(e.Value) == 0 && len(e.Name) > 0 {
 		value, found := os.LookupEnv(e.Name)
 
-		if !found {
+		if !found && !ignoreNotFound {
 			return fmt.Errorf("environment variable %q not found, skipping", e.Name)
 		}
 		e.Value = value

--- a/pkg/plugins/resources/shell/environment.go
+++ b/pkg/plugins/resources/shell/environment.go
@@ -41,11 +41,11 @@ type Environment struct {
 	// Name defines the environment variable name
 	Name string `yaml:",omitempty" jsonschema:"required"`
 	// Value defines the environment variable value
-	Value string `yaml:",omitempty"`
+	Value *string `yaml:",omitempty"`
 }
 
 func (e Environment) String() string {
-	return fmt.Sprintf("%s=%s", e.Name, e.Value)
+	return fmt.Sprintf("%s=%s", e.Name, *e.Value)
 }
 
 // Load updates the environment value based on Updatecli environment variables, if the value is not defined yet
@@ -57,13 +57,13 @@ func (e *Environment) Load(ignoreNotFound bool) error {
 
 	// If an environment variable name is specified and specified without value
 	// then it inherits the value from Updatecli process environment
-	if len(e.Value) == 0 && len(e.Name) > 0 {
+	if e.Value == nil && len(e.Name) > 0 {
 		value, found := os.LookupEnv(e.Name)
 
 		if !found && !ignoreNotFound {
 			return fmt.Errorf("environment variable %q not found, skipping", e.Name)
 		}
-		e.Value = value
+		e.Value = &value
 	}
 	return nil
 }

--- a/pkg/plugins/resources/shell/environments.go
+++ b/pkg/plugins/resources/shell/environments.go
@@ -72,10 +72,10 @@ func (e Environments) Validate() error {
 }
 
 // Load updates all environment value based on Updatecli environment variables, at the condition that the value is not defined yet
-func (e *Environments) Load() error {
+func (e *Environments) Load(ignoreNotFound bool) error {
 	environments := *e
 	for id := range environments {
-		err := environments[id].Load()
+		err := environments[id].Load(ignoreNotFound)
 		if err != nil {
 			logrus.Errorln(err)
 		}

--- a/pkg/plugins/resources/shell/main.go
+++ b/pkg/plugins/resources/shell/main.go
@@ -53,7 +53,7 @@ type Spec struct {
 	//   with an allow list of environment variables.
 	//
 	Environments *Environments `yaml:",omitempty"`
-	// ChangedIf defines how to interprete shell command execution.
+	// ChangedIf defines how to interpret shell command execution.
 	// What a success means, what an error means, and what a warning would mean in the context of Updatecli.
 	//
 	// Please note that in the context of Updatecli,

--- a/pkg/plugins/resources/shell/main.go
+++ b/pkg/plugins/resources/shell/main.go
@@ -14,24 +14,143 @@ import (
 // parsed from an updatecli manifest file
 type Spec struct {
 	// command specifies the shell command to execute by Updatecli
+	//
+	// default:
+	//   empty
+	//
+	// remark:
+	//   When the shell plugin is used in the context of condition, or target, the default source output is passed as an argument to the shell command.
+	//   for example the two following snippets are equivalent:
+	//
+	//   ---
+	//   targets:
+	//     default:
+	//       name: Example 2
+	//       kind: shell
+	//       sourceid: default
+	//       spec:
+	//         command: 'echo'
+	//   ---
+	//   targets:
+	//     default:
+	//       name: Example 2
+	//       kind: shell
+	//       disablesourceinput: true
+	//       spec:
+	//         command: 'echo {{ source "default"}}'
+	//   ---
+
 	Command string `yaml:",omitempty" jsonschema:"required"`
-	// environments allows to pass environment variable(s) to the shell script. By default no environment variable are shared.
-	Environments Environments `yaml:",omitempty"`
-	// ChangedIf defines how to interpreted shell command success criteria. What a success means, what an error means, and what a warning would mean
+	// environments allows to pass environment variable(s) to the shell script.
+	//
+	//  default:
+	//     If environments is unset then it depends on the operating system.
+	//       - Windows: ["PATH","", "PSModulePath", "PSModuleAnalysisCachePath", "", "PATHEXT", "", "TEMP", "", "HOME", "", "USERPROFILE", "", "PROFILE"]
+	//       - Darwin/Linux: ["PATH", "", "HOME", "", "USER", "", "LOGNAME", "", "SHELL", "", "LANG", "", "LC_ALL"]
+	//
+	// remark:
+	//   For security reason, Updatecli doesn't pass the entire environment to the shell command but instead works
+	//   with an allow list of environment variables.
+	//
+	Environments *Environments `yaml:",omitempty"`
+	// ChangedIf defines how to interprete shell command execution.
+	// What a success means, what an error means, and what a warning would mean in the context of Updatecli.
+	//
+	// Please note that in the context of Updatecli,
+	//  - a success means nothing changed
+	//  - a warning means something changed
+	//  - an error means something went wrong
+	//
+	// Changedif can be of kind "exitcode", "console/output", or "file/checksum"
+	//
+	//   "console/output" (default)
+	//     Check the output of the command to identify if Updatecli should report a success, a warning, or an error.
+	//     If a target returns anything to stdout, Updatecli interprets it as a something changed, otherwise it's a success.
+	//
+	//     example:
+	//
+	//
+	//     ---
+	//     targets:
+	//       default:
+	//         name: 'doc: synchronize release note'
+	//         kind: 'shell'
+	//         disablesourceinput: true
+	//         spec:
+	//           command: 'releasepost --dry-run="$DRY_RUN" --config {{ .config }} --clean'
+	//     ---
+	//
+	//   "exitcode":
+	//     Check the exit code of the command to identify if Updatecli should report a success, a warning, or an error.
+	//
+	//     example:
+	//
+	//     ---
+	//     targets:
+	//       default:
+	//         name: 'doc: synchronize release note'
+	//         kind: 'shell'
+	//         disablesourceinput: true
+	//         spec:
+	//           command: 'releasepost --dry-run="$DRY_RUN" --config {{ .config }} --clean'
+	//           environments:
+	//             - name: 'GITHUB_TOKEN'
+	//             - name: 'PATH'
+	//           changedif:
+	//             kind: 'exitcode'
+	//             spec:
+	//               warning: 0
+	//               success: 1
+	//               failure: 2
+	//     ---
+	//
+	//
+	//   "file/checksum":
+	//     Check the checksum of file(s) to identify if Updatecli should report a success, a warning, or an error.
+	//
+	//     example:
+	//
+	//     ---
+	//     targets:
+	//       default:
+	//         disablesourceinput: true
+	//         name: Example of a shell command with a checksum success criteria
+	//         kind: shell
+	//         spec:
+	//           command: |
+	//     	  	   yq -i '.a.b[0].c = "cool"' file.yaml
+	//           changedif:
+	//             kind: file/checksum
+	//             spec:
+	//               files:
+	//                 - file.yaml
+	//     ---
+	//
+	//
+	//
 	ChangedIf SpecChangedIf `yaml:",omitempty" json:",omitempty"`
-	// Shell specifies which shell interpreter to use. Default to powershell(Windows) and "/bin/sh" (Darwin/Linux)
+	// Shell specifies which shell interpreter to use.
+	//
+	// default:
+	//   Depends on the operating system:
+	//     - Windows: "powershell"
+	//     - Darwin/Linux: "/bin/sh"
+	//
 	Shell string `yaml:",omitempty"`
 	// workdir specifies the working directory path from where to execute the command. It defaults to the current context path (scm or current shell). Updatecli join the current path and the one specified in parameter if the parameter one contains a relative path.
+	//
+	// default: If a scmid is specified then the default
 	WorkDir string `yaml:",omitempty"`
 }
 
 // Shell defines a resource of kind "shell"
 type Shell struct {
-	executor    commandExecutor
-	spec        Spec
-	result      commandResult
-	success     Successer
-	interpreter string
+	executor     commandExecutor
+	spec         Spec
+	result       commandResult
+	success      Successer
+	interpreter  string
+	environments Environments
 }
 
 // New returns a reference to a newly initialized Shell object from a ShellSpec
@@ -48,20 +167,34 @@ func New(spec interface{}) (*Shell, error) {
 		return nil, &ErrEmptyCommand{}
 	}
 
-	err = newSpec.Environments.Validate()
-	if err != nil {
-		return nil, err
-	}
-
 	interpreter := getDefaultShell()
 	if newSpec.Shell != "" {
 		interpreter = newSpec.Shell
 	}
 
+	environments := Environments{}
+
+	if newSpec.Environments != nil {
+		environments = *newSpec.Environments
+	} else {
+		switch runtime.GOOS {
+		case WINOS:
+			environments = DefaultWinEnvVariables
+		default:
+			environments = DefaultUnixEnvVariables
+		}
+	}
+
+	err = environments.Validate()
+	if err != nil {
+		return nil, err
+	}
+
 	s := Shell{
-		executor:    &nativeCommandExecutor{},
-		spec:        newSpec,
-		interpreter: interpreter,
+		executor:     &nativeCommandExecutor{},
+		spec:         newSpec,
+		interpreter:  interpreter,
+		environments: environments,
 	}
 
 	err = s.InitChangedIf()

--- a/pkg/plugins/resources/shell/main_test.go
+++ b/pkg/plugins/resources/shell/main_test.go
@@ -17,16 +17,19 @@ func TestShell_New(t *testing.T) {
 		{
 			name: "Normal case",
 			spec: Spec{
-				Command: "echo Hello",
-				Shell:   "/bin/bash",
+				Command:      "echo Hello",
+				Shell:        "/bin/bash",
+				Environments: &Environments{},
 			},
 			wantErr: false,
 			wantShell: &Shell{
-				executor:    &nativeCommandExecutor{},
-				interpreter: "/bin/bash",
+				executor:     &nativeCommandExecutor{},
+				interpreter:  "/bin/bash",
+				environments: Environments{},
 				spec: Spec{
-					Command: "echo Hello",
-					Shell:   "/bin/bash",
+					Command:      "echo Hello",
+					Shell:        "/bin/bash",
+					Environments: &Environments{},
 				},
 			},
 		},
@@ -41,7 +44,7 @@ func TestShell_New(t *testing.T) {
 			name: "Missing env name despite env value specified",
 			spec: Spec{
 				Command: "echo World",
-				Environments: Environments{
+				Environments: &Environments{
 					Environment{
 						Value: "xxx",
 					},
@@ -50,9 +53,14 @@ func TestShell_New(t *testing.T) {
 			wantErr: true,
 			wantShell: &Shell{
 				executor: &nativeCommandExecutor{},
+				environments: Environments{
+					Environment{
+						Value: "xxx",
+					},
+				},
 				spec: Spec{
 					Command: "echo World",
-					Environments: Environments{
+					Environments: &Environments{
 						Environment{
 							Value: "xxx",
 						},
@@ -65,7 +73,7 @@ func TestShell_New(t *testing.T) {
 			name: "Inherit PATH environment variable",
 			spec: Spec{
 				Command: "echo Hello",
-				Environments: Environments{
+				Environments: &Environments{
 					Environment{
 						Name: "PATH",
 					},
@@ -75,9 +83,14 @@ func TestShell_New(t *testing.T) {
 			wantShell: &Shell{
 				executor:    &nativeCommandExecutor{},
 				interpreter: getDefaultShell(),
+				environments: Environments{
+					Environment{
+						Name: "PATH",
+					},
+				},
 				spec: Spec{
 					Command: "echo Hello",
-					Environments: Environments{
+					Environments: &Environments{
 						Environment{
 							Name: "PATH",
 						},
@@ -89,7 +102,7 @@ func TestShell_New(t *testing.T) {
 			name: "can't specify PATH environment variable multiple times",
 			spec: Spec{
 				Command: "echo Hello",
-				Environments: Environments{
+				Environments: &Environments{
 					Environment{
 						Name: "PATH",
 					},
@@ -101,9 +114,17 @@ func TestShell_New(t *testing.T) {
 			wantErr: true,
 			wantShell: &Shell{
 				executor: &nativeCommandExecutor{},
+				environments: Environments{
+					Environment{
+						Name: "PATH",
+					},
+					Environment{
+						Name: "PATH",
+					},
+				},
 				spec: Spec{
 					Command: "echo Hello",
-					Environments: Environments{
+					Environments: &Environments{
 						Environment{
 							Name: "PATH",
 						},
@@ -119,7 +140,7 @@ func TestShell_New(t *testing.T) {
 			name: "Not allowed to specify DRY_RUN environment variable",
 			spec: Spec{
 				Command: "echo Hello",
-				Environments: Environments{
+				Environments: &Environments{
 					Environment{
 						Name: "DRY_RUN",
 					},
@@ -128,10 +149,15 @@ func TestShell_New(t *testing.T) {
 			wantErr: true,
 			wantShell: &Shell{
 				executor: &nativeCommandExecutor{},
+				environments: Environments{
+					Environment{
+						Name: "DRY_RUN",
+					},
+				},
 				spec: Spec{
 					Command: "echo Hello",
 					Shell:   "/bin/sh",
-					Environments: Environments{
+					Environments: &Environments{
 						Environment{
 							Name: "PATH",
 						},

--- a/pkg/plugins/resources/shell/main_test.go
+++ b/pkg/plugins/resources/shell/main_test.go
@@ -7,6 +7,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var (
+	defaultFakeValue = "xxx"
+)
+
 func TestShell_New(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -46,7 +50,7 @@ func TestShell_New(t *testing.T) {
 				Command: "echo World",
 				Environments: &Environments{
 					Environment{
-						Value: "xxx",
+						Value: &defaultFakeValue,
 					},
 				},
 			},
@@ -55,14 +59,14 @@ func TestShell_New(t *testing.T) {
 				executor: &nativeCommandExecutor{},
 				environments: Environments{
 					Environment{
-						Value: "xxx",
+						Value: &defaultFakeValue,
 					},
 				},
 				spec: Spec{
 					Command: "echo World",
 					Environments: &Environments{
 						Environment{
-							Value: "xxx",
+							Value: &defaultFakeValue,
 						},
 					},
 				},

--- a/pkg/plugins/resources/shell/source.go
+++ b/pkg/plugins/resources/shell/source.go
@@ -13,7 +13,8 @@ func (s *Shell) Source(workingDir string, resultSource *result.Source) error {
 	// Ensure environment variable(s) are up to date
 	// either it already has a value specified, or it retrieves
 	// the value from the Updatecli process
-	err := s.spec.Environments.Load()
+	ignoreEnvironmentsNotFound := s.spec.Environments == nil
+	err := s.environments.Load(ignoreEnvironmentsNotFound)
 	if err != nil {
 		return &ExecutionFailedError{}
 	}
@@ -23,7 +24,7 @@ func (s *Shell) Source(workingDir string, resultSource *result.Source) error {
 	// so we don't fallback to use the current process environment as explained
 	// on https://pkg.go.dev/os/exec#Cmd
 	// Provides the "DRY_RUN" environment variable to the shell command (true if "diff", false if "apply")
-	env := append(s.spec.Environments, Environment{
+	env := append(s.environments, Environment{
 		Name:  CurrentStageVariableName,
 		Value: "source",
 	})

--- a/pkg/plugins/resources/shell/source.go
+++ b/pkg/plugins/resources/shell/source.go
@@ -24,9 +24,10 @@ func (s *Shell) Source(workingDir string, resultSource *result.Source) error {
 	// so we don't fallback to use the current process environment as explained
 	// on https://pkg.go.dev/os/exec#Cmd
 	// Provides the "DRY_RUN" environment variable to the shell command (true if "diff", false if "apply")
+	sourceStageValue := "source"
 	env := append(s.environments, Environment{
 		Name:  CurrentStageVariableName,
-		Value: "source",
+		Value: &sourceStageValue,
 	})
 
 	// PreCommand is executed to collect information before running the shell command

--- a/pkg/plugins/resources/shell/target.go
+++ b/pkg/plugins/resources/shell/target.go
@@ -52,15 +52,17 @@ func (s *Shell) target(source, workingDir string, dryRun bool, resultTarget *res
 	// It's only purpose is to have at least one environment variable
 	// so we don't fallback to use the current process environment as explained
 	// on https://pkg.go.dev/os/exec#Cmd
+	targetStageValue := "target"
 	env := append(s.environments, Environment{
 		Name:  CurrentStageVariableName,
-		Value: "target",
+		Value: &targetStageValue,
 	})
 
 	// Provides the "DRY_RUN" environment variable to the shell command (true if "diff", false if "apply")
+	dryRunValue := fmt.Sprintf("%v", dryRun)
 	env = append(env, Environment{
 		Name:  DryRunVariableName,
-		Value: fmt.Sprintf("%v", dryRun),
+		Value: &dryRunValue,
 	})
 
 	err = s.success.PreCommand(s.getWorkingDirPath(workingDir))

--- a/pkg/plugins/resources/shell/target.go
+++ b/pkg/plugins/resources/shell/target.go
@@ -42,7 +42,8 @@ func (s *Shell) target(source, workingDir string, dryRun bool, resultTarget *res
 	// Ensure environment variable(s) are up to date
 	// either it already has a value specified, or it retrieves
 	// the value from the Updatecli process
-	err := s.spec.Environments.Load()
+	ignoreEnvironmentsNotFound := s.spec.Environments == nil
+	err := s.environments.Load(ignoreEnvironmentsNotFound)
 	if err != nil {
 		return err
 	}
@@ -51,7 +52,7 @@ func (s *Shell) target(source, workingDir string, dryRun bool, resultTarget *res
 	// It's only purpose is to have at least one environment variable
 	// so we don't fallback to use the current process environment as explained
 	// on https://pkg.go.dev/os/exec#Cmd
-	env := append(s.spec.Environments, Environment{
+	env := append(s.environments, Environment{
 		Name:  CurrentStageVariableName,
 		Value: "target",
 	})


### PR DESCRIPTION
Fix #1768 

Share a set of default environment variable with the shell plugin.
Improve the shell plugin parameter documentation.

## Test

To test this pull request, you can run the following commands:

```shell
updatecli diff --config /tmp/updatecli.yaml
```

where updatecli.yaml contains

```
targets:
  default:
    kind: shell
    spec:
      command: updatecli version
```

## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via pull request in [website](https://github.com/updatecli/website) repository.

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
