### PR TITLE
fix: udash publish without config  file

### DIFF
--- a/pkg/core/udash/publish.go
+++ b/pkg/core/udash/publish.go
@@ -42,7 +42,7 @@ func Publish(r *reports.Report) error {
 
 	configUdashURLString, configUdashApiURLString, configUdashToken, err := getConfigFromFile("")
 	if err != nil {
-		logrus.Debugf("retrieving service access token: %s", err)
+		logrus.Debugf("get Udash config from file: %s", err)
 	}
 
 	setDefaultParam(&envUdashApiURLString, configUdashApiURLString, DefaultEnvVariableAPIURL, "api")
@@ -50,8 +50,7 @@ func Publish(r *reports.Report) error {
 	setDefaultParam(&envUdashToken, configUdashToken, DefaultEnvVariableAccessToken, "token")
 
 	if envUdashApiURLString == "" {
-		logrus.Infof("no Udash endpoint detected, skipping report publication")
-		return nil
+		return ErrNoUdashAPIURL
 	}
 
 	reportApiURL, err := url.Parse(envUdashApiURLString)


### PR DESCRIPTION
Fix a case where Updatecli can't publish report to udash if the udash configuration doesn't exist even thought the parameters are available via environment variable

<!-- Describe the changes introduced by this pull request -->

## Test

Tested manually

## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via pull request in [website](https://github.com/updatecli/website) repository.

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
