### PR TITLE
fix: Correctly set  default action title based on pipeline title

### DIFF
--- a/pkg/core/pipeline/actions.go
+++ b/pkg/core/pipeline/actions.go
@@ -95,7 +95,6 @@ func (p *Pipeline) RunActions() error {
 		inheritedSCM := p.SCMs[action.Config.ScmID]
 		action.Scm = &inheritedSCM
 
-		action = p.Actions[id]
 		action.Config = p.Config.Spec.Actions[id]
 
 		if p.Report.Actions == nil {


### PR DESCRIPTION
While investigating #6607 I noticed that the action object would drop the change done a few line aboves
So this line is not needed

<!-- Describe the changes introduced by this pull request -->

## Test

I test this change with an action that doesn't content a title such as 

```
  actions:
    default:
      kind: github/pullrequest
      spec:
        automerge: false
        labels:
          - chore
          - skip-changelog
      scmid: default

```

## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via pull request in [website](https://github.com/updatecli/website) repository.

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
