### PR TITLE
fix(pyproject): use uv lock instead of uv add to preserve pyproject.toml

### DIFF
--- a/pkg/plugins/autodiscovery/pyproject/dependencies.go
+++ b/pkg/plugins/autodiscovery/pyproject/dependencies.go
@@ -139,7 +139,7 @@ func (p Pyproject) processDependencies(
 			continue
 		}
 
-		params := p.buildTemplateParams(dep, group, relativeFile, lockSupport, projectName, workdir)
+		params := p.buildTemplateParams(dep, group, lockSupport, projectName, workdir)
 
 		var buf bytes.Buffer
 		if err := tmpl.Execute(&buf, params); err != nil {
@@ -157,7 +157,6 @@ func (p Pyproject) processDependencies(
 func (p Pyproject) buildTemplateParams(
 	dep pythonDependency,
 	group string,
-	relativeFile string,
 	lockSupport lockFileSupport,
 	projectName string,
 	workdir string,
@@ -199,13 +198,6 @@ func (p Pyproject) buildTemplateParams(
 		}
 	}
 
-	// uv add flag for optional dependency groups.
-	// Trailing space is intentional — the template concatenates this directly before the quoted package spec.
-	var uvAddGroupFlag string
-	if group != "" {
-		uvAddGroupFlag = "--optional " + group + " "
-	}
-
 	relLockFile := filepath.Join(workdir, "uv.lock")
 
 	return manifestTemplateParams{
@@ -222,8 +214,6 @@ func (p Pyproject) buildTemplateParams(
 		TargetName:                 fmt.Sprintf("deps(pypi): bump %q to {{ source %q }}", dep.Name, dep.Name),
 		ScmID:                      p.scmID,
 		UvEnabled:                  lockSupport.uv,
-		UvAddGroupFlag:             uvAddGroupFlag,
-		PyprojectFile:              relativeFile,
 		LockFile:                   relLockFile,
 		Workdir:                    workdir,
 	}

--- a/pkg/plugins/autodiscovery/pyproject/main_test.go
+++ b/pkg/plugins/autodiscovery/pyproject/main_test.go
@@ -38,12 +38,11 @@ targets:
     name: 'deps(pypi): bump "flask" to {{ source "flask" }}'
     kind: 'shell'
     spec:
-      command: 'uv add --frozen "flask>={{ source "flask" }}"'
+      command: 'uv lock --upgrade-package flask=={{ source "flask" }}'
       changedif:
         kind: file/checksum
         spec:
           files:
-            - "pyproject.toml"
             - "uv.lock"
       environments:
         - name: PATH
@@ -65,12 +64,11 @@ targets:
     name: 'deps(pypi): bump "requests" to {{ source "requests" }}'
     kind: 'shell'
     spec:
-      command: 'uv add --frozen "requests>={{ source "requests" }}"'
+      command: 'uv lock --upgrade-package requests=={{ source "requests" }}'
       changedif:
         kind: file/checksum
         spec:
           files:
-            - "pyproject.toml"
             - "uv.lock"
       environments:
         - name: PATH
@@ -123,12 +121,11 @@ targets:
     name: 'deps(pypi): bump "requests" to {{ source "requests" }}'
     kind: 'shell'
     spec:
-      command: 'uv add --frozen "requests>={{ source "requests" }}"'
+      command: 'uv lock --upgrade-package requests=={{ source "requests" }}'
       changedif:
         kind: file/checksum
         spec:
           files:
-            - "pyproject.toml"
             - "uv.lock"
       environments:
         - name: PATH
@@ -150,12 +147,11 @@ targets:
     name: 'deps(pypi): bump "pytest" to {{ source "pytest" }}'
     kind: 'shell'
     spec:
-      command: 'uv add --frozen --optional dev "pytest>={{ source "pytest" }}"'
+      command: 'uv lock --upgrade-package pytest=={{ source "pytest" }}'
       changedif:
         kind: file/checksum
         spec:
           files:
-            - "pyproject.toml"
             - "uv.lock"
       environments:
         - name: PATH
@@ -177,12 +173,11 @@ targets:
     name: 'deps(pypi): bump "ruff" to {{ source "ruff" }}'
     kind: 'shell'
     spec:
-      command: 'uv add --frozen --optional dev "ruff>={{ source "ruff" }}"'
+      command: 'uv lock --upgrade-package ruff=={{ source "ruff" }}'
       changedif:
         kind: file/checksum
         spec:
           files:
-            - "pyproject.toml"
             - "uv.lock"
       environments:
         - name: PATH
@@ -218,12 +213,11 @@ targets:
     scmid: 'git'
     kind: 'shell'
     spec:
-      command: 'uv add --frozen "flask>={{ source "flask" }}"'
+      command: 'uv lock --upgrade-package flask=={{ source "flask" }}'
       changedif:
         kind: file/checksum
         spec:
           files:
-            - "pyproject.toml"
             - "uv.lock"
       environments:
         - name: PATH
@@ -250,12 +244,11 @@ targets:
     scmid: 'git'
     kind: 'shell'
     spec:
-      command: 'uv add --frozen "requests>={{ source "requests" }}"'
+      command: 'uv lock --upgrade-package requests=={{ source "requests" }}'
       changedif:
         kind: file/checksum
         spec:
           files:
-            - "pyproject.toml"
             - "uv.lock"
       environments:
         - name: PATH
@@ -289,12 +282,11 @@ targets:
     name: 'deps(pypi): bump "requests" to {{ source "requests" }}'
     kind: 'shell'
     spec:
-      command: 'uv add --frozen "requests>={{ source "requests" }}"'
+      command: 'uv lock --upgrade-package requests=={{ source "requests" }}'
       changedif:
         kind: file/checksum
         spec:
           files:
-            - "pyproject.toml"
             - "uv.lock"
       environments:
         - name: PATH
@@ -328,12 +320,11 @@ targets:
     name: 'deps(pypi): bump "requests" to {{ source "requests" }}'
     kind: 'shell'
     spec:
-      command: 'uv add --frozen "requests>={{ source "requests" }}"'
+      command: 'uv lock --upgrade-package requests=={{ source "requests" }}'
       changedif:
         kind: file/checksum
         spec:
           files:
-            - "pyproject.toml"
             - "uv.lock"
       environments:
         - name: PATH
@@ -362,12 +353,11 @@ targets:
     name: 'deps(pypi): bump "pywin32" to {{ source "pywin32" }}'
     kind: 'shell'
     spec:
-      command: 'uv add --frozen "pywin32>={{ source "pywin32" }}"'
+      command: 'uv lock --upgrade-package pywin32=={{ source "pywin32" }}'
       changedif:
         kind: file/checksum
         spec:
           files:
-            - "pyproject.toml"
             - "uv.lock"
       environments:
         - name: PATH
@@ -389,12 +379,11 @@ targets:
     name: 'deps(pypi): bump "requests" to {{ source "requests" }}'
     kind: 'shell'
     spec:
-      command: 'uv add --frozen "requests>={{ source "requests" }}"'
+      command: 'uv lock --upgrade-package requests=={{ source "requests" }}'
       changedif:
         kind: file/checksum
         spec:
           files:
-            - "pyproject.toml"
             - "uv.lock"
       environments:
         - name: PATH
@@ -423,12 +412,11 @@ targets:
     name: 'deps(pypi): bump "numpy" to {{ source "numpy" }}'
     kind: 'shell'
     spec:
-      command: 'uv add --frozen "numpy>={{ source "numpy" }}"'
+      command: 'uv lock --upgrade-package numpy=={{ source "numpy" }}'
       changedif:
         kind: file/checksum
         spec:
           files:
-            - "pyproject.toml"
             - "uv.lock"
       environments:
         - name: PATH
@@ -459,12 +447,11 @@ targets:
     name: 'deps(pypi): bump "flask" to {{ source "flask" }}'
     kind: 'shell'
     spec:
-      command: 'uv add --frozen "flask>={{ source "flask" }}"'
+      command: 'uv lock --upgrade-package flask=={{ source "flask" }}'
       changedif:
         kind: file/checksum
         spec:
           files:
-            - "pyproject.toml"
             - "uv.lock"
       environments:
         - name: PATH
@@ -487,12 +474,11 @@ targets:
     name: 'deps(pypi): bump "requests" to {{ source "requests" }}'
     kind: 'shell'
     spec:
-      command: 'uv add --frozen "requests>={{ source "requests" }}"'
+      command: 'uv lock --upgrade-package requests=={{ source "requests" }}'
       changedif:
         kind: file/checksum
         spec:
           files:
-            - "pyproject.toml"
             - "uv.lock"
       environments:
         - name: PATH
@@ -522,12 +508,11 @@ targets:
     name: 'deps(pypi): bump "flask" to {{ source "flask" }}'
     kind: 'shell'
     spec:
-      command: 'uv add --frozen "flask>={{ source "flask" }}"'
+      command: 'uv lock --upgrade-package flask=={{ source "flask" }}'
       changedif:
         kind: file/checksum
         spec:
           files:
-            - "pyproject.toml"
             - "uv.lock"
       environments:
         - name: PATH
@@ -549,12 +534,11 @@ targets:
     name: 'deps(pypi): bump "requests" to {{ source "requests" }}'
     kind: 'shell'
     spec:
-      command: 'uv add --frozen "requests>={{ source "requests" }}"'
+      command: 'uv lock --upgrade-package requests=={{ source "requests" }}'
       changedif:
         kind: file/checksum
         spec:
           files:
-            - "pyproject.toml"
             - "uv.lock"
       environments:
         - name: PATH

--- a/pkg/plugins/autodiscovery/pyproject/manifestTemplate.go
+++ b/pkg/plugins/autodiscovery/pyproject/manifestTemplate.go
@@ -32,12 +32,11 @@ targets:
 {{- end }}
     kind: 'shell'
     spec:
-      command: 'uv add --frozen {{ .UvAddGroupFlag }}"{{ .DependencyName }}>={{ "{{" }} source "{{ .SourceID }}" {{ "}}" }}"'
+      command: 'uv lock --upgrade-package {{ .DependencyName }}=={{ "{{" }} source "{{ .SourceID }}" {{ "}}" }}'
       changedif:
         kind: file/checksum
         spec:
           files:
-            - "{{ .PyprojectFile }}"
             - "{{ .LockFile }}"
       environments:
         - name: PATH
@@ -61,8 +60,6 @@ type manifestTemplateParams struct {
 	TargetName                 string
 	ScmID                      string
 	UvEnabled                  bool
-	UvAddGroupFlag             string // e.g. "--optional dev " or ""
-	PyprojectFile              string
 	LockFile                   string
 	Workdir                    string
 }

--- a/pkg/plugins/utils/version/pep440.go
+++ b/pkg/plugins/utils/version/pep440.go
@@ -55,6 +55,15 @@ func (p *Pep440) Search(versions []string) error {
 	p.Sort()
 
 	if p.Constraint == "" || p.Constraint == "*" {
+		// Prefer stable versions over pre-releases.
+		for _, v := range p.versions {
+			if !v.IsPreRelease() {
+				p.FoundVersion.ParsedVersion = v.String()
+				p.FoundVersion.OriginalVersion = v.Original()
+				return nil
+			}
+		}
+		// Fall back to highest pre-release if no stable version exists.
 		p.FoundVersion.ParsedVersion = p.versions[0].String()
 		p.FoundVersion.OriginalVersion = p.versions[0].Original()
 		return nil

--- a/pkg/plugins/utils/version/pep440_test.go
+++ b/pkg/plugins/utils/version/pep440_test.go
@@ -103,6 +103,45 @@ var (
 			ExpectedParsedVersion:   "2.0.post1",
 			ExpectedOriginalVersion: "2.0.post1",
 		},
+		{
+			// Wildcard skips dev pre-release in favor of the highest stable version.
+			Versions:                []string{"0.28.1", "1.0.dev3"},
+			SortedVersions:          []string{"1.0.dev3", "0.28.1"},
+			ExpectedInitErr:         nil,
+			ExpectedSearchErr:       nil,
+			ExpectedParsedVersion:   "0.28.1",
+			ExpectedOriginalVersion: "0.28.1",
+		},
+		{
+			// Wildcard skips alpha pre-release in favor of the highest stable version.
+			Versions:                []string{"2.57.0", "3.0.0a7"},
+			SortedVersions:          []string{"3.0.0a7", "2.57.0"},
+			ExpectedInitErr:         nil,
+			ExpectedSearchErr:       nil,
+			ExpectedParsedVersion:   "2.57.0",
+			ExpectedOriginalVersion: "2.57.0",
+		},
+		{
+			// Wildcard falls back to the highest pre-release when no stable version exists.
+			Versions:                []string{"1.0a1", "1.0b2"},
+			SortedVersions:          []string{"1.0b2", "1.0a1"},
+			ExpectedInitErr:         nil,
+			ExpectedSearchErr:       nil,
+			ExpectedParsedVersion:   "1.0b2",
+			ExpectedOriginalVersion: "1.0b2",
+		},
+		{
+			// Empty constraint behaves identically to wildcard: skips pre-releases.
+			Pep440: Pep440{
+				Constraint: "",
+			},
+			Versions:                []string{"2.57.0", "3.0.0a7"},
+			SortedVersions:          []string{"3.0.0a7", "2.57.0"},
+			ExpectedInitErr:         nil,
+			ExpectedSearchErr:       nil,
+			ExpectedParsedVersion:   "2.57.0",
+			ExpectedOriginalVersion: "2.57.0",
+		},
 	}
 )
 


### PR DESCRIPTION
Fix #8339

The `pyproject` autodiscovery generated shell targets using `uv add --frozen "PACKAGE>=VERSION"` which modifies **both** `pyproject.toml` and `uv.lock`. This replaces it with `uv lock --upgrade-package PACKAGE==VERSION` which only updates `uv.lock`, preserving the version constraints in `pyproject.toml`.

Changes:
- Target command: `uv add --frozen` → `uv lock --upgrade-package PACKAGE==VERSION`
- `changedif` now only watches `uv.lock` (no longer tracks `pyproject.toml`)
- Removed `UvAddGroupFlag` (`--optional`) since `uv lock --upgrade-package` doesn't need it
- Removed `PyprojectFile` from template params

**Note:** This PR also fixes PEP 440 wildcard version filtering to exclude pre-release versions (dev, alpha, beta, rc) by default, per PEP 440 spec. Previously, `*` would return e.g. `1.0.dev3` over `0.28.1` or `3.0.0a7` over `2.57.0`. Now prefers stable versions, falling back to pre-release only when no stable version exists.

## Test

```shell
cd pkg/plugins/autodiscovery/pyproject && go test
cd pkg/plugins/utils/version && go test -run TestPep440
```

Tested manually against a real project with `uv.lock` — only `uv.lock` is modified, `pyproject.toml` stays untouched, and pre-release versions are no longer selected.

## Additional Information

### Checklist

- [ ] I have updated the documentation via pull request in [website](https://github.com/updatecli/website) repository.

### Tradeoff

None.

### Potential improvement

- Could add a spec option to opt-in to pre-release versions for users who want them.