### PR TITLE
chore(jsonschema): set empty console output spec

### DIFF
--- a/pkg/plugins/resources/shell/changeIf.go
+++ b/pkg/plugins/resources/shell/changeIf.go
@@ -20,7 +20,7 @@ import (
 
 var (
 	MappingSpecChangedIf = map[string]interface{}{
-		"console/output": nil,
+		"console/output": &console.Spec{},
 		"exitcode":       &exitcode.Spec{},
 		"file/checksum":  &checksum.Spec{},
 	}

--- a/pkg/plugins/resources/shell/success/console/main.go
+++ b/pkg/plugins/resources/shell/success/console/main.go
@@ -8,6 +8,10 @@ import (
 	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
+// Spec is an empty struct used as a placeholder for the jsonschema.
+type Spec struct {
+}
+
 type Console struct {
 	exitCode *int
 	output   *string


### PR DESCRIPTION
Fix #7799

After some investigation, it appears that the generated jsonschema detect the spec as a boolean and not a object.

## Test

To test this pull request, you can run the following commands:

```shell
cd <to_package_directory>
go test
```

## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via pull request in [website](https://github.com/updatecli/website) repository.

### Tradeoff

/

### Potential improvement

/
