### PR TITLE
fix: remove linux/aarch64 from temurin e2e test

### DIFF
--- a/e2e/updatecli.d/success.d/temurin/conditions.yaml
+++ b/e2e/updatecli.d/success.d/temurin/conditions.yaml
@@ -49,4 +49,3 @@ conditions:
     spec:
       platforms:
         - linux/x64
-        - linux/aarch64


### PR DESCRIPTION
It seems that e2e are failing due to this line


## Test

To test this pull request, you can run the following commands:

```shell
updatecli diff --config e2e/updatecli.d/success.d/temurin/conditions.yaml
```

## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via pull request in [website](https://github.com/updatecli/website) repository.

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
