### PR TITLE
deps: automerge golang patch update version

### DIFF
--- a/updatecli/values.d/golang_patch.yaml
+++ b/updatecli/values.d/golang_patch.yaml
@@ -1,6 +1,7 @@
 name: "deps: bump patch version for Golang module"
 pipelineid: "golang/gomod/patch"
 groupby: individual
+automerge: true
 
 spec:
   versionfilter:


### PR DESCRIPTION
We already have a lot of tests, so I think it's safe enough to automerge patch update version when available