### PR TITLE
fix(updatecli): ignore some Go module version update for github.com/hashicorp/hcl/v2

### DIFF
--- a/updatecli/values.d/golang_major.yaml
+++ b/updatecli/values.d/golang_major.yaml
@@ -26,6 +26,11 @@ spec:
         k8s.io/utils: ""
         # https://pkg.go.dev/golang.org/x/exp?tab=versions
         golang.org/x/exp: ""
+        # github.com/minamijoyo/hcledit v0.2.17 depends on
+        # the golang module github.com/hashicorp/hcl/v2 v2.23.1-0.20250211201033-5c140ce1cb20
+        # It's not possible for Updatecli to detect version based on a commit so we just ignore
+        # that version until github.com/hashicorp/hcl/v2 v2.23.1 is not released
+        github.com/hashicorp/hcl/v2: ">= v2.23.0-0 < v2.23.2-0"
 
   only:
     # This repository contains other go.sum file used for testing.

--- a/updatecli/values.d/golang_minor.yaml
+++ b/updatecli/values.d/golang_minor.yaml
@@ -26,6 +26,11 @@ spec:
         k8s.io/utils: ""
         # https://pkg.go.dev/golang.org/x/exp?tab=versions
         golang.org/x/exp: ""
+        # github.com/minamijoyo/hcledit v0.2.17 depends on
+        # the golang module github.com/hashicorp/hcl/v2 v2.23.1-0.20250211201033-5c140ce1cb20
+        # It's not possible for Updatecli to detect version based on a commit so we just ignore
+        # that version until github.com/hashicorp/hcl/v2 v2.23.1 is not released
+        github.com/hashicorp/hcl/v2: ">= v2.23.0-0 < v2.23.2-0"
 
   only:
     # This repository contains other go.sum file used for testing.

--- a/updatecli/values.d/golang_patch.yaml
+++ b/updatecli/values.d/golang_patch.yaml
@@ -26,6 +26,11 @@ spec:
         k8s.io/utils: ""
         # https://pkg.go.dev/golang.org/x/exp?tab=versions
         golang.org/x/exp: ""
+        # github.com/minamijoyo/hcledit v0.2.17 depends on
+        # the golang module github.com/hashicorp/hcl/v2 v2.23.1-0.20250211201033-5c140ce1cb20
+        # It's not possible for Updatecli to detect version based on a commit so we just ignore
+        # that version until github.com/hashicorp/hcl/v2 v2.23.1 is not released
+        github.com/hashicorp/hcl/v2: ">= v2.23.0-0 < v2.23.2-0"
 
   only:
     # This repository contains other go.sum file used for testing.


### PR DESCRIPTION
Fix Updatecli pipelines 

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
cd <to_package_directory>
go test
```

## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via pull request in [website](https://github.com/updatecli/website) repository.

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
