### PR TITLE
feat: allow to store policy assets on oci registry

### DIFF
--- a/cmd/manifest_push.go
+++ b/cmd/manifest_push.go
@@ -58,6 +58,7 @@ func init() {
 	manifestPushCmd.Flags().StringArrayVarP(&valuesFiles, "values", "v", []string{}, "Sets values file uses for templating")
 	manifestPushCmd.Flags().StringArrayVarP(&manifestPushPolicyReference, "tag", "t", []string{}, `Name and optionally a tag (format: "name:tag")`)
 	manifestPushCmd.Flags().StringArrayVar(&secretsFiles, "secrets", []string{}, "Sets secrets file uses for templating")
+	manifestPushCmd.Flags().StringArrayVar(&assetsFiles, "assets", []string{}, "Sets assets file to be pushed to the registry")
 	manifestPushCmd.Flags().BoolVar(&disableTLS, "disable-tls", false, "Disable TLS verification like '--disable-tls=true'")
 	manifestPushCmd.Flags().BoolVar(&manifestPushOverwrite, "overwrite", false, "Overwrite existing manifest(s) in the registry like '--overwrite=true'")
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -33,6 +33,7 @@ var (
 	valuesFiles      []string
 	valuesInline     []string
 	secretsFiles     []string
+	assetsFiles      []string
 	policyReferences []string
 	e                engine.Engine
 	verbose          bool
@@ -223,6 +224,7 @@ func run(command string) error {
 			manifestFiles,
 			valuesFiles,
 			secretsFiles,
+			assetsFiles,
 			manifestPushPolicyReference,
 			disableTLS,
 			manifestPushPolicyFile,

--- a/pkg/core/engine/registry.go
+++ b/pkg/core/engine/registry.go
@@ -22,7 +22,7 @@ func (e *Engine) PullFromRegistry(policyReference string, disableTLS bool) (err 
 }
 
 // PushToRegistry pushes an Updatecli policy to an OCI registry.
-func (e *Engine) PushToRegistry(manifests, valuesFiles, secretsFiles, policyReference []string, disableTLS bool, policyMetadataFile, fileStore string, overwrite bool) error {
+func (e *Engine) PushToRegistry(manifests, valuesFiles, secretsFiles, assetsFiles, policyReference []string, disableTLS bool, policyMetadataFile, fileStore string, overwrite bool) error {
 
 	PrintTitle("Registry")
 
@@ -61,7 +61,17 @@ func (e *Engine) PushToRegistry(manifests, valuesFiles, secretsFiles, policyRefe
 
 	relativeFromFileStore(manifests)
 
-	err := registry.Push(policyMetadataFile, manifests, valuesFiles, secretsFiles, policyReference, disableTLS, fileStore, overwrite)
+	err := registry.Push(registry.PushData{
+		PolicyMetadataFile:   policyMetadataFile,
+		ManifestsFiles:       manifests,
+		ValuesFiles:          valuesFiles,
+		SecretsFiles:         secretsFiles,
+		AssetsFiles:          assetsFiles,
+		PolicyReferenceNames: policyReference,
+		DisableTLS:           disableTLS,
+		FileStore:            fileStore,
+		Overwrite:            overwrite,
+	})
 	if err != nil {
 		return err
 	}

--- a/pkg/core/registry/pullpush_test.go
+++ b/pkg/core/registry/pullpush_test.go
@@ -49,91 +49,96 @@ func TestPushPullPolicy(t *testing.T) {
 
 	testData := []struct {
 		name                      string
-		toPushPolicyName          []string
 		toPushPolicyFile          string
-		toPushManifestFiles       []string
-		toPushValueFiles          []string
-		toPushSecretFiles         []string
-		toPushFileStore           string
 		expectedPullManifestFiles []string
 		expectedPullValuesFiles   []string
 		expectedPullSecretsFiles  []string
-		disableTLS                bool
-		overwrite                 bool
+		expectedPullAssetsFiles   []string
+		toPushFileStore           string
+		pushData                  PushData
 	}{
 		{
 			name:                      "Validate that we can push and pull a policy using the latest tag, even thought the tag is ignored",
-			toPushPolicyName:          []string{fmt.Sprintf("localhost:%d/myrepo:latest", port.Int())},
-			disableTLS:                true,
-			toPushPolicyFile:          "testdata/Policy.yaml",
-			toPushManifestFiles:       []string{"testdata/venom.yaml"},
-			toPushValueFiles:          []string{"testdata/values.yaml"},
-			toPushSecretFiles:         []string{"testdata/secrets.yaml"},
 			expectedPullManifestFiles: []string{"testdata/venom.yaml"},
 			expectedPullValuesFiles:   []string{"testdata/values.yaml"},
 			expectedPullSecretsFiles:  []string{"testdata/secrets.yaml"},
+			pushData: PushData{
+				PolicyReferenceNames: []string{fmt.Sprintf("localhost:%d/myrepo:latest", port.Int())},
+				PolicyMetadataFile:   "testdata/Policy.yaml",
+				DisableTLS:           true,
+				ManifestsFiles:       []string{"testdata/venom.yaml"},
+				ValuesFiles:          []string{"testdata/values.yaml"},
+				SecretsFiles:         []string{"testdata/secrets.yaml"},
+			},
+			toPushFileStore: ".",
 		},
 		{
 			name:                      "Validate that we can push and pull a policy without tag",
-			toPushPolicyName:          []string{fmt.Sprintf("localhost:%d/myrepo", port.Int())},
-			disableTLS:                true,
-			toPushPolicyFile:          "testdata/Policy.yaml",
-			toPushManifestFiles:       []string{"testdata/venom.yaml"},
-			toPushValueFiles:          []string{"testdata/values.yaml"},
-			toPushSecretFiles:         []string{"testdata/secrets.yaml"},
 			expectedPullManifestFiles: []string{"testdata/venom.yaml"},
 			expectedPullValuesFiles:   []string{"testdata/values.yaml"},
 			expectedPullSecretsFiles:  []string{"testdata/secrets.yaml"},
+			pushData: PushData{
+				PolicyReferenceNames: []string{fmt.Sprintf("localhost:%d/myrepo", port.Int())},
+				PolicyMetadataFile:   "testdata/Policy.yaml",
+				DisableTLS:           true,
+				ManifestsFiles:       []string{"testdata/venom.yaml"},
+				ValuesFiles:          []string{"testdata/values.yaml"},
+				SecretsFiles:         []string{"testdata/secrets.yaml"},
+			},
+			toPushFileStore: ".",
 		},
 		{
 			name:                      "Validate that we can push and pull a policy without tag from a different file store",
-			toPushPolicyName:          []string{fmt.Sprintf("localhost:%d/myrepo", port.Int())},
-			disableTLS:                true,
-			toPushPolicyFile:          "testdata/Policy.yaml",
-			toPushManifestFiles:       []string{"testdata/venom.yaml"},
-			toPushValueFiles:          []string{"testdata/values.yaml"},
-			toPushSecretFiles:         []string{"testdata/secrets.yaml"},
 			expectedPullManifestFiles: []string{"testdata/venom.yaml"},
 			expectedPullValuesFiles:   []string{"testdata/values.yaml"},
 			expectedPullSecretsFiles:  []string{"testdata/secrets.yaml"},
 			toPushFileStore:           ".",
+			pushData: PushData{
+				PolicyReferenceNames: []string{fmt.Sprintf("localhost:%d/myrepo", port.Int())},
+				PolicyMetadataFile:   "testdata/Policy.yaml",
+				DisableTLS:           true,
+				ManifestsFiles:       []string{"testdata/venom.yaml"},
+				ValuesFiles:          []string{"testdata/values.yaml"},
+				SecretsFiles:         []string{"testdata/secrets.yaml"},
+			},
+		},
+		{
+			name:                      "Validate that we can push and pull a policy with assets",
+			expectedPullManifestFiles: []string{"testdata/venom.yaml"},
+			expectedPullValuesFiles:   []string{"testdata/values.yaml"},
+			expectedPullSecretsFiles:  []string{"testdata/secrets.yaml"},
+			expectedPullAssetsFiles:   []string{"testdata/asset.sh"},
+			toPushFileStore:           ".",
+			pushData: PushData{
+				PolicyReferenceNames: []string{fmt.Sprintf("localhost:%d/myrepo", port.Int())},
+				DisableTLS:           true,
+				PolicyMetadataFile:   "testdata/Policy.yaml",
+				AssetsFiles:          []string{"testdata/asset.sh"},
+				ManifestsFiles:       []string{"testdata/venom.yaml"},
+				ValuesFiles:          []string{"testdata/values.yaml"},
+				SecretsFiles:         []string{"testdata/secrets.yaml"},
+			},
 		},
 	}
 
 	for _, data := range testData {
 
 		t.Run(data.name, func(t *testing.T) {
-			err = Push(
-				data.toPushPolicyFile,
-				data.toPushManifestFiles,
-				data.toPushValueFiles,
-				data.toPushSecretFiles,
-				data.toPushPolicyName,
-				data.disableTLS,
-				data.toPushFileStore,
-				data.overwrite)
+			err = Push(data.pushData)
 			require.NoError(t, err)
 
-			err = Push(
-				data.toPushPolicyFile,
-				data.toPushManifestFiles,
-				data.toPushValueFiles,
-				data.toPushSecretFiles,
-				data.toPushPolicyName,
-				data.disableTLS,
-				data.toPushFileStore,
-				data.overwrite)
+			err = Push(data.pushData)
 			require.NoError(t, err)
 
 			gotManifests, gotValues, gotSecrets, err := Pull(
-				data.toPushPolicyName[0],
-				data.disableTLS,
+				data.pushData.PolicyReferenceNames[0],
+				data.pushData.DisableTLS,
 			)
 			require.NoError(t, err)
 
 			expectedManifest, expectedValues, expectedSecrets, err := sanitizeDirPath(
-				data.toPushPolicyName[0],
-				data.disableTLS,
+				data.pushData.PolicyReferenceNames[0],
+				data.pushData.DisableTLS,
 				data.expectedPullManifestFiles,
 				data.expectedPullValuesFiles,
 				data.expectedPullSecretsFiles,

--- a/pkg/core/registry/push.go
+++ b/pkg/core/registry/push.go
@@ -19,26 +19,40 @@ import (
 	"oras.land/oras-go/v2/registry/remote/auth"
 )
 
+// PushData is the data structure for the Push function.
+type PushData struct {
+	PolicyMetadataFile   string
+	ManifestsFiles       []string
+	ValuesFiles          []string
+	SecretsFiles         []string
+	AssetsFiles          []string
+	PolicyReferenceNames []string
+	DisableTLS           bool
+	FileStore            string
+	Overwrite            bool
+}
+
 // Push pushes updatecli manifest(s) as an OCI image to an OCI registry.
-func Push(policyMetadataFile string, manifests []string, values []string, secrets []string, policyReferenceNames []string, disableTLS bool, fileStore string, overwrite bool) error {
+// func Push(policyMetadataFile string, manifests []string, values []string, secrets []string, assets []string, policyReferenceNames []string, disableTLS bool, fileStore string, overwrite bool) error {
+func Push(p PushData) error {
 	var err error
 
-	policySpec, err := LoadPolicyFile(policyMetadataFile)
+	policySpec, err := LoadPolicyFile(p.PolicyMetadataFile)
 	if err != nil {
 		return fmt.Errorf("load policy file: %w", err)
 	}
 
-	logrus.Infof("Pushing Updatecli policy:\n\t=> %s\n\n", strings.Join(policyReferenceNames, "\n\t=> "))
+	logrus.Infof("Pushing Updatecli policy:\n\t=> %s\n\n", strings.Join(p.PolicyReferenceNames, "\n\t=> "))
 
-	if fileStore == "" {
-		fileStore, err = os.Getwd()
+	if p.FileStore == "" {
+		p.FileStore, err = os.Getwd()
 		if err != nil {
 			logrus.Errorln(err)
 		}
 	}
 
 	// Create a file store
-	fs, err := file.New(fileStore)
+	fs, err := file.New(p.FileStore)
 	if err != nil {
 		return fmt.Errorf("create file store: %w", err)
 	}
@@ -47,7 +61,7 @@ func Push(policyMetadataFile string, manifests []string, values []string, secret
 	ctx := context.Background()
 
 	// Add files to the file store
-	fileDescriptors := make([]v1.Descriptor, 0, len(manifests))
+	fileDescriptors := make([]v1.Descriptor, 0, len(p.ManifestsFiles))
 
 	addfiles := func(files []string, mediaType string) error {
 		for i := range files {
@@ -61,16 +75,20 @@ func Push(policyMetadataFile string, manifests []string, values []string, secret
 		return nil
 	}
 
-	if err = addfiles(manifests, updatecliManifestMediaType); err != nil {
+	if err = addfiles(p.ManifestsFiles, updatecliManifestMediaType); err != nil {
 		return fmt.Errorf("add manifests: %w", err)
 	}
 
-	if err = addfiles(values, updatecliValueMediaType); err != nil {
+	if err = addfiles(p.ValuesFiles, updatecliValueMediaType); err != nil {
 		return fmt.Errorf("add values: %w", err)
 	}
 
-	if err = addfiles(secrets, updatecliSecretMediaType); err != nil {
+	if err = addfiles(p.SecretsFiles, updatecliSecretMediaType); err != nil {
 		return fmt.Errorf("add secrets: %w", err)
+	}
+
+	if err = addfiles(p.AssetsFiles, updatecliAssetMediaType); err != nil {
+		return fmt.Errorf("add assets: %w", err)
 	}
 
 	// 2. Pack the files and tag the packed manifest
@@ -101,9 +119,9 @@ func Push(policyMetadataFile string, manifests []string, values []string, secret
 		return fmt.Errorf("pack manifest: %w", err)
 	}
 
-	for i := range policyReferenceNames {
+	for i := range p.PolicyReferenceNames {
 
-		refName, err := name.ParseReference(policyReferenceNames[i])
+		refName, err := name.ParseReference(p.PolicyReferenceNames[i])
 		if err != nil {
 			logrus.Errorf("parse reference: %s", err)
 			continue
@@ -122,7 +140,7 @@ func Push(policyMetadataFile string, manifests []string, values []string, secret
 		}
 		ctx = auth.AppendRepositoryScope(ctx, repo.Reference, auth.ActionPush, auth.ActionPull)
 
-		if disableTLS {
+		if p.DisableTLS {
 			repo.PlainHTTP = true
 		}
 
@@ -132,16 +150,16 @@ func Push(policyMetadataFile string, manifests []string, values []string, secret
 		}
 
 		_, _, err = repo.FetchReference(ctx, tag)
-		if err == nil && !overwrite {
-			logrus.Infof("tag %q already published for policy %s", tag, policyReferenceNames[i])
+		if err == nil && !p.Overwrite {
+			logrus.Infof("tag %q already published for policy %s", tag, p.PolicyReferenceNames[i])
 			return nil
 		} else if err == nil {
-			logrus.Infof("overwriting, already published, tag %q for policy %s", tag, policyReferenceNames[i])
+			logrus.Infof("overwriting, already published, tag %q for policy %s", tag, p.PolicyReferenceNames[i])
 
 		} else if errors.Is(err, errdef.ErrNotFound) {
 			logrus.Infof("publishing policy %s", tag)
 		} else {
-			return fmt.Errorf("check if %s is already published: %s", policyReferenceNames[i], err)
+			return fmt.Errorf("check if %s is already published: %s", p.PolicyReferenceNames[i], err)
 		}
 
 		// 3. Copy from the file store to the remote repository

--- a/pkg/core/registry/var.go
+++ b/pkg/core/registry/var.go
@@ -7,6 +7,8 @@ var (
 	updatecliValueMediaType string = "application/io.updatecli.policy.value.alpha"
 	// updatecliSecretMediaType is the OCI media type for updatecli secret file.
 	updatecliSecretMediaType string = "application/io.updatecli.policy.secret.alpha"
+	// updatecliAssetMediaType is the OCI media type for updatecli asset file.
+	updatecliAssetMediaType string = "application/io.updatecli.policy.asset.alpha"
 	// ociArtifactType is the media type for updatecli OCI artifacts.
 	ociArtifactType string = "application/io.updatecli.policy.alpha"
 	// ociLatestTag is the default tag for updatecli OCI images.


### PR DESCRIPTION
Fix #8299

Opening for visibility, while testing this pull request, I realize that it's useless without #8300

## Test

To test this pull request, you can run the following commands:

```shell
cd pkg/core/registry/
go test
```

## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via pull request in [website](https://github.com/updatecli/website) repository.

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
