### PR TITLE
fix(autodiscovery/flux): skip HelmRelease without chart template to avoid nil pointer panic

### DIFF
--- a/pkg/plugins/autodiscovery/flux/helmreleaseManifests.go
+++ b/pkg/plugins/autodiscovery/flux/helmreleaseManifests.go
@@ -30,6 +30,10 @@ func (f Flux) discoverHelmreleaseManifests() [][]byte {
 		}
 
 		for index, d := range dataDocuments {
+			if d.Spec.Chart == nil {
+				logrus.Debugf("Ignoring Helmrelease from %q, as it does not define a chart template", relativeFoundFluxFile)
+				continue
+			}
 			helmChartName := d.Spec.Chart.Spec.Chart
 			helmChartVersion := d.Spec.Chart.Spec.Version
 

--- a/pkg/plugins/autodiscovery/flux/main_test.go
+++ b/pkg/plugins/autodiscovery/flux/main_test.go
@@ -316,6 +316,14 @@ targets:
 `},
 		},
 		{
+			name:              "Scenario - helmrelease without chart template",
+			digest:            true,
+			rootDir:           "testdata/helmrelease/chartref",
+			scmID:             "defaultscmid",
+			actionID:          "defaultactionid",
+			expectedPipelines: []string{},
+		},
+		{
 			name:    "Scenario - ocirepository ",
 			digest:  false,
 			rootDir: "testdata/ociRepository",

--- a/pkg/plugins/autodiscovery/flux/testdata/helmrelease/chartref/helmrelease.yaml
+++ b/pkg/plugins/autodiscovery/flux/testdata/helmrelease/chartref/helmrelease.yaml
@@ -1,0 +1,18 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: envoy-gateway
+  namespace: flux-system
+spec:
+  serviceAccountName: helm-controller
+  releaseName: envoy-gateway
+  targetNamespace: envoy-gateway-system
+  storageNamespace: envoy-gateway-system
+  chartRef:
+    kind: OCIRepository
+    name: gateway-helm
+  install:
+    crds: Skip
+  upgrade:
+    crds: Skip
+  interval: 5m

--- a/pkg/plugins/autodiscovery/flux/utils_test.go
+++ b/pkg/plugins/autodiscovery/flux/utils_test.go
@@ -19,6 +19,7 @@ func TestSearchFluxFiles(t *testing.T) {
 	}
 
 	expectedHelmReleaseFile := []string{
+		"testdata/helmrelease/chartref/helmrelease.yaml",
 		"testdata/helmrelease/multi-release/multi-helmrelease.yaml",
 		"testdata/helmrelease/oci/helmrelease.yaml",
 		"testdata/helmrelease/oci-combined/helmrelease-helmrepository.yaml",


### PR DESCRIPTION
Fix #8679

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
go test -test.fullpath=true -timeout 30s -run ^TestDiscoverManifests$ github.com/updatecli/updatecli/pkg/plugins/autodiscovery/flux
```

## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via pull request in [website](https://github.com/updatecli/website) repository.

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
