### PR TITLE
chore: cleanup space in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,6 +16,13 @@ jobs:
       DOCKER_CLI_EXPERIMENTAL: "enabled"
       DOCKER_BUILDKIT: 1
     steps:
+      - run: df -h
+      - name: "node-cleanup"
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force
+          sudo docker builder prune -a
+      - run: df -h
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0


### PR DESCRIPTION
For a few releases now, I get issues like 

 | /opt/hostedtoolcache/go/1.24.3/x64/pkg/tool/linux_amd64/link: mapping output file failed: no space left on device 

Runner comes with a lot of things by default which I probably don't need