### PR TITLE
chore: update gitlab.com/gitlab-org/api/client-go to v1.0.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -74,7 +74,7 @@ require (
 )
 
 require (
-	cel.dev/expr v0.24.0 // indirect
+	cel.dev/expr v0.25.1 // indirect
 	cloud.google.com/go v0.121.6 // indirect
 	cloud.google.com/go/auth v0.16.5 // indirect
 	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect
@@ -308,8 +308,8 @@ require (
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
 	github.com/xlab/treeprint v1.2.0 // indirect
-	gitlab.com/gitlab-org/api/client-go v0.129.0
-	golang.org/x/crypto v0.45.0 // indirect
+	gitlab.com/gitlab-org/api/client-go v1.0.0
+	golang.org/x/crypto v0.44.0 // indirect
 	golang.org/x/mod v0.30.0
 	golang.org/x/net v0.47.0
 	golang.org/x/sync v0.18.0 // indirect
@@ -318,7 +318,7 @@ require (
 	golang.org/x/tools v0.38.0 // indirect
 	google.golang.org/api v0.250.0 // indirect
 	google.golang.org/grpc v1.75.1 // indirect
-	google.golang.org/protobuf v1.36.9 // indirect
+	google.golang.org/protobuf v1.36.10 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 c2sp.org/CCTV/age v0.0.0-20240306222714-3ec4d716e805 h1:u2qwJeEvnypw+OCPUHmoZE3IqwfuN5kgDfo5MLzpNM0=
 c2sp.org/CCTV/age v0.0.0-20240306222714-3ec4d716e805/go.mod h1:FomMrUJ2Lxt5jCLmZkG3FHa72zUprnhd3v/Z18Snm4w=
-cel.dev/expr v0.24.0 h1:56OvJKSH3hDGL0ml5uSxZmz3/3Pq4tJ+fb1unVLAFcY=
-cel.dev/expr v0.24.0/go.mod h1:hLPLo1W4QUmuYdA72RBX06QTs6MXw941piREPl3Yfiw=
+cel.dev/expr v0.25.1 h1:1KrZg61W6TWSxuNZ37Xy49ps13NUovb66QLprthtwi4=
+cel.dev/expr v0.25.1/go.mod h1:hrXvqGP6G6gyx8UAHSHJ5RGk//1Oj5nXQ2NI02Nrsg4=
 cloud.google.com/go v0.121.6 h1:waZiuajrI28iAf40cWgycWNgaXPO06dupuS+sgibK6c=
 cloud.google.com/go v0.121.6/go.mod h1:coChdst4Ea5vUpiALcYKXEpR1S9ZgXbhEzzMcMR66vI=
 cloud.google.com/go/auth v0.16.5 h1:mFWNQ2FEVWAliEQWpAdH80omXFokmrnbDhUS9cBywsI=
@@ -753,8 +753,8 @@ github.com/zclconf/go-cty-debug v0.0.0-20240509010212-0d6042c53940 h1:4r45xpDWB6
 github.com/zclconf/go-cty-debug v0.0.0-20240509010212-0d6042c53940/go.mod h1:CmBdvvj3nqzfzJ6nTCIwDTPZ56aVGvDrmztiO5g3qrM=
 github.com/zeebo/errs v1.4.0 h1:XNdoD/RRMKP7HD0UhJnIzUy74ISdGGxURlYG8HSWSfM=
 github.com/zeebo/errs v1.4.0/go.mod h1:sgbWHsvVuTPHcqJJGQ1WhI5KbWlHYz+2+2C/LSEtCw4=
-gitlab.com/gitlab-org/api/client-go v0.129.0 h1:o9KLn6fezmxBQWYnQrnilwyuOjlx4206KP0bUn3HuBE=
-gitlab.com/gitlab-org/api/client-go v0.129.0/go.mod h1:ZhSxLAWadqP6J9lMh40IAZOlOxBLPRh7yFOXR/bMJWM=
+gitlab.com/gitlab-org/api/client-go v1.0.0 h1:k1kdiJRPHNNPveJ5Kww8MAGZFJCMaItLuLyDZ8j0/Ns=
+gitlab.com/gitlab-org/api/client-go v1.0.0/go.mod h1:hxFLApm0RqUWU3xmXCrRpxO47BQnAIWdZh9VtMaV648=
 go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=
 go.opentelemetry.io/auto/sdk v1.1.0/go.mod h1:3wSPjt5PWp2RhlCcmmOial7AvC4DQqZb7a7wCow3W8A=
 go.opentelemetry.io/contrib/bridges/prometheus v0.57.0 h1:UW0+QyeyBVhn+COBec3nGhfnFe5lwB0ic1JBVjzhk0w=
@@ -820,8 +820,8 @@ golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0
 golang.org/x/crypto v0.19.0/go.mod h1:Iy9bg/ha4yyC70EfRS8jz+B6ybOBKMaSxLj6P6oBDfU=
 golang.org/x/crypto v0.22.0/go.mod h1:vr6Su+7cTlO45qkww3VDJlzDn0ctJvRgYbC2NvXHt+M=
 golang.org/x/crypto v0.23.0/go.mod h1:CKFgDieR+mRhux2Lsu27y0fO304Db0wZe70UKqHu0v8=
-golang.org/x/crypto v0.45.0 h1:jMBrvKuj23MTlT0bQEOBcAE0mjg8mK9RXFhRH6nyF3Q=
-golang.org/x/crypto v0.45.0/go.mod h1:XTGrrkGJve7CYK7J8PEww4aY7gM3qMCElcJQ8n8JdX4=
+golang.org/x/crypto v0.44.0 h1:A97SsFvM3AIwEEmTBiaxPPTYpDC47w720rdiiUvgoAU=
+golang.org/x/crypto v0.44.0/go.mod h1:013i+Nw79BMiQiMsOPcVCB5ZIJbYkerPrGnOa00tvmc=
 golang.org/x/exp v0.0.0-20250408133849-7e4ce0ab07d0 h1:R84qjqJb5nVJMxqWYb3np9L5ZsaDtB+a39EqjV0JSUM=
 golang.org/x/exp v0.0.0-20250408133849-7e4ce0ab07d0/go.mod h1:S9Xr4PYopiDyqSyp5NjCrhFrqg6A5zA2E/iPHPhqnS8=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
@@ -945,8 +945,8 @@ google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQ
 google.golang.org/protobuf v1.20.1-0.20200309200217-e05f789c0967/go.mod h1:A+miEFZTKqfCUM6K7xSMQL9OKL/b6hQv+e19PK+JZNE=
 google.golang.org/protobuf v1.21.0/go.mod h1:47Nbq4nVaFHyn7ilMalzfO3qCViNmqZ2kzikPIcrTAo=
 google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
-google.golang.org/protobuf v1.36.9 h1:w2gp2mA27hUeUzj9Ex9FBjsBm40zfaDtEWow293U7Iw=
-google.golang.org/protobuf v1.36.9/go.mod h1:fuxRtAxBytpl4zzqUh6/eyUujkJdNiuEkXntxiD/uRU=
+google.golang.org/protobuf v1.36.10 h1:AYd7cD/uASjIL6Q9LiTjz8JLcrh/88q5UObnmY3aOOE=
+google.golang.org/protobuf v1.36.10/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=

--- a/pkg/plugins/resources/gitlab/client/main.go
+++ b/pkg/plugins/resources/gitlab/client/main.go
@@ -34,19 +34,6 @@ func New(s Spec) (Client, error) {
 		return client, nil
 	}
 
-	// provide a custom http.Client with a transport
-	// that injects the private GitLab token through
-	// the either PRIVATE_TOKEN or AUTHORIZATION header variable.
-	if strings.ToLower(s.TokenType) == "bearer" {
-
-		client.Client.Transport = &transport.BearerToken{
-			Base:  client.Client.Transport,
-			Token: s.Token,
-		}
-
-		return client, nil
-	}
-
 	client.Client.Transport = &transport.PrivateToken{
 		Token: s.Token,
 		Base:  client.Client.Transport,

--- a/pkg/plugins/resources/gitlab/client/spec.go
+++ b/pkg/plugins/resources/gitlab/client/spec.go
@@ -22,10 +22,4 @@ type Spec struct {
 	//	  For more information, about a SOPS file, please refer to the following documentation:
 	//    https://github.com/getsops/sops
 	Token string `yaml:",omitempty"`
-
-	// "tokentype" defines type of provided token. Valid values are "private" and "bearer"
-	//
-	//  default:
-	// 		"private"
-	TokenType string `yaml:",omitempty"`
 }

--- a/pkg/plugins/resources/gitlab/mergerequest/main.go
+++ b/pkg/plugins/resources/gitlab/mergerequest/main.go
@@ -32,21 +32,13 @@ type Gitlab struct {
 }
 
 func getGitlabClient(spec client.Spec) (*gitlabapi.Client, error) {
-	tokenType := strings.ToLower(spec.TokenType)
 
 	var opt gitlabapi.ClientOptionFunc
 	if len(spec.URL) > 0 {
 		opt = gitlabapi.WithBaseURL(spec.URL)
 	}
 
-	switch tokenType {
-	case "bearer":
-		return gitlabapi.NewOAuthClient(spec.Token, opt)
-	case "private", "":
-		return gitlabapi.NewClient(spec.Token, opt)
-	default:
-		return nil, fmt.Errorf("error: unknown tokenType '%s'", tokenType)
-	}
+	return gitlabapi.NewClient(spec.Token, opt)
 }
 
 // New returns a new valid GitLab object.
@@ -81,10 +73,6 @@ func New(spec interface{}, scm *gitlabscm.Gitlab) (Gitlab, error) {
 
 		if len(clientSpec.Username) == 0 && len(scm.Spec.Username) > 0 {
 			clientSpec.Username = scm.Spec.Username
-		}
-
-		if len(clientSpec.TokenType) == 0 && len(scm.Spec.TokenType) > 0 {
-			clientSpec.TokenType = scm.Spec.TokenType
 		}
 	}
 

--- a/pkg/plugins/resources/gitlab/mergerequest/spec.go
+++ b/pkg/plugins/resources/gitlab/mergerequest/spec.go
@@ -77,23 +77,23 @@ type Spec struct {
 	// default: empty
 	//
 	// remark:
-	//		assignees only accept GitLab User IDs.
-	// 		To find the user ID:
-	// 			1. Go to the users’ profile page.
-	// 			2. On the profile page, in the upper-right corner, select Actions (or ⋮).
-	// 			3. Select Copy user ID.
-	Assignees []int `yaml:",omitempty"`
+	//   assignees only accept GitLab User IDs.
+	//   To find the user ID:
+	//    1. Go to the users’ profile page.
+	//    2. On the profile page, in the upper-right corner, select Actions (or ⋮).
+	//    3. Select Copy user ID.
+	Assignees []int64 `yaml:",omitempty"`
 	// "reviewers" contains the list of reviewers to add to the merge request
 	//
 	// default: empty
 	//
 	// remark:
-	// 		assignees only accept GitLab User IDs.
-	// 		To find the user ID:
-	// 			1. Go to the users’ profile page.
-	// 			2. On the profile page, in the upper-right corner, select Actions (or ⋮).
-	// 			3. Select Copy user ID.
-	Reviewers []int `yaml:",omitempty"`
+	//   assignees only accept GitLab User IDs.
+	//   To find the user ID:
+	//    1. Go to the users’ profile page.
+	//    2. On the profile page, in the upper-right corner, select Actions (or ⋮).
+	//    3. Select Copy user ID.
+	Reviewers []int64 `yaml:",omitempty"`
 	// "squash" defines if all commits should be squashed into a single commit on merge
 	//
 	// default: false

--- a/pkg/plugins/resources/gitlab/mergerequest/utils.go
+++ b/pkg/plugins/resources/gitlab/mergerequest/utils.go
@@ -17,7 +17,8 @@ func (g *Gitlab) findExistingMR() (mr *gitlabapi.BasicMergeRequest, err error) {
 	defer cancelList()
 
 	const perPage = 30
-	page := 0
+	var page int64
+
 	for {
 		optsList := gitlabapi.ListProjectMergeRequestsOptions{
 			SourceBranch: &g.SourceBranch,
@@ -96,7 +97,7 @@ func (g *Gitlab) isRemoteBranchesExist() (bool, error) {
 
 	foundRemoteSourceBranch := false
 	foundRemoteTargetBranch := false
-	page := 0
+	var page int64
 	const perPage = 30
 	for {
 		ctx, cancel := context.WithTimeout(ctx, gitlabRequestTimeout)


### PR DESCRIPTION
Update gitlab.com/gitlab-org/api/client-go to v1.0.0

This pull request also remove the tokentype parameter which doesn't seem to be used anymore

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
cd pkg/plugins/resources/gitlab/mergerequest/
go test
```

## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via pull request in [website](https://github.com/updatecli/website) repository.

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
