### PR TITLE
fix: avoid loading partial when not needed

### DIFF
--- a/pkg/core/engine/utils.go
+++ b/pkg/core/engine/utils.go
@@ -15,6 +15,12 @@ import (
 // a list of files that can be used as helpers.
 func sanitizeUpdatecliManifestFilePath(rawFilePaths []string) (sanitizedFilePaths, sanitizedPartialPaths []string) {
 	for _, rawFilePath := range rawFilePaths {
+		// Only sanitize Updatecli manifest which are not partial manifests.
+		rawBaseFilePath := filepath.Base(rawFilePath)
+		if strings.HasPrefix(rawBaseFilePath, "_") {
+			continue
+		}
+
 		rawFileInfo, err := os.Stat(rawFilePath)
 		if err != nil {
 			logrus.Error(fmt.Sprintf("Loading Updatecli manifest %q: %s", rawFilePath, err))


### PR DESCRIPTION
During some testing of the new partial failure,
I noticed that Updatecli would try to load partial files and then return an error.
While it doesn't affect the behavior of Updatecli, it does return a confusing error

<details><summary>Example</summary>

```
ERROR: failed loading pipeline(s)
	* /tmp/updatecli/store/f2ce0c8e474787ae75f35f8adc4792017a5b158cf8b5fd1b5a1db6ad25346540/updatecli.d/_scm.github.yaml:
		* Partial files:
			* /tmp/updatecli/store/f2ce0c8e474787ae75f35f8adc4792017a5b158cf8b5fd1b5a1db6ad25346540/updatecli.d/_scm.bitbucket.yaml
			* /tmp/updatecli/store/f2ce0c8e474787ae75f35f8adc4792017a5b158cf8b5fd1b5a1db6ad25346540/updatecli.d/_scm.gitea.yaml
			* /tmp/updatecli/store/f2ce0c8e474787ae75f35f8adc4792017a5b158cf8b5fd1b5a1db6ad25346540/updatecli.d/_scm.github.yaml
			* /tmp/updatecli/store/f2ce0c8e474787ae75f35f8adc4792017a5b158cf8b5fd1b5a1db6ad25346540/updatecli.d/_scm.gitlab.yaml
			* /tmp/updatecli/store/f2ce0c8e474787ae75f35f8adc4792017a5b158cf8b5fd1b5a1db6ad25346540/updatecli.d/_scm.stash.yaml
		* Error:
			yaml: unmarshal errors:
			  line 47: mapping key "actions" already defined at line 8
			  line 60: mapping key "scms" already defined at line 21
```

</details>

This PR just ignore manifest with an underscore

<!-- Describe the changes introduced by this pull request -->

## Test

Test manually on this repository running:

```
go build -o bin/updatecli .
./bin/updatecli diff --values updatecli/values.d/scm.yaml --values updatecli/values.d/golang_patch.yaml ghcr.io/updatecli/policies/golang/autodiscovery --debug

```

## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via pull request in [website](https://github.com/updatecli/website) repository.

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
