### PR TITLE
fix: do not generate empty argocd pipeline using autodiscovery

### DIFF
--- a/pkg/core/config/main.go
+++ b/pkg/core/config/main.go
@@ -44,6 +44,8 @@ const (
 type Config struct {
 	// filename contains the updatecli manifest filename
 	filename string
+	// manifestID contains the effective manifest identifier used by the engine.
+	manifestID string
 	// Spec describe an updatecli manifest
 	Spec Spec
 	// gitHandler holds a git client implementation to manipulate git SCMs
@@ -63,6 +65,32 @@ type Spec struct {
 	// 	* "name" is often used a default values for other configuration such as pullrequest title.
 	// 	* "name" shouldn't contain any dynamic information such as source output.
 	Name string `yaml:",omitempty" jsonschema:"required"`
+	// "id" defines a manifest dependency identifier that can be referenced by other manifests.
+	//
+	// example:
+	// 	* "id: nodejs"
+	// 	* "id: docker/alpine"
+	//
+	// remark:
+	// 	* "id" only affects manifest execution ordering.
+	// 	* "id" is used by the root manifest "dependson" keyword.
+	// 	* multiple manifests may intentionally share the same "id".
+	// 	* unlike "pipelineid", "id" does not affect branch naming or workflow grouping.
+	ID string `yaml:",omitempty"`
+	// "dependson" defines which manifest IDs must run before the current manifest.
+	//
+	// example:
+	// ---
+	// dependson:
+	//   - base-images
+	//   - shared-policies
+	// ---
+	//
+	// remark:
+	// 	* entries reference root manifest "id" values.
+	// 	* if multiple manifests share the same "id" then all of them must run first.
+	// 	* "dependson" only affects manifest execution ordering.
+	DependsOn []string `yaml:",omitempty"`
 	// "pipelineid" allows to identify a full pipeline run.
 	//
 	// example:
@@ -208,6 +236,26 @@ func (config *Config) Reset() {
 	*config = Config{
 		gitHandler: &gitgeneric.GoGit{},
 	}
+}
+
+// ManifestID returns the internal manifest identifier used by the engine.
+func (config *Config) ManifestID() string {
+	return config.manifestID
+}
+
+// DependencyID returns the manifest identifier exposed to dependson resolution.
+func (config *Config) DependencyID() string {
+	return config.Spec.ID
+}
+
+// SetManifestID configures the effective manifest identifier.
+//
+// The provided seed is hashed so each manifest has a deterministic internal
+// identifier even when user-facing dependency IDs are shared across manifests.
+func (config *Config) SetManifestID(seed string) {
+	hash := sha256.New()
+	hash.Write([]byte(seed))
+	config.manifestID = fmt.Sprintf("%x", hash.Sum(nil))
 }
 
 // New reads an updatecli configuration file
@@ -357,6 +405,7 @@ func New(option Option, pipelineIDFilters []string, pipelineLabels map[string]st
 
 		config.filename = option.ManifestFile
 		config.Spec = specs[id]
+		config.SetManifestID(fmt.Sprintf("%s#%d", option.ManifestFile, id))
 		// config.PipelineID is required for config.Validate()
 		if len(config.Spec.PipelineID) == 0 {
 			logrus.Debugln("pipelineid undefined, we'll try to generate one")

--- a/pkg/core/config/main_test.go
+++ b/pkg/core/config/main_test.go
@@ -3,6 +3,8 @@ package config
 import (
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -1018,4 +1020,52 @@ func TestNew(t *testing.T) {
 			require.Equal(t, data.expectedResult[i].Spec.Name, got[i].Spec.Name)
 		}
 	}
+}
+
+func TestNewManifestIDAndDependsOn(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	manifestPath := filepath.Join(tempDir, "updatecli.yaml")
+
+	err := os.WriteFile(manifestPath, []byte(`
+name: Ordered manifest
+id: ordered-manifest
+dependson:
+  - base-manifest
+  - shared-policy
+labels:
+  team: core
+`), 0600)
+	require.NoError(t, err)
+
+	got, err := New(Option{ManifestFile: manifestPath}, nil, nil)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+
+	require.Equal(t, "ordered-manifest", got[0].Spec.ID)
+	require.Equal(t, []string{"base-manifest", "shared-policy"}, got[0].Spec.DependsOn)
+	require.Equal(t, "ordered-manifest", got[0].DependencyID())
+	require.NotEmpty(t, got[0].ManifestID())
+}
+
+func TestNewGeneratesLegacyManifestID(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	manifestPath := filepath.Join(tempDir, "updatecli.yaml")
+
+	err := os.WriteFile(manifestPath, []byte(`
+name: Legacy manifest
+labels:
+  team: core
+`), 0600)
+	require.NoError(t, err)
+
+	got, err := New(Option{ManifestFile: manifestPath}, nil, nil)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+
+	require.Empty(t, got[0].Spec.ID)
+	require.NotEmpty(t, got[0].ManifestID())
 }

--- a/pkg/core/engine/autodiscovery.go
+++ b/pkg/core/engine/autodiscovery.go
@@ -30,20 +30,20 @@ func (e *Engine) LoadAutoDiscovery(ctx context.Context, defaultEnabled bool) err
 	if defaultEnabled {
 		logrus.Debugf("Default Autodiscovery crawlers enabled")
 		var defaultPipeline pipeline.Pipeline
-
-		err := defaultPipeline.Init(
-			&config.Config{
-				Spec: config.Spec{
-					Name:          "Local AutoDiscovery",
-					AutoDiscovery: autodiscovery.GetDefaultCrawlerSpecs(),
-				},
+		defaultConfig := &config.Config{
+			Spec: config.Spec{
+				Name:          "Local AutoDiscovery",
+				AutoDiscovery: autodiscovery.GetDefaultCrawlerSpecs(),
 			},
-			pipeline.Options{},
-		)
+		}
+		defaultConfig.SetManifestID("autodiscovery/default")
+
+		err := defaultPipeline.Init(defaultConfig, pipeline.Options{})
 		if err != nil {
 			logrus.Errorln(err)
 		} else {
 			e.Pipelines = append(e.Pipelines, &defaultPipeline)
+			e.configurations = append(e.configurations, defaultConfig)
 		}
 	}
 
@@ -123,6 +123,7 @@ func (e *Engine) LoadAutoDiscovery(ctx context.Context, defaultEnabled bool) err
 			logrus.Infof("nothing detected")
 		}
 
+		generatedManifestIndex := 0
 		for _, crawlerResult := range crawlerResults {
 			for i := range crawlerResult.Manifests {
 				manifest := config.Spec{}
@@ -177,6 +178,12 @@ func (e *Engine) LoadAutoDiscovery(ctx context.Context, defaultEnabled bool) err
 					manifest.PipelineID = fmt.Sprintf("%x", hash.Sum(nil))
 				}
 
+				if manifest.ID == "" {
+					manifest.ID = p.Config.Spec.ID
+				}
+
+				manifest.DependsOn = mergeManifestDependencies(manifest.DependsOn, p.Config.Spec.DependsOn)
+
 				// Only add the scm if it is not already defined
 				if len(manifest.SCMs) == 0 {
 					manifest.SCMs = make(map[string]scm.Config)
@@ -229,6 +236,13 @@ func (e *Engine) LoadAutoDiscovery(ctx context.Context, defaultEnabled bool) err
 				newConfig := config.Config{
 					Spec: manifest,
 				}
+				newConfig.SetManifestID(fmt.Sprintf("%s/autodiscovery/%s/%d/%x",
+					p.Config.ManifestID(),
+					crawlerResult.Kind,
+					generatedManifestIndex,
+					sha256.Sum256(crawlerResult.Manifests[i]),
+				))
+				generatedManifestIndex++
 
 				newPipeline := pipeline.Pipeline{}
 				err = newPipeline.Init(&newConfig, e.Options.Pipeline)

--- a/pkg/core/engine/autodiscovery.go
+++ b/pkg/core/engine/autodiscovery.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"context"
 	"crypto/sha256"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -14,7 +15,11 @@ import (
 	"github.com/updatecli/updatecli/pkg/core/pipeline"
 	"github.com/updatecli/updatecli/pkg/core/pipeline/action"
 	"github.com/updatecli/updatecli/pkg/core/pipeline/autodiscovery"
+	"github.com/updatecli/updatecli/pkg/core/pipeline/condition"
+	"github.com/updatecli/updatecli/pkg/core/pipeline/resource"
 	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
+	"github.com/updatecli/updatecli/pkg/core/pipeline/source"
+	"github.com/updatecli/updatecli/pkg/core/pipeline/target"
 	"github.com/updatecli/updatecli/pkg/core/result"
 	"github.com/updatecli/updatecli/pkg/core/version"
 	"go.yaml.in/yaml/v3"
@@ -236,11 +241,16 @@ func (e *Engine) LoadAutoDiscovery(ctx context.Context, defaultEnabled bool) err
 				newConfig := config.Config{
 					Spec: manifest,
 				}
-				newConfig.SetManifestID(fmt.Sprintf("%s/autodiscovery/%s/%d/%x",
+				manifestFingerprint, err := autodiscoveryManifestFingerprint(newConfig.Spec, p.Config.Spec.PipelineID)
+				if err != nil {
+					return fmt.Errorf("computing autodiscovery manifest fingerprint for %q: %w", manifest.Name, err)
+				}
+
+				newConfig.SetManifestID(fmt.Sprintf("%s/autodiscovery/%s/%d/%s",
 					p.Config.ManifestID(),
 					crawlerResult.Kind,
 					generatedManifestIndex,
-					sha256.Sum256(crawlerResult.Manifests[i]),
+					manifestFingerprint,
 				))
 				generatedManifestIndex++
 
@@ -294,4 +304,84 @@ func (e *Engine) LoadAutoDiscovery(ctx context.Context, defaultEnabled bool) err
 	}
 
 	return nil
+}
+
+func autodiscoveryManifestFingerprint(manifest config.Spec, pipelineID string) (string, error) {
+	sanitized := manifest
+
+	if len(manifest.Sources) > 0 {
+		sanitized.Sources = make(map[string]source.Config, len(manifest.Sources))
+		for id, cfg := range manifest.Sources {
+			reportConfig, err := resource.GetReportConfig(cfg.ResourceConfig)
+			if err != nil {
+				return "", fmt.Errorf("sanitizing source %q: %w", id, err)
+			}
+
+			sanitizedResourceConfig, ok := reportConfig.(resource.ResourceConfig)
+			if !ok {
+				return "", fmt.Errorf("unexpected report config type %T", reportConfig)
+			}
+
+			cfg.ResourceConfig = sanitizedResourceConfig
+			sanitized.Sources[id] = cfg
+		}
+	}
+
+	if len(manifest.Conditions) > 0 {
+		sanitized.Conditions = make(map[string]condition.Config, len(manifest.Conditions))
+		for id, cfg := range manifest.Conditions {
+			reportConfig, err := resource.GetReportConfig(cfg.ResourceConfig)
+			if err != nil {
+				return "", fmt.Errorf("sanitizing condition %q: %w", id, err)
+			}
+
+			sanitizedResourceConfig, ok := reportConfig.(resource.ResourceConfig)
+			if !ok {
+				return "", fmt.Errorf("unexpected report config type %T", reportConfig)
+			}
+
+			cfg.ResourceConfig = sanitizedResourceConfig
+			sanitized.Conditions[id] = cfg
+		}
+	}
+
+	if len(manifest.Targets) > 0 {
+		sanitized.Targets = make(map[string]target.Config, len(manifest.Targets))
+		for id, cfg := range manifest.Targets {
+			reportConfig, err := resource.GetReportConfig(cfg.ResourceConfig)
+			if err != nil {
+				return "", fmt.Errorf("sanitizing target %q: %w", id, err)
+			}
+
+			sanitizedResourceConfig, ok := reportConfig.(resource.ResourceConfig)
+			if !ok {
+				return "", fmt.Errorf("unexpected report config type %T", reportConfig)
+			}
+
+			cfg.ResourceConfig = sanitizedResourceConfig
+			sanitized.Targets[id] = cfg
+		}
+	}
+
+	if len(manifest.SCMs) > 0 {
+		sanitized.SCMs = make(map[string]scm.Config, len(manifest.SCMs))
+		for id, cfg := range manifest.SCMs {
+			if cfg.Disabled || cfg.Spec == nil {
+				cfg.Spec = nil
+			} else if generatedSCM, err := scm.New(&cfg, pipelineID); err == nil && generatedSCM.Handler != nil {
+				cfg.Spec = generatedSCM.Handler.Summary()
+			} else {
+				cfg.Spec = cfg.Kind
+			}
+
+			sanitized.SCMs[id] = cfg
+		}
+	}
+
+	data, err := json.Marshal(sanitized)
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("%x", sha256.Sum256(data)), nil
 }

--- a/pkg/core/engine/autodiscovery_test.go
+++ b/pkg/core/engine/autodiscovery_test.go
@@ -1,0 +1,143 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/updatecli/updatecli/pkg/core/config"
+	"github.com/updatecli/updatecli/pkg/core/pipeline/resource"
+	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
+	"github.com/updatecli/updatecli/pkg/core/pipeline/source"
+	"github.com/updatecli/updatecli/pkg/plugins/resources/updateclihttp"
+	githubscm "github.com/updatecli/updatecli/pkg/plugins/scms/github"
+)
+
+func TestAutodiscoveryManifestFingerprintIgnoresSecrets(t *testing.T) {
+	t.Parallel()
+
+	manifestWithFirstSecrets := config.Spec{
+		Name: "discovered manifest",
+		Sources: map[string]source.Config{
+			"version": {
+				ResourceConfig: resource.ResourceConfig{
+					Name: "version",
+					Kind: "http",
+					Spec: updateclihttp.Spec{
+						Url:                  "https://user:first-secret@example.com/releases/latest",
+						ReturnResponseHeader: "etag",
+					},
+				},
+			},
+		},
+		SCMs: map[string]scm.Config{
+			"default": {
+				Kind: "github",
+				Spec: githubscm.Spec{
+					Owner:      "updatecli",
+					Repository: "updatecli",
+					Token:      "first-token",
+					Branch:     "main",
+				},
+			},
+		},
+	}
+
+	manifestWithSecondSecrets := config.Spec{
+		Name: "discovered manifest",
+		Sources: map[string]source.Config{
+			"version": {
+				ResourceConfig: resource.ResourceConfig{
+					Name: "version",
+					Kind: "http",
+					Spec: updateclihttp.Spec{
+						Url:                  "https://user:second-secret@example.com/releases/latest",
+						ReturnResponseHeader: "etag",
+					},
+				},
+			},
+		},
+		SCMs: map[string]scm.Config{
+			"default": {
+				Kind: "github",
+				Spec: githubscm.Spec{
+					Owner:      "updatecli",
+					Repository: "updatecli",
+					Token:      "second-token",
+					Branch:     "main",
+				},
+			},
+		},
+	}
+
+	firstFingerprint, err := autodiscoveryManifestFingerprint(manifestWithFirstSecrets, "parent-pipeline")
+	require.NoError(t, err)
+
+	secondFingerprint, err := autodiscoveryManifestFingerprint(manifestWithSecondSecrets, "parent-pipeline")
+	require.NoError(t, err)
+
+	require.Equal(t, firstFingerprint, secondFingerprint)
+}
+
+func TestAutodiscoveryManifestFingerprintTracksSanitizedIdentity(t *testing.T) {
+	t.Parallel()
+
+	manifestA := config.Spec{
+		Name: "discovered manifest",
+		Sources: map[string]source.Config{
+			"version": {
+				ResourceConfig: resource.ResourceConfig{
+					Name: "version",
+					Kind: "http",
+					Spec: updateclihttp.Spec{
+						Url:                  "https://example.com/releases/latest",
+						ReturnResponseHeader: "etag",
+					},
+				},
+			},
+		},
+		SCMs: map[string]scm.Config{
+			"default": {
+				Kind: "github",
+				Spec: githubscm.Spec{
+					Owner:      "updatecli",
+					Repository: "updatecli",
+					Branch:     "main",
+				},
+			},
+		},
+	}
+
+	manifestB := config.Spec{
+		Name: "discovered manifest",
+		Sources: map[string]source.Config{
+			"version": {
+				ResourceConfig: resource.ResourceConfig{
+					Name: "version",
+					Kind: "http",
+					Spec: updateclihttp.Spec{
+						Url:                  "https://example.com/releases/stable",
+						ReturnResponseHeader: "etag",
+					},
+				},
+			},
+		},
+		SCMs: map[string]scm.Config{
+			"default": {
+				Kind: "github",
+				Spec: githubscm.Spec{
+					Owner:      "updatecli",
+					Repository: "website",
+					Branch:     "main",
+				},
+			},
+		},
+	}
+
+	fingerprintA, err := autodiscoveryManifestFingerprint(manifestA, "parent-pipeline")
+	require.NoError(t, err)
+
+	fingerprintB, err := autodiscoveryManifestFingerprint(manifestB, "parent-pipeline")
+	require.NoError(t, err)
+
+	require.NotEqual(t, fingerprintA, fingerprintB)
+}

--- a/pkg/core/engine/autodiscovery_test.go
+++ b/pkg/core/engine/autodiscovery_test.go
@@ -22,6 +22,7 @@ func TestAutodiscoveryManifestFingerprintIgnoresSecrets(t *testing.T) {
 				ResourceConfig: resource.ResourceConfig{
 					Name: "version",
 					Kind: "http",
+					// #nosec G101 -- This URL is not real and is only used for testing the fingerprinting logic.
 					Spec: updateclihttp.Spec{
 						Url:                  "https://user:first-secret@example.com/releases/latest",
 						ReturnResponseHeader: "etag",
@@ -50,6 +51,7 @@ func TestAutodiscoveryManifestFingerprintIgnoresSecrets(t *testing.T) {
 					Name: "version",
 					Kind: "http",
 					Spec: updateclihttp.Spec{
+						// #nosec G101 -- This URL is not real and is only used for testing the fingerprinting logic.
 						Url:                  "https://user:second-secret@example.com/releases/latest",
 						ReturnResponseHeader: "etag",
 					},

--- a/pkg/core/engine/order.go
+++ b/pkg/core/engine/order.go
@@ -1,0 +1,171 @@
+package engine
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/updatecli/updatecli/pkg/core/config"
+	"github.com/updatecli/updatecli/pkg/core/pipeline"
+)
+
+type manifestNode struct {
+	id        string
+	groupID   string
+	name      string
+	dependsOn []string
+	index     int
+}
+
+// OrderPipelines resolves manifest-level dependencies and reorders pipelines accordingly.
+func (e *Engine) OrderPipelines() error {
+	if len(e.Pipelines) == 0 {
+		return nil
+	}
+
+	nodes := make([]manifestNode, len(e.Pipelines))
+	indicesByGroupID := make(map[string][]int, len(e.Pipelines))
+
+	for i, p := range e.Pipelines {
+		if p == nil || p.Config == nil {
+			return fmt.Errorf("pipeline at index %d is missing configuration", i)
+		}
+
+		manifestID := p.Config.ManifestID()
+		if manifestID == "" {
+			return fmt.Errorf("pipeline %q has no manifest identifier", p.Name)
+		}
+
+		nodes[i] = manifestNode{
+			id:        manifestID,
+			groupID:   p.Config.DependencyID(),
+			name:      p.Name,
+			dependsOn: uniqueManifestDependencies(p.Config.Spec.DependsOn),
+			index:     i,
+		}
+
+		if nodes[i].groupID != "" {
+			indicesByGroupID[nodes[i].groupID] = append(indicesByGroupID[nodes[i].groupID], i)
+		}
+	}
+
+	indegree := make([]int, len(nodes))
+	successors := make([][]int, len(nodes))
+
+	for i, node := range nodes {
+		for _, dependencyID := range node.dependsOn {
+			dependencyIndexes, ok := indicesByGroupID[dependencyID]
+			if !ok || len(dependencyIndexes) == 0 {
+				return fmt.Errorf("manifest %s depends on unknown manifest id %q",
+					describeManifestNode(node), dependencyID)
+			}
+
+			for _, dependencyIndex := range dependencyIndexes {
+				if dependencyIndex == i {
+					return fmt.Errorf("manifest %s cannot depend on its own id %q",
+						describeManifestNode(node), dependencyID)
+				}
+
+				successors[dependencyIndex] = append(successors[dependencyIndex], i)
+				indegree[i]++
+			}
+		}
+	}
+
+	ready := make([]int, 0, len(nodes))
+	for i := range nodes {
+		if indegree[i] == 0 {
+			ready = append(ready, i)
+		}
+	}
+
+	orderedIndices := make([]int, 0, len(nodes))
+	for len(ready) > 0 {
+		currentBatch := append([]int{}, ready...)
+		ready = ready[:0]
+
+		for _, current := range currentBatch {
+			orderedIndices = append(orderedIndices, current)
+
+			for _, successor := range successors[current] {
+				indegree[successor]--
+				if indegree[successor] == 0 {
+					ready = append(ready, successor)
+				}
+			}
+		}
+
+		slices.Sort(ready)
+	}
+
+	if len(orderedIndices) != len(nodes) {
+		cycle := []string{}
+		for i, degree := range indegree {
+			if degree > 0 {
+				cycle = append(cycle, describeManifestNode(nodes[i]))
+			}
+		}
+
+		return fmt.Errorf("manifest dependency cycle detected involving %s", strings.Join(cycle, ", "))
+	}
+
+	orderedPipelines := make([]*pipeline.Pipeline, 0, len(orderedIndices))
+	orderedConfigurations := make([]*config.Config, 0, len(orderedIndices))
+
+	for _, index := range orderedIndices {
+		orderedPipelines = append(orderedPipelines, e.Pipelines[index])
+		orderedConfigurations = append(orderedConfigurations, e.Pipelines[index].Config)
+	}
+
+	e.Pipelines = orderedPipelines
+	e.configurations = orderedConfigurations
+
+	return nil
+}
+
+func describeManifestNode(node manifestNode) string {
+	manifestID := node.groupID
+	if manifestID == "" {
+		manifestID = node.id
+	}
+
+	if node.name == "" {
+		return fmt.Sprintf("manifest id %q", manifestID)
+	}
+
+	return fmt.Sprintf("manifest %q (id %q)", node.name, manifestID)
+}
+
+func describePipeline(p *pipeline.Pipeline, index int) string {
+	if p == nil || p.Config == nil {
+		return fmt.Sprintf("pipeline at index %d", index)
+	}
+
+	return describeManifestNode(manifestNode{
+		id:   p.Config.ManifestID(),
+		name: p.Name,
+	})
+}
+
+func uniqueManifestDependencies(dependencies []string) []string {
+	result := []string{}
+	seen := map[string]struct{}{}
+
+	for _, dependency := range dependencies {
+		if _, ok := seen[dependency]; ok {
+			continue
+		}
+
+		seen[dependency] = struct{}{}
+		result = append(result, dependency)
+	}
+
+	return result
+}
+
+func mergeManifestDependencies(baseDependencies, inheritedDependencies []string) []string {
+	result := append([]string{}, inheritedDependencies...)
+	result = append(result, baseDependencies...)
+
+	return uniqueManifestDependencies(result)
+}

--- a/pkg/core/engine/order.go
+++ b/pkg/core/engine/order.go
@@ -14,7 +14,6 @@ type manifestNode struct {
 	groupID   string
 	name      string
 	dependsOn []string
-	index     int
 }
 
 // OrderPipelines resolves manifest-level dependencies and reorders pipelines accordingly.
@@ -41,7 +40,6 @@ func (e *Engine) OrderPipelines() error {
 			groupID:   p.Config.DependencyID(),
 			name:      p.Name,
 			dependsOn: uniqueManifestDependencies(p.Config.Spec.DependsOn),
-			index:     i,
 		}
 
 		if nodes[i].groupID != "" {

--- a/pkg/core/engine/order.go
+++ b/pkg/core/engine/order.go
@@ -136,17 +136,6 @@ func describeManifestNode(node manifestNode) string {
 	return fmt.Sprintf("manifest %q (id %q)", node.name, manifestID)
 }
 
-func describePipeline(p *pipeline.Pipeline, index int) string {
-	if p == nil || p.Config == nil {
-		return fmt.Sprintf("pipeline at index %d", index)
-	}
-
-	return describeManifestNode(manifestNode{
-		id:   p.Config.ManifestID(),
-		name: p.Name,
-	})
-}
-
 func uniqueManifestDependencies(dependencies []string) []string {
 	result := []string{}
 	seen := map[string]struct{}{}

--- a/pkg/core/engine/order_test.go
+++ b/pkg/core/engine/order_test.go
@@ -1,0 +1,143 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/updatecli/updatecli/pkg/core/config"
+	"github.com/updatecli/updatecli/pkg/core/pipeline"
+)
+
+func TestOrderPipelines(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		engine        Engine
+		expectedOrder []string
+		expectedError string
+	}{
+		{
+			name: "sorts by manifest dependencies while preserving insertion order for siblings",
+			engine: Engine{
+				Pipelines: []*pipeline.Pipeline{
+					newPipelineForOrderTest("app", "app", []string{"base"}),
+					newPipelineForOrderTest("base", "base", nil),
+					newPipelineForOrderTest("docs", "docs", nil),
+				},
+			},
+			expectedOrder: []string{"base", "docs", "app"},
+		},
+		{
+			name: "keeps legacy manifests without explicit ids in insertion order",
+			engine: Engine{
+				Pipelines: []*pipeline.Pipeline{
+					newLegacyPipelineForOrderTest("first", "seed-1"),
+					newLegacyPipelineForOrderTest("second", "seed-2"),
+				},
+			},
+			expectedOrder: []string{"first", "second"},
+		},
+		{
+			name: "depends on all manifests sharing the same id",
+			engine: Engine{
+				Pipelines: []*pipeline.Pipeline{
+					newPipelineForOrderTest("app", "app", []string{"shared"}),
+					newPipelineForOrderTest("first", "shared", nil),
+					newPipelineForOrderTest("second", "shared", nil),
+				},
+			},
+			expectedOrder: []string{"first", "second", "app"},
+		},
+		{
+			name: "fails on unknown dependency target",
+			engine: Engine{
+				Pipelines: []*pipeline.Pipeline{
+					newPipelineForOrderTest("app", "app", []string{"missing"}),
+				},
+			},
+			expectedError: `depends on unknown manifest id "missing"`,
+		},
+		{
+			name: "fails on dependency cycles",
+			engine: Engine{
+				Pipelines: []*pipeline.Pipeline{
+					newPipelineForOrderTest("one", "one", []string{"two"}),
+					newPipelineForOrderTest("two", "two", []string{"one"}),
+				},
+			},
+			expectedError: "manifest dependency cycle detected",
+		},
+		{
+			name: "fails when depending on its own shared id",
+			engine: Engine{
+				Pipelines: []*pipeline.Pipeline{
+					newPipelineForOrderTest("one", "shared", []string{"shared"}),
+					newPipelineForOrderTest("two", "shared", nil),
+				},
+			},
+			expectedError: `cannot depend on its own id "shared"`,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := test.engine.OrderPipelines()
+
+			if test.expectedError != "" {
+				require.ErrorContains(t, err, test.expectedError)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Len(t, test.engine.Pipelines, len(test.expectedOrder))
+			require.Len(t, test.engine.configurations, len(test.expectedOrder))
+
+			for i, expectedName := range test.expectedOrder {
+				require.Equal(t, expectedName, test.engine.Pipelines[i].Name)
+				require.Same(t, test.engine.Pipelines[i].Config, test.engine.configurations[i])
+			}
+		})
+	}
+}
+
+func TestMergeManifestDependencies(t *testing.T) {
+	t.Parallel()
+
+	got := mergeManifestDependencies([]string{"child", "shared"}, []string{"parent", "shared"})
+
+	require.Equal(t, []string{"parent", "shared", "child"}, got)
+}
+
+func newPipelineForOrderTest(name, id string, dependsOn []string) *pipeline.Pipeline {
+	cfg := &config.Config{
+		Spec: config.Spec{
+			Name:      name,
+			ID:        id,
+			DependsOn: dependsOn,
+		},
+	}
+	cfg.SetManifestID("seed/" + name)
+
+	return &pipeline.Pipeline{
+		Name:   name,
+		Config: cfg,
+	}
+}
+
+func newLegacyPipelineForOrderTest(name, seed string) *pipeline.Pipeline {
+	cfg := &config.Config{
+		Spec: config.Spec{
+			Name: name,
+		},
+	}
+	cfg.SetManifestID(seed)
+
+	return &pipeline.Pipeline{
+		Name:   name,
+		Config: cfg,
+	}
+}

--- a/pkg/core/engine/prepare.go
+++ b/pkg/core/engine/prepare.go
@@ -74,6 +74,18 @@ func (e *Engine) Prepare(ctx context.Context) (err error) {
 		adSpan.End()
 	}
 
+	{
+		_, orderSpan := tracer.Start(ctx, "updatecli.order_pipelines")
+		err = e.OrderPipelines()
+		if err != nil {
+			telemetry.RecordSpanError(orderSpan, err)
+			orderSpan.End()
+			telemetry.RecordSpanError(span, err)
+			return err
+		}
+		orderSpan.End()
+	}
+
 	if len(e.Pipelines) == 0 {
 		err = fmt.Errorf("no valid pipeline found")
 		telemetry.RecordSpanError(span, err)

--- a/pkg/plugins/autodiscovery/argocd/application.go
+++ b/pkg/plugins/autodiscovery/argocd/application.go
@@ -109,7 +109,9 @@ func (f ArgoCD) discoverArgoCDManifests() ([][]byte, error) {
 					continue
 				}
 
-				manifests = append(manifests, manifest)
+				if manifest != nil {
+					manifests = append(manifests, manifest)
+				}
 			}
 
 			if !data.Spec.Template.Spec.Source.IsZero() {
@@ -124,7 +126,9 @@ func (f ArgoCD) discoverArgoCDManifests() ([][]byte, error) {
 					continue
 				}
 
-				manifests = append(manifests, manifest)
+				if manifest != nil {
+					manifests = append(manifests, manifest)
+				}
 			}
 
 			for i, source := range data.Spec.Sources {
@@ -143,7 +147,9 @@ func (f ArgoCD) discoverArgoCDManifests() ([][]byte, error) {
 					continue
 				}
 
-				manifests = append(manifests, manifest)
+				if manifest != nil {
+					manifests = append(manifests, manifest)
+				}
 			}
 		}
 	}

--- a/pkg/plugins/autodiscovery/argocd/main_test.go
+++ b/pkg/plugins/autodiscovery/argocd/main_test.go
@@ -18,6 +18,18 @@ func TestDiscoverManifests(t *testing.T) {
 		spec              Spec
 	}{
 		{
+			name:    "Expected no pipelines due to ignore rules",
+			rootDir: "testdata/multi-release",
+			spec: Spec{
+				Only: MatchingRules{
+					{
+						Path: "donotexist",
+					},
+				},
+			},
+			expectedPipelines: []string{},
+		},
+		{
 			name:    "ArgoCD manifests discovered with multiple documents",
 			rootDir: "testdata/multi-release",
 			expectedPipelines: []string{


### PR DESCRIPTION
When pipeline were ignored using the only/ignore rule, the autodiscovery would create "empty" pipeline which created noise in the console output 

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
cd pkg/plugins/autodiscovery/argocd
go test
```

## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via pull request in [website](https://github.com/updatecli/website) repository.

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
