### PR TITLE
feat(golang/autodiscovery): make it easier to restrict to go module orr go version update

### DIFF
--- a/e2e/updatecli.d/success.d/autodiscovery/golang/golangOnly.2.yaml
+++ b/e2e/updatecli.d/success.d/autodiscovery/golang/golangOnly.2.yaml
@@ -1,0 +1,29 @@
+name: "Bump Golang Version"
+scms:
+  default:
+    kind: github
+    spec:
+      owner: updatecli-test
+      repository: updatecli
+      token: '{{ requiredEnv "GITHUB_TOKEN" }}'
+      username: '{{ requiredEnv "GITHUB_ACTOR" }}'
+      branch: e2e-tests-golang
+
+actions:
+    default:
+        kind: github/pullrequest
+        scmid: default
+        spec:
+          labels:
+            - "dependencies"
+
+autodiscovery:
+  scmid: default
+  actionid:  default
+  crawlers:
+    golang/gomod:
+      goversiononly: true
+      versionfilter:
+        kind: semver
+        pattern: minor
+

--- a/e2e/updatecli.d/success.d/autodiscovery/golang/golangOnly.2.yaml
+++ b/e2e/updatecli.d/success.d/autodiscovery/golang/golangOnly.2.yaml
@@ -22,7 +22,7 @@ autodiscovery:
   actionid:  default
   crawlers:
     golang/gomod:
-      goversiononly: true
+      onlygoversion: true
       versionfilter:
         kind: semver
         pattern: minor

--- a/e2e/updatecli.d/success.d/autodiscovery/golang/golangOnly.2.yaml
+++ b/e2e/updatecli.d/success.d/autodiscovery/golang/golangOnly.2.yaml
@@ -26,4 +26,6 @@ autodiscovery:
       versionfilter:
         kind: semver
         pattern: minor
+      only:
+        - path: go.mod
 

--- a/e2e/updatecli.d/success.d/autodiscovery/golang/golangOnly.yaml
+++ b/e2e/updatecli.d/success.d/autodiscovery/golang/golangOnly.yaml
@@ -27,4 +27,5 @@ autodiscovery:
         pattern: minor
       only:
         - goversion: "*"
+          path: go.mod
 

--- a/e2e/updatecli.d/success.d/autodiscovery/golang/minorOnly.yaml
+++ b/e2e/updatecli.d/success.d/autodiscovery/golang/minorOnly.yaml
@@ -25,11 +25,9 @@ autodiscovery:
       versionfilter:
         kind: semver
         pattern: minor
-      ignore:
-        # Ignoring the following modules as they do not publish release
+      only:
         - modules:
-            github.com/ProtonMail/go-crypto:
-            github.com/shurcooL/githubv4:
-            github.com/nirasan/go-oauth-pkce-code-verifier:
-            github.com/skratchdot/open-golang:
+            dario.cat/mergo:
+            github.com/go-git/go-git/v5:
+            oras.land/oras-go/v2:
 

--- a/e2e/updatecli.d/success.d/autodiscovery/golang/moduleonly.yaml
+++ b/e2e/updatecli.d/success.d/autodiscovery/golang/moduleonly.yaml
@@ -27,7 +27,7 @@ autodiscovery:
   groupby: all
   crawlers:
     golang/gomod:
-      onlyGoModule: true
+      onlygomodule: true
       versionfilter:
         kind: semver
         pattern: minor

--- a/e2e/updatecli.d/success.d/autodiscovery/golang/moduleonly.yaml
+++ b/e2e/updatecli.d/success.d/autodiscovery/golang/moduleonly.yaml
@@ -1,0 +1,33 @@
+name: "Bump Patch version for Golang module"
+scms:
+  default:
+    kind: github
+    spec:
+      owner: updatecli
+      repository: updatemonitor
+      token: {{ requiredEnv "GITHUB_TOKEN" }}
+      username: {{ requiredEnv "GITHUB_ACTOR" }}
+      branch: main
+
+actions:
+    default:
+        # The action title is used to define the pullrequest title
+        # Since we use the groupby: we need to be sure that the pullrequest title
+        # is the same for all the subpipeline.
+        title: Bump Patch version for Golang module
+        kind: github/pullrequest
+        scmid: default
+        spec:
+          labels:
+            - "dependencies"
+
+autodiscovery:
+  scmid: default
+  actionid:  default
+  groupby: all
+  crawlers:
+    golang/gomod:
+      onlyGoModule: true
+      versionfilter:
+        kind: semver
+        pattern: minor

--- a/e2e/updatecli.d/success.d/autodiscovery/golang/patchOnly.yaml
+++ b/e2e/updatecli.d/success.d/autodiscovery/golang/patchOnly.yaml
@@ -34,19 +34,4 @@ autodiscovery:
       only:
         - modules:
             github.com/beevik/etree: ""
-      #ignore:
-      #  - modules:
-      #      # Ignoring the following modules as they do not publish release
-      #      github.com/ProtonMail/go-crypto:
-      #      # Ignoring the following modules as they do not publish release
-      #      github.com/shurcooL/githubv4:
-      #      # Ignore module using version matching constraint 1.x
-      #      helm.sh/helm/v3: "1.x"
-      #      # The remote version uses the version v0.0.0-20190318233801-ac98e3ecb4b0 which do not exists anymore
-      #      # the patch version will try to fetch the version matching 0.0.x and finds nothing
-      #      github.com/iancoleman/orderedmap:
-      #      # Same for https://pkg.go.dev/golang.org/x/time?tab=versions
-      #      golang.org/x/time:
-      #      github.com/nirasan/go-oauth-pkce-code-verifier:
-      #      github.com/skratchdot/open-golang:
 

--- a/pkg/plugins/autodiscovery/golang/dependency.go
+++ b/pkg/plugins/autodiscovery/golang/dependency.go
@@ -73,7 +73,7 @@ func (g Golang) discoverDependencyManifests() ([][]byte, error) {
 
 		for goModule, goModuleVersion := range goModules {
 			// Skip golang module manifest if there is only one rule on the go version
-			if g.spec.Only.isGoVersionOnly() {
+			if g.spec.Only.isGoVersionOnly() || g.onlygoVersion {
 				break
 			}
 			// Test if the ignore rule based on path is respected
@@ -115,7 +115,7 @@ func (g Golang) discoverDependencyManifests() ([][]byte, error) {
 			manifests = append(manifests, moduleManifest)
 		}
 
-		if g.spec.Only.isGoModuleOnly() {
+		if g.spec.Only.isGoModuleOnly() || g.onlyGoModule {
 			return manifests, nil
 		}
 


### PR DESCRIPTION
This pull request simplify the configuration of the Golang autodiscovery plugin to restrict version update to Go modules or go version by providing two new parameters

`onlygoversion` and `onlygomodule`

## Test

To test this pull request, you can run the following commands:

```shell
go build -o bin/updatecli .
./bin/updatecli diff --config e2e/updatecli.d/success.d/autodiscovery/golang/moduleonly.yaml
./bin/updatecli diff --config e2e/updatecli.d/success.d/autodiscovery/golang/golangOnly.2.yaml
```

## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via pull request in [website](https://github.com/updatecli/website) repository.

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
