### PR TITLE
chore: allow to run Updatecli daily on monitored pipeline

### DIFF
--- a/.github/workflows/updatecli_update.yaml
+++ b/.github/workflows/updatecli_update.yaml
@@ -26,6 +26,16 @@ jobs:
           go-version-file: "go.mod"
         id: go
 
+      - name: "Run updatecli only on monitored pipelines"
+        run: updatecli compose apply --clean-git-branches=true --labels="monitoring:enabled" --experimental
+        env:
+          UPDATECLI_GITHUB_APP_CLIENT_ID: ${{ secrets.UPDATECLIBOT_APP_ID }}
+          UPDATECLI_GITHUB_APP_PRIVATE_KEY: ${{ secrets.UPDATECLIBOT_APP_PRIVKEY }}
+          UPDATECLI_GITHUB_APP_INSTALLATION_ID: ${{ secrets.UPDATECLIBOT_APP_INSTALLATION_ID }}
+          UPDATECLI_UDASH_API_URL: ${{ secrets.UPDATECLI_UDASH_API_URL }}
+          UPDATECLI_UDASH_ACCESS_TOKEN: ${{ secrets.UPDATECLI_UDASH_ACCESS_TOKEN }}
+          UPDATECLI_UDASH_URL: ${{ secrets.UPDATECLI_UDASH_URL }}
+
       - name: "Run updatecli only on existing pipelines"
         run: updatecli compose apply --clean-git-branches=true --existing-only=true --experimental
         env:

--- a/updatecli/updatecli.d/updatecli.yaml
+++ b/updatecli/updatecli.d/updatecli.yaml
@@ -1,6 +1,9 @@
 name: "docs: bump updatecli version"
 
 pipelineid: "updatecli"
+labels:
+  event: release
+  monitoring: enabled
 
 actions:
   default:


### PR DESCRIPTION
This pull request allows to run Updatecli daily on specific monitored pipeline.
It leverages the newly introduced label selection

## Test

To test this pull request, you can run the following commands:

```shell
cd <to_package_directory>
go test
```

## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via pull request in [website](https://github.com/updatecli/website) repository.

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
