### PR TITLE
feat(bitbucket): add support for pull request description merging

### DIFF
--- a/pkg/core/reports/action.go
+++ b/pkg/core/reports/action.go
@@ -114,12 +114,16 @@ func (a *Action) sort() {
 // updateTargetDescriptions updates descriptions from being console friendly to markdown friendly
 func (a *Action) updateTargetDescriptions() {
 	for id, target := range a.Targets {
-		a.Targets[id].Description = strings.ReplaceAll(target.Description, "\n\t*", "\n\n*")
+		d := target.Description
+		d = strings.Replace(d, "\n\t*", "\n\n*", 1)
+		d = strings.ReplaceAll(d, "\n\t*", "\n*")
+		a.Targets[id].Description = d
 	}
 }
 
 // ToActionsString show an action report formatted as a string
 func (a Action) ToActionsString() string {
+	a.sort()
 	a.updateTargetDescriptions()
 
 	output, err := xml.MarshalIndent(

--- a/pkg/core/reports/action_markdown_template.go
+++ b/pkg/core/reports/action_markdown_template.go
@@ -3,9 +3,13 @@ package reports
 // markdownReportTemplate is the Go template used to generate markdown report
 var markdownReportTemplate string = `# {{ .PipelineTitle }}
 
+Pipeline ID: ` + "`" + `{{ .ID }}` + "`" + `
+
 {{- range .Targets}}
 
 ## {{ .Title }}
+
+Target ID: ` + "`" + `{{ .ID }}` + "`" + `
 
 {{- if .Description }}
 
@@ -29,5 +33,5 @@ var markdownReportTemplate string = `# {{ .PipelineTitle }}
 
 {{- if .PipelineURL }}
 
-[{{ .PipelineURL.Name }}]({{ .PipelineURL.URL }})
+Pipeline URL: [{{ .PipelineURL.Name }}]({{ .PipelineURL.URL }})
 {{- end}}`

--- a/pkg/core/reports/action_test.go
+++ b/pkg/core/reports/action_test.go
@@ -366,12 +366,12 @@ func TestToActionsMarkdownString(t *testing.T) {
 						},
 					},
 					{
-						ID:          "4567",
+						ID:          "4568",
 						Title:       "Target Two",
 						Description: "Description",
 					},
 					{
-						ID:    "4567",
+						ID:    "4569",
 						Title: "Target Three",
 						Changelogs: []ActionTargetChangelog{
 							{
@@ -384,7 +384,11 @@ func TestToActionsMarkdownString(t *testing.T) {
 			},
 			expectedOutput: `# Test Title
 
+Pipeline ID: ` + "`" + `1234` + "`" + `
+
 ## Target One
+
+Target ID: ` + "`" + `4567` + "`" + `
 
 ### 1.0.0
 
@@ -392,9 +396,13 @@ func TestToActionsMarkdownString(t *testing.T) {
 
 ## Target Two
 
+Target ID: ` + "`" + `4568` + "`" + `
+
 Description
 
 ## Target Three
+
+Target ID: ` + "`" + `4569` + "`" + `
 
 ### 1.0.0
 
@@ -427,7 +435,7 @@ Description
 					{
 						ID:          "4568",
 						Title:       "Target Two",
-						Description: "Something happened\n\t* to other this file",
+						Description: "Something happened\n\t* to this other file\n\t* and this other file",
 					},
 					{
 						ID:    "4569",
@@ -443,7 +451,11 @@ Description
 			},
 			expectedOutput: `# Test Title
 
+Pipeline ID: ` + "`" + `1234` + "`" + `
+
 ## Target One
+
+Target ID: ` + "`" + `4567` + "`" + `
 
 Something happened
 
@@ -467,11 +479,16 @@ fix: something fixed
 
 ## Target Two
 
+Target ID: ` + "`" + `4568` + "`" + `
+
 Something happened
 
-* to other this file
+* to this other file
+* and this other file
 
 ## Target Three
+
+Target ID: ` + "`" + `4569` + "`" + `
 
 ### 1.0.0
 
@@ -507,12 +524,12 @@ feat: something cool
 						},
 					},
 					{
-						ID:          "4567",
+						ID:          "4568",
 						Title:       "Target Two",
 						Description: "Description",
 					},
 					{
-						ID:    "4567",
+						ID:    "4569",
 						Title: "Target Three",
 						Changelogs: []ActionTargetChangelog{
 							{
@@ -525,7 +542,11 @@ feat: something cool
 			},
 			expectedOutput: `# Test Title
 
+Pipeline ID: ` + "`" + `1234` + "`" + `
+
 ## Target One
+
+Target ID: ` + "`" + `4567` + "`" + `
 
 ### 1.0.0
 
@@ -533,9 +554,13 @@ feat: something cool
 
 ## Target Two
 
+Target ID: ` + "`" + `4568` + "`" + `
+
 Description
 
 ## Target Three
+
+Target ID: ` + "`" + `4569` + "`" + `
 
 ### 1.0.0
 
@@ -543,13 +568,22 @@ Description
 Description
 ` + "```" + `
 
-[updatecli](https://www.updatecli.io/)`,
+Pipeline URL: [updatecli](https://www.updatecli.io/)`,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expectedOutput, tt.report.ToActionsMarkdownString())
+			markdown := tt.report.ToActionsMarkdownString()
+			assert.Equal(t, tt.expectedOutput, markdown)
+
+			// roundtrip to ensure no information loss
+			var newReport Actions
+			err := markdownToActions(markdown, &newReport)
+			assert.Nil(t, err)
+			newReport.Actions[0].Title = "Action Title"
+
+			assert.Equal(t, &Actions{Actions: []Action{tt.report}}, &newReport)
 		})
 	}
 }

--- a/pkg/core/reports/actions.go
+++ b/pkg/core/reports/actions.go
@@ -1,11 +1,16 @@
 package reports
 
 import (
+	"bytes"
 	"encoding/xml"
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/sirupsen/logrus"
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/text"
 )
 
 type Actions struct {
@@ -105,4 +110,153 @@ func unmarshal(input []byte, a *Actions) (err error) {
 		b.Actions[i].sort()
 	}
 	return nil
+}
+
+func markdownToActions(input string, actions *Actions) error {
+	source := []byte(input)
+
+	actionCount := -1
+	actionTargetCount := -1
+	actionTargetChangeLogCount := -1
+
+	md := goldmark.New()
+	node := md.Parser().Parse(text.NewReader(source))
+
+	err := ast.Walk(node, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering {
+			return ast.WalkContinue, nil
+		}
+		switch n := n.(type) {
+		case *ast.Heading:
+			title := string(n.Lines().Value(source))
+
+			switch n.Level {
+			case 1:
+				action := Action{
+					PipelineTitle: title,
+				}
+				actions.Actions = append(actions.Actions, action)
+				actionCount++
+				actionTargetCount = -1
+				actionTargetChangeLogCount = -1
+			case 2:
+				actionTarget := ActionTarget{
+					Title: title,
+				}
+				actions.Actions[actionCount].Targets = append(actions.Actions[actionCount].Targets, actionTarget)
+				actionTargetCount++
+				actionTargetChangeLogCount = -1
+			case 3:
+				actionTargetChangelog := ActionTargetChangelog{
+					Title: title,
+				}
+				actions.Actions[actionCount].Targets[actionTargetCount].Changelogs = append(
+					actions.Actions[actionCount].Targets[actionTargetCount].Changelogs,
+					actionTargetChangelog)
+				actionTargetChangeLogCount++
+			}
+			return ast.WalkSkipChildren, nil
+		case *ast.Paragraph:
+			contents := n.Lines().Value(source)
+			if child, ok := n.FirstChild().(*ast.Text); ok {
+				switch string(child.Value(source)) {
+				case "Pipeline ID: ":
+					if sibling, ok := child.NextSibling().(*ast.CodeSpan); ok {
+						if codespanValue, ok := sibling.FirstChild().(*ast.Text); ok {
+							actions.Actions[actionCount].ID = string(codespanValue.Value(source))
+						}
+					}
+					return ast.WalkSkipChildren, nil
+				case "Target ID: ":
+					if sibling, ok := child.NextSibling().(*ast.CodeSpan); ok {
+						if codespanValue, ok := sibling.FirstChild().(*ast.Text); ok {
+							actions.Actions[actionCount].Targets[actionTargetCount].ID = string(codespanValue.Value(source))
+						}
+					}
+					return ast.WalkSkipChildren, nil
+				case "Pipeline URL: ":
+					if sibling, ok := child.NextSibling().(*ast.Link); ok {
+						var name string
+						if codespanValue, ok := sibling.FirstChild().(*ast.Text); ok {
+							name = string(codespanValue.Value(source))
+						}
+						actions.Actions[actionCount].PipelineURL = &PipelineURL{
+							Name: name,
+							URL:  string(sibling.Destination),
+						}
+					}
+					return ast.WalkSkipChildren, nil
+				}
+			}
+			if actionCount > -1 && actionTargetCount > -1 {
+				actions.Actions[actionCount].Targets[actionTargetCount].Description = string(contents)
+				return ast.WalkSkipChildren, nil
+			}
+		case *ast.FencedCodeBlock:
+			if actionTargetChangeLogCount > -1 {
+				contents := n.Lines().Value(source)
+				actions.Actions[actionCount].Targets[actionTargetCount].Changelogs[actionTargetChangeLogCount].Description = strings.TrimSpace(string(contents))
+				return ast.WalkSkipChildren, nil
+			}
+		case *ast.List:
+			if actionCount > -1 && actionTargetCount > -1 {
+				var buf bytes.Buffer
+				for children := n.FirstChild(); children != nil; children = children.NextSibling() {
+					if listValue, ok := children.FirstChild().(*ast.TextBlock); ok {
+						buf.Write([]byte("\n* "))
+						buf.Write(listValue.Lines().Value(source))
+					}
+				}
+				actions.Actions[actionCount].Targets[actionTargetCount].Description += "\n"
+				actions.Actions[actionCount].Targets[actionTargetCount].Description += buf.String()
+				return ast.WalkSkipChildren, nil
+			}
+		case *ast.ThematicBreak:
+			// start of footer stop processing
+			return ast.WalkStop, nil
+		}
+
+		return ast.WalkContinue, nil
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func MergeFromMarkdown(old, new string) (string, error) {
+	var oldReport Actions
+	var newReport Actions
+
+	if old == "" && new != "" {
+		return new, nil
+	}
+
+	if old != "" && new == "" {
+		return old, nil
+	}
+
+	if err := markdownToActions(old, &oldReport); err != nil {
+		return "", err
+	}
+
+	if err := markdownToActions(new, &newReport); err != nil {
+		return "", err
+	}
+
+	newReport.Merge(&oldReport)
+	newReport.sort()
+
+	var report string
+
+	for i, action := range newReport.Actions {
+		if i > 0 {
+			report += "\n\n"
+		}
+		r := action.ToActionsMarkdownString()
+		report += r
+	}
+
+	return report, nil
 }

--- a/pkg/core/reports/actions_test.go
+++ b/pkg/core/reports/actions_test.go
@@ -1629,3 +1629,233 @@ This is not a html formatted report
 		})
 	}
 }
+
+func TestMergeFromMarkdown(t *testing.T) {
+	tests := []struct {
+		name                string
+		oldReport           string
+		newReport           string
+		expectedFinalReport string
+	}{
+		{
+			name: "Default none situation",
+			oldReport: `# Test Title
+
+Pipeline ID: ` + "`" + `1234` + "`" + `
+
+## Target One
+
+Target ID: ` + "`" + `4567` + "`" + `
+
+### 1.0.0
+
+### 1.0.1
+
+## Target Two
+
+Target ID: ` + "`" + `4568` + "`" + `
+
+## Target Three
+
+Target ID: ` + "`" + `4569` + "`",
+			newReport: `# Test Title
+
+Pipeline ID: ` + "`" + `1234` + "`" + `
+
+## Target One
+
+Target ID: ` + "`" + `4567` + "`" + `
+
+### 1.0.0
+
+### 1.0.1
+
+## Target Two
+
+Target ID: ` + "`" + `4568` + "`" + `
+
+## Target Three
+
+Target ID: ` + "`" + `4569` + "`",
+			expectedFinalReport: `# Test Title
+
+Pipeline ID: ` + "`" + `1234` + "`" + `
+
+## Target One
+
+Target ID: ` + "`" + `4567` + "`" + `
+
+### 1.0.0
+
+### 1.0.1
+
+## Target Two
+
+Target ID: ` + "`" + `4568` + "`" + `
+
+## Target Three
+
+Target ID: ` + "`" + `4569` + "`",
+		},
+		{
+			name: "Test target merge",
+			oldReport: `# Test Title
+
+Pipeline ID: ` + "`" + `1234` + "`" + `
+
+## Target One
+
+Target ID: ` + "`" + `4567` + "`" + `
+
+### 1.0.0
+
+### 1.0.1`,
+			newReport: `# Test Title
+
+Pipeline ID: ` + "`" + `1234` + "`" + `
+
+## Target Two
+
+Target ID: ` + "`" + `4568` + "`" + `
+
+## Target Three
+
+Target ID: ` + "`" + `4569` + "`",
+			expectedFinalReport: `# Test Title
+
+Pipeline ID: ` + "`" + `1234` + "`" + `
+
+## Target One
+
+Target ID: ` + "`" + `4567` + "`" + `
+
+### 1.0.0
+
+### 1.0.1
+
+## Target Two
+
+Target ID: ` + "`" + `4568` + "`" + `
+
+## Target Three
+
+Target ID: ` + "`" + `4569` + "`",
+		},
+		{
+			name: "Test that old report includes unexpected text",
+			oldReport: `This is not a markdown expected format
+
+# Test Title
+
+Pipeline ID: ` + "`" + `1234` + "`" + `
+
+## Target Two
+
+Target ID: ` + "`" + `4568` + "`" + `
+
+## Target Three
+
+Target ID: ` + "`" + `4569` + "`",
+			newReport: `# Test Title
+
+Pipeline ID: ` + "`" + `1234` + "`" + `
+
+## Target Two
+
+Target ID: ` + "`" + `4568` + "`" + `
+
+## Target Three
+
+Target ID: ` + "`" + `4569` + "`",
+			expectedFinalReport: `# Test Title
+
+Pipeline ID: ` + "`" + `1234` + "`" + `
+
+## Target Two
+
+Target ID: ` + "`" + `4568` + "`" + `
+
+## Target Three
+
+Target ID: ` + "`" + `4569` + "`",
+		},
+		{
+			name: "Test Pipeline merge",
+			oldReport: `# Old Pipeline
+
+Pipeline ID: ` + "`" + `1234` + "`" + `
+
+## Target One
+
+Target ID: ` + "`" + `4567` + "`" + `
+
+### 1.0.0
+
+### 1.0.1`,
+			newReport: `# New Pipeline
+
+Pipeline ID: ` + "`" + `1234` + "`" + `
+
+## Target Two
+
+Target ID: ` + "`" + `4568` + "`" + `
+
+## Target Three
+
+Target ID: ` + "`" + `4569` + "`",
+			expectedFinalReport: `# New Pipeline
+
+Pipeline ID: ` + "`" + `1234` + "`" + `
+
+## Target One
+
+Target ID: ` + "`" + `4567` + "`" + `
+
+### 1.0.0
+
+### 1.0.1
+
+## Target Two
+
+Target ID: ` + "`" + `4568` + "`" + `
+
+## Target Three
+
+Target ID: ` + "`" + `4569` + "`",
+		},
+		{
+			name: "No merge needed",
+			newReport: `# New Pipeline
+
+Pipeline ID: ` + "`" + `1234` + "`" + `
+
+## Target One
+
+Target ID: ` + "`" + `4567` + "`" + `
+
+### 1.0.0
+
+### 1.0.1`,
+			oldReport: "",
+			expectedFinalReport: `# New Pipeline
+
+Pipeline ID: ` + "`" + `1234` + "`" + `
+
+## Target One
+
+Target ID: ` + "`" + `4567` + "`" + `
+
+### 1.0.0
+
+### 1.0.1`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotFinalReport, err := MergeFromMarkdown(tt.oldReport, tt.newReport)
+			assert.Nil(t, err)
+			assert.Equal(t, tt.expectedFinalReport, gotFinalReport)
+		})
+	}
+}


### PR DESCRIPTION
Fix #5174

Merges markdown pipeline and targets output together.

Uses [goldmark](https://github.com/yuin/goldmark) ast to parse the markdown. 

It makes assumptions about the format, and possibly has edge cases missed. That might come out in the wild.

Also fix a bug with #5309 that doesn't support more than one item in the list.

## Test

To test this pull request, you can run the following commands:

```shell
cd pkg/core/reports
go test
```

```shell
go build -o bin/updatecli
export BITBUCKET_TOKEN="xxx"
# update scm.yaml to hit test repo etc.
bin/updatecli --config e2e/updatecli.d/success.d/bitbucket/scm.yaml --debug apply
# update scm.yaml to change Target and PR Title
bin/updatecli --config e2e/updatecli.d/success.d/bitbucket/scm.yaml --debug apply
```

## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via pull request in [website](https://github.com/updatecli/website) repository.

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
