### PR TITLE
feat(autodiscovery): propagate npm resource-level spec

### DIFF
--- a/pkg/plugins/autodiscovery/npm/dependency.go
+++ b/pkg/plugins/autodiscovery/npm/dependency.go
@@ -197,6 +197,9 @@ func (n Npm) discoverDependencyManifests() ([][]byte, error) {
 					SourceVersionFilterKind:    sourceVersionFilterKind,
 					SourceVersionFilterPattern: sourceVersionFilterPattern,
 					SourceVersionFilterRegex:   sourceVersionFilterRegex,
+					SourceNpmrcPath:            n.npmrcPath,
+					SourceURL:                  n.url,
+					SourceRegistryToken:        n.registryToken,
 					TargetID:                   "npm",
 					TargetName:                 fmt.Sprintf("Bump %q package version to {{ source \"npm\" }}", dependencyName),
 					// NPM package allows dot in package name which has a different meaning in Dasel query

--- a/pkg/plugins/autodiscovery/npm/main.go
+++ b/pkg/plugins/autodiscovery/npm/main.go
@@ -52,6 +52,15 @@ type Spec struct {
 	//    so we can use versionFilter to retrieve the last Major/Minor/Patch version but in case of complex version constraints, such as ">=1.0.0 <2.0.0",
 	//    Updatecli will convert it to the first version it detects such as 1.0.0 in our example
 	IgnoreVersionConstraints *bool `yaml:",omitempty"`
+	// NpmrcPath defines the path to the .npmrc file to use for all discovered packages.
+	// This will be propagated to all generated npm resource specs.
+	NpmrcPath string `yaml:"npmrcpath,omitempty"`
+	// URL defines the registry url (defaults to `https://registry.npmjs.org/`).
+	// This will be propagated to all generated npm resource specs.
+	URL string `yaml:",omitempty"`
+	// RegistryToken defines the token to use when connecting to the registry.
+	// This will be propagated to all generated npm resource specs.
+	RegistryToken string `yaml:",omitempty"`
 }
 
 // Npm holds all information needed to generate npm manifest.
@@ -68,6 +77,12 @@ type Npm struct {
 	versionFilter version.Filter
 	// ignoreVersionConstraint indicates whether to respect version constraints defined in package.json or not.
 	ignoreVersionConstraint bool
+	// npmrcPath holds the path to the .npmrc file to propagate to generated manifests
+	npmrcPath string
+	// url holds the registry URL to propagate to generated manifests
+	url string
+	// registryToken holds the registry token to propagate to generated manifests
+	registryToken string
 }
 
 // New return a new valid object.
@@ -112,6 +127,9 @@ func New(spec interface{}, rootDir, scmID, actionID string) (Npm, error) {
 		scmID:                   scmID,
 		versionFilter:           newFilter,
 		ignoreVersionConstraint: ignoreVersionConstraint,
+		npmrcPath:               s.NpmrcPath,
+		url:                     s.URL,
+		registryToken:           s.RegistryToken,
 	}, nil
 
 }

--- a/pkg/plugins/autodiscovery/npm/manifestTemplate.go
+++ b/pkg/plugins/autodiscovery/npm/manifestTemplate.go
@@ -9,6 +9,15 @@ sources:
     kind: '{{ .SourceKind }}'
     spec:
       name: '{{ .SourceNPMName }}'
+{{- if .SourceNpmrcPath }}
+      npmrcpath: '{{ .SourceNpmrcPath }}'
+{{- end }}
+{{- if .SourceURL }}
+      url: '{{ .SourceURL }}'
+{{- end }}
+{{- if .SourceRegistryToken }}
+      registrytoken: '{{ .SourceRegistryToken }}'
+{{- end }}
       versionfilter:
         kind: '{{ .SourceVersionFilterKind }}'
         pattern: '{{ .SourceVersionFilterPattern }}'
@@ -115,6 +124,9 @@ type manifestTemplateParams struct {
 	SourceVersionFilterKind    string
 	SourceVersionFilterPattern string
 	SourceVersionFilterRegex   string
+	SourceNpmrcPath            string
+	SourceURL                  string
+	SourceRegistryToken        string
 	TargetID                   string
 	TargetName                 string
 	TargetKey                  string


### PR DESCRIPTION
Allow setting `npmrcpath`, `url`, and `registrytoken` at npm autodiscovery
level. Fields propagate to all generated npm source manifests.

Fix #7478



<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
cd pkg/plugins/autodiscovery/npm
go test
```

## Additional Information

### Checklist

- [x] <!-- If applicable,--> I have updated the documentation via pull request in [website](https://github.com/updatecli/website) repository. https://github.com/updatecli/website/pull/2584

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
