### PR TITLE
feat(config): enable pipe operations on source function output

### DIFF
--- a/pkg/core/config/funcsUpdatecli.go
+++ b/pkg/core/config/funcsUpdatecli.go
@@ -68,6 +68,12 @@ func updatecliRuntimeFuncMap(data interface{}) template.FuncMap {
 				then we assume that the value will be set later in the run.
 				Otherwise it returns the value.
 				This func is design to constantly reevaluate if a configuration changed
+				
+				The source function output can be piped to sprig template functions for transformation.
+				Examples:
+				  - {{ source "version" | replace "." "_" }}
+				  - {{ source "name" | upper }}
+				  - {{ source "id" | replace "." "_" | replace "-" "_" }}
 			*/
 
 			sourceResult, err := getFieldValueByQuery(data, []string{"Sources", s, "Result", "Result"})

--- a/pkg/core/config/main.go
+++ b/pkg/core/config/main.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/Masterminds/sprig/v3"
 	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
 
@@ -777,7 +778,10 @@ func (config *Config) Update(data interface{}) (err error) {
 		return err
 	}
 
-	tmpl, err := template.New("cfg").Funcs(updatecliRuntimeFuncMap(data)).Parse(string(content))
+	tmpl, err := template.New("cfg").
+		Funcs(sprig.FuncMap()).
+		Funcs(updatecliRuntimeFuncMap(data)).
+		Parse(string(content))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fix #6789

Enable pipe operations on `{{ source }}` function output to allow transformation of source values at runtime using sprig template functions.

## Changes

- Added sprig functions to runtime template processing in `pkg/core/config/main.go`
- Updated source function documentation with pipe examples
- Added test coverage for pipe operations with source function

## Example

```yaml
sourceid: '{{ source "version" | replace "." "_" }}'
```

## Test

To test this pull request, you can run the following commands:

```shell
cd pkg/core/config
go test -v -run TestUpdate/10
```

## Additional Information

### Checklist

- [ ] I have updated the documentation via pull request in [website](https://github.com/updatecli/website) repository.

### Tradeoff

No breaking changes. All existing `{{ source }}` usage continues to work. Adding sprig functions to runtime templates provides flexibility with minimal performance impact.

### Potential improvement
