### PR TITLE
fix(cache): include SCM identity in source cache key

### DIFF
--- a/pkg/core/cache/source.go
+++ b/pkg/core/cache/source.go
@@ -41,21 +41,32 @@ func NewSourceCache() *SourceCache {
 	}
 }
 
-// cacheKeyInput contains only the fields that determine what a source plugin
-// returns. Name, Transformers, DependsOn, and SCMID are excluded so that
-// sources with identical plugin config share the same cache entry regardless
-// of how they are named or wired in different pipelines.
-type cacheKeyInput struct {
-	Kind string `json:"kind"`
-	Spec any    `json:"spec"`
+// SCMIdentity is the resolved repo URL and source branch a source reads from.
+// Credentials are excluded: they live in separate Config fields and do not
+// change the fetched content.
+type SCMIdentity struct {
+	URL    string `json:"url"`
+	Branch string `json:"branch"`
 }
 
-// Key computes a cache key from a ResourceConfig by hashing only the Kind and
-// sanitized Spec (via ReportConfig). This instantiates the resource plugin
-// internally; on a cache miss the caller will instantiate it again for
-// execution. Returns empty string when hashing fails; callers treat that as a
-// cache miss.
-func Key(rc resource.ResourceConfig) string {
+// cacheKeyInput contains only the fields that determine what a source plugin
+// returns. Name, Transformers, DependsOn, and the SCMID label are excluded so
+// that sources with identical plugin config share the same cache entry
+// regardless of how they are named or wired in different pipelines. The
+// resolved SCM URL+branch are included because the same SCMID label in two
+// pipelines can point at different repositories (issue #8522).
+type cacheKeyInput struct {
+	Kind string       `json:"kind"`
+	Spec any          `json:"spec"`
+	SCM  *SCMIdentity `json:"scm,omitempty"`
+}
+
+// Key computes a cache key from a ResourceConfig and, when bound to an SCM,
+// the resolved SCM identity. Pass scm=nil for sources that run without an SCM;
+// the omitempty tag on cacheKeyInput.SCM keeps the hash identical to the
+// pre-SCM form in that case. Returns empty string when hashing fails; callers
+// treat that as a cache miss.
+func Key(rc resource.ResourceConfig, scm *SCMIdentity) string {
 	r, err := resource.New(rc)
 	if err != nil {
 		logrus.Debugf("source cache: failed to instantiate resource for key: %v", err)
@@ -65,6 +76,7 @@ func Key(rc resource.ResourceConfig) string {
 	data, err := json.Marshal(cacheKeyInput{
 		Kind: rc.Kind,
 		Spec: r.ReportConfig(),
+		SCM:  scm,
 	})
 	if err != nil {
 		logrus.Debugf("source cache: failed to marshal config for key: %v", err)

--- a/pkg/core/cache/source_test.go
+++ b/pkg/core/cache/source_test.go
@@ -164,7 +164,7 @@ func TestKey_EmptyKind(t *testing.T) {
 	}
 
 	// Act
-	key := Key(rc)
+	key := Key(rc, nil)
 
 	// Assert
 	assert.Equal(t, "", key)
@@ -193,8 +193,8 @@ func TestKey_SameConfigProducesSameKey(t *testing.T) {
 	}
 
 	// Act
-	key1 := Key(rc)
-	key2 := Key(rc)
+	key1 := Key(rc, nil)
+	key2 := Key(rc, nil)
 
 	// Assert
 	require.NotEmpty(t, key1)
@@ -208,8 +208,8 @@ func TestKey_SameSpecDifferentNamesShareKey(t *testing.T) {
 	rc1 := resource.ResourceConfig{Kind: "shell", Name: "name-a", Spec: spec}
 	rc2 := resource.ResourceConfig{Kind: "shell", Name: "name-b", Spec: spec}
 
-	key1 := Key(rc1)
-	key2 := Key(rc2)
+	key1 := Key(rc1, nil)
+	key2 := Key(rc2, nil)
 
 	require.NotEmpty(t, key1)
 	assert.Equal(t, key1, key2)
@@ -223,11 +223,58 @@ func TestKey_DifferentSpecsProduceDifferentKeys(t *testing.T) {
 	rc2 := resource.ResourceConfig{Kind: "shell", Name: "source-b", Spec: shellSpec("echo b")}
 
 	// Act
-	key1 := Key(rc1)
-	key2 := Key(rc2)
+	key1 := Key(rc1, nil)
+	key2 := Key(rc2, nil)
 
 	// Assert
 	require.NotEmpty(t, key1)
 	require.NotEmpty(t, key2)
 	assert.NotEqual(t, key1, key2)
+}
+
+// TestKey_SameSpecDifferentSCMsProduceDifferentKeys is the regression for
+// issue #8522: two pipelines reusing the same SCMID label against different
+// repos must not collide in the source cache.
+func TestKey_SameSpecDifferentSCMsProduceDifferentKeys(t *testing.T) {
+	rc := resource.ResourceConfig{Kind: "shell", Name: "source", Spec: shellSpec("cat LICENSE")}
+
+	scmA := &SCMIdentity{URL: "https://github.com/example/repo-a.git", Branch: "main"}
+	scmB := &SCMIdentity{URL: "https://github.com/example/repo-b.git", Branch: "main"}
+
+	keyA := Key(rc, scmA)
+	keyB := Key(rc, scmB)
+
+	require.NotEmpty(t, keyA)
+	require.NotEmpty(t, keyB)
+	assert.NotEqual(t, keyA, keyB)
+}
+
+// TestKey_NilSCMMatchesNilSCMSameSpec guarantees the nil-SCM path still
+// dedupes identical Kind+Spec configs (unchanged pre-fix behavior).
+func TestKey_NilSCMMatchesNilSCMSameSpec(t *testing.T) {
+	spec := shellSpec("echo hello")
+	rc1 := resource.ResourceConfig{Kind: "shell", Name: "name-a", Spec: spec}
+	rc2 := resource.ResourceConfig{Kind: "shell", Name: "name-b", Spec: spec}
+
+	key1 := Key(rc1, nil)
+	key2 := Key(rc2, nil)
+
+	require.NotEmpty(t, key1)
+	assert.Equal(t, key1, key2)
+}
+
+// TestKey_NilVsNonNilSCMProduceDifferentKeys is the third case of the #8522
+// regression: identical Kind+Spec with a nil SCM vs a non-nil SCM must not
+// collide, since cacheKeyInput.SCM uses json:"scm,omitempty".
+func TestKey_NilVsNonNilSCMProduceDifferentKeys(t *testing.T) {
+	rc := resource.ResourceConfig{Kind: "shell", Name: "source", Spec: shellSpec("cat LICENSE")}
+
+	scm := &SCMIdentity{URL: "https://github.com/example/repo-a.git", Branch: "main"}
+
+	keyNil := Key(rc, nil)
+	keySCM := Key(rc, scm)
+
+	require.NotEmpty(t, keyNil)
+	require.NotEmpty(t, keySCM)
+	assert.NotEqual(t, keyNil, keySCM)
 }

--- a/pkg/core/pipeline/source/main.go
+++ b/pkg/core/pipeline/source/main.go
@@ -57,7 +57,16 @@ func (s *Source) Run(ctx context.Context, sourceCache *cache.SourceCache) (err e
 	defer logrus.SetOutput(os.Stdout)
 	defer s.Result.SetConsoleOutput(&consoleOutput)
 
-	cacheKey := cache.Key(s.Config.ResourceConfig)
+	var scmIdentity *cache.SCMIdentity
+	if s.Scm != nil {
+		sourceBranch, _, _ := (*s.Scm).GetBranches()
+		scmIdentity = &cache.SCMIdentity{
+			URL:    (*s.Scm).GetURL(),
+			Branch: sourceBranch,
+		}
+	}
+
+	cacheKey := cache.Key(s.Config.ResourceConfig, scmIdentity)
 	cacheHit := false
 
 	if sourceCache != nil {


### PR DESCRIPTION
Fix #8522

Two pipelines reusing the same SCMID label (e.g. scmid: source) against different repositories collide in the source cache when their Kind+Spec match, serving the first pipeline's content to the second.

Fold the resolved SCM URL and source branch into the cache key. Nil-SCM callers keep the pre-fix hash via json:"scm,omitempty". Credentials live in separate Config fields and are not part of the identity.

## Test

To test this pull request, you can run the following commands:

```shell
cd pkg/core/cache
go test
```

## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via pull request in [website](https://github.com/updatecli/website) repository.

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
