### PR TITLE
feat(autodiscovery/argocd): enhance support of ApplicationSet with multiple sources

### DIFF
--- a/pkg/plugins/autodiscovery/argocd/application.go
+++ b/pkg/plugins/autodiscovery/argocd/application.go
@@ -26,7 +26,8 @@ type ArgoCDApplicationSpec struct {
 		Sources  []ApplicationSourceSpec
 		Template struct {
 			Spec struct {
-				Source ApplicationSourceSpec
+				Source  ApplicationSourceSpec
+				Sources []ApplicationSourceSpec
 			}
 		}
 	}
@@ -140,6 +141,27 @@ func (f ArgoCD) discoverArgoCDManifests() ([][]byte, error) {
 					source,
 					relativeFilepath,
 					fmt.Sprintf("$.spec.sources[%d]", i),
+					documentIndex,
+				)
+				if err != nil {
+					logrus.Errorf("error discovering application source: %s", err)
+					continue
+				}
+
+				if manifest != nil {
+					manifests = append(manifests, manifest)
+				}
+			}
+
+			for i, source := range data.Spec.Template.Spec.Sources {
+				if source.IsZero() {
+					continue
+				}
+
+				manifest, err := f.generateManifestBySource(
+					source,
+					relativeFilepath,
+					fmt.Sprintf("$.spec.template.spec.sources[%d]", i),
 					documentIndex,
 				)
 				if err != nil {

--- a/pkg/plugins/autodiscovery/argocd/main_test.go
+++ b/pkg/plugins/autodiscovery/argocd/main_test.go
@@ -356,6 +356,50 @@ targets:
     sourceid: 'nginx'
 `},
 		},
+		{
+			name:    "ArgoCD ApplicationSet manifests discovery with several sources",
+			rootDir: "testdata/appset-sealed-secrets_sources",
+			expectedPipelines: []string{`name: 'deps(helm): bump Helm chart "sealed-secrets" in ArgoCD manifest "manifest.yaml"'
+sources:
+  sealed-secrets:
+    name: 'Get latest "sealed-secrets" Helm chart version'
+    kind: 'helmchart'
+    spec:
+      name: 'sealed-secrets'
+      url: 'https://bitnami-labs.github.io/sealed-secrets'
+      versionfilter:
+        kind: 'semver'
+        pattern: '*'
+conditions:
+  sealed-secrets-name:
+    name: 'Ensure Helm chart name sealed-secrets is specified'
+    kind: 'yaml'
+    disablesourceinput: true
+    spec:
+      file: 'manifest.yaml'
+      key: '$.spec.template.spec.sources[0].chart'
+      documentindex: 0
+      value: 'sealed-secrets'
+  sealed-secrets-repository:
+    name: 'Ensure Helm chart repository https://bitnami-labs.github.io/sealed-secrets is specified'
+    kind: 'yaml'
+    disablesourceinput: true
+    spec:
+      file: 'manifest.yaml'
+      key: '$.spec.template.spec.sources[0].repoURL'
+      documentindex: 0
+      value: 'https://bitnami-labs.github.io/sealed-secrets'
+targets:
+  sealed-secrets:
+    name: 'deps(helm): update Helm chart "sealed-secrets" to {{ source "sealed-secrets" }}'
+    kind: 'yaml'
+    spec:
+      file: 'manifest.yaml'
+      key: '$.spec.template.spec.sources[0].targetRevision'
+      documentindex: 0
+    sourceid: 'sealed-secrets'
+`},
+		},
 	}
 
 	for _, tt := range testdata {

--- a/pkg/plugins/autodiscovery/argocd/testdata/appset-sealed-secrets_sources/manifest.yaml
+++ b/pkg/plugins/autodiscovery/argocd/testdata/appset-sealed-secrets_sources/manifest.yaml
@@ -1,0 +1,28 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: sealed-secrets
+  namespace: argocd
+spec:
+  generators:
+    - list:
+        elements:
+          - cluster: cluster-1
+            url: https://kubernetes.default.svc
+  template:
+    metadata:
+      name: sealed-secrets-{{cluster}}
+    spec:
+      project: default
+      sources:
+        - chart: sealed-secrets
+          repoURL: https://bitnami-labs.github.io/sealed-secrets
+          targetRevision: 1.16.1
+          helm:
+            releaseName: sealed-secrets
+        - repoURL: 'https://git.example.com/org/value-files.git'
+          targetRevision: HEAD
+          ref: values
+      destination:
+        server: "{{url}}"
+        namespace: kubeseal

--- a/pkg/plugins/autodiscovery/argocd/utils.go
+++ b/pkg/plugins/autodiscovery/argocd/utils.go
@@ -104,7 +104,8 @@ func readManifest(filename string) (map[int]*ArgoCDApplicationSpec, error) {
 		// Check if the document contains a source definition that we can use to generate an Updatecli manifest
 		if !data.Spec.Source.IsZero() ||
 			!data.Spec.Template.Spec.Source.IsZero() ||
-			len(data.Spec.Sources) > 0 {
+			len(data.Spec.Sources) > 0 ||
+			len(data.Spec.Template.Spec.Sources) > 0 {
 			result[docNum-1] = &data
 		}
 

--- a/pkg/plugins/autodiscovery/argocd/utils_test.go
+++ b/pkg/plugins/autodiscovery/argocd/utils_test.go
@@ -15,6 +15,7 @@ func TestSearchFiles(t *testing.T) {
 	}
 
 	expectedFiles := []string{
+		"testdata/appset-sealed-secrets_sources/manifest.yaml",
 		"testdata/empty/manifest.yaml",
 		"testdata/multi-release/manifest.yaml",
 		"testdata/oci-helm-source/manifest.yaml",


### PR DESCRIPTION
## Issue
The ArgoCD autodiscovery plugin currently supports multiple sources only for `Application` resources, 
not for `ApplicationSet`. When the autodiscovery runs in a folder containing ApplicationSets with 
multiple sources, it fails to detect them:
```
ARGOCD
=======
Manifest detected: 0
```

## Enhancement
Add support for `ApplicationSet` resources with multiple sources (`spec.template.spec.sources[]`).

### Before
- Application with single source: `spec.source` :white_check_mark: 
- Application with multiple sources: `spec.sources[]` :white_check_mark: 
- ApplicationSet with single source: `spec.template.spec.source` :white_check_mark: 
-  ApplicationSet with multiple sources: `spec.template.spec.sources[]` :arrow_right:  **Not supported**

### After
- Application with single source: `spec.source` :white_check_mark: 
- Application with multiple sources: `spec.sources[]` :white_check_mark: 
- ApplicationSet with single source: `spec.template.spec.source` :white_check_mark: 
-  ApplicationSet with multiple sources: `spec.template.spec.sources[]` :white_check_mark: 

## Test

To test this pull request, you can run the following commands:

```shell
cd pkg/plugins/autodiscovery/argocd
go test -v
```
