### PR TITLE
feat: add support for digest in precommit autodiscovery

### DIFF
--- a/pkg/plugins/autodiscovery/precommit/dependency.go
+++ b/pkg/plugins/autodiscovery/precommit/dependency.go
@@ -78,6 +78,10 @@ func (p Precommit) discoverDependencyManifests() ([][]byte, error) {
 				continue
 			}
 
+			targetSource := "gittag"
+			if p.digest {
+				targetSource = fmt.Sprintf("%s_digest", targetSource)
+			}
 			params := struct {
 				ActionID                   string
 				ManifestName               string
@@ -94,6 +98,7 @@ func (p Precommit) discoverDependencyManifests() ([][]byte, error) {
 				TargetKey                  string
 				File                       string
 				ScmID                      string
+				Digest                     bool
 			}{
 				ActionID:                   p.actionID,
 				ManifestName:               fmt.Sprintf("Bump %q repo version", repo.Repo),
@@ -105,11 +110,12 @@ func (p Precommit) discoverDependencyManifests() ([][]byte, error) {
 				SourceVersionFilterKind:    p.versionFilter.Kind,
 				SourceVersionFilterPattern: versionPattern,
 				TargetID:                   ".pre-commit-config.yaml",
-				TargetName:                 fmt.Sprintf("deps(precommit): bump %q repo version to {{ source %q }}", repo.Repo, "gittag"),
+				TargetName:                 fmt.Sprintf("deps(precommit): bump %q repo version to {{ source %q }}", repo.Repo, targetSource),
 				TargetKey:                  fmt.Sprintf("$.repos[?(@.repo == '%s')].rev", repo.Repo),
 				TargetEngine:               yaml.EngineYamlPath,
 				File:                       relativeFoundFile,
 				ScmID:                      p.scmID,
+				Digest:                     p.digest,
 			}
 
 			manifest := bytes.Buffer{}

--- a/pkg/plugins/autodiscovery/precommit/main.go
+++ b/pkg/plugins/autodiscovery/precommit/main.go
@@ -42,6 +42,9 @@ type Spec struct {
 		and its type like regex, semver, or just latest.
 	*/
 	VersionFilter version.Filter `yaml:",omitempty"`
+	// Digest provides parameters to specify if the generated manifest should use a digest instead of the branch or tag.
+	// This is equivalent to using the [`--freeze`](https://pre-commit.com/#pre-commit-autoupdate) option of precommit
+	Digest *bool `yaml:",omitempty"`
 }
 
 // Precommit holds all information needed to generate precommit manifest.
@@ -56,6 +59,8 @@ type Precommit struct {
 	scmID string
 	// versionFilter holds the "valid" version.filter, that might be different from the user-specified filter (Spec.VersionFilter)
 	versionFilter version.Filter
+	// digest holds the value of the digest parameter
+	digest bool
 }
 
 // New return a new valid object.
@@ -87,12 +92,18 @@ func New(spec interface{}, rootDir, scmID, actionID string) (Precommit, error) {
 		newFilter.Pattern = "*"
 	}
 
+	digest := false
+	if s.Digest != nil {
+		digest = *s.Digest
+	}
+
 	return Precommit{
 		actionID:      actionID,
 		spec:          s,
 		rootDir:       dir,
 		scmID:         scmID,
 		versionFilter: newFilter,
+		digest:        digest,
 	}, nil
 
 }

--- a/pkg/plugins/autodiscovery/precommit/manifestTemplate.go
+++ b/pkg/plugins/autodiscovery/precommit/manifestTemplate.go
@@ -18,6 +18,17 @@ sources:
         kind: '{{ .SourceVersionFilterKind }}'
         pattern: '{{ .SourceVersionFilterPattern }}'
       url: '{{ .SourceScmUrl }}'
+{{- if .Digest }}
+  '{{ .SourceID }}_digest':
+    name: '{{ .SourceName }}'
+    kind: '{{ .SourceKind }}'
+    spec:
+      versionfilter:
+        kind: '{{ .SourceVersionFilterKind }}'
+        pattern: '{{ .SourceVersionFilterPattern }}'
+      url: '{{ .SourceScmUrl }}'
+      key: 'hash'
+{{- end }}
 
 targets:
   '{{ .TargetID }}':
@@ -26,7 +37,7 @@ targets:
 {{- if .ScmID }}
     scmid: '{{ .ScmID }}'
 {{ end }}
-    sourceid: '{{ .SourceID }}'
+    sourceid: '{{ .SourceID }}{{if .Digest}}_digest{{end}}'
     spec:
       file: '{{ .File }}'
       key: "{{ .TargetKey }}"


### PR DESCRIPTION
Similar to https://github.com/updatecli/updatecli/pull/3508 but for precommit

This is something supported by the [pre-commit tool](https://pre-commit.com/#pre-commit-autoupdate)

## Test

To test this pull request, you can run the following commands:

```shell
cd pkg/plugions/autodiscovery/precommit
go test
```

## Additional Information

### Checklist

- [x] <!-- If applicable,--> I have updated the documentation via pull request in [website](https://github.com/updatecli/website) repository.: https://github.com/updatecli/website/pull/2148

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
