### PR TITLE
fix(dockerfile): typo in yaml specification

### DIFF
--- a/pkg/plugins/resources/dockerfile/main.go
+++ b/pkg/plugins/resources/dockerfile/main.go
@@ -27,7 +27,7 @@ type Spec struct {
 	// - If not defined, the last stage will be considered
 	// For Condition and Targets:
 	// - If not defined, all stages will be considered
-	Stage string `yaml:"value,omitempty"`
+	Stage string `yaml:"stage,omitempty"`
 }
 
 // Dockerfile defines a resource of kind "dockerfile"


### PR DESCRIPTION
Fix #5136 

The yaml specification had duplicate key, which where breaking the export.

This issue was introduced in https://github.com/updatecli/updatecli/pull/2591 and is in fact a typo.

## Test

To test this pull request, you can run the following commands:

```shell
cd <to_package_directory>
go test
```

## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via pull request in [website](https://github.com/updatecli/website) repository.

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
