### PR TITLE
fix(actions) ensure HTML of change requests is valid (missing closingtag for `img`)

### DIFF
--- a/pkg/plugins/utils/action/main.go
+++ b/pkg/plugins/utils/action/main.go
@@ -24,7 +24,7 @@ const PULLREQUESTBODYTEMPLATE = `
 <table>
   <tr>
     <td width="77">
-      <img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="50" height="50">
+      <img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="50" height="50" />
     </td>
     <td>
       <p>


### PR DESCRIPTION
This PR is a quick fix to avoid, when an action updates an existing change request, the error below:

```
Existing GitHub pull request found: <url redacted>

Pull Request available at:

        <url redacted>

ERROR: failed parsing old report: XML syntax error on line 26: element <img> closed by </td>
Existing GitHub pull request found: <url redacted>
```
