### PR TITLE
test(report): switch to testing report Merge instead of FromString

### DIFF
--- a/pkg/core/reports/action_test.go
+++ b/pkg/core/reports/action_test.go
@@ -101,38 +101,36 @@ func TestHTMLUnmarshal(t *testing.T) {
 					},
 				},
 			},
-			report: `<actions>
-	<action id="1234">
-	    <h3>Test Title</h3>
-	    <p></p>
-	    <details id="4567">
-	        <summary>Target One</summary>
-	        <p></p>
-	        <details>
-	            <summary>1.0.0</summary>
-	            <p></p>
-	        </details>
-	        <details>
-	            <summary>1.0.1</summary>
-	            <p></p>
-	        </details>
-	    </details>
-	    <details id="4567">
-	        <summary>Target Two</summary>
-	        <p></p>
-	    </details>
-	</action>
-</actions>`,
+			report: `<Actions>
+    <action id="1234">
+        <h3>Test Title</h3>
+        <details id="4567">
+            <summary>Target One</summary>
+            <details>
+                <summary>1.0.0</summary>
+            </details>
+            <details>
+                <summary>1.0.1</summary>
+            </details>
+        </details>
+        <details id="4567">
+            <summary>Target Two</summary>
+        </details>
+    </action>
+</Actions>`,
 		},
 	}
 
-	for i := range tests {
-		t.Run(tests[i].name, func(t *testing.T) {
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
 			var gotOutput Actions
-			err := unmarshal([]byte(tests[i].report), &gotOutput)
+			err := unmarshal([]byte(tt.report), &gotOutput)
 			require.NoError(t, err)
 
-			assert.Equal(t, tests[i].expectedOutput, gotOutput)
+			assert.Equal(t, tt.expectedOutput, gotOutput)
+
+			// test round trip
+			assert.Equal(t, tt.report, gotOutput.Actions[0].ToActionsString())
 		})
 	}
 }
@@ -247,15 +245,15 @@ func TestSort(t *testing.T) {
 		},
 	}
 
-	for i := range tests {
-		t.Run(tests[i].name, func(t *testing.T) {
-			tests[i].report.sort()
-			assert.Equal(t, tests[i].expectedOutput, tests[i].report)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.report.sort()
+			assert.Equal(t, tt.expectedOutput, tt.report)
 		})
 	}
 }
 
-func TestMerge(t *testing.T) {
+func TestActionMerge(t *testing.T) {
 	tests := []struct {
 		name           string
 		report1        Action

--- a/pkg/core/reports/actions_test.go
+++ b/pkg/core/reports/actions_test.go
@@ -6,6 +6,1371 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestActionsMerge(t *testing.T) {
+	tests := []struct {
+		name                string
+		oldReport           Actions
+		newReport           Actions
+		expectedFinalReport Actions
+	}{
+		{
+			name: "Default none situation",
+			oldReport: Actions{
+				Actions: []Action{
+					{
+						ID:            "1234",
+						PipelineTitle: "Test Title",
+						Targets: []ActionTarget{
+							{
+								ID:    "4567",
+								Title: "Target One",
+								Changelogs: []ActionTargetChangelog{
+									{
+										Title: "1.0.0",
+									},
+									{
+										Title: "1.0.1",
+									},
+								},
+							},
+							{
+								ID:    "4568",
+								Title: "Target Two",
+							},
+							{
+								ID:    "4569",
+								Title: "Target Three",
+							},
+						},
+					},
+				},
+			},
+			newReport: Actions{
+				Actions: []Action{
+					{
+						ID:            "1234",
+						PipelineTitle: "Test Title",
+						Targets: []ActionTarget{
+							{
+								ID:    "4567",
+								Title: "Target One",
+								Changelogs: []ActionTargetChangelog{
+									{
+										Title: "1.0.0",
+									},
+									{
+										Title: "1.0.1",
+									},
+								},
+							},
+							{
+								ID:    "4568",
+								Title: "Target Two",
+							},
+							{
+								ID:    "4569",
+								Title: "Target Three",
+							},
+						},
+					},
+				},
+			},
+			expectedFinalReport: Actions{
+				Actions: []Action{
+					{
+						ID:            "1234",
+						PipelineTitle: "Test Title",
+						Targets: []ActionTarget{
+							{
+								ID:    "4567",
+								Title: "Target One",
+								Changelogs: []ActionTargetChangelog{
+									{
+										Title: "1.0.0",
+									},
+									{
+										Title: "1.0.1",
+									},
+								},
+							},
+							{
+								ID:    "4568",
+								Title: "Target Two",
+							},
+							{
+								ID:    "4569",
+								Title: "Target Three",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Test target merge",
+			oldReport: Actions{
+				Actions: []Action{
+					{
+						ID:            "1234",
+						PipelineTitle: "Test Title",
+						Targets: []ActionTarget{
+							{
+								ID:    "4567",
+								Title: "Target One",
+								Changelogs: []ActionTargetChangelog{
+									{
+										Title: "1.0.0",
+									},
+									{
+										Title: "1.0.1",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			newReport: Actions{
+				Actions: []Action{
+					{
+						ID:            "1234",
+						PipelineTitle: "Test Title",
+						Targets: []ActionTarget{
+							{
+								ID:    "4568",
+								Title: "Target Two",
+							},
+							{
+								ID:    "4569",
+								Title: "Target Three",
+							},
+						},
+					},
+				},
+			},
+			expectedFinalReport: Actions{
+				Actions: []Action{
+					{
+						ID:            "1234",
+						PipelineTitle: "Test Title",
+						Targets: []ActionTarget{
+							{
+								ID:    "4567",
+								Title: "Target One",
+								Changelogs: []ActionTargetChangelog{
+									{
+										Title: "1.0.0",
+									},
+									{
+										Title: "1.0.1",
+									},
+								},
+							},
+							{
+								ID:    "4568",
+								Title: "Target Two",
+							},
+							{
+								ID:    "4569",
+								Title: "Target Three",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Test Pipeline merge",
+			oldReport: Actions{
+				Actions: []Action{
+					{
+						ID:            "1234",
+						PipelineTitle: "Old Pipeline",
+						Targets: []ActionTarget{
+							{
+								ID:    "4567",
+								Title: "Target One",
+								Changelogs: []ActionTargetChangelog{
+									{
+										Title: "1.0.0",
+									},
+									{
+										Title: "1.0.1",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			newReport: Actions{
+				Actions: []Action{
+					{
+						ID:            "1235",
+						PipelineTitle: "New Pipeline",
+						Targets: []ActionTarget{
+							{
+								ID:    "4568",
+								Title: "Target Two",
+							},
+							{
+								ID:    "4569",
+								Title: "Target Three",
+							},
+						},
+					},
+				},
+			},
+			expectedFinalReport: Actions{
+				Actions: []Action{
+					{
+						ID:            "1234",
+						PipelineTitle: "Old Pipeline",
+						Targets: []ActionTarget{
+							{
+								ID:    "4567",
+								Title: "Target One",
+								Changelogs: []ActionTargetChangelog{
+									{
+										Title: "1.0.0",
+									},
+									{
+										Title: "1.0.1",
+									},
+								},
+							},
+						},
+					},
+					{
+						ID:            "1235",
+						PipelineTitle: "New Pipeline",
+						Targets: []ActionTarget{
+							{
+								ID:    "4568",
+								Title: "Target Two",
+							},
+							{
+								ID:    "4569",
+								Title: "Target Three",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Test Pipeline merge scenario 2",
+			oldReport: Actions{
+				Actions: []Action{
+					{
+						ID:            "1234",
+						PipelineTitle: "New Pipeline",
+						Targets: []ActionTarget{
+							{
+								ID:    "4568",
+								Title: "Target Two",
+							},
+							{
+								ID:    "4569",
+								Title: "Target Three",
+							},
+						},
+					},
+				},
+			},
+			newReport: Actions{
+				Actions: []Action{
+					{
+						ID:            "1235",
+						PipelineTitle: "Old Pipeline",
+						Targets: []ActionTarget{
+							{
+								ID:    "4567",
+								Title: "Target One",
+								Changelogs: []ActionTargetChangelog{
+									{
+										Title: "1.0.0",
+									},
+									{
+										Title: "1.0.1",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedFinalReport: Actions{
+				Actions: []Action{
+					{
+						ID:            "1234",
+						PipelineTitle: "New Pipeline",
+						Targets: []ActionTarget{
+							{
+								ID:    "4568",
+								Title: "Target Two",
+							},
+							{
+								ID:    "4569",
+								Title: "Target Three",
+							},
+						},
+					},
+					{
+						ID:            "1235",
+						PipelineTitle: "Old Pipeline",
+						Targets: []ActionTarget{
+							{
+								ID:    "4567",
+								Title: "Target One",
+								Changelogs: []ActionTargetChangelog{
+									{
+										Title: "1.0.0",
+									},
+									{
+										Title: "1.0.1",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Test Pipeline merge scenario 3",
+			oldReport: Actions{
+				Actions: []Action{
+					{
+						ID:            "1234",
+						PipelineTitle: "Old Pipeline 1",
+						Targets: []ActionTarget{
+							{
+								ID:    "4568",
+								Title: "Target Two",
+							},
+							{
+								ID:    "4569",
+								Title: "Target Three",
+							},
+						},
+					},
+					{
+						ID:            "1236",
+						PipelineTitle: "Old Pipeline 2",
+						Targets: []ActionTarget{
+							{
+								ID:    "4568",
+								Title: "Target Two",
+							},
+							{
+								ID:    "4569",
+								Title: "Target Three",
+							},
+						},
+					},
+				},
+			},
+			newReport: Actions{
+				Actions: []Action{
+					{
+						ID:            "1235",
+						PipelineTitle: "New Pipeline",
+						Targets: []ActionTarget{
+							{
+								ID:    "4567",
+								Title: "Target One",
+								Changelogs: []ActionTargetChangelog{
+									{
+										Title: "1.0.0",
+									},
+									{
+										Title: "1.0.1",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedFinalReport: Actions{
+				Actions: []Action{
+					{
+						ID:            "1234",
+						PipelineTitle: "Old Pipeline 1",
+						Targets: []ActionTarget{
+							{
+								ID:    "4568",
+								Title: "Target Two",
+							},
+							{
+								ID:    "4569",
+								Title: "Target Three",
+							},
+						},
+					},
+					{
+						ID:            "1235",
+						PipelineTitle: "New Pipeline",
+						Targets: []ActionTarget{
+							{
+								ID:    "4567",
+								Title: "Target One",
+								Changelogs: []ActionTargetChangelog{
+									{
+										Title: "1.0.0",
+									},
+									{
+										Title: "1.0.1",
+									},
+								},
+							},
+						},
+					},
+					{
+						ID:            "1236",
+						PipelineTitle: "Old Pipeline 2",
+						Targets: []ActionTarget{
+							{
+								ID:    "4568",
+								Title: "Target Two",
+							},
+							{
+								ID:    "4569",
+								Title: "Target Three",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:      "No merge needed",
+			oldReport: Actions{},
+			newReport: Actions{
+				Actions: []Action{
+					{
+						ID:            "1235",
+						PipelineTitle: "New Pipeline",
+						Targets: []ActionTarget{
+							{
+								ID:    "4567",
+								Title: "Target One",
+								Changelogs: []ActionTargetChangelog{
+									{
+										Title: "1.0.0",
+									},
+									{
+										Title: "1.0.1",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedFinalReport: Actions{
+				Actions: []Action{
+					{
+						ID:            "1235",
+						PipelineTitle: "New Pipeline",
+						Targets: []ActionTarget{
+							{
+								ID:    "4567",
+								Title: "Target One",
+								Changelogs: []ActionTargetChangelog{
+									{
+										Title: "1.0.0",
+									},
+									{
+										Title: "1.0.1",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Update target title numbers match",
+			oldReport: Actions{
+				Actions: []Action{
+					{
+						ID:            "1234",
+						PipelineTitle: "Test Title",
+						Targets: []ActionTarget{
+							{
+								ID:    "4567",
+								Title: "Target One",
+							},
+							{
+								ID:    "4568",
+								Title: "Target Two",
+							},
+							{
+								ID:    "4569",
+								Title: "Target Three",
+							},
+						},
+					},
+				},
+			},
+			newReport: Actions{
+				Actions: []Action{
+					{
+						ID:            "1234",
+						PipelineTitle: "Test Title",
+						Targets: []ActionTarget{
+							{
+								ID:    "4567",
+								Title: "New Target One",
+							},
+							{
+								ID:    "4568",
+								Title: "Target Two",
+							},
+							{
+								ID:    "4569",
+								Title: "Target Three",
+							},
+						},
+					},
+				},
+			},
+			expectedFinalReport: Actions{
+				Actions: []Action{
+					{
+						ID:            "1234",
+						PipelineTitle: "Test Title",
+						Targets: []ActionTarget{
+							{
+								ID:    "4567",
+								Title: "New Target One",
+							},
+							{
+								ID:    "4568",
+								Title: "Target Two",
+							},
+							{
+								ID:    "4569",
+								Title: "Target Three",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Update pipeline title with new report having more targets",
+			oldReport: Actions{
+				Actions: []Action{
+					{
+						ID:            "1234",
+						PipelineTitle: "Test Title",
+						Targets: []ActionTarget{
+							{
+								ID:    "4567",
+								Title: "Target One",
+							},
+						},
+					},
+				},
+			},
+			newReport: Actions{
+				Actions: []Action{
+					{
+						ID:            "1234",
+						PipelineTitle: "Test Title",
+						Targets: []ActionTarget{
+							{
+								ID:    "4567",
+								Title: "New Target One",
+							},
+							{
+								ID:    "4568",
+								Title: "Target Two",
+							},
+							{
+								ID:    "4569",
+								Title: "Target Three",
+							},
+						},
+					},
+				},
+			},
+			expectedFinalReport: Actions{
+				Actions: []Action{
+					{
+						ID:            "1234",
+						PipelineTitle: "Test Title",
+						Targets: []ActionTarget{
+							{
+								ID:    "4567",
+								Title: "New Target One",
+							},
+							{
+								ID:    "4568",
+								Title: "Target Two",
+							},
+							{
+								ID:    "4569",
+								Title: "Target Three",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Update pipeline title with old report having more targets",
+			oldReport: Actions{
+				Actions: []Action{
+					{
+						ID:            "1234",
+						PipelineTitle: "Test Title",
+						Targets: []ActionTarget{
+							{
+								ID:    "4567",
+								Title: "Target One",
+							},
+							{
+								ID:    "4568",
+								Title: "Target Two",
+							},
+							{
+								ID:    "4569",
+								Title: "Target Three",
+							},
+						},
+					},
+				},
+			},
+			newReport: Actions{
+				Actions: []Action{
+					{
+						ID:            "1234",
+						PipelineTitle: "Test Title",
+						Targets: []ActionTarget{
+							{
+								ID:    "4569",
+								Title: "New Target Three",
+							},
+						},
+					},
+				},
+			},
+			expectedFinalReport: Actions{
+				Actions: []Action{
+					{
+						ID:            "1234",
+						PipelineTitle: "Test Title",
+						Targets: []ActionTarget{
+							{
+								ID:    "4567",
+								Title: "Target One",
+							},
+							{
+								ID:    "4568",
+								Title: "Target Two",
+							},
+							{
+								ID:    "4569",
+								Title: "New Target Three",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Update target title numbers match and old report having more pipelines",
+			oldReport: Actions{
+				Actions: []Action{
+					{
+						ID:            "1234",
+						PipelineTitle: "Test Title",
+						Targets: []ActionTarget{
+							{
+								ID:    "4567",
+								Title: "Target One",
+							},
+							{
+								ID:    "4568",
+								Title: "Target Two",
+							},
+							{
+								ID:    "4569",
+								Title: "Target Three",
+							},
+						},
+					},
+					{
+						ID:            "1235",
+						PipelineTitle: "Other Title",
+					},
+				},
+			},
+			newReport: Actions{
+				Actions: []Action{
+					{
+						ID:            "1234",
+						PipelineTitle: "Test Title",
+						Targets: []ActionTarget{
+							{
+								ID:    "4567",
+								Title: "New Target One",
+							},
+							{
+								ID:    "4568",
+								Title: "Target Two",
+							},
+							{
+								ID:    "4569",
+								Title: "Target Three",
+							},
+						},
+					},
+				},
+			},
+			expectedFinalReport: Actions{
+				Actions: []Action{
+					{
+						ID:            "1234",
+						PipelineTitle: "Test Title",
+						Targets: []ActionTarget{
+							{
+								ID:    "4567",
+								Title: "New Target One",
+							},
+							{
+								ID:    "4568",
+								Title: "Target Two",
+							},
+							{
+								ID:    "4569",
+								Title: "Target Three",
+							},
+						},
+					},
+					{
+						ID:            "1235",
+						PipelineTitle: "Other Title",
+					},
+				},
+			},
+		},
+		{
+			name: "Update pipeline title with new report having more targets and old report having more pipelines",
+			oldReport: Actions{
+				Actions: []Action{
+					{
+						ID:            "1234",
+						PipelineTitle: "Test Title",
+						Targets: []ActionTarget{
+							{
+								ID:    "4567",
+								Title: "Target One",
+							},
+						},
+					},
+					{
+						ID:            "1235",
+						PipelineTitle: "Other Title",
+					},
+				},
+			},
+			newReport: Actions{
+				Actions: []Action{
+					{
+						ID:            "1234",
+						PipelineTitle: "Test Title",
+						Targets: []ActionTarget{
+							{
+								ID:    "4567",
+								Title: "New Target One",
+							},
+							{
+								ID:    "4568",
+								Title: "Target Two",
+							},
+							{
+								ID:    "4569",
+								Title: "Target Three",
+							},
+						},
+					},
+				},
+			},
+			expectedFinalReport: Actions{
+				Actions: []Action{
+					{
+						ID:            "1234",
+						PipelineTitle: "Test Title",
+						Targets: []ActionTarget{
+							{
+								ID:    "4567",
+								Title: "New Target One",
+							},
+							{
+								ID:    "4568",
+								Title: "Target Two",
+							},
+							{
+								ID:    "4569",
+								Title: "Target Three",
+							},
+						},
+					},
+					{
+						ID:            "1235",
+						PipelineTitle: "Other Title",
+					},
+				},
+			},
+		},
+		{
+			name: "Update pipeline title with old report having more targets and old report having more pipelines",
+			oldReport: Actions{
+				Actions: []Action{
+					{
+						ID:            "1234",
+						PipelineTitle: "Test Title",
+						Targets: []ActionTarget{
+							{
+								ID:    "4567",
+								Title: "Target One",
+							},
+							{
+								ID:    "4568",
+								Title: "Target Two",
+							},
+							{
+								ID:    "4569",
+								Title: "Target Three",
+							},
+						},
+					},
+					{
+						ID:            "1235",
+						PipelineTitle: "Other Title",
+					},
+				},
+			},
+			newReport: Actions{
+				Actions: []Action{
+					{
+						ID:            "1234",
+						PipelineTitle: "Test Title",
+						Targets: []ActionTarget{
+							{
+								ID:    "4569",
+								Title: "New Target Three",
+							},
+						},
+					},
+				},
+			},
+			expectedFinalReport: Actions{
+				Actions: []Action{
+					{
+						ID:            "1234",
+						PipelineTitle: "Test Title",
+						Targets: []ActionTarget{
+							{
+								ID:    "4567",
+								Title: "Target One",
+							},
+							{
+								ID:    "4568",
+								Title: "Target Two",
+							},
+							{
+								ID:    "4569",
+								Title: "New Target Three",
+							},
+						},
+					},
+					{
+						ID:            "1235",
+						PipelineTitle: "Other Title",
+					},
+				},
+			},
+		},
+		{
+			name: "Update target title numbers match and new report having more pipelines",
+			oldReport: Actions{
+				Actions: []Action{
+					{
+						ID:            "1234",
+						PipelineTitle: "Test Title",
+						Targets: []ActionTarget{
+							{
+								ID:    "4567",
+								Title: "Target One",
+							},
+							{
+								ID:    "4568",
+								Title: "Target Two",
+							},
+							{
+								ID:    "4569",
+								Title: "Target Three",
+							},
+						},
+					},
+				},
+			},
+			newReport: Actions{
+				Actions: []Action{
+					{
+						ID:            "1234",
+						PipelineTitle: "Test Title",
+						Targets: []ActionTarget{
+							{
+								ID:    "4567",
+								Title: "New Target One",
+							},
+							{
+								ID:    "4568",
+								Title: "Target Two",
+							},
+							{
+								ID:    "4569",
+								Title: "Target Three",
+							},
+						},
+					},
+					{
+						ID:            "1235",
+						PipelineTitle: "Other Title",
+					},
+				},
+			},
+			expectedFinalReport: Actions{
+				Actions: []Action{
+					{
+						ID:            "1234",
+						PipelineTitle: "Test Title",
+						Targets: []ActionTarget{
+							{
+								ID:    "4567",
+								Title: "New Target One",
+							},
+							{
+								ID:    "4568",
+								Title: "Target Two",
+							},
+							{
+								ID:    "4569",
+								Title: "Target Three",
+							},
+						},
+					},
+					{
+						ID:            "1235",
+						PipelineTitle: "Other Title",
+					},
+				},
+			},
+		},
+		{
+			name: "Update pipeline title with new report having more targets and new report having more pipelines",
+			oldReport: Actions{
+				Actions: []Action{
+					{
+						ID:            "1234",
+						PipelineTitle: "Test Title",
+						Targets: []ActionTarget{
+							{
+								ID:    "4567",
+								Title: "Target One",
+							},
+						},
+					},
+				},
+			},
+			newReport: Actions{
+				Actions: []Action{
+					{
+						ID:            "1234",
+						PipelineTitle: "Test Title",
+						Targets: []ActionTarget{
+							{
+								ID:    "4567",
+								Title: "New Target One",
+							},
+							{
+								ID:    "4568",
+								Title: "Target Two",
+							},
+							{
+								ID:    "4569",
+								Title: "Target Three",
+							},
+						},
+					},
+					{
+						ID:            "1235",
+						PipelineTitle: "Other Title",
+					},
+				},
+			},
+			expectedFinalReport: Actions{
+				Actions: []Action{
+					{
+						ID:            "1234",
+						PipelineTitle: "Test Title",
+						Targets: []ActionTarget{
+							{
+								ID:    "4567",
+								Title: "New Target One",
+							},
+							{
+								ID:    "4568",
+								Title: "Target Two",
+							},
+							{
+								ID:    "4569",
+								Title: "Target Three",
+							},
+						},
+					},
+					{
+						ID:            "1235",
+						PipelineTitle: "Other Title",
+					},
+				},
+			},
+		},
+		{
+			name: "Update pipeline title with old report having more targets and new report having more pipelines",
+			oldReport: Actions{
+				Actions: []Action{
+					{
+						ID:            "1234",
+						PipelineTitle: "Test Title",
+						Targets: []ActionTarget{
+							{
+								ID:    "4567",
+								Title: "Target One",
+							},
+							{
+								ID:    "4568",
+								Title: "Target Two",
+							},
+							{
+								ID:    "4569",
+								Title: "Target Three",
+							},
+						},
+					},
+				},
+			},
+			newReport: Actions{
+				Actions: []Action{
+					{
+						ID:            "1234",
+						PipelineTitle: "Test Title",
+						Targets: []ActionTarget{
+							{
+								ID:    "4569",
+								Title: "New Target Three",
+							},
+						},
+					},
+					{
+						ID:            "1235",
+						PipelineTitle: "Other Title",
+					},
+				},
+			},
+			expectedFinalReport: Actions{
+				Actions: []Action{
+					{
+						ID:            "1234",
+						PipelineTitle: "Test Title",
+						Targets: []ActionTarget{
+							{
+								ID:    "4567",
+								Title: "Target One",
+							},
+							{
+								ID:    "4568",
+								Title: "Target Two",
+							},
+							{
+								ID:    "4569",
+								Title: "New Target Three",
+							},
+						},
+					},
+					{
+						ID:            "1235",
+						PipelineTitle: "Other Title",
+					},
+				},
+			},
+		},
+		{
+			name: "Update pipeline title with old report having same number actions",
+			oldReport: Actions{
+				Actions: []Action{
+					{
+						ID:            "1234",
+						PipelineTitle: "Test Title",
+					},
+				},
+			},
+			newReport: Actions{
+				Actions: []Action{
+					{
+						ID:            "1234",
+						PipelineTitle: "New Title",
+					},
+				},
+			},
+			expectedFinalReport: Actions{
+				Actions: []Action{
+					{
+						ID:            "1234",
+						PipelineTitle: "New Title",
+					},
+				},
+			},
+		},
+		{
+			name: "Update pipeline title with old report having more actions",
+			oldReport: Actions{
+				Actions: []Action{
+					{
+						ID:            "1234",
+						PipelineTitle: "Test Title",
+					},
+					{
+						ID:            "1235",
+						PipelineTitle: "Old Title",
+					},
+				},
+			},
+			newReport: Actions{
+				Actions: []Action{
+					{
+						ID:            "1234",
+						PipelineTitle: "New Title",
+					},
+				},
+			},
+			expectedFinalReport: Actions{
+				Actions: []Action{
+					{
+						ID:            "1234",
+						PipelineTitle: "New Title",
+					},
+					{
+						ID:            "1235",
+						PipelineTitle: "Old Title",
+					},
+				},
+			},
+		},
+		{
+			name: "Update pipeline title with new report having more actions",
+			oldReport: Actions{
+				Actions: []Action{
+					{
+						ID:            "1234",
+						PipelineTitle: "Test Title",
+					},
+				},
+			},
+			newReport: Actions{
+				Actions: []Action{
+					{
+						ID:            "1234",
+						PipelineTitle: "New Title",
+					},
+					{
+						ID:            "1235",
+						PipelineTitle: "Other Title",
+					},
+				},
+			},
+			expectedFinalReport: Actions{
+				Actions: []Action{
+					{
+						ID:            "1234",
+						PipelineTitle: "New Title",
+					},
+					{
+						ID:            "1235",
+						PipelineTitle: "Other Title",
+					},
+				},
+			},
+		},
+		{
+			name: "Test changelog merge with old report having more items",
+			oldReport: Actions{
+				Actions: []Action{
+					{
+						ID:            "1234",
+						PipelineTitle: "Test Title",
+						Targets: []ActionTarget{
+							{
+								ID:    "4567",
+								Title: "Target One",
+								Changelogs: []ActionTargetChangelog{
+									{
+										Title: "1.0.0",
+									},
+									{
+										Title: "1.0.1",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			newReport: Actions{
+				Actions: []Action{
+					{
+						ID:            "1234",
+						PipelineTitle: "Test Title",
+						Targets: []ActionTarget{
+							{
+								ID:    "4567",
+								Title: "Target One",
+								Changelogs: []ActionTargetChangelog{
+									{
+										Title: "1.0.2",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedFinalReport: Actions{
+				Actions: []Action{
+					{
+						ID:            "1234",
+						PipelineTitle: "Test Title",
+						Targets: []ActionTarget{
+							{
+								ID:    "4567",
+								Title: "Target One",
+								Changelogs: []ActionTargetChangelog{
+									{
+										Title: "1.0.0",
+									},
+									{
+										Title: "1.0.1",
+									},
+									{
+										Title: "1.0.2",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+
+		{
+			name: "Test changelog merge with new report having more items",
+			oldReport: Actions{
+				Actions: []Action{
+					{
+						ID:            "1234",
+						PipelineTitle: "Test Title",
+						Targets: []ActionTarget{
+							{
+								ID:    "4567",
+								Title: "Target One",
+								Changelogs: []ActionTargetChangelog{
+									{
+										Title: "1.0.0",
+									},
+									{
+										Title: "1.0.1",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			newReport: Actions{
+				Actions: []Action{
+					{
+						ID:            "1234",
+						PipelineTitle: "Test Title",
+						Targets: []ActionTarget{
+							{
+								ID:    "4567",
+								Title: "Target One",
+								Changelogs: []ActionTargetChangelog{
+									{
+										Title: "1.0.2",
+									},
+									{
+										Title: "1.0.3",
+									},
+									{
+										Title: "1.0.4",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedFinalReport: Actions{
+				Actions: []Action{
+					{
+						ID:            "1234",
+						PipelineTitle: "Test Title",
+						Targets: []ActionTarget{
+							{
+								ID:    "4567",
+								Title: "Target One",
+								Changelogs: []ActionTargetChangelog{
+									{
+										Title: "1.0.0",
+									},
+									{
+										Title: "1.0.1",
+									},
+									{
+										Title: "1.0.2",
+									},
+									{
+										Title: "1.0.3",
+									},
+									{
+										Title: "1.0.4",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.newReport.Merge(&tt.oldReport)
+			tt.newReport.sort()
+			assert.Equal(t, tt.expectedFinalReport, tt.newReport)
+		})
+	}
+}
+
 func TestFromString(t *testing.T) {
 	tests := []struct {
 		name                string
@@ -224,126 +1589,6 @@ This is not a html formatted report
 </Actions>`,
 		},
 		{
-			name: "Test Pipeline merge scenario 2",
-			newReport: `<actions>
-    <action id="1235">
-        <h3>Old Pipeline</h3>
-        <details id="4567">
-            <summary>Target One</summary>
-            <details>
-                <summary>1.0.0</summary>
-            </details>
-            <details>
-                <summary>1.0.1</summary>
-            </details>
-        </details>
-    </action>
-</actions>`,
-			oldReport: `<actions>
-    <action id="1234">
-        <h3>New Pipeline</h3>
-        <details id="4568">
-            <summary>Target Two</summary>
-        </details>
-        <details id="4569">
-            <summary>Target Three</summary>
-        </details>
-    </action>
-</actions>`,
-			expectedFinalReport: `<Actions>
-    <action id="1234">
-        <h3>New Pipeline</h3>
-        <details id="4568">
-            <summary>Target Two</summary>
-        </details>
-        <details id="4569">
-            <summary>Target Three</summary>
-        </details>
-    </action>
-    <action id="1235">
-        <h3>Old Pipeline</h3>
-        <details id="4567">
-            <summary>Target One</summary>
-            <details>
-                <summary>1.0.0</summary>
-            </details>
-            <details>
-                <summary>1.0.1</summary>
-            </details>
-        </details>
-    </action>
-</Actions>`,
-		},
-		{
-			name: "Test Pipeline merge scenario 3",
-			newReport: `<Actions>
-    <action id="1235">
-        <h3>New Pipeline</h3>
-        <details id="4567">
-            <summary>Target One</summary>
-            <details>
-                <summary>1.0.0</summary>
-            </details>
-            <details>
-                <summary>1.0.1</summary>
-            </details>
-        </details>
-    </action>
-</Actions>`,
-			oldReport: `<actions>
-    <action id="1234">
-        <h3>Old Pipeline 1</h3>
-        <details id="4568">
-            <summary>Target Two</summary>
-        </details>
-        <details id="4569">
-            <summary>Target Three</summary>
-        </details>
-    </action>
-    <action id="1236">
-        <h3>Old Pipeline 2</h3>
-        <details id="4568">
-            <summary>Target Two</summary>
-        </details>
-        <details id="4569">
-            <summary>Target Three</summary>
-        </details>
-    </action>
-</actions>`,
-			expectedFinalReport: `<Actions>
-    <action id="1234">
-        <h3>Old Pipeline 1</h3>
-        <details id="4568">
-            <summary>Target Two</summary>
-        </details>
-        <details id="4569">
-            <summary>Target Three</summary>
-        </details>
-    </action>
-    <action id="1235">
-        <h3>New Pipeline</h3>
-        <details id="4567">
-            <summary>Target One</summary>
-            <details>
-                <summary>1.0.0</summary>
-            </details>
-            <details>
-                <summary>1.0.1</summary>
-            </details>
-        </details>
-    </action>
-    <action id="1236">
-        <h3>Old Pipeline 2</h3>
-        <details id="4568">
-            <summary>Target Two</summary>
-        </details>
-        <details id="4569">
-            <summary>Target Three</summary>
-        </details>
-    </action>
-</Actions>`,
-		},
-		{
 			name: "No merge needed",
 			newReport: `<Actions>
     <action id="1235">
@@ -375,486 +1620,12 @@ This is not a html formatted report
     </action>
 </Actions>`,
 		},
-		{
-			name: "Update target title numbers match",
-			oldReport: `<Actions>
-    <action id="1234">
-        <h3>Test Title</h3>
-        <details id="4567">
-            <summary>Target One</summary>
-        </details>
-        <details id="4568">
-            <summary>Target Two</summary>
-        </details>
-        <details id="4569">
-            <summary>Target Three</summary>
-        </details>
-    </action>
-</Actions>`,
-			newReport: `<Actions>
-    <action id="1234">
-        <h3>Test Title</h3>
-        <p></p>
-        <details id="4567">
-            <summary>New Target One</summary>
-        </details>
-        <details id="4568">
-            <summary>Target Two</summary>
-        </details>
-        <details id="4569">
-            <summary>Target Three</summary>
-        </details>
-    </action>
-</Actions>`,
-			expectedFinalReport: `<Actions>
-    <action id="1234">
-        <h3>Test Title</h3>
-        <details id="4567">
-            <summary>New Target One</summary>
-        </details>
-        <details id="4568">
-            <summary>Target Two</summary>
-        </details>
-        <details id="4569">
-            <summary>Target Three</summary>
-        </details>
-    </action>
-</Actions>`,
-		},
-		{
-			name: "Update pipeline title with new report having more targets",
-			oldReport: `<Actions>
-    <action id="1234">
-        <h3>Test Title</h3>
-        <details id="4567">
-            <summary>Target One</summary>
-        </details>
-    </action>
-</Actions>`,
-			newReport: `<actions>
-    <action id="1234">
-        <h3>Test Title</h3>
-        <details id="4567">
-            <summary>New Target One</summary>
-        </details>
-        <details id="4568">
-            <summary>Target Two</summary>
-        </details>
-        <details id="4569">
-            <summary>Target Three</summary>
-        </details>
-    </action>
-</actions>`,
-			expectedFinalReport: `<Actions>
-    <action id="1234">
-        <h3>Test Title</h3>
-        <details id="4567">
-            <summary>New Target One</summary>
-        </details>
-        <details id="4568">
-            <summary>Target Two</summary>
-        </details>
-        <details id="4569">
-            <summary>Target Three</summary>
-        </details>
-    </action>
-</Actions>`,
-		},
-		{
-			name: "Update pipeline title with old report having more targets",
-			oldReport: `<Actions>
-    <action id="1234">
-        <h3>Test Title</h3>
-        <details id="4567">
-            <summary>Target One</summary>
-        </details>
-        <details id="4568">
-            <summary>Target Two</summary>
-        </details>
-        <details id="4569">
-            <summary>Target Three</summary>
-        </details>
-    </action>
-</Actions>`,
-			newReport: `<actions>
-    <action id="1234">
-        <h3>Test Title</h3>
-        <details id="4569">
-            <summary>New Target Three</summary>
-        </details>
-    </action>
-</actions>`,
-			expectedFinalReport: `<Actions>
-    <action id="1234">
-        <h3>Test Title</h3>
-        <details id="4567">
-            <summary>Target One</summary>
-        </details>
-        <details id="4568">
-            <summary>Target Two</summary>
-        </details>
-        <details id="4569">
-            <summary>New Target Three</summary>
-        </details>
-    </action>
-</Actions>`,
-		},
-		{
-			name: "Update target title numbers match and old report having more pipelines",
-			oldReport: `<Actions>
-    <action id="1234">
-        <h3>Test Title</h3>
-        <details id="4567">
-            <summary>Target One</summary>
-        </details>
-        <details id="4568">
-            <summary>Target Two</summary>
-        </details>
-        <details id="4569">
-            <summary>Target Three</summary>
-        </details>
-    </action>
-    <action id="1235">
-        <h3>Other Title</h3>
-    </action>
-</Actions>`,
-			newReport: `<Actions>
-    <action id="1234">
-        <h3>Test Title</h3>
-        <p></p>
-        <details id="4567">
-            <summary>New Target One</summary>
-        </details>
-        <details id="4568">
-            <summary>Target Two</summary>
-        </details>
-        <details id="4569">
-            <summary>Target Three</summary>
-        </details>
-    </action>
-</Actions>`,
-			expectedFinalReport: `<Actions>
-    <action id="1234">
-        <h3>Test Title</h3>
-        <details id="4567">
-            <summary>New Target One</summary>
-        </details>
-        <details id="4568">
-            <summary>Target Two</summary>
-        </details>
-        <details id="4569">
-            <summary>Target Three</summary>
-        </details>
-    </action>
-    <action id="1235">
-        <h3>Other Title</h3>
-    </action>
-</Actions>`,
-		},
-		{
-			name: "Update pipeline title with new report having more targets and old report having more pipelines",
-			oldReport: `<Actions>
-    <action id="1234">
-        <h3>Test Title</h3>
-        <details id="4567">
-            <summary>Target One</summary>
-        </details>
-    </action>
-    <action id="1235">
-        <h3>Other Title</h3>
-    </action>
-</Actions>`,
-			newReport: `<actions>
-    <action id="1234">
-        <h3>Test Title</h3>
-        <details id="4567">
-            <summary>New Target One</summary>
-        </details>
-        <details id="4568">
-            <summary>Target Two</summary>
-        </details>
-        <details id="4569">
-            <summary>Target Three</summary>
-        </details>
-    </action>
-</actions>`,
-			expectedFinalReport: `<Actions>
-    <action id="1234">
-        <h3>Test Title</h3>
-        <details id="4567">
-            <summary>New Target One</summary>
-        </details>
-        <details id="4568">
-            <summary>Target Two</summary>
-        </details>
-        <details id="4569">
-            <summary>Target Three</summary>
-        </details>
-    </action>
-    <action id="1235">
-        <h3>Other Title</h3>
-    </action>
-</Actions>`,
-		},
-		{
-			name: "Update pipeline title with old report having more targets and old report having more pipelines",
-			oldReport: `<Actions>
-    <action id="1234">
-        <h3>Test Title</h3>
-        <details id="4567">
-            <summary>Target One</summary>
-        </details>
-        <details id="4568">
-            <summary>Target Two</summary>
-        </details>
-        <details id="4569">
-            <summary>Target Three</summary>
-        </details>
-    </action>
-    <action id="1235">
-        <h3>Other Title</h3>
-    </action>
-</Actions>`,
-			newReport: `<actions>
-    <action id="1234">
-        <h3>Test Title</h3>
-        <details id="4569">
-            <summary>New Target Three</summary>
-        </details>
-    </action>
-</actions>`,
-			expectedFinalReport: `<Actions>
-    <action id="1234">
-        <h3>Test Title</h3>
-        <details id="4567">
-            <summary>Target One</summary>
-        </details>
-        <details id="4568">
-            <summary>Target Two</summary>
-        </details>
-        <details id="4569">
-            <summary>New Target Three</summary>
-        </details>
-    </action>
-    <action id="1235">
-        <h3>Other Title</h3>
-    </action>
-</Actions>`,
-		},
-		{
-			name: "Update target title numbers match and new report having more pipelines",
-			oldReport: `<Actions>
-    <action id="1234">
-        <h3>Test Title</h3>
-        <details id="4567">
-            <summary>Target One</summary>
-        </details>
-        <details id="4568">
-            <summary>Target Two</summary>
-        </details>
-        <details id="4569">
-            <summary>Target Three</summary>
-        </details>
-    </action>
-</Actions>`,
-			newReport: `<Actions>
-    <action id="1234">
-        <h3>Test Title</h3>
-        <p></p>
-        <details id="4567">
-            <summary>New Target One</summary>
-        </details>
-        <details id="4568">
-            <summary>Target Two</summary>
-        </details>
-        <details id="4569">
-            <summary>Target Three</summary>
-        </details>
-    </action>
-    <action id="1235">
-        <h3>Other Title</h3>
-    </action>
-</Actions>`,
-			expectedFinalReport: `<Actions>
-    <action id="1234">
-        <h3>Test Title</h3>
-        <details id="4567">
-            <summary>New Target One</summary>
-        </details>
-        <details id="4568">
-            <summary>Target Two</summary>
-        </details>
-        <details id="4569">
-            <summary>Target Three</summary>
-        </details>
-    </action>
-    <action id="1235">
-        <h3>Other Title</h3>
-    </action>
-</Actions>`,
-		},
-		{
-			name: "Update pipeline title with new report having more targets and new report having more pipelines",
-			oldReport: `<Actions>
-    <action id="1234">
-        <h3>Test Title</h3>
-        <details id="4567">
-            <summary>Target One</summary>
-        </details>
-    </action>
-</Actions>`,
-			newReport: `<actions>
-    <action id="1234">
-        <h3>Test Title</h3>
-        <details id="4567">
-            <summary>New Target One</summary>
-        </details>
-        <details id="4568">
-            <summary>Target Two</summary>
-        </details>
-        <details id="4569">
-            <summary>Target Three</summary>
-        </details>
-    </action>
-    <action id="1235">
-        <h3>Other Title</h3>
-    </action>
-</actions>`,
-			expectedFinalReport: `<Actions>
-    <action id="1234">
-        <h3>Test Title</h3>
-        <details id="4567">
-            <summary>New Target One</summary>
-        </details>
-        <details id="4568">
-            <summary>Target Two</summary>
-        </details>
-        <details id="4569">
-            <summary>Target Three</summary>
-        </details>
-    </action>
-    <action id="1235">
-        <h3>Other Title</h3>
-    </action>
-</Actions>`,
-		},
-		{
-			name: "Update pipeline title with old report having more targets and new report having more pipelines",
-			oldReport: `<Actions>
-    <action id="1234">
-        <h3>Test Title</h3>
-        <details id="4567">
-            <summary>Target One</summary>
-        </details>
-        <details id="4568">
-            <summary>Target Two</summary>
-        </details>
-        <details id="4569">
-            <summary>Target Three</summary>
-        </details>
-    </action>
-</Actions>`,
-			newReport: `<actions>
-    <action id="1234">
-        <h3>Test Title</h3>
-        <details id="4569">
-            <summary>New Target Three</summary>
-        </details>
-    </action>
-    <action id="1235">
-        <h3>Other Title</h3>
-    </action>
-</actions>`,
-			expectedFinalReport: `<Actions>
-    <action id="1234">
-        <h3>Test Title</h3>
-        <details id="4567">
-            <summary>Target One</summary>
-        </details>
-        <details id="4568">
-            <summary>Target Two</summary>
-        </details>
-        <details id="4569">
-            <summary>New Target Three</summary>
-        </details>
-    </action>
-    <action id="1235">
-        <h3>Other Title</h3>
-    </action>
-</Actions>`,
-		},
-		{
-			name: "Update pipeline title with old report having same number actions",
-			oldReport: `<Actions>
-    <action id="1234">
-        <h3>Test Title</h3>
-    </action>
-</Actions>`,
-			newReport: `<actions>
-    <action id="1234">
-        <h3>New Title</h3>
-    </action>
-</actions>`,
-			expectedFinalReport: `<Actions>
-    <action id="1234">
-        <h3>New Title</h3>
-    </action>
-</Actions>`,
-		},
-		{
-			name: "Update pipeline title with old report having more actions",
-			oldReport: `<Actions>
-    <action id="1234">
-        <h3>Test Title</h3>
-    </action>
-    <action id="1235">
-        <h3>Old Title</h3>
-    </action>
-</Actions>`,
-			newReport: `<actions>
-    <action id="1234">
-        <h3>New Title</h3>
-    </action>
-</actions>`,
-			expectedFinalReport: `<Actions>
-    <action id="1234">
-        <h3>New Title</h3>
-    </action>
-    <action id="1235">
-        <h3>Old Title</h3>
-    </action>
-</Actions>`,
-		},
-		{
-			name: "Update pipeline title with new report having more actions",
-			oldReport: `<Actions>
-    <action id="1234">
-        <h3>Test Title</h3>
-    </action>
-</Actions>`,
-			newReport: `<actions>
-    <action id="1234">
-        <h3>New Title</h3>
-    </action>
-    <action id="1235">
-        <h3>Other Title</h3>
-    </action>
-</actions>`,
-			expectedFinalReport: `<Actions>
-    <action id="1234">
-        <h3>New Title</h3>
-    </action>
-    <action id="1235">
-        <h3>Other Title</h3>
-    </action>
-</Actions>`,
-		},
 	}
 
-	for i := range tests {
-		t.Run(tests[i].name, func(t *testing.T) {
-			gotFinalReport := MergeFromString(tests[i].oldReport, tests[i].newReport)
-			assert.Equal(t, tests[i].expectedFinalReport, gotFinalReport)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotFinalReport := MergeFromString(tt.oldReport, tt.newReport)
+			assert.Equal(t, tt.expectedFinalReport, gotFinalReport)
 		})
 	}
 }


### PR DESCRIPTION
When working on #5189 I found it difficult to update the tests as it relied on the correct string indentation.

Using https://github.com/sanity-io/litter to get the objects out of the existing tests, I've converted all the `FromString` tests to `.Merge` tests. This made it easier to update tests.

Also checked coverage and added a new Changelog scenarios where the new and old report have more items respectively. 

Also added a test for `ToActionsString` as a part of existing test ensuring the object round trips.

## Test

To test this pull request, you can run the following commands:

```shell
cd pkg/core/reports
go test
```

## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via pull request in [website](https://github.com/updatecli/website) repository.

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
