### PR TITLE
fix(autodiscovery/helmfile): error on invalid ignore spec

### DIFF
--- a/pkg/core/pipeline/autodiscovery/main.go
+++ b/pkg/core/pipeline/autodiscovery/main.go
@@ -301,8 +301,9 @@ func New(spec Config, workDir string) (*AutoDiscovery, error) {
 
 	if len(errs) > 0 {
 		for i := range errs {
-			logrus.Info(errs[i])
+			logrus.Errorln(errs[i])
 		}
+		return &g, fmt.Errorf("autodiscovery failed with %d error(s)", len(errs))
 	}
 
 	return &g, nil

--- a/pkg/plugins/autodiscovery/helmfile/main_test.go
+++ b/pkg/plugins/autodiscovery/helmfile/main_test.go
@@ -135,3 +135,68 @@ targets:
 	}
 
 }
+
+func TestNewWithInvalidIgnoreSpec(t *testing.T) {
+	tests := []struct {
+		name        string
+		spec        Spec
+		rootDir     string
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name: "valid ignore spec should pass",
+			spec: Spec{
+				Ignore: MatchingRules{
+					{Repositories: []string{"https://helm.example.com"}},
+				},
+			},
+			rootDir:     "testdata",
+			expectError: false,
+		},
+		{
+			name: "empty ignore rule should fail",
+			spec: Spec{
+				Ignore: MatchingRules{
+					{},
+				},
+			},
+			rootDir:     "testdata",
+			expectError: true,
+			errorMsg:    "invalid ignore spec",
+		},
+		{
+			name: "valid only spec should pass",
+			spec: Spec{
+				Only: MatchingRules{
+					{Path: "testdata/*.yaml"},
+				},
+			},
+			rootDir:     "testdata",
+			expectError: false,
+		},
+		{
+			name: "empty only rule should fail",
+			spec: Spec{
+				Only: MatchingRules{
+					{},
+				},
+			},
+			rootDir:     "testdata",
+			expectError: true,
+			errorMsg:    "invalid only spec",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := New(tt.spec, tt.rootDir, "", "")
+			if tt.expectError {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errorMsg)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/plugins/autodiscovery/helmfile/matchingRule.go
+++ b/pkg/plugins/autodiscovery/helmfile/matchingRule.go
@@ -1,6 +1,7 @@
 package helmfile
 
 import (
+	"fmt"
 	"path/filepath"
 
 	"github.com/Masterminds/semver/v3"
@@ -18,6 +19,17 @@ type MatchingRule struct {
 }
 
 type MatchingRules []MatchingRule
+
+// Validate checks that each matching rule has at least one non-empty field.
+// Returns an error if any rule has no valid fields specified.
+func (m MatchingRules) Validate() error {
+	for i, rule := range m {
+		if rule.Path == "" && len(rule.Repositories) == 0 && len(rule.Charts) == 0 {
+			return fmt.Errorf("rule %d has no valid fields (path, repositories, or charts must be specified)", i+1)
+		}
+	}
+	return nil
+}
 
 // isMatchingRules checks if a specific file content matches the "only" rule
 func (m MatchingRules) isMatchingRules(rootDir, filePath, repositoryURL, chartName, chartVersion string) bool {

--- a/pkg/plugins/autodiscovery/helmfile/matchingRule_test.go
+++ b/pkg/plugins/autodiscovery/helmfile/matchingRule_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestIsMatchingRule(t *testing.T) {
@@ -74,6 +75,81 @@ func TestIsMatchingRule(t *testing.T) {
 				d.chartVersion)
 
 			assert.Equal(t, d.expectedResult, gotResult)
+		})
+	}
+}
+
+func TestMatchingRulesValidate(t *testing.T) {
+	tests := []struct {
+		name        string
+		rules       MatchingRules
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name:        "empty rules should pass",
+			rules:       MatchingRules{},
+			expectError: false,
+		},
+		{
+			name: "rule with path should pass",
+			rules: MatchingRules{
+				{Path: "testdata/helmfile.d/*.yaml"},
+			},
+			expectError: false,
+		},
+		{
+			name: "rule with repositories should pass",
+			rules: MatchingRules{
+				{Repositories: []string{"https://helm.example.com"}},
+			},
+			expectError: false,
+		},
+		{
+			name: "rule with charts should pass",
+			rules: MatchingRules{
+				{Charts: map[string]string{"datadog": ""}},
+			},
+			expectError: false,
+		},
+		{
+			name: "rule with multiple fields should pass",
+			rules: MatchingRules{
+				{
+					Path:         "testdata/*.yaml",
+					Repositories: []string{"https://helm.example.com"},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "empty rule should fail",
+			rules: MatchingRules{
+				{},
+			},
+			expectError: true,
+			errorMsg:    "rule 1 has no valid fields",
+		},
+		{
+			name: "second empty rule should fail",
+			rules: MatchingRules{
+				{Path: "testdata/*.yaml"},
+				{},
+			},
+			expectError: true,
+			errorMsg:    "rule 2 has no valid fields",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.rules.Validate()
+			if tt.expectError {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errorMsg)
+			} else {
+				require.NoError(t, err)
+			}
 		})
 	}
 }


### PR DESCRIPTION
Fix #7461

## Summary

This PR makes Helmfile autodiscovery fail fast on invalid `spec.ignore` rules instead of silently discovering 0 items.

- Treat empty matching rules (no `path`, `repositories`, or `charts`) as invalid.
- Return a clear error for invalid ignore specs so the CLI exits non-zero.
- Add tests to prevent regressions.

## Test

- Run the existing test suite: `go test ./...`
- Reproduce with the config from #7461 and confirm it fails with an error (non-zero exit).

## Additional Information

### Checklist

- [x] I have updated the documentation via pull request in the website repository (if applicable).

### Tradeoff

- This introduces stricter validation: previously invalid ignore specs could be accepted and result in 0 discoveries.
  Now they are rejected with an error to avoid silent failures.

### Potential improvement

- If maintainers want a more user-friendly UX, we could expand the error message to include examples of the supported `spec.ignore` structure.
