### PR TITLE
fix: correct decoding logic for GitLab clientSpec to allow overwriting

### DIFF
--- a/pkg/plugins/resources/gitlab/mergerequest/main.go
+++ b/pkg/plugins/resources/gitlab/mergerequest/main.go
@@ -57,14 +57,14 @@ func New(spec interface{}, scm *gitlabscm.Gitlab) (Gitlab, error) {
 
 	// mapstructure.Decode cannot handle embedded fields
 	// hence we decode it in two steps
-	err := mapstructure.Decode(spec, &clientSpec)
+	err := mapstructure.Decode(spec, &s)
 	if err != nil {
 		return Gitlab{}, err
 	}
 
-	err = mapstructure.Decode(spec, &s)
+	err = mapstructure.Decode(s.Spec, &clientSpec)
 	if err != nil {
-		return Gitlab{}, nil
+		return Gitlab{}, err
 	}
 
 	if scm != nil {


### PR DESCRIPTION
In this PR I switched the order of decoding to reference the `clientSpec` to  the action's sub spec when decoding.

I was trying to overwrite the username and token inside the GitLab Merge Request action's spec using below config but it was not passed to the `clientSpec` correctly. That's why the scm credentials were used instead.

```yaml
actions:
  default:
    kind: gitlab/mergerequest
    scmid: gitlab
    title: "my-title"
    spec:
      removesourcebranch: true
      spec:
        username: mr
        token: gplat-mr-token

scms:
  gitlab:
    kind: gitlab
    spec:
      owner: "owner"
      repository: "my-group/my-repository"
      username: gitlab-ci-token
      token: {{ requiredEnv "CI_JOB_TOKEN" }}
```

## Test

To test this pull request, you can run the following commands:

```shell
cd <to_package_directory>
go test
```

## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via pull request in [website](https://github.com/updatecli/website) repository.

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
