### PR TITLE
fix: redact version v0.999.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/updatecli/updatecli
 
 go 1.25.4
 
+retract v0.999.0 // Published accidentilly.
+
 require (
 	dario.cat/mergo v1.0.2
 	github.com/Masterminds/semver/v3 v3.4.0


### PR DESCRIPTION
Once a version has been published, the golang project doesn't allow us to remove it but just to high it.
To avoid situation like https://github.com/updatecli/udash/pull/319