### PR TITLE
fix(file): file condition bug with searchpattern and matchpattern

### DIFF
--- a/e2e/updatecli.d/success.d/file/noscm.yaml
+++ b/e2e/updatecli.d/success.d/file/noscm.yaml
@@ -20,7 +20,6 @@ sources:
       file: file://ADOPTE??.md
       searchpattern: true
 
-
   adoptersHTTPSScheme:
     name: "Get content from ADOPTERS.md using https scheme"
     kind: file
@@ -50,11 +49,21 @@ conditions:
       file: ADOPTE??.md
       searchpattern: true
 
+  adoptersFilePatternMatch:
+    name: "Update ADOPTE??.md content"
+    sourceid: adopters
+    kind: file
+    spec:
+      file: ADOPTE??.md
+      searchpattern: true
+      matchpattern: "donotexist"
+
 targets:
   adopters:
     name: "Update ADOPTERS.md content"
     sourceid: adopters
     kind: file
+    disableconditions: true
     spec:
       file: ADOPTERS.md
 
@@ -62,6 +71,19 @@ targets:
     name: "Update ADOPTE??.md content"
     sourceid: adopters
     kind: file
+    disableconditions: true
     spec:
       file: ADOPTE??.md
       searchpattern: true
+
+  adoptersFilePatternMatch:
+    name: "Update ADOPTE??.md content should be skipped due to failed condition"
+    sourceid: adopters
+    kind: file
+    dependson:
+      - condition#adoptersFilePatternMatch
+    spec:
+      file: ADOPTE??.md
+      searchpattern: true
+      matchpattern: "donotexist"
+      replacepattern: "xxx"

--- a/pkg/plugins/resources/file/condition.go
+++ b/pkg/plugins/resources/file/condition.go
@@ -15,7 +15,6 @@ import (
 // Condition test if a file content matches the content provided via configuration.
 // If the configuration doesn't specify a value then it fall back to the source output
 func (f *File) Condition(source string, scm scm.ScmHandler) (pass bool, message string, err error) {
-
 	workDir := ""
 	if scm != nil {
 		workDir = scm.GetDirectory()
@@ -85,7 +84,13 @@ func (f *File) condition(source string) (bool, error) {
 					// When using both a file path pattern AND a content matching regex, then we want to ignore files that don't match the pattern
 					// as otherwise we trigger error for files we don't care about.
 					logrus.Debugf("No match found for pattern %q in file %q, removing it from the list of files to update", f.spec.MatchPattern, filePath)
+
 					delete(f.files, filePath)
+
+					if len(f.files) == 0 {
+						logrus.Infof("no file found matching criteria %q", f.spec.MatchPattern)
+						return false, nil
+					}
 					continue
 				}
 
@@ -95,11 +100,6 @@ func (f *File) condition(source string) (bool, error) {
 					logMessage,
 					f.spec.MatchPattern,
 				)
-				return false, nil
-			}
-
-			if len(f.files) == 0 {
-				logrus.Debugf("no file found matching criteria")
 				return false, nil
 			}
 


### PR DESCRIPTION
While reviewing #7614 I realize that the condition file match pattern was also broken

Note that #7614 should be merged first

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
go build -o bin/updatecli .
./bin/updatecli diff --config e2e/updatecli.d/success.d/file/noscm.yaml
```

## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via pull request in [website](https://github.com/updatecli/website) repository.

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
