### PR TITLE
fix: remove duplicate generate schema

### DIFF
--- a/pkg/core/engine/schema.go
+++ b/pkg/core/engine/schema.go
@@ -57,10 +57,6 @@ func GenerateSchema(baseSchemaID, schemaDir string) error {
 		return nil
 	}
 
-	if err = generateSchema(baseSchemaID, schemaDir, "", config.Spec{}); err != nil {
-		return fmt.Errorf("unable to generate schema - %s", err)
-	}
-
 	if err = generateSchema(baseSchemaID, schemaDir, "policy/manifest", config.Spec{}); err != nil {
 		return fmt.Errorf("unable to generate schema - %s", err)
 	}


### PR DESCRIPTION
remove duplicate `s.GenerateSchema(spec)`

## Test

To test this pull request, you can run the following commands:

```shell
go build
.\updatecli.exe jsonschema
```

## Question

Should I remove one of them?

I checked https://www.schemastore.org/json/, and only `policy/manifest` exists.


```go
        if err = generateSchema(baseSchemaID, schemaDir, "", config.Spec{}); err != nil {
		return fmt.Errorf("unable to generate schema - %s", err)
	}
	if err = generateSchema(baseSchemaID, schemaDir, "policy/manifest", config.Spec{}); err != nil {
		return fmt.Errorf("unable to generate schema - %s", err)
	}
```