### PR TITLE
fix(gitlab): Panic when create merge request times out

### DIFF
--- a/pkg/plugins/resources/gitlab/mergerequest/create.go
+++ b/pkg/plugins/resources/gitlab/mergerequest/create.go
@@ -13,7 +13,7 @@ import (
 	gitlab "gitlab.com/gitlab-org/api/client-go"
 )
 
-const gitlabRequestTimeout = 30 * time.Second
+const gitlabRequestTimeout = 60 * time.Second
 
 // CreateAction opens a Merge Request on the GitLab server
 func (g *Gitlab) CreateAction(report *reports.Action, resetDescription bool) error {
@@ -166,7 +166,9 @@ func (g *Gitlab) CreateAction(report *reports.Action, resetDescription bool) err
 	)
 
 	if err != nil {
-		logrus.Debugf("HTTP Response:\n\tReturn code: %d\n\n", resp.StatusCode)
+		if resp != nil {
+			logrus.Debugf("HTTP Response:\n\tReturn code: %d\n\n", resp.StatusCode)
+		}
 
 		return fmt.Errorf("create GitLab mergerequest: %v", err)
 	}


### PR DESCRIPTION
Creating a Merge request on at least one of our repositories on gitlab.com seems to always take > 30 seconds. This caused a panic that is fixed by this PR. After fixing that I could troubleshoot it and couldn't find any obvious reason except gitlab.com sometimes being extremely slow when creating an MR. 

To solve that issue I ended up bumping the timeout to 60 seconds which also seems to be the default [timeout used by Gitlab itself](https://gitlab.com/gitlab-org/gitlab/-/issues/217483). I'm also open to other solutions if anyone has any suggestions.

I've verified that, with these changes, the MR can be created against our repository. 

I wasn't sure if I should also create an issue for this first, if needed I can still do that.

## Test

To test this pull request, you can run the following commands:

```shell
cd <to_package_directory>
go test
```

## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via pull request in [website](https://github.com/updatecli/website) repository.

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
