### PR TITLE
refactor(autodiscovery): unify discovery spec & reduce boilerplate code & fix `terragrunt` missing in jsonschema

### DIFF
--- a/pkg/core/engine/autodiscovery.go
+++ b/pkg/core/engine/autodiscovery.go
@@ -33,7 +33,7 @@ func (e *Engine) LoadAutoDiscovery(defaultEnabled bool) error {
 			&config.Config{
 				Spec: config.Spec{
 					Name:          "Local AutoDiscovery",
-					AutoDiscovery: autodiscovery.DefaultCrawlerSpecs,
+					AutoDiscovery: autodiscovery.GetDefaultCrawlerSpecs(),
 				},
 			},
 			pipeline.Options{},
@@ -99,7 +99,6 @@ func (e *Engine) LoadAutoDiscovery(defaultEnabled bool) error {
 
 		c, err := autodiscovery.New(
 			p.Config.Spec.AutoDiscovery, workDir)
-
 		if err != nil {
 			e.Pipelines[id].Report.Result = result.FAILURE
 			logrus.Errorln(err)
@@ -108,7 +107,6 @@ func (e *Engine) LoadAutoDiscovery(defaultEnabled bool) error {
 
 		errs := []error{}
 		bytesManifests, err := c.Run()
-
 		if err != nil {
 			e.Pipelines[id].Report.Result = result.FAILURE
 			logrus.Errorln(err)
@@ -254,5 +252,4 @@ func (e *Engine) LoadAutoDiscovery(defaultEnabled bool) error {
 	}
 
 	return nil
-
 }

--- a/pkg/core/pipeline/autodiscovery/config.go
+++ b/pkg/core/pipeline/autodiscovery/config.go
@@ -26,4 +26,4 @@ type Config struct {
 }
 
 // CrawlersConfig is a custom type used to generated the jsonschema.
-type CrawlersConfig map[string]interface{}
+type CrawlersConfig map[string]any

--- a/pkg/core/pipeline/autodiscovery/jsonschema.go
+++ b/pkg/core/pipeline/autodiscovery/jsonschema.go
@@ -11,5 +11,5 @@ func (CrawlersConfig) JSONSchema() *jschema.Schema {
 
 	return jsonschema.AppendMapToJsonSchema(
 		CrawlersConfigAlias{},
-		AutodiscoverySpecsMapping)
+		GetAutodiscoverySpecsMapping())
 }

--- a/pkg/core/pipeline/autodiscovery/main.go
+++ b/pkg/core/pipeline/autodiscovery/main.go
@@ -58,7 +58,7 @@ var (
 		},
 	}
 	// AutodiscoverySpecs is a map of all Autodiscovery specification
-	AutodiscoverySpecsMapping = map[string]any{
+	AutodiscoverySpecsMapping = CrawlersConfig{
 		"argocd":        &argocd.Spec{},
 		"cargo":         &cargo.Spec{},
 		"dockercompose": &dockercompose.Spec{},
@@ -78,7 +78,8 @@ var (
 		"prow":          &kubernetes.Spec{},
 		"rancher/fleet": &fleet.Spec{},
 		"terraform":     &terraform.Spec{},
-		"updatecli":     &updatecli.Spec{},
+		// "terragrunt":    &terragrunt.Spec{}, // TODO missing ??
+		"updatecli": &updatecli.Spec{},
 	}
 )
 


### PR DESCRIPTION
1. unify discovery spec
2. reduce boilerplate code
3. fix `terragrunt` missing in jsonschema <https://www.updatecli.io/schema/latest/config.json>
## Test

To test this pull request, you can run the following commands:

```shell
go build

.\updatecli.exe jsonschema
# check terragrunt is in schema

.\updatecli.exe apply --debug > debug.out
# check all discovery is in output
```

![image](https://github.com/user-attachments/assets/5ec84948-8243-4c93-9c05-5fcccb127dda)

