### PR TITLE
docs: fix how to verify release assets

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -48,11 +48,11 @@ Updatecli is a Go binary available for Linux, MacOS and Windows from the link:ht
 **Verify File Checksum Signature**
 
 Instead of signing all release assets, Updatecli signs the checksums file containing the different release assets checksum.
-You can download/copy the three files 'checksums.txt.pem', 'checksums.txt.sig', 'checksums.txt' from the latest https://github.com/updatecli/updatecli/releases/latest[release].
+You can download/copy the three files 'checksums.txt.sig' and 'checksums.txt' from the latest https://github.com/updatecli/updatecli/releases/latest[release].
 Once you have the three files locally, you can execute the following command
 
 ```
-cosign verify-blob --certificate-identity-regexp "https://github.com/updatecli/updatecli" --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' --cert https://github.com/updatecli/updatecli/releases/download/v0.110.3/checksums.txt.pem --signature https://github.com/updatecli/updatecli/releases/download/v0.110.3/checksums.txt.sig checksums.txt
+cosign verify-blob --certificate-identity-regexp "https://github.com/updatecli/updatecli" --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' --bundle checksums.txt.sig checksums.txt
 ```
 
 A successful output looks like


### PR DESCRIPTION
Fix #XXX

- https://github.com/updatecli/updatecli/issues/7032

<!-- Describe the changes introduced by this pull request -->

This pull request fixes how to verify release assets using `cosign`.

## Test

To test this pull request, you can run the following commands:

```shell
cd <to_package_directory>
go test
```

## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via pull request in [website](https://github.com/updatecli/website) repository.

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->

The verify command depends on the version of installed updatecli.