### PR TITLE
fix: e2e tests related to updatecli pipeline deprecation

### DIFF
--- a/e2e/updatecli.d/deprecated.d/yaml/duplicate.yaml
+++ b/e2e/updatecli.d/deprecated.d/yaml/duplicate.yaml
@@ -26,14 +26,14 @@ sources:
     name: Test URL scheme
     kind: yaml
     spec:
-      file: https://raw.githubusercontent.com/updatecli/updatecli/main/e2e/venom.d/test_diff.yaml
+      file: https://raw.githubusercontent.com/updatecli/updatecli/main/e2e/venom.d/test_pipeline.yaml
       key: name
 
   scenario31:
     name: Test URL scheme
     kind: yaml
     spec:
-      file: https://raw.githubusercontent.com/updatecli/updatecli/main/e2e/venom.d/test_diff.yaml
+      file: https://raw.githubusercontent.com/updatecli/updatecli/main/e2e/venom.d/test_pipeline.yaml
       key: name
 
 conditions:
@@ -43,8 +43,8 @@ conditions:
     disablesourceinput: true
     spec:
       files:
-      - e2e/updatecli.d/success.d/yaml/noscm.yaml
-      - e2e/updatecli.d/success.d/yaml/duplicate.yaml
+        - e2e/updatecli.d/success.d/yaml/noscm.yaml
+        - e2e/updatecli.d/success.d/yaml/duplicate.yaml
       key: sources.scenario1.kind
       value: yaml
 
@@ -54,8 +54,8 @@ conditions:
     disablesourceinput: true
     spec:
       files:
-      - file://e2e/updatecli.d/success.d/yaml/noscm.yaml
-      - file://e2e/updatecli.d/success.d/yaml/duplicate.yaml
+        - file://e2e/updatecli.d/success.d/yaml/noscm.yaml
+        - file://e2e/updatecli.d/success.d/yaml/duplicate.yaml
       key: sources.scenario1.kind
       value: yaml
 
@@ -65,8 +65,8 @@ conditions:
     disablesourceinput: true
     spec:
       files:
-      - https://raw.githubusercontent.com/updatecli/updatecli/main/e2e/updatecli.d/success.d/yaml/noscm.yaml
-      - https://raw.githubusercontent.com/updatecli/updatecli/main/e2e/updatecli.d/success.d/yaml/duplicate.yaml
+        - https://raw.githubusercontent.com/updatecli/updatecli/main/e2e/updatecli.d/success.d/yaml/noscm.yaml
+        - https://raw.githubusercontent.com/updatecli/updatecli/main/e2e/updatecli.d/success.d/yaml/duplicate.yaml
       key: sources.scenario1.kind
       value: yaml
 
@@ -77,8 +77,8 @@ targets:
     sourceid: scenario1
     spec:
       files:
-      - e2e/updatecli.d/success.d/yaml/noscm.yaml
-      - e2e/updatecli.d/success.d/yaml/duplicate.yaml
+        - e2e/updatecli.d/success.d/yaml/noscm.yaml
+        - e2e/updatecli.d/success.d/yaml/duplicate.yaml
       key: sources.scenario1.kind
     transformers:
       - addsuffix: -beta

--- a/e2e/updatecli.d/deprecated.d/yaml/noscm.yaml
+++ b/e2e/updatecli.d/deprecated.d/yaml/noscm.yaml
@@ -26,15 +26,15 @@ sources:
     name: Test URL scheme
     kind: yaml
     spec:
-      file: https://raw.githubusercontent.com/updatecli/updatecli/main/e2e/venom.d/test_diff.yaml
+      file: https://raw.githubusercontent.com/updatecli/updatecli/main/e2e/venom.d/test_pipeline.yaml
       key: name
 
   scenario31:
     name: Test URL scheme
     kind: yaml
     spec:
-      file: https://raw.githubusercontent.com/updatecli/updatecli/main/e2e/venom.d/test_diff.yaml
       key: name
+      file: https://raw.githubusercontent.com/updatecli/updatecli/main/e2e/venom.d/test_pipeline.yaml
 
 conditions:
   scenario1:
@@ -43,8 +43,8 @@ conditions:
     disablesourceinput: true
     spec:
       files:
-      - e2e/updatecli.d/success.d/yaml/noscm.yaml
-      - e2e/updatecli.d/success.d/yaml/duplicate.yaml
+        - e2e/updatecli.d/success.d/yaml/noscm.yaml
+        - e2e/updatecli.d/success.d/yaml/duplicate.yaml
       key: sources.scenario1.kind
       value: yaml
 
@@ -54,8 +54,8 @@ conditions:
     disablesourceinput: true
     spec:
       files:
-      - file://e2e/updatecli.d/success.d/yaml/noscm.yaml
-      - file://e2e/updatecli.d/success.d/yaml/duplicate.yaml
+        - file://e2e/updatecli.d/success.d/yaml/noscm.yaml
+        - file://e2e/updatecli.d/success.d/yaml/duplicate.yaml
       key: sources.scenario1.kind
       value: yaml
 
@@ -65,8 +65,8 @@ conditions:
     disablesourceinput: true
     spec:
       files:
-      - https://raw.githubusercontent.com/updatecli/updatecli/main/e2e/updatecli.d/success.d/yaml/noscm.yaml
-      - https://raw.githubusercontent.com/updatecli/updatecli/main/e2e/updatecli.d/success.d/yaml/duplicate.yaml
+        - https://raw.githubusercontent.com/updatecli/updatecli/main/e2e/updatecli.d/success.d/yaml/noscm.yaml
+        - https://raw.githubusercontent.com/updatecli/updatecli/main/e2e/updatecli.d/success.d/yaml/duplicate.yaml
       key: sources.scenario1.kind
       value: yaml
 
@@ -79,7 +79,6 @@ targets:
       - addsuffix: -beta
     spec:
       files:
-      - e2e/updatecli.d/success.d/yaml/noscm.yaml
-      - e2e/updatecli.d/success.d/yaml/duplicate.yaml
+        - e2e/updatecli.d/success.d/yaml/noscm.yaml
+        - e2e/updatecli.d/success.d/yaml/duplicate.yaml
       key: sources.scenario1.kind
-

--- a/e2e/updatecli.d/success.d/yaml/duplicate.yaml
+++ b/e2e/updatecli.d/success.d/yaml/duplicate.yaml
@@ -26,14 +26,14 @@ sources:
     name: Test URL scheme
     kind: yaml
     spec:
-      file: https://raw.githubusercontent.com/updatecli/updatecli/main/e2e/venom.d/test_diff.yaml
+      file: https://raw.githubusercontent.com/updatecli/updatecli/main/e2e/venom.d/test_pipeline.yaml
       key: $.name
 
   scenario31:
     name: Test URL scheme
     kind: yaml
     spec:
-      file: https://raw.githubusercontent.com/updatecli/updatecli/main/e2e/venom.d/test_diff.yaml
+      file: https://raw.githubusercontent.com/updatecli/updatecli/main/e2e/venom.d/test_pipeline.yaml
       key: $.name
 
 conditions:
@@ -43,8 +43,8 @@ conditions:
     disablesourceinput: true
     spec:
       files:
-      - e2e/updatecli.d/success.d/yaml/noscm.yaml
-      - e2e/updatecli.d/success.d/yaml/duplicate.yaml
+        - e2e/updatecli.d/success.d/yaml/noscm.yaml
+        - e2e/updatecli.d/success.d/yaml/duplicate.yaml
       key: $.sources.scenario1.kind
       value: yaml
 
@@ -54,8 +54,8 @@ conditions:
     disablesourceinput: true
     spec:
       files:
-      - file://e2e/updatecli.d/success.d/yaml/noscm.yaml
-      - file://e2e/updatecli.d/success.d/yaml/duplicate.yaml
+        - file://e2e/updatecli.d/success.d/yaml/noscm.yaml
+        - file://e2e/updatecli.d/success.d/yaml/duplicate.yaml
       key: $.sources.scenario1.kind
       value: yaml
 
@@ -65,8 +65,8 @@ conditions:
     disablesourceinput: true
     spec:
       files:
-      - https://raw.githubusercontent.com/updatecli/updatecli/main/e2e/updatecli.d/success.d/yaml/noscm.yaml
-      - https://raw.githubusercontent.com/updatecli/updatecli/main/e2e/updatecli.d/success.d/yaml/duplicate.yaml
+        - https://raw.githubusercontent.com/updatecli/updatecli/main/e2e/updatecli.d/success.d/yaml/noscm.yaml
+        - https://raw.githubusercontent.com/updatecli/updatecli/main/e2e/updatecli.d/success.d/yaml/duplicate.yaml
       key: $.sources.scenario1.kind
       value: yaml
 
@@ -77,8 +77,8 @@ targets:
     sourceid: scenario1
     spec:
       files:
-      - e2e/updatecli.d/success.d/yaml/noscm.yaml
-      - e2e/updatecli.d/success.d/yaml/duplicate.yaml
+        - e2e/updatecli.d/success.d/yaml/noscm.yaml
+        - e2e/updatecli.d/success.d/yaml/duplicate.yaml
       key: $.sources.scenario1.kind
     transformers:
       - addsuffix: -beta

--- a/e2e/updatecli.d/success.d/yaml/noscm.yaml
+++ b/e2e/updatecli.d/success.d/yaml/noscm.yaml
@@ -26,14 +26,14 @@ sources:
     name: Test URL scheme
     kind: yaml
     spec:
-      file: https://raw.githubusercontent.com/updatecli/updatecli/main/e2e/venom.d/test_diff.yaml
+      file: https://raw.githubusercontent.com/updatecli/updatecli/main/e2e/venom.d/test_pipeline.yaml
       key: $.name
 
   scenario31:
     name: Test URL scheme
     kind: yaml
     spec:
-      file: https://raw.githubusercontent.com/updatecli/updatecli/main/e2e/venom.d/test_diff.yaml
+      file: https://raw.githubusercontent.com/updatecli/updatecli/main/e2e/venom.d/test_pipeline.yaml
       key: $.name
 
   getGo-Version-File:
@@ -51,8 +51,8 @@ conditions:
     disablesourceinput: true
     spec:
       files:
-      - e2e/updatecli.d/success.d/yaml/noscm.yaml
-      - e2e/updatecli.d/success.d/yaml/duplicate.yaml
+        - e2e/updatecli.d/success.d/yaml/noscm.yaml
+        - e2e/updatecli.d/success.d/yaml/duplicate.yaml
       key: $.sources.scenario1.kind
       value: yaml
 
@@ -62,8 +62,8 @@ conditions:
     disablesourceinput: true
     spec:
       files:
-      - file://e2e/updatecli.d/success.d/yaml/noscm.yaml
-      - file://e2e/updatecli.d/success.d/yaml/duplicate.yaml
+        - file://e2e/updatecli.d/success.d/yaml/noscm.yaml
+        - file://e2e/updatecli.d/success.d/yaml/duplicate.yaml
       key: $.sources.scenario1.kind
       value: yaml
 
@@ -73,8 +73,8 @@ conditions:
     disablesourceinput: true
     spec:
       files:
-      - https://raw.githubusercontent.com/updatecli/updatecli/main/e2e/updatecli.d/success.d/yaml/noscm.yaml
-      - https://raw.githubusercontent.com/updatecli/updatecli/main/e2e/updatecli.d/success.d/yaml/duplicate.yaml
+        - https://raw.githubusercontent.com/updatecli/updatecli/main/e2e/updatecli.d/success.d/yaml/noscm.yaml
+        - https://raw.githubusercontent.com/updatecli/updatecli/main/e2e/updatecli.d/success.d/yaml/duplicate.yaml
       key: $.sources.scenario1.kind
       value: yaml
 
@@ -87,7 +87,6 @@ targets:
       - addsuffix: -beta
     spec:
       files:
-      - e2e/updatecli.d/success.d/yaml/noscm.yaml
-      - e2e/updatecli.d/success.d/yaml/duplicate.yaml
+        - e2e/updatecli.d/success.d/yaml/noscm.yaml
+        - e2e/updatecli.d/success.d/yaml/duplicate.yaml
       key: $.sources.scenario1.kind
-


### PR DESCRIPTION
Follow up of https://github.com/updatecli/updatecli/pull/7613