### PR TITLE
fix(reports): update target description to output correctly in markdown

### DIFF
--- a/pkg/core/reports/action.go
+++ b/pkg/core/reports/action.go
@@ -5,6 +5,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"sort"
+	"strings"
 	"text/template"
 
 	"github.com/sirupsen/logrus"
@@ -110,8 +111,17 @@ func (a *Action) sort() {
 	}
 }
 
+// updateTargetDescriptions updates descriptions from being console friendly to markdown friendly
+func (a *Action) updateTargetDescriptions() {
+	for id, target := range a.Targets {
+		a.Targets[id].Description = strings.ReplaceAll(target.Description, "\n\t*", "\n\n*")
+	}
+}
+
 // ToActionsString show an action report formatted as a string
 func (a Action) ToActionsString() string {
+	a.updateTargetDescriptions()
+
 	output, err := xml.MarshalIndent(
 		Actions{
 			Actions: []Action{
@@ -127,6 +137,8 @@ func (a Action) ToActionsString() string {
 
 // ToActionsMarkdownString show an action report formatted as a string using markdown
 func (a Action) ToActionsMarkdownString() string {
+	a.updateTargetDescriptions()
+
 	tmpl, err := template.New("actions").Parse(markdownReportTemplate)
 	if err != nil {
 		logrus.Errorf("error: %v\n", err)

--- a/pkg/core/reports/action_test.go
+++ b/pkg/core/reports/action_test.go
@@ -403,6 +403,85 @@ Description
 ` + "```",
 		},
 		{
+			name: "Multiline",
+			report: Action{
+				ID:            "1234",
+				Title:         "Action Title",
+				PipelineTitle: "Test Title",
+				Targets: []ActionTarget{
+					{
+						ID:          "4567",
+						Title:       "Target One",
+						Description: "Something happened\n\t* to this file",
+						Changelogs: []ActionTargetChangelog{
+							{
+								Title:       "1.0.0",
+								Description: "# v1.0.0\n\nfeat: something cool",
+							},
+							{
+								Title:       "1.0.1",
+								Description: "# v1.0.1\n\nfix: something fixed",
+							},
+						},
+					},
+					{
+						ID:          "4568",
+						Title:       "Target Two",
+						Description: "Something happened\n\t* to other this file",
+					},
+					{
+						ID:    "4569",
+						Title: "Target Three",
+						Changelogs: []ActionTargetChangelog{
+							{
+								Title:       "1.0.0",
+								Description: "# v1.0.0\n\nfeat: something cool",
+							},
+						},
+					},
+				},
+			},
+			expectedOutput: `# Test Title
+
+## Target One
+
+Something happened
+
+* to this file
+
+### 1.0.0
+
+` + "```" + `
+# v1.0.0
+
+feat: something cool
+` + "```" + `
+
+### 1.0.1
+
+` + "```" + `
+# v1.0.1
+
+fix: something fixed
+` + "```" + `
+
+## Target Two
+
+Something happened
+
+* to other this file
+
+## Target Three
+
+### 1.0.0
+
+` + "```" + `
+# v1.0.0
+
+feat: something cool
+` + "```",
+		},
+		{
 			name: "with PipelineUrl",
 			report: Action{
 				ID:            "1234",


### PR DESCRIPTION
Again in my battle with markdown reports for bitbucket i noticed a bug in the descriptions.

We use `...\n\t* ...` throughout the code ([here](https://github.com/updatecli/updatecli/blob/79f248bedcbbbceb7a28e888ca4e359b949b7792/pkg/plugins/resources/yaml/target.go#L100), [here](https://github.com/updatecli/updatecli/blob/79f248bedcbbbceb7a28e888ca4e359b949b7792/pkg/plugins/resources/json/target.go#L151) and [here](https://github.com/updatecli/updatecli/blob/79f248bedcbbbceb7a28e888ca4e359b949b7792/pkg/plugins/resources/file/target.go#L188)), this doesn't output correctly in GitHub or Bitbucket (and probably GitLab) but haven't checked.

This can be replicated in common mark tester [here](https://spec.commonmark.org/dingus/?text=Something%20change%0A%09*%20value) 

<details><summary>GitHub Example</summary>
<p>

![image](https://github.com/user-attachments/assets/a7207cb8-02be-4ed8-9c13-440422dda649)

</p>
</details> 

Ref: https://github.com/updatecli/updatecli/pull/5291


<details><summary>Bitbucket Before</summary>
<p>

![image](https://github.com/user-attachments/assets/fc933e5a-bdfd-4466-93d3-e62c535ec3c6)

</p>
</details> 


<details><summary>Bitbucket After</summary>
<p>

![image](https://github.com/user-attachments/assets/93810cef-f4a6-431c-87bf-ce15915b3557)

</p>
</details> 


## Test

To test this pull request, you can run the following commands:

```shell
cd pkg/core/reports
go test
```

## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via pull request in [website](https://github.com/updatecli/website) repository.

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
