### PR TITLE
fix(json): Don't check for query + versionFilter with dasel/v2

### DIFF
--- a/pkg/plugins/resources/json/source.go
+++ b/pkg/plugins/resources/json/source.go
@@ -19,8 +19,9 @@ func (j *Json) Source(workingDir string, resultSource *result.Source) error {
 		return errors.New("source only supports one file")
 	}
 
-	if (len(j.spec.Query) > 0 && j.spec.VersionFilter.IsZero()) ||
-		(len(j.spec.Query) == 0) && !j.spec.VersionFilter.IsZero() {
+	if j.engine != ENGINEDASEL_V2 &&
+		((len(j.spec.Query) > 0 && j.spec.VersionFilter.IsZero()) ||
+			(len(j.spec.Query) == 0 && !j.spec.VersionFilter.IsZero())) {
 		return ErrSpecVersionFilterRequireMultiple
 	}
 

--- a/pkg/plugins/resources/json/source_test.go
+++ b/pkg/plugins/resources/json/source_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/updatecli/updatecli/pkg/core/result"
+	"github.com/updatecli/updatecli/pkg/plugins/utils/version"
 )
 
 func strPtr(s string) *string {
@@ -113,6 +114,18 @@ func TestSource(t *testing.T) {
 				Engine: strPtr(ENGINEDASEL_V2),
 			},
 			expectedResult: "Thomas",
+		},
+		{
+			name: "Version filter with Dasel v2",
+			spec: Spec{
+				File:   "testdata/data.json",
+				Key:    ".children.all()",
+				Engine: strPtr(ENGINEDASEL_V2),
+				VersionFilter: version.Filter{
+					Kind: "latest",
+				},
+			},
+			expectedResult: "Trevor",
 		},
 	}
 


### PR DESCRIPTION
With dasel/v2, only `key` is for single *and* multiple results, so this check no longer makes sense.

## Test

To test this pull request, you can run the following commands:

```shell
cd <to_package_directory>
go test
```

## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via pull request in [website](https://github.com/updatecli/website) repository.

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
