### PR TITLE
fix: use github token to publish asset

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -84,7 +84,7 @@ jobs:
         env:
           AUR_KEY: ${{ secrets.AUR_KEY }}
           COSIGN_PWD: ${{ secrets.COSIGN_PWD }}
-          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
         run: |
           make release


### PR DESCRIPTION
Revert this change https://github.com/updatecli/updatecli/commit/9b2454b24d472f63c495490aad6ab65be416eaaa#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaR56-L75

To unblock the release process