### PR TITLE
fix(autodiscovery/githubaction): replace deprecated key hash by hashtag

### DIFF
--- a/pkg/plugins/autodiscovery/githubaction/main_test.go
+++ b/pkg/plugins/autodiscovery/githubaction/main_test.go
@@ -228,7 +228,7 @@ sources:
       repository: 'checkout'
       url: 'https://github.com'
       token: 'xxx'
-      key: 'hash'
+      key: 'taghash'
       versionfilter:
         kind: 'regex'
         pattern: '{{ source "release" }}'
@@ -253,7 +253,7 @@ sources:
     spec:
       url: "https://github.com/actions/checkout.git"
       password: 'xxx'
-      key: 'hash'
+      key: 'taghash'
       versionfilter:
         kind: 'regex'
         pattern: '{{ source "tag" }}'
@@ -278,7 +278,7 @@ sources:
     spec:
       url: "https://github.com/actions/checkout.git"
       password: 'xxx'
-      key: 'hash'
+      key: 'taghash'
       versionfilter:
         kind: 'regex'
         pattern: '{{ source "branch" }}'
@@ -387,7 +387,7 @@ sources:
       repository: 'checkout'
       url: 'https://github.com'
       token: 'xxx'
-      key: 'hash'
+      key: 'taghash'
       versionfilter:
         kind: 'regex'
         pattern: '{{ source "release" }}'
@@ -412,7 +412,7 @@ sources:
     spec:
       url: "https://github.com/actions/checkout.git"
       password: 'xxx'
-      key: 'hash'
+      key: 'taghash'
       versionfilter:
         kind: 'regex'
         pattern: '{{ source "tag" }}'
@@ -437,7 +437,7 @@ sources:
     spec:
       url: "https://github.com/actions/checkout.git"
       password: 'xxx'
-      key: 'hash'
+      key: 'taghash'
       versionfilter:
         kind: 'regex'
         pattern: '{{ source "branch" }}'
@@ -545,7 +545,7 @@ sources:
       repository: 'checkout'
       url: 'https://github.com'
       token: 'xxx'
-      key: 'hash'
+      key: 'taghash'
       versionfilter:
         kind: 'regex'
         pattern: '{{ source "release" }}'
@@ -569,7 +569,7 @@ sources:
     spec:
       url: "https://github.com/actions/checkout.git"
       password: 'xxx'
-      key: 'hash'
+      key: 'taghash'
       versionfilter:
         kind: 'regex'
         pattern: '{{ source "tag" }}'
@@ -593,7 +593,7 @@ sources:
     spec:
       url: "https://github.com/actions/checkout.git"
       password: 'xxx'
-      key: 'hash'
+      key: 'taghash'
       versionfilter:
         kind: 'regex'
         pattern: '{{ source "branch" }}'

--- a/pkg/plugins/autodiscovery/githubaction/templateGHAGitHub.go
+++ b/pkg/plugins/autodiscovery/githubaction/templateGHAGitHub.go
@@ -37,7 +37,7 @@ sources:
       repository: '{{ .Repository }}'
       url: '{{ .URL }}'
       token: '{{ .Token }}'
-      key: 'hash'
+      key: 'taghash'
       versionfilter:
         kind: 'regex'
         pattern: '{{ "{{" }} source "release" {{ "}}" }}'
@@ -68,7 +68,7 @@ sources:
     spec:
       url: "{{ .URL }}/{{ .Owner }}/{{ .Repository }}.git"
       password: '{{ .Token }}'
-      key: 'hash'
+      key: 'taghash'
       versionfilter:
         kind: 'regex'
         pattern: '{{ "{{" }} source "tag" {{ "}}" }}'
@@ -99,7 +99,7 @@ sources:
     spec:
       url: "{{ .URL }}/{{ .Owner }}/{{ .Repository }}.git"
       password: '{{ .Token }}'
-      key: 'hash'
+      key: 'taghash'
       versionfilter:
         kind: 'regex'
         pattern: '{{ "{{" }} source "branch" {{ "}}" }}'


### PR DESCRIPTION
Fix e2e tests to remove warning message from the githubaction autodiscovery plugin

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
cd pkg/plugins/autodiscovery/githubaction/
go test .
```

## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via pull request in [website](https://github.com/updatecli/website) repository.

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
