### PR TITLE
fix(terragrunt): strip double slash path separator from git URLs

### DIFF
--- a/pkg/plugins/autodiscovery/terragrunt/utils.go
+++ b/pkg/plugins/autodiscovery/terragrunt/utils.go
@@ -176,7 +176,13 @@ func parseSourceUrl(evaluatedSource string, rawSource string, allowNoVersion boo
 			parts := strings.Split(fmt.Sprintf("%s:%s", u.Scheme, u.Opaque), "://")
 			if len(parts) == 2 {
 				source.protocol = parts[0]
-				source.baseUrl = parts[1]
+				// Strip Terragrunt's // path separator (used for subdirectories)
+				// e.g., "https://github.com/foo/bar//subdir" -> "https://github.com/foo/bar"
+				baseUrl := parts[1]
+				if idx := strings.Index(baseUrl, "//"); idx != -1 {
+					baseUrl = baseUrl[:idx]
+				}
+				source.baseUrl = baseUrl
 			}
 		default:
 			// Github

--- a/pkg/plugins/autodiscovery/terragrunt/utils_test.go
+++ b/pkg/plugins/autodiscovery/terragrunt/utils_test.go
@@ -212,6 +212,30 @@ func TestToSourceUrl(t *testing.T) {
 			},
 		},
 		{
+			name:   "git http repo with double slash path separator",
+			source: "git::https://github.com/terraform-aws-modules/terraform-aws-lambda.git//?ref=v6.0.0",
+			expectedModule: terragruntModuleSource{
+				protocol:        "git::https",
+				baseUrl:         "github.com/terraform-aws-modules/terraform-aws-lambda.git",
+				rawSource:       "git::https://github.com/terraform-aws-modules/terraform-aws-lambda.git//?ref=v6.0.0",
+				evaluatedSource: "git::https://github.com/terraform-aws-modules/terraform-aws-lambda.git//?ref=v6.0.0",
+				version:         "6.0.0",
+				sourceType:      SourceTypeGit,
+			},
+		},
+		{
+			name:   "git http repo with double slash and submodule",
+			source: "git::https://github.com/terraform-aws-modules/terraform-aws-eks.git//modules/karpenter?ref=v20.0.0",
+			expectedModule: terragruntModuleSource{
+				protocol:        "git::https",
+				baseUrl:         "github.com/terraform-aws-modules/terraform-aws-eks.git",
+				rawSource:       "git::https://github.com/terraform-aws-modules/terraform-aws-eks.git//modules/karpenter?ref=v20.0.0",
+				evaluatedSource: "git::https://github.com/terraform-aws-modules/terraform-aws-eks.git//modules/karpenter?ref=v20.0.0",
+				version:         "20.0.0",
+				sourceType:      SourceTypeGit,
+			},
+		},
+		{
 			name:   "github repo",
 			source: "github.com/gruntwork-io/terraform-google-network.git//modules/vpc-network?ref=v0.2.9",
 			expectedModule: terragruntModuleSource{


### PR DESCRIPTION
## Problem

Terragrunt autodiscovery was failing with "repository not found" errors for all git-based module sources. The generated git URLs contained Terragrunt's `//` path separator, creating invalid repository URLs like:
```
https://github.com/seedcx/tf-aws-network//
```

## Root Cause

Terragrunt uses `//` as a special path separator for subdirectories in module sources:
```hcl
source = "git::https://github.com/org/repo//subdir?ref=v1.0.0"
```

When Updatecli parsed these sources, it included the `//` in the `baseUrl`, which was then used directly in git clone operations, causing failures.

See https://community.gruntwork.io/t/relative-paths-in-terragrunt-modules/144
## Solution

Strip the `//` path separator and everything after it from the `baseUrl` when parsing git sources. The full source (including `//subdir`) is preserved in `rawSource` and `evaluatedSource` for other uses, but the `baseUrl` now contains only the clean repository URL needed for cloning.

## Testing

Added test cases covering:
- Git URL with trailing `//`
- Git URL with `//subdir` path

All tests pass.

## Impact

Fixes repository cloning for all git-based Terragrunt modules during autodiscovery.
