### PR TITLE
feat(file,golang): improve changelog generation with capture groups

### DIFF
--- a/pkg/plugins/resources/file/main.go
+++ b/pkg/plugins/resources/file/main.go
@@ -83,6 +83,14 @@ type Spec struct {
 	       * condition
 	       * target
 
+	   remarks:
+	       * For targets: Capture groups (parentheses) in the pattern automatically extract
+	         the current value for changelog generation
+	       * Without capture groups, changelogs show generic "unknown" version changes
+	       * With capture groups, changelogs show actual version changes (e.g., "1.24.5" → "1.25.1")
+	       * Example: `"version":\s*"([\d\.]+)"` captures version numbers for changelogs
+	       * Supports full Go regexp syntax
+
 	*/
 	MatchPattern string `yaml:",omitempty"`
 	/*

--- a/pkg/plugins/resources/go/language/changelog.go
+++ b/pkg/plugins/resources/go/language/changelog.go
@@ -13,53 +13,29 @@ import (
 func (l *Language) Changelog(from, to string) *result.Changelogs {
 
 	var err error
-	var froundVersion *semver.Version
 
 	if from == "" && to == "" {
 		return nil
 	}
 
-	versions, err := l.versions()
+	// Parse the target version (to) for changelog generation
+	toVersion, err := semver.NewVersion(to)
 	if err != nil {
-		logrus.Errorf("failed to retrieve golang version: %s", err)
+		logrus.Errorf("failing parsing to version %q - %q",
+			to, err)
 		return nil
 	}
 
-	if len(versions) == 0 {
-		logrus.Errorf("no Golang version found")
-		return nil
-	}
+	title := toVersion.String()
+	url := fmt.Sprintf("https://go.dev/doc/devel/release#go%d.%d.minor", toVersion.Major(), toVersion.Minor())
+	body := fmt.Sprintf("Golang changelog for version %q is available on %q", toVersion.String(), redact.URL(url))
 
-	fromVersion, err := semver.NewVersion(from)
-	if err != nil {
-		logrus.Errorf("failing parsing from version %q - %q",
-			from, err)
-		return nil
-	}
-
-	for i := range versions {
-		froundVersion, err = semver.NewVersion(versions[i])
-		if err != nil {
-			logrus.Debugf("failing parsing from version %q - %q",
-				versions[i], err)
-			return nil
-		}
-
-		if fromVersion.Equal(froundVersion) {
-			break
-		}
-	}
-
-	title := froundVersion.String()
-	url := fmt.Sprintf("https://go.dev/doc/devel/release#go%d.%d.minor", froundVersion.Major(), froundVersion.Minor())
-	body := fmt.Sprintf("Golang changelog for version %q is available on %q", froundVersion.String(), redact.URL(url))
-
-	if froundVersion.Patch() == 0 {
-		title = fmt.Sprintf("%d.%d", froundVersion.Major(), froundVersion.Minor())
-		url = fmt.Sprintf("https://go.dev/doc/go%d.%d", froundVersion.Major(), froundVersion.Minor())
+	if toVersion.Patch() == 0 {
+		title = fmt.Sprintf("%d.%d", toVersion.Major(), toVersion.Minor())
+		url = fmt.Sprintf("https://go.dev/doc/go%d.%d", toVersion.Major(), toVersion.Minor())
 		body = fmt.Sprintf(`Golang changelog for version "%d.%d" is available on %q`,
-			froundVersion.Major(),
-			froundVersion.Minor(),
+			toVersion.Major(),
+			toVersion.Minor(),
 			redact.URL(url))
 	}
 


### PR DESCRIPTION
- File targets now extract the first capture group from matchpattern for Information field
- Replaces hardcoded "unknown" Information field with actual extracted value
- Go language changelog now generates changelog for target version (to) instead of source version (from)
- Enables proper changelog generation showing actual value transitions
- Adds comprehensive test coverage for capture group extraction scenarios
- Updates matchpattern documentation with capture group usage and benefits

The extracted value can be any text matched by the first capture group (versions,
configurations, identifiers, etc.), improving
changelog accuracy for all file updates.

Fixes issues where:
- File targets always showed "unknown" as the from value in changelogs
- Go language changelogs showed old version instead of new version being updated to

From:

`ERROR: failing parsing from version "unknown" - "invalid semantic version"`

```
target: target#update_build_go_templates_json_go_default
------------------------------------------------

**Dry Run enabled**

"templates.json" updated with [dry run] content "\"GO_VERSION\": \"(1.24.7)\""

--- templates.json
+++ templates.json
@@ -1,7 +1,7 @@
 {
   "1.24-focal": {
     "vars": {
-      "GO_VERSION": "1.24.6",
+      "GO_VERSION": "1.24.7",
@@ -15,7 +15,7 @@
   },
   "1.24-jammy": {
     "vars": {
-      "GO_VERSION": "1.24.6",
+      "GO_VERSION": "1.24.7",

⚠ - 1 file(s) updated with "\"GO_VERSION\": \"(1.24.7)\"":
	* templates.json
Searching for version matching pattern "1.24.x"

ERROR: failing parsing from version "unknown" - "invalid semantic version"
```

To:

No error anymore when generating the changelog.

```
target: target#update_build_go_templates_json_go_default
------------------------------------------------
"templates.json" updated with content "\"GO_VERSION\": \"1.24.7\""

--- templates.json
+++ templates.json
@@ -1,7 +1,7 @@
 {
   "1.24-focal": {
     "vars": {
-      "GO_VERSION": "1.24.6",
+      "GO_VERSION": "1.24.7",
@@ -15,7 +15,7 @@
   },
   "1.24-jammy": {
     "vars": {
-      "GO_VERSION": "1.24.6",
+      "GO_VERSION": "1.24.7",

⚠ - 1 file(s) updated with "\"GO_VERSION\": \"1.24.7\"":
	* templates.json


CHANGELOG:
----------

Title: 1.24.7
Published At:
Link: https://go.dev/doc/devel/release#go1.24.minor
Description: Golang changelog for version "1.24.7" is available on "https://go.dev/doc/devel/release#go1.24.minor"
```
