### PR TITLE
fix: panic when Updatecli manifests doesn't exist

### DIFF
--- a/pkg/core/engine/utils.go
+++ b/pkg/core/engine/utils.go
@@ -16,6 +16,10 @@ import (
 func sanitizeUpdatecliManifestFilePath(rawFilePaths []string) (sanitizedFilePaths, sanitizedPartialPaths []string) {
 	for _, rawFilePath := range rawFilePaths {
 		rawFileInfo, err := os.Stat(rawFilePath)
+		if err != nil {
+			logrus.Error(fmt.Sprintf("Loading Updatecli manifest %q: %s", rawFilePath, err))
+			continue
+		}
 
 		// If the manifest if a directory, then we walk trough it to find all manifest files
 		// and partial files.


### PR DESCRIPTION
Fix #5541 

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
go build -o bin/updatecli . 
./bin/updatecli diff --config xxxxx
```

## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via pull request in [website](https://github.com/updatecli/website) repository.

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
