### PR TITLE
fix(bitbucket): use FindBranch and paginate PR listing in pullrequest…

### DIFF
--- a/pkg/plugins/resources/bitbucket/pullrequest/utils.go
+++ b/pkg/plugins/resources/bitbucket/pullrequest/utils.go
@@ -8,7 +8,6 @@ import (
 	"github.com/drone/go-scm/scm"
 	"github.com/sirupsen/logrus"
 	"github.com/updatecli/updatecli/pkg/core/result"
-	"github.com/updatecli/updatecli/pkg/plugins/resources/bitbucket/client"
 )
 
 type pullRequestDetails struct {
@@ -25,47 +24,55 @@ func (b *Bitbucket) isPullRequestExist() (exists bool, details pullRequestDetail
 	ctx, cancelList := context.WithTimeout(ctx, 30*time.Second)
 	defer cancelList()
 
-	optsSearch := scm.PullRequestListOptions{
-		Page:   1,
-		Size:   30,
-		Open:   true,
-		Closed: false,
-	}
-
-	pullrequests, resp, err := b.client.PullRequests.List(
-		ctx,
-		strings.Join([]string{
-			b.Owner,
-			b.Repository,
-		}, "/"),
-		optsSearch,
-	)
-	if err != nil {
-		logrus.Debugf("RC: %d\nBody:\n%s", resp.Status, resp.Body)
-		return false, pullRequestDetails{}, err
-	}
-
-	if resp.Status > 400 {
-		logrus.Debugf("RC: %d\nBody:\n%s", resp.Status, resp.Body)
-	}
-
-	for _, p := range pullrequests {
-		if p.Source == b.SourceBranch &&
-			p.Target == b.TargetBranch &&
-			!p.Closed &&
-			!p.Merged {
-
-			logrus.Infof("%s Bitbucket pullrequest detected at:\n\t%s",
-				result.SUCCESS,
-				p.Link)
-
-			return true, pullRequestDetails{
-				Number:      p.Number,
-				Title:       p.Title,
-				Description: p.Body,
-				Link:        p.Link,
-			}, nil
+	page := 1
+	for {
+		optsSearch := scm.PullRequestListOptions{
+			Page:   page,
+			Size:   30,
+			Open:   true,
+			Closed: false,
 		}
+
+		pullrequests, resp, err := b.client.PullRequests.List(
+			ctx,
+			strings.Join([]string{
+				b.Owner,
+				b.Repository,
+			}, "/"),
+			optsSearch,
+		)
+		if err != nil {
+			logrus.Debugf("RC: %d\nBody:\n%s", resp.Status, resp.Body)
+			return false, pullRequestDetails{}, err
+		}
+
+		if resp.Status > 400 {
+			logrus.Debugf("RC: %d\nBody:\n%s", resp.Status, resp.Body)
+		}
+
+		for _, p := range pullrequests {
+			if p.Source == b.SourceBranch &&
+				p.Target == b.TargetBranch &&
+				!p.Closed &&
+				!p.Merged {
+
+				logrus.Infof("%s Bitbucket pullrequest detected at:\n\t%s",
+					result.SUCCESS,
+					p.Link)
+
+				return true, pullRequestDetails{
+					Number:      p.Number,
+					Title:       p.Title,
+					Description: p.Body,
+					Link:        p.Link,
+				}, nil
+			}
+		}
+
+		if resp.Page.Next == 0 {
+			break
+		}
+		page = resp.Page.Next
 	}
 	return false, pullRequestDetails{}, nil
 }
@@ -99,60 +106,30 @@ func (s *Bitbucket) isRemoteBranchesExist() (bool, error) {
 		repository = s.spec.Repository
 	}
 
+	repo := strings.Join([]string{owner, repository}, "/")
+
 	// Timeout api query after 30sec
 	ctx := context.Background()
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	remoteBranches, resp, err := s.client.Git.ListBranches(
-		ctx,
-		strings.Join([]string{owner, repository}, "/"),
-		scm.ListOptions{
-			URL:  client.URL(),
-			Page: 1,
-			Size: 30,
-		},
-	)
-	if err != nil {
-		logrus.Debugf("RC: %d\nBody:\n%s", resp.Status, resp.Body)
+	if _, _, err := s.client.Git.FindBranch(ctx, repo, sourceBranch); err != nil {
+		if err.Error() == scm.ErrNotFound.Error() {
+			logrus.Warningf("Branch %q not found on remote repository %s", sourceBranch, repo)
+			return false, nil
+		}
 		return false, err
 	}
 
-	if resp.Status > 400 {
-		logrus.Debugf("RC: %d\nBody:\n%s", resp.Status, resp.Body)
-	}
-
-	foundRemoteSourceBranch := false
-	foundRemoteTargetBranch := false
-
-	for _, remoteBranch := range remoteBranches {
-		if remoteBranch.Name == sourceBranch {
-			foundRemoteSourceBranch = true
+	if _, _, err := s.client.Git.FindBranch(ctx, repo, targetBranch); err != nil {
+		if err.Error() == scm.ErrNotFound.Error() {
+			logrus.Warningf("Branch %q not found on remote repository %s", targetBranch, repo)
+			return false, nil
 		}
-		if remoteBranch.Name == targetBranch {
-			foundRemoteTargetBranch = true
-		}
-
-		if foundRemoteSourceBranch && foundRemoteTargetBranch {
-			return true, nil
-		}
+		return false, err
 	}
 
-	if !foundRemoteSourceBranch {
-		logrus.Debugf("Branch %q not found on remote repository %s/%s",
-			sourceBranch,
-			owner,
-			repository)
-	}
-
-	if !foundRemoteTargetBranch {
-		logrus.Debugf("Branch %q not found on remote repository %s/%s",
-			targetBranch,
-			owner,
-			repository)
-	}
-
-	return false, nil
+	return true, nil
 }
 
 // inheritFromScm retrieve missing bitbucket settings from the bitbucket scm object.


### PR DESCRIPTION

  ---
  Problem

  isRemoteBranchesExist() and isPullRequestExist() both fetch only the first page of results (Page: 1, Size: 30) with no follow-through pagination. On repositories with more than 30 branches, if either the source branch or target branch (main)
  sorts alphabetically past position 30, the function silently returns false — causing CreateAction to log "skipping pull request creation" at Debug level and exit with nil. The job appears green with no PR created and no visible explanation in
  normal log output.

  Root cause / history

  The Stash plugin (PR #1246, March 2023) used ListBranches with a manual name-match loop. The Bitbucket Cloud plugin (PR #2847, October 2024) copy-pasted this approach verbatim; no reviewer questioned it. FindBranch has been present in both
  go-scm Bitbucket drivers since 2018 and was never unavailable. Branch names are never wildcards or patterns — there was no reason to list all branches. PR #5133 silently switched to FindBranch elsewhere in a refactor, but the Bitbucket Cloud
  plugin was not updated.

  Fix

  Replace the ListBranches scan in isRemoteBranchesExist() with two direct FindBranch calls — one per branch. This is O(1) regardless of branch count, matches the approach used by GitHub's GraphQL ref(qualifiedName:) lookup, and treats a 404
  response as "branch not found" logged at Warning level so the failure is visible without --debug.

  Also fix isPullRequestExist() which has the same Size: 30 truncation: it now paginates using resp.Page.Next until all open pull requests have been checked.

  Relates to #1905 (same class of bug observed in GitLab). Introduced in #2847.


## Test

To test this pull request, you can run the following commands:

```shell
cd <to_package_directory>
go test
```

## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via pull request in [website](https://github.com/updatecli/website) repository.

