### PR TITLE
feat: Add build-dependencies support to cargo autodiscovery

### DIFF
--- a/pkg/plugins/autodiscovery/cargo/dependencies.go
+++ b/pkg/plugins/autodiscovery/cargo/dependencies.go
@@ -27,15 +27,17 @@ type crateDependency struct {
 }
 
 type crateMetadata struct {
-	Name                     string
-	CargoFile                string
-	CargoLockFile            string
-	Workspace                bool
-	WorkspaceMembers         []crateMetadata
-	WorkspaceDependencies    []crateDependency
-	WorkspaceDevDependencies []crateDependency
-	Dependencies             []crateDependency
-	DevDependencies          []crateDependency
+	Name                       string
+	CargoFile                  string
+	CargoLockFile              string
+	Workspace                  bool
+	WorkspaceMembers           []crateMetadata
+	WorkspaceDependencies      []crateDependency
+	WorkspaceBuildDependencies []crateDependency
+	WorkspaceDevDependencies   []crateDependency
+	Dependencies               []crateDependency
+	BuildDependencies          []crateDependency
+	DevDependencies            []crateDependency
 }
 
 func (c Cargo) generateManifest(
@@ -244,6 +246,10 @@ func (c Cargo) processCrateMetadata(
 	sort.Slice(dependencies, func(i, j int) bool {
 		return dependencies[i].Name < dependencies[j].Name
 	})
+	buildDependencies := cr.BuildDependencies
+	sort.Slice(buildDependencies, func(i, j int) bool {
+		return buildDependencies[i].Name < buildDependencies[j].Name
+	})
 	devDependencies := cr.DevDependencies
 	sort.Slice(devDependencies, func(i, j int) bool {
 		return devDependencies[i].Name < devDependencies[j].Name
@@ -252,14 +258,20 @@ func (c Cargo) processCrateMetadata(
 	sort.Slice(workspaceDependencies, func(i, j int) bool {
 		return workspaceDependencies[i].Name < workspaceDependencies[j].Name
 	})
+	workspaceBuildDependencies := cr.WorkspaceBuildDependencies
+	sort.Slice(workspaceBuildDependencies, func(i, j int) bool {
+		return workspaceBuildDependencies[i].Name < workspaceBuildDependencies[j].Name
+	})
 	workspaceDevDependencies := cr.WorkspaceDevDependencies
 	sort.Slice(workspaceDevDependencies, func(i, j int) bool {
 		return workspaceDevDependencies[i].Name < workspaceDevDependencies[j].Name
 	})
 
 	c.processDependencies(manifests, &crate, dependencies, "dependencies", "dependency")
+	c.processDependencies(manifests, &crate, buildDependencies, "build-dependencies", "build dependency")
 	c.processDependencies(manifests, &crate, devDependencies, "dev-dependencies", "dev dependency")
 	c.processDependencies(manifests, &crate, workspaceDependencies, "workspace.dependencies", "workspace dependency")
+	c.processDependencies(manifests, &crate, workspaceBuildDependencies, "workspace.build-dependencies", "workspace build dependency")
 	c.processDependencies(manifests, &crate, workspaceDevDependencies, "workspace.dev-dependencies", "workspace dev dependency")
 }
 

--- a/pkg/plugins/autodiscovery/cargo/main_test.go
+++ b/pkg/plugins/autodiscovery/cargo/main_test.go
@@ -89,6 +89,37 @@ targets:
       file: 'Cargo.toml'
       key: 'dependencies.rand.version'
     sourceid: 'rand'
+`, `name: 'deps(cargo): bump build dependency "built" for "test-crate" crate'
+sources:
+  built:
+    name: 'Get latest "built" crate version'
+    kind: 'cargopackage'
+    spec:
+      package: 'built'
+      versionfilter:
+        kind: 'semver'
+        pattern: '*'
+  built-current-version:
+    name: 'Get current "built" crate version'
+    kind: 'toml'
+    spec:
+      file: 'Cargo.toml'
+      Key: 'build-dependencies.built'
+conditions:
+  built:
+    name: 'Test if version of "built" {{ source "built-current-version" }} differs from {{ source "built" }}'
+    kind: 'shell'
+    sourceid: 'built'
+    spec:
+      command: 'test {{ source "built-current-version" }} != '
+targets:
+  built:
+    name: 'deps(cargo): bump crate build dependency "built" to {{ source "built" }}'
+    kind: 'toml'
+    spec:
+      file: 'Cargo.toml'
+      key: 'build-dependencies.built'
+    sourceid: 'built'
 `, `name: 'deps(cargo): bump dev dependency "futures" for "test-crate" crate'
 sources:
   futures:
@@ -189,6 +220,37 @@ targets:
       file: 'Cargo.toml'
       key: 'dependencies.rand.version'
     sourceid: 'rand'
+`, `name: 'deps(cargo): bump build dependency "built" for "test-crate" crate'
+sources:
+  built:
+    name: 'Get latest "built" crate version'
+    kind: 'cargopackage'
+    spec:
+      package: 'built'
+      versionfilter:
+        kind: 'semver'
+        pattern: '*'
+  built-current-version:
+    name: 'Get current "built" crate version'
+    kind: 'toml'
+    spec:
+      file: 'Cargo.toml'
+      Key: 'build-dependencies.built'
+conditions:
+  built:
+    name: 'Test if version of "built" {{ source "built-current-version" }} differs from {{ source "built" }}'
+    kind: 'shell'
+    sourceid: 'built'
+    spec:
+      command: 'test {{ source "built-current-version" }} != '
+targets:
+  built:
+    name: 'deps(cargo): bump crate build dependency "built" to {{ source "built" }}'
+    kind: 'toml'
+    spec:
+      file: 'Cargo.toml'
+      key: 'build-dependencies.built'
+    sourceid: 'built'
 `, `name: 'deps(cargo): bump dev dependency "futures" for "test-crate" crate'
 sources:
   futures:
@@ -301,6 +363,46 @@ targets:
           ARGS="--dry-run"
         fi
         cargo upgrade $ARGS --manifest-path Cargo.toml --package rand@{{ source "rand" }}
+      changedif:
+        kind: file/checksum
+        spec:
+          files:
+            - "Cargo.toml"
+    disablesourceinput: true
+`, `name: 'deps(cargo): bump build dependency "built" for "test-crate" crate'
+sources:
+  built:
+    name: 'Get latest "built" crate version'
+    kind: 'cargopackage'
+    spec:
+      package: 'built'
+      versionfilter:
+        kind: 'semver'
+        pattern: '*'
+  built-current-version:
+    name: 'Get current "built" crate version'
+    kind: 'toml'
+    spec:
+      file: 'Cargo.toml'
+      Key: 'build-dependencies.built'
+conditions:
+  built:
+    name: 'Test if version of "built" {{ source "built-current-version" }} differs from {{ source "built" }}'
+    kind: 'shell'
+    sourceid: 'built'
+    spec:
+      command: 'test {{ source "built-current-version" }} != '
+targets:
+  built:
+    name: 'deps(cargo): bump crate build dependency "built" to {{ source "built" }}'
+    kind: 'shell'
+    spec:
+      command: |
+        ARGS=""
+        if [ "$DRY_RUN" = "true" ]; then
+          ARGS="--dry-run"
+        fi
+        cargo upgrade $ARGS --manifest-path Cargo.toml --package built@{{ source "built" }}
       changedif:
         kind: file/checksum
         spec:
@@ -679,6 +781,37 @@ targets:
       file: 'Cargo.toml'
       key: 'workspace.dependencies.anyhow'
     sourceid: 'anyhow'
+`, `name: 'deps(cargo): bump workspace build dependency "built"'
+sources:
+  built:
+    name: 'Get latest "built" crate version'
+    kind: 'cargopackage'
+    spec:
+      package: 'built'
+      versionfilter:
+        kind: 'semver'
+        pattern: '*'
+  built-current-version:
+    name: 'Get current "built" crate version'
+    kind: 'toml'
+    spec:
+      file: 'Cargo.toml'
+      Key: 'workspace.build-dependencies.built'
+conditions:
+  built:
+    name: 'Test if version of "built" {{ source "built-current-version" }} differs from {{ source "built" }}'
+    kind: 'shell'
+    sourceid: 'built'
+    spec:
+      command: 'test {{ source "built-current-version" }} != '
+targets:
+  built:
+    name: 'deps(cargo): bump workspace build dependency "built" to {{ source "built" }}'
+    kind: 'toml'
+    spec:
+      file: 'Cargo.toml'
+      key: 'workspace.build-dependencies.built'
+    sourceid: 'built'
 `,
 				`name: 'deps(cargo): bump dependency "rand" for "simple_crate" crate'
 sources:
@@ -780,6 +913,37 @@ targets:
       file: 'Cargo.toml'
       key: 'workspace.dependencies.anyhow'
     sourceid: 'anyhow'
+`, `name: 'deps(cargo): bump workspace build dependency "built"'
+sources:
+  built:
+    name: 'Get latest "built" crate version'
+    kind: 'cargopackage'
+    spec:
+      package: 'built'
+      versionfilter:
+        kind: 'semver'
+        pattern: '*'
+  built-current-version:
+    name: 'Get current "built" crate version'
+    kind: 'toml'
+    spec:
+      file: 'Cargo.toml'
+      Key: 'workspace.build-dependencies.built'
+conditions:
+  built:
+    name: 'Test if version of "built" {{ source "built-current-version" }} differs from {{ source "built" }}'
+    kind: 'shell'
+    sourceid: 'built'
+    spec:
+      command: 'test {{ source "built-current-version" }} != '
+targets:
+  built:
+    name: 'deps(cargo): bump workspace build dependency "built" to {{ source "built" }}'
+    kind: 'toml'
+    spec:
+      file: 'Cargo.toml'
+      key: 'workspace.build-dependencies.built'
+    sourceid: 'built'
 `,
 				`name: 'deps(cargo): bump dependency "rand" for "simple_crate" crate'
 sources:
@@ -883,6 +1047,46 @@ targets:
           ARGS="--dry-run"
         fi
         cargo upgrade $ARGS --manifest-path Cargo.toml --package anyhow@{{ source "anyhow" }}
+      changedif:
+        kind: file/checksum
+        spec:
+          files:
+            - "Cargo.toml"
+    disablesourceinput: true
+`, `name: 'deps(cargo): bump workspace build dependency "built"'
+sources:
+  built:
+    name: 'Get latest "built" crate version'
+    kind: 'cargopackage'
+    spec:
+      package: 'built'
+      versionfilter:
+        kind: 'semver'
+        pattern: '*'
+  built-current-version:
+    name: 'Get current "built" crate version'
+    kind: 'toml'
+    spec:
+      file: 'Cargo.toml'
+      Key: 'workspace.build-dependencies.built'
+conditions:
+  built:
+    name: 'Test if version of "built" {{ source "built-current-version" }} differs from {{ source "built" }}'
+    kind: 'shell'
+    sourceid: 'built'
+    spec:
+      command: 'test {{ source "built-current-version" }} != '
+targets:
+  built:
+    name: 'deps(cargo): bump workspace build dependency "built" to {{ source "built" }}'
+    kind: 'shell'
+    spec:
+      command: |
+        ARGS=""
+        if [ "$DRY_RUN" = "true" ]; then
+          ARGS="--dry-run"
+        fi
+        cargo upgrade $ARGS --manifest-path Cargo.toml --package built@{{ source "built" }}
       changedif:
         kind: file/checksum
         spec:

--- a/pkg/plugins/autodiscovery/cargo/testdata/simple_crate/Cargo.toml
+++ b/pkg/plugins/autodiscovery/cargo/testdata/simple_crate/Cargo.toml
@@ -7,8 +7,10 @@ version = "0.1.0"
 anyhow = "1.0.1"
 rand = { version = "0.8.0" }
 itoa = { git = "https://github.com/dtolnay/itoa", rev = "1.0.15" }
+
+[build-dependencies]
+built = "0.8.0"
+
 [dev-dependencies]
 futures = { version = "0.3.21" }
-
-
 

--- a/pkg/plugins/autodiscovery/cargo/testdata/workspace/Cargo.toml
+++ b/pkg/plugins/autodiscovery/cargo/testdata/workspace/Cargo.toml
@@ -8,3 +8,7 @@ members = [
 [workspace.dependencies]
 anyhow = "1"
 itoa = { git = "https://github.com/dtolnay/itoa", rev = "1.0.15" }
+
+[workspace.build-dependencies]
+built = "0.8.0"
+

--- a/pkg/plugins/autodiscovery/cargo/utils.go
+++ b/pkg/plugins/autodiscovery/cargo/utils.go
@@ -155,8 +155,10 @@ func getCrateMetadata(rootDir string) (crateMetadata, error) {
 
 	crate.WorkspaceMembers = workspaceMembers
 	crate.Dependencies, _ = getDependencies(&tomlFile, "dependencies")
+	crate.BuildDependencies, _ = getDependencies(&tomlFile, "build-dependencies")
 	crate.DevDependencies, _ = getDependencies(&tomlFile, "dev-dependencies")
 	crate.WorkspaceDependencies, _ = getDependencies(&tomlFile, "workspace.dependencies")
+	crate.WorkspaceBuildDependencies, _ = getDependencies(&tomlFile, "workspace.build-dependencies")
 	crate.WorkspaceDevDependencies, _ = getDependencies(&tomlFile, "workspace.dev-dependencies")
 
 	logrus.Debugf("Crate: %q\n", name)

--- a/pkg/plugins/autodiscovery/cargo/utils_test.go
+++ b/pkg/plugins/autodiscovery/cargo/utils_test.go
@@ -52,6 +52,9 @@ func TestGetCrateMetadata(t *testing.T) {
 					{Name: "anyhow", Version: "1.0.1", Inlined: true},
 					{Name: "rand", Version: "0.8.0"},
 				},
+				BuildDependencies: []crateDependency{
+					{Name: "built", Version: "0.8.0", Inlined: true},
+				},
 				DevDependencies: []crateDependency{
 					{Name: "futures", Version: "0.3.21"},
 				},
@@ -81,6 +84,9 @@ func TestGetCrateMetadata(t *testing.T) {
 				Workspace: true,
 				WorkspaceDependencies: []crateDependency{
 					{Name: "anyhow", Version: "1", Inlined: true},
+				},
+				WorkspaceBuildDependencies: []crateDependency{
+					{Name: "built", Version: "0.8.0", Inlined: true},
 				},
 				WorkspaceMembers: []crateMetadata{
 					{Name: "simple_crate",


### PR DESCRIPTION
Right now it handles regular and dev dependencies, but not build dependencies, which just get skipped.