### PR TITLE
fix: devcontainer update pipeline

### DIFF
--- a/updatecli/updatecli.d/devcontainer.yaml
+++ b/updatecli/updatecli.d/devcontainer.yaml
@@ -48,6 +48,7 @@ targets:
   devcontainer: 
     name: 'deps: update devcontainer to golang {{ source "golang" }}'
     kind: file
+    scmid: default
     spec:
       file: '.devcontainer/devcontainer.json'
       matchpattern: '"image": "mcr\.microsoft\.com/devcontainers/go:.*"'


### PR DESCRIPTION
Recently discovered that the update pipeline wouldn't update devcontainers 

## Test

To test this pull request, you can run the following commands:

```shell
cd <to_package_directory>
go test
```

## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via pull request in [website](https://github.com/updatecli/website) repository.

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
