### PR TITLE
feat: support basic authorization for non-oci private helm repos

### DIFF
--- a/pkg/plugins/resources/helm/utils.go
+++ b/pkg/plugins/resources/helm/utils.go
@@ -2,6 +2,7 @@ package helm
 
 import (
 	"bytes"
+	"encoding/base64"
 	"fmt"
 	"io"
 	"net/http"
@@ -117,6 +118,11 @@ func (c *Chart) GetRepoIndexFromURL() (repo.IndexFile, error) {
 	req, err := http.NewRequest("GET", URL, nil)
 	if err != nil {
 		return repo.IndexFile{}, err
+	}
+
+	if c.spec.Username != "" && c.spec.Password != "" {
+		userPass := []byte(fmt.Sprintf("%s:%s", c.spec.Username, c.spec.Password))
+		req.Header.Add("Authorization", fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString(userPass)))
 	}
 
 	res, err := http.DefaultClient.Do(req)


### PR DESCRIPTION
This PR adds support of basic authorization for non-oci private helm repos

<!-- Describe the changes introduced by this pull request -->

