### PR TITLE
feat: digest should allow handling of main

### DIFF
--- a/e2e/updatecli.d/success.d/autodiscovery/github/action/digest.yaml
+++ b/e2e/updatecli.d/success.d/autodiscovery/github/action/digest.yaml
@@ -1,4 +1,4 @@
-name: "deps: bump GitHub Action"
+name: "deps: bump GitHub Action digest"
 scms:
   default:
     kind: github
@@ -22,9 +22,5 @@ autodiscovery:
   actionid: default
   crawlers:
     github/action:
-      #versionfilter:
-      #  kind: semver
-      #  pattern: minor
-      #only:
-      #  - actions:
-      #      "updatecli/updatecli-action": ""
+      digest: true
+      rootdir: pkg/plugins/autodiscovery/githubaction/testdata/digest/.github/

--- a/pkg/plugins/autodiscovery/githubaction/main_test.go
+++ b/pkg/plugins/autodiscovery/githubaction/main_test.go
@@ -519,6 +519,162 @@ targets:
       key: '$.jobs.updatecli.steps[1].uses'
       engine: 'yamlpath'
       comment: '{{ source "branch" }}'
+`, `name: 'deps: bump actions/checkout GitHub workflow'
+
+sources:
+  release:
+    dependson:
+      - 'condition#release:and'
+    name: 'Get latest GitHub Release for actions/checkout'
+    kind: 'githubrelease'
+    spec:
+      owner: 'actions'
+      repository: 'checkout'
+      url: 'https://github.com'
+      token: 'xxx'
+      versionfilter:
+        kind: 'latest'
+
+  release_digest:
+    dependson:
+      - 'condition#release:and'
+    name: 'Get latest GitHub Release for actions/checkout'
+    kind: 'githubrelease'
+    spec:
+      owner: 'actions'
+      repository: 'checkout'
+      url: 'https://github.com'
+      token: 'xxx'
+      key: 'hash'
+      versionfilter:
+        kind: 'regex'
+        pattern: '{{ source "release" }}'
+
+  tag:
+    dependson:
+      - 'condition#tag:and'
+    name: 'Get latest tag for actions/checkout'
+    kind: 'gittag'
+    spec:
+      url: "https://github.com/actions/checkout.git"
+      password: 'xxx'
+      versionfilter:
+        kind: 'latest'
+
+  tag_digest:
+    dependson:
+      - 'condition#tag:and'
+    name: 'Get latest tag for actions/checkout'
+    kind: 'gittag'
+    spec:
+      url: "https://github.com/actions/checkout.git"
+      password: 'xxx'
+      key: 'hash'
+      versionfilter:
+        kind: 'regex'
+        pattern: '{{ source "tag" }}'
+
+  branch:
+    dependson:
+      - 'condition#branch:and'
+    name: 'Get latest branch for actions/checkout'
+    kind: 'gitbranch'
+    spec:
+      url: "https://github.com/actions/checkout.git"
+      password: 'xxx'
+      versionfilter:
+        kind: 'latest'
+
+  branch_digest:
+    dependson:
+      - 'condition#branch:and'
+    name: 'Get latest branch for actions/checkout'
+    kind: 'gitbranch'
+    spec:
+      url: "https://github.com/actions/checkout.git"
+      password: 'xxx'
+      key: 'hash'
+      versionfilter:
+        kind: 'regex'
+        pattern: '{{ source "branch" }}'
+
+conditions:
+  release:
+    name: 'Check if actions/checkout@main is a GitHub release'
+    kind: 'githubrelease'
+    disablesourceinput: true
+    spec:
+      owner: 'actions'
+      repository: 'checkout'
+      url: 'https://github.com'
+      token: 'xxx'
+      tag: 'main'
+
+  tag:
+    name: 'Check if actions/checkout@main is a tag'
+    kind: 'gittag'
+    disablesourceinput: true
+    spec:
+      url: "https://github.com/actions/checkout.git"
+      password: 'xxx'
+      versionfilter:
+        kind: 'regex'
+        pattern: '^main$'
+
+  branch:
+    name: 'Check if actions/checkout@main is a branch'
+    kind: 'gitbranch'
+    disablesourceinput: true
+    spec:
+      branch: 'main'
+      url: "https://github.com/actions/checkout.git"
+      password: 'xxx'
+
+targets:
+  release:
+    dependson:
+      - 'condition#release:and'
+    disableconditions: true
+    name: 'deps(github): bump Action release for actions/checkout from main to {{ source "release_digest" }} (Pinned from {{ source "release" }})'
+    kind: 'yaml'
+    sourceid: 'release_digest'
+    transformers:
+      - addprefix: 'actions/checkout@'
+    spec:
+      file: '.github/workflows/updatecli.yaml'
+      key: '$.jobs.updatecli.steps[2].uses'
+      engine: 'yamlpath'
+      comment: '{{ source "release" }}'
+
+  tag:
+    dependson:
+      - 'condition#tag:and'
+    disableconditions: true
+    name: 'deps(github): bump Action tag for actions/checkout from main to {{ source "tag_digest" }} (Pinned from {{ source "tag" }})'
+    kind: 'yaml'
+    sourceid: 'tag_digest'
+    transformers:
+      - addprefix: 'actions/checkout@'
+    spec:
+      file: '.github/workflows/updatecli.yaml'
+      key: '$.jobs.updatecli.steps[2].uses'
+      engine: 'yamlpath'
+      comment: '{{ source "tag" }}'
+
+  branch:
+    dependson:
+      - 'condition#branch:and'
+    disableconditions: true
+    name: 'deps(github): bump Action branch for actions/checkout from main to {{ source "branch_digest" }} (Pinned from {{ source "branch" }})'
+    kind: yaml
+    sourceid: branch_digest
+    transformers:
+      - addprefix: 'actions/checkout@'
+    spec:
+      file: '.github/workflows/updatecli.yaml'
+      key: '$.jobs.updatecli.steps[2].uses'
+      engine: 'yamlpath'
+      comment: '{{ source "branch" }}'
 `},
 		},
 		{

--- a/pkg/plugins/autodiscovery/githubaction/templateGHAGitHub.go
+++ b/pkg/plugins/autodiscovery/githubaction/templateGHAGitHub.go
@@ -22,8 +22,9 @@ sources:
       token: '{{ .Token }}'
       versionfilter:
         kind: '{{ .VersionFilterKind }}'
+{{- if ne .VersionFilterKind "latest" }}
         pattern: '{{ .VersionFilterPattern }}'
-
+{{- end }}
 {{- if .Digest }}
 
   release_digest:
@@ -53,7 +54,9 @@ sources:
       password: '{{ .Token }}'
       versionfilter:
         kind: '{{ .VersionFilterKind }}'
+{{- if ne .VersionFilterKind "latest" }}
         pattern: '{{ .VersionFilterPattern }}'
+{{- end }}
 
 {{- if .Digest }}
 
@@ -82,7 +85,9 @@ sources:
       password: '{{ .Token }}'
       versionfilter:
         kind: '{{ .VersionFilterKind }}'
+{{- if ne .VersionFilterKind "latest" }}
         pattern: '{{ .VersionFilterPattern }}'
+{{- end }}
 
 {{- if .Digest }}
 

--- a/pkg/plugins/autodiscovery/githubaction/testdata/digest/.github/workflows/updatecli.yaml
+++ b/pkg/plugins/autodiscovery/githubaction/testdata/digest/.github/workflows/updatecli.yaml
@@ -23,4 +23,6 @@ jobs:
       - name: "Checkout"
         uses: "actions/checkout@v4"
       - name: "Checkout"
-        uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683"  # v4.2.2
+        uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683" # v4.2.2
+      - name: "Checkout"
+        uses: "actions/checkout@main"

--- a/pkg/plugins/autodiscovery/githubaction/testdata/updatecli/.github/workflows/updatecli.yaml
+++ b/pkg/plugins/autodiscovery/githubaction/testdata/updatecli/.github/workflows/updatecli.yaml
@@ -26,6 +26,10 @@ jobs:
       - name: "Setup updatecli"
         uses: "./"
 
+        # Should be ignored
+      - name: "Checkout"
+        uses: "actions/checkout@main"
+
     #  - name: Set up Go
     #    uses: actions/setup-go@v5
     #    with:

--- a/pkg/plugins/autodiscovery/githubaction/workflowGHAManifest.go
+++ b/pkg/plugins/autodiscovery/githubaction/workflowGHAManifest.go
@@ -38,7 +38,9 @@ func (g GitHubAction) getGitHubActionManifest(spec *githubActionManifestSpec) ([
 	case "":
 		return nil, nil
 	case "main", "master":
-		return nil, nil
+		if !g.digest {
+			return nil, nil
+		}
 	}
 
 	actionName := ""
@@ -75,7 +77,7 @@ func (g GitHubAction) getGitHubActionManifest(spec *githubActionManifestSpec) ([
 		}
 	}
 
-	if slices.Contains([]string{"latest", "master", "main"}, spec.Reference) {
+	if !g.digest && slices.Contains([]string{"latest", "master", "main"}, spec.Reference) {
 		logrus.Debugf("Ignoring GitHub Action %q as it uses the reference %q \n",
 			actionName,
 			spec.Reference,


### PR DESCRIPTION
Fix #4958 

I've updated the discoverManifest command to allow `main` and `master` when digest is set

## Test

To test this pull request, you can run the following commands:

```shell
cd <to_package_directory>
go test
```

## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via pull request in [website](https://github.com/updatecli/website) repository.

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
