### PR TITLE
fix(autodiscovery/flux): don't ignore flux helmrelease update if using an actionID

### DIFF
--- a/pkg/plugins/autodiscovery/flux/helmreleaseManifestTemplate.go
+++ b/pkg/plugins/autodiscovery/flux/helmreleaseManifestTemplate.go
@@ -6,8 +6,8 @@ const (
 {{- if .ActionID }}
 actions:
   {{ .ActionID }}:
-    title: 'deps: update Helm chart to {{ "{{" }} source "{{ .SourceID }}" {{ "}}" }}'
-{{ end }}
+    title: 'deps: update Helm chart to {{ "{{" }} source "helmrelease" {{ "}}" }}'
+{{- end }}
 sources:
   helmrelease:
     name: 'Get latest "{{ .ChartName }}" Helm chart version'
@@ -25,7 +25,7 @@ conditions:
     disablesourceinput: true
 {{- if .ScmID }}
     scmid: {{ .ScmID }}
-{{ end }}
+{{- end }}
     spec:
       file: '{{ .File }}'
       key: '$.spec.chart.spec.chart'
@@ -36,7 +36,7 @@ targets:
     kind: 'yaml'
 {{- if .ScmID }}
     scmid: {{ .ScmID }}
-{{ end }}
+{{- end }}
     spec:
       file: '{{ .File }}'
       key: '$.spec.chart.spec.version'

--- a/pkg/plugins/autodiscovery/flux/ociRepositoryManifestTemplate.go
+++ b/pkg/plugins/autodiscovery/flux/ociRepositoryManifestTemplate.go
@@ -3,6 +3,11 @@ package flux
 const (
 	// ociRepositoryManifestTemplateLatest is the Go template used to generate Flux manifests for ocirepository resources without digest
 	ociRepositoryManifestTemplateLatest string = `name: 'deps(flux): bump ociRepository "{{ .OCIName }}"'
+{{- if .ActionID }}
+actions:
+  {{ .ActionID }}:
+    title: 'deps: update OCI repository to {{ "{{" }} source "oci" {{ "}}" }}'
+{{- end }}
 sources:
   oci:
     name: 'Get latest "{{ .OCIName }}" OCI artifact tag'
@@ -19,7 +24,7 @@ targets:
     kind: 'yaml'
 {{- if .ScmID }}
     scmid: {{ .ScmID }}
-{{ end }}
+{{- end }}
     spec:
       file: '{{ .File }}'
       key: '$.spec.ref.tag'
@@ -27,6 +32,11 @@ targets:
 `
 	// ociRepositoryManifestTemplateDigestAndLatest is the Go template used to generate Flux manifests for ocirepository resources with digest and latest
 	ociRepositoryManifestTemplateDigestAndLatest string = `name: 'deps(flux): bump ociRepository "{{ .OCIName }}"'
+{{- if .ActionID }}
+actions:
+  {{ .ActionID }}:
+    title: 'deps: update OCI repository digest for {{ .OCIName }}:{{ "{{" }} source "oci" {{ "}}" }}'
+{{- end }}
 sources:
   oci:
     name: 'Get latest "{{ .OCIName }}" OCI artifact tag'
@@ -51,7 +61,7 @@ targets:
     kind: 'yaml'
 {{- if .ScmID }}
     scmid: {{ .ScmID }}
-{{ end }}
+{{- end }}
     spec:
       file: '{{ .File }}'
       key: '$.spec.ref.tag'
@@ -59,6 +69,11 @@ targets:
 `
 	// ociRepositoryManifestTemplateDigest is the Go template used to generate Flux manifests for ocirepository resources with digest without updating the tag.
 	ociRepositoryManifestTemplateDigest string = `name: 'deps(flux): bump ociRepository "{{ .OCIName }}"'
+{{- if .ActionID }}
+actions:
+  {{ .ActionID }}:
+    title: 'deps: update OCI repository digest for {{ .OCIName }}:{{ .OCIVersion }}'
+{{- end }}
 sources:
   oci-digest:
     name: 'Get latest "{{ .OCIName }}" OCI artifact digest'
@@ -72,7 +87,7 @@ targets:
     kind: 'yaml'
 {{- if .ScmID }}
     scmid: {{ .ScmID }}
-{{ end }}
+{{- end }}
     spec:
       file: '{{ .File }}'
       key: '$.spec.ref.tag'

--- a/pkg/plugins/autodiscovery/flux/ociRepositoryManifests.go
+++ b/pkg/plugins/autodiscovery/flux/ociRepositoryManifests.go
@@ -100,6 +100,7 @@ func (f Flux) discoverOCIRepositoryManifests() [][]byte {
 		}
 
 		params := struct {
+			ActionID             string
 			OCIName              string
 			OCIVersion           string
 			File                 string
@@ -109,6 +110,7 @@ func (f Flux) discoverOCIRepositoryManifests() [][]byte {
 			ScmID                string
 			TagFilter            string
 		}{
+			ActionID:             f.actionID,
 			OCIName:              ociName,
 			OCIVersion:           ociVersion,
 			File:                 relateFoundFluxFile,


### PR DESCRIPTION
Fix #4012 

Due to a regression introduced in #3797 
Flux helmrelease update would be ignored if actionID was set as it would result in a wrong manifest.

While looking into this package, I also noticed that ocirepository didn't support actionID correctly.
Some tests have been added to avoid this situation in the future.


<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
cd pkg/plugins/autodiscovery/flux/
go test
```

I also tested this on the repository https://github.com/Bealvio/bealv@main
using 

```
updatecli diff --config updatecli/updatecli.d/flux-discovery.yaml
```


## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via pull request in [website](https://github.com/updatecli/website) repository.

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
