### PR TITLE
feat: default yaml plugin should also support adding comments

### DIFF
--- a/pkg/plugins/resources/yaml/main.go
+++ b/pkg/plugins/resources/yaml/main.go
@@ -16,125 +16,116 @@ import (
 It can be used as a "source", a "condition", or a "target".
 */
 type Spec struct {
-	/*
-		"engine" defines the engine to use to manipulate the yaml file.
-
-		There is no one good Golang library to manipulate yaml files.
-		And each one of them have has its pros and cons so we decided to allow this customization based on user's needs.
-
-		remark:
-			* Accepted value is one of "yamlpath", "go-yaml","default" or nothing
-			* go-yaml, "default" and "" are equivalent
-	*/
+	//"engine" defines the engine to use to manipulate the yaml file.
+	//
+	//There is no one good Golang library to manipulate yaml files.
+	//And each one of them have has its pros and cons so we decided to allow this customization based on user's needs.
+	//
+	//remark:
+	//  * Accepted value is one of "yamlpath", "go-yaml","default" or nothing
+	//  * go-yaml, "default" and "" are equivalent
 	Engine string `yaml:",omitempty"`
-	/*
-		"file" defines the yaml file path to interact with.
-
-		compatible:
-			* source
-			* condition
-			* target
-
-		remark:
-			* "file" and "files" are mutually exclusive
-			* scheme "https://", "http://", and "file://" are supported in path for source and condition
-	*/
+	//"file" defines the yaml file path to interact with.
+	//
+	//compatible:
+	//  * source
+	//  * condition
+	//  * target
+	//
+	//remark:
+	//  * "file" and "files" are mutually exclusive
+	//  * scheme "https://", "http://", and "file://" are supported in path for source and condition
+	//
 	File string `yaml:",omitempty"`
-	/*
-		"files" defines the list of yaml files path to interact with.
-
-		compatible:
-			* condition
-			* target
-
-		remark:
-			* file and files are mutually exclusive
-			* protocols "https://", "http://", and "file://" are supported in file path for source and condition
-	*/
+	//"files" defines the list of yaml files path to interact with.
+	//
+	//compatible:
+	//  * condition
+	//  * target
+	//
+	//remark:
+	//  * file and files are mutually exclusive
+	//  * protocols "https://", "http://", and "file://" are supported in file path for source and condition
+	//
 	Files []string `yaml:",omitempty"`
-	/*
-		"key" defines the yaml keypath.
-
-		compatible:
-			* source
-			* condition
-			* target
-
-		remark:
-			* key is a simpler version of yamlpath accepts keys.
-
-		example using default engine:
-			* key: $.name
-			* key: $.agent.name
-			* key: $.agents[0].name
-			* key: $.agents[*].name
-			* key: $.'agents.name'
-			* key: $.repos[?(@.repository == 'website')].owner" (require engine set to yamlpath)
-
-		remark:
-			field path with key/value is not supported at the moment.
-			some help would be useful on https://github.com/goccy/go-yaml/issues/290
-
-	*/
+	//"key" defines the yaml keypath.
+	//
+	//compatible:
+	//  * source
+	//  * condition
+	//  * target
+	//
+	//remark:
+	//  * key is a simpler version of yamlpath accepts keys.
+	//
+	//example using default engine:
+	//  * key: $.name
+	//  * key: $.agent.name
+	//  * key: $.agents[0].name
+	//  * key: $.agents[*].name
+	//  * key: $.'agents.name'
+	//  * key: $.repos[?(@.repository == 'website')].owner" (require engine set to yamlpath)
+	//
+	//remark:
+	//  field path with key/value is not supported at the moment.
+	//  some help would be useful on https://github.com/goccy/go-yaml/issues/290
+	//
 	Key string `yaml:",omitempty"`
-	/*
-		"value" is the value associated with a yaml key.
-
-		compatible:
-			* source
-			* condition
-			* target
-
-		default:
-			When used from a condition or a target, the default value is set to linked source output.
-	*/
+	//value is the value associated with a yaml key.
+	//
+	//compatible:
+	//  * source
+	//  * condition
+	//  * target
+	//
+	//default:
+	//	When used from a condition or a target, the default value is set to the associated source output.
+	//
 	Value string `yaml:",omitempty"`
-	/*
-		"keyonly" allows to only check if a key exist and do not return an error otherwise
-
-		compatible:
-			* condition
-
-		default:
-			false
-	*/
+	//keyonly allows to check only if a key exist and do not return an error otherwise
+	//
+	//compatible:
+	//	* condition
+	//
+	//default:
+	//	false
+	//
 	KeyOnly bool `yaml:",omitempty"`
-	/*
-	   `searchpattern` defines if the MatchPattern should be applied on the file(s) path
-
-	   If set to true, it modifies the behavior of the `file` and `files` attributes to search for files matching the pattern instead of searching for files with the exact name.
-	   When looking for file path pattern, it requires pattern to match all of name, not just a substring.
-
-	   The pattern syntax is:
-
-	   ```
-	       pattern:
-	           { term }
-	       term:
-	           '*'         matches any sequence of non-Separator characters
-	           '?'         matches any single non-Separator character
-	           '[' [ '^' ] { character-range } ']'
-	                       character class (must be non-empty)
-	           c           matches character c (c != '*', '?', '\\', '[')
-	           '\\' c      matches character c
-
-	       character-range:
-	           c           matches character c (c != '\\', '-', ']')
-	           '\\' c      matches character c
-	           lo '-' hi   matches character c for lo <= c <= hi
-	   ```
-
-	*/
+	//searchpattern defines if the MatchPattern should be applied on the file(s) path
+	//
+	//If set to true, it modifies the behavior of the `file` and `files` attributes to search for files matching the pattern instead of searching for files with the exact name.
+	//When looking for file path pattern, it requires pattern to match all of name, not just a substring.
+	//
+	//The pattern syntax is:
+	//
+	//```
+	//    pattern:
+	//        { term }
+	//    term:
+	//        '*'         matches any sequence of non-Separator characters
+	//        '?'         matches any single non-Separator character
+	//        '[' [ '^' ] { character-range } ']'
+	//                    character class (must be non-empty)
+	//        c           matches character c (c != '*', '?', '\\', '[')
+	//        '\\' c      matches character c
+	//
+	//    character-range:
+	//        c           matches character c (c != '\\', '-', ']')
+	//        '\\' c      matches character c
+	//        lo '-' hi   matches character c for lo <= c <= hi
+	//```
+	//
 	SearchPattern bool `yaml:",omitempty"`
-	/*
-				"comment" defines a comment to add after the value.
-
-				compatible:
-					* target
-
-		   remarks:
-		            * require engine set to yamlpath
-	*/
+	//comment defines a comment to add after the value.
+	//
+	//default: empty
+	//
+	//compatible:
+	//  * target
+	//
+	//remarks:
+	//  * Please note that the comment is added if the value is modified by Updatecli
+	//
 	Comment string `yaml:",omitempty"`
 }
 

--- a/pkg/plugins/resources/yaml/target_test.go
+++ b/pkg/plugins/resources/yaml/target_test.go
@@ -25,6 +25,55 @@ func Test_Target(t *testing.T) {
 		dryRun           bool
 	}{
 		{
+			name: "Passing case with 'Files' (one already up to date), both input source and specified value (specified value should be used) and updated comment",
+			spec: Spec{
+				Files: []string{
+					"test.yaml",
+					"bar.yaml",
+				},
+				Key:     "github.owner",
+				Value:   "obiwankenobi",
+				Comment: "comment that should be added",
+			},
+			files: map[string]file{
+				"test.yaml": {
+					filePath:         "test.yaml",
+					originalFilePath: "test.yaml",
+				},
+				"bar.yaml": {
+					filePath:         "test.yaml",
+					originalFilePath: "bar.yaml",
+				},
+			},
+			inputSourceValue: "olblak",
+			mockedContents: map[string]string{
+				"test.yaml": `---
+github:
+  owner: olblak
+  repository: charts
+`,
+				"bar.yaml": `---
+github:
+  owner: obiwankenobi
+  repository: charts
+`,
+			},
+			wantedContents: map[string]string{
+				"test.yaml": `---
+github:
+  owner: obiwankenobi # comment that should be added
+  repository: charts
+`,
+				// Please note that the comment shouldn't be added as the value wasn't changed
+				"bar.yaml": `---
+github:
+  owner: obiwankenobi
+  repository: charts
+`,
+			},
+			wantedResult: true,
+		},
+		{
 			name: "Passing case with both complex input source and specified value (specified value should be used)",
 			spec: Spec{
 				File:   "test.yaml",


### PR DESCRIPTION
Fix #9940

* This pull request allows setting comment with the default yaml plugin engine, if the yaml value changed
* I am also taking the opportunity to reformat the comment as this format improve the visualization from IDE

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
cd pkg/plugins/resources/yaml/ 
go test .
```

## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via pull request in [website](https://github.com/updatecli/website) repository.

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
