### PR TITLE
fix(autodiscovery/golang): correctly handle pseudo version

### DIFF
--- a/pkg/plugins/autodiscovery/golang/dependency.go
+++ b/pkg/plugins/autodiscovery/golang/dependency.go
@@ -105,7 +105,7 @@ func (g Golang) discoverDependencyManifests() ([][]byte, error) {
 					}
 
 				case true:
-					logrus.Debugf("Module %q has a pseudo-version %q, so ignoring version filter pattern for this module as the registry will only return one version for this module\n", goModule, goModuleVersion)
+					logrus.Debugf("Module %q uses a pseudo-version %q, so ignoring version filter pattern for this module as the registry will only return one version", goModule, goModuleVersion)
 					// If the new version is a pseudo-version,
 					// we cannot apply a version filter pattern as
 					// golang registry will only return one version for this module.
@@ -171,7 +171,7 @@ func (g Golang) discoverDependencyManifests() ([][]byte, error) {
 					// we cannot apply a version filter pattern as
 					// golang registry will only return one version for this module.
 
-					logrus.Debugf("Module %q has a pseudo-version %q, so ignoring version filter pattern for this module as the registry will only return one version for this module\n", replace.NewPath, replace.NewVersion)
+					logrus.Debugf("Module %q uses a pseudo-version %q, so ignoring version filter for this module as the registry will only return one version", replace.NewPath, replace.NewVersion)
 
 					goModuleVersionKind = "latest"
 					goModuleVersionPattern = ""

--- a/pkg/plugins/autodiscovery/golang/dependency.go
+++ b/pkg/plugins/autodiscovery/golang/dependency.go
@@ -94,16 +94,29 @@ func (g Golang) discoverDependencyManifests() ([][]byte, error) {
 					}
 				}
 
-				goModuleVersionPattern, err := g.versionFilter.GreaterThanPattern(goModuleVersion)
-				if err != nil {
-					logrus.Debugf("skipping golang module %q due to: %s", goModule, err)
-					continue
+				goModuleVersionPattern := g.versionFilter.Pattern
+				goModuleVersionKind := g.versionFilter.Kind
+				switch isPseudoVersion(goModuleVersion) {
+				case false:
+					goModuleVersionPattern, err = g.versionFilter.GreaterThanPattern(goModuleVersion)
+					if err != nil {
+						logrus.Debugf("skipping golang module %q due to: %s", goModule, err)
+						continue
+					}
+
+				case true:
+					logrus.Debugf("Module %q has a pseudo-version %q, so ignoring version filter pattern for this module as the registry will only return one version for this module\n", goModule, goModuleVersion)
+					// If the new version is a pseudo-version,
+					// we cannot apply a version filter pattern as
+					// golang registry will only return one version for this module.
+					goModuleVersionKind = "latest"
+					goModuleVersionPattern = ""
 				}
 
 				moduleManifest, err := getGolangModuleManifest(
 					relativeFoundFile,
 					goModule,
-					g.versionFilter.Kind,
+					goModuleVersionKind,
 					goModuleVersionPattern,
 					g.versionFilter.Regex,
 					g.scmID,
@@ -143,10 +156,25 @@ func (g Golang) discoverDependencyManifests() ([][]byte, error) {
 					}
 				}
 
-				goModuleVersionPattern, err := g.versionFilter.GreaterThanPattern(replace.NewVersion)
-				if err != nil {
-					logrus.Debugf("skipping golang module %q due to: %s", replace.NewPath, err)
-					continue
+				goModuleVersionPattern := g.versionFilter.Pattern
+				goModuleVersionKind := g.versionFilter.Kind
+				switch isPseudoVersion(replace.NewVersion) {
+				case false:
+					goModuleVersionPattern, err = g.versionFilter.GreaterThanPattern(replace.NewVersion)
+					if err != nil {
+						logrus.Debugf("skipping golang module %q due to: %s", replace.NewPath, err)
+						continue
+					}
+
+				case true:
+					// If the new version is a pseudo-version,
+					// we cannot apply a version filter pattern as
+					// golang registry will only return one version for this module.
+
+					logrus.Debugf("Module %q has a pseudo-version %q, so ignoring version filter pattern for this module as the registry will only return one version for this module\n", replace.NewPath, replace.NewVersion)
+
+					goModuleVersionKind = "latest"
+					goModuleVersionPattern = ""
 				}
 
 				moduleManifest, err := getGolangReplaceModuleManifest(
@@ -154,7 +182,7 @@ func (g Golang) discoverDependencyManifests() ([][]byte, error) {
 					replace.OldPath,
 					replace.OldVersion,
 					replace.NewPath,
-					g.versionFilter.Kind,
+					goModuleVersionKind,
 					goModuleVersionPattern,
 					g.versionFilter.Regex,
 					g.scmID,

--- a/pkg/plugins/autodiscovery/golang/dependency.go
+++ b/pkg/plugins/autodiscovery/golang/dependency.go
@@ -12,6 +12,8 @@ import (
 
 // discoverDependencyManifests search for each go.mod file
 // and then try to update both "direct" Go module and the Golang version
+//
+//nolint:funlen
 func (g Golang) discoverDependencyManifests() ([][]byte, error) {
 
 	var manifests [][]byte

--- a/pkg/plugins/autodiscovery/golang/main_test.go
+++ b/pkg/plugins/autodiscovery/golang/main_test.go
@@ -16,6 +16,45 @@ func TestDiscoverManifests(t *testing.T) {
 		expectedPipelines []string
 	}{
 		{
+			name:    "Test with pseudo version",
+			rootDir: "testdata/pseudoVersion",
+			expectedPipelines: []string{`name: 'deps(go): bump module github.com/shurcooL/githubv4'
+sources:
+  module:
+    name: 'Get latest golang module github.com/shurcooL/githubv4 version'
+    kind: 'golang/module'
+    spec:
+      module: 'github.com/shurcooL/githubv4'
+      versionfilter:
+        kind: 'latest'
+        pattern: ''
+targets:
+  module:
+    name: 'deps(go): bump module github.com/shurcooL/githubv4 to {{ source "module" }}'
+    kind: 'golang/gomod'
+    sourceid: 'module'
+    spec:
+      file: 'go.mod'
+      module: 'github.com/shurcooL/githubv4'
+`, `name: 'deps(golang): bump Go version'
+sources:
+  go:
+    name: 'Get latest Go version'
+    kind: 'golang'
+    spec:
+      versionfilter:
+        kind: 'semver'
+        pattern: '>=1.20.0'
+targets:
+  go:
+    name: 'deps(golang): bump Go version to {{ source "go" }}'
+    kind: 'golang/gomod'
+    sourceid: 'go'
+    spec:
+      file: 'go.mod'
+`},
+		},
+		{
 			name:    "Golang Replace module",
 			rootDir: "testdata/replace",
 			expectedPipelines: []string{`name: 'deps(go): bump module github.com/crewjam/saml'

--- a/pkg/plugins/autodiscovery/golang/testdata/pseudoVersion/go.mod
+++ b/pkg/plugins/autodiscovery/golang/testdata/pseudoVersion/go.mod
@@ -1,0 +1,7 @@
+module github.com/updatecli/updatecli
+
+go 1.20
+
+require (
+    github.com/shurcooL/githubv4 v0.0.0-20230215024106-420ad0987b9b
+)

--- a/pkg/plugins/autodiscovery/golang/utils.go
+++ b/pkg/plugins/autodiscovery/golang/utils.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/sirupsen/logrus"
@@ -14,6 +15,11 @@ import (
 
 const (
 	GoModFile string = "go.mod"
+)
+
+var (
+	// pseudoVersionRegex is a regular expression to match Go pseudo-versions.
+	pseudoVersionRegex *regexp.Regexp = regexp.MustCompile(`^v\d+\.\d+\.\d+-\d{14}-[a-f0-9]{12}$`)
 )
 
 type Replace struct {
@@ -95,4 +101,9 @@ func getGoModContent(filename string) (goVersion string, goModules map[string]st
 	}
 
 	return goVersion, goModules, replaceGoModules, nil
+}
+
+// isPseudoVersion checks if the provided version is a pseudo-version.
+func isPseudoVersion(version string) bool {
+	return pseudoVersionRegex.MatchString(version)
 }

--- a/pkg/plugins/autodiscovery/golang/utils.go
+++ b/pkg/plugins/autodiscovery/golang/utils.go
@@ -6,20 +6,15 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"regexp"
 	"strings"
 
 	"github.com/sirupsen/logrus"
 	"golang.org/x/mod/modfile"
+	"golang.org/x/mod/module"
 )
 
 const (
 	GoModFile string = "go.mod"
-)
-
-var (
-	// pseudoVersionRegex is a regular expression to match Go pseudo-versions.
-	pseudoVersionRegex *regexp.Regexp = regexp.MustCompile(`^v\d+\.\d+\.\d+-\d{14}-[a-f0-9]{12}$`)
 )
 
 type Replace struct {
@@ -105,5 +100,5 @@ func getGoModContent(filename string) (goVersion string, goModules map[string]st
 
 // isPseudoVersion checks if the provided version is a pseudo-version.
 func isPseudoVersion(version string) bool {
-	return pseudoVersionRegex.MatchString(version)
+	return module.IsPseudoVersion(version) || module.IsZeroPseudoVersion(version)
 }

--- a/pkg/plugins/autodiscovery/golang/utils_test.go
+++ b/pkg/plugins/autodiscovery/golang/utils_test.go
@@ -98,12 +98,42 @@ func TestPseudoVersion(t *testing.T) {
 	}{
 		{
 			name:           "Valid pseudo-version",
-			version:        "v1.2.3-20230215024106-420ad0987b9b",
+			version:        "v0.0.0-20230215024106-420ad0987b9b",
 			expectedResult: true,
 		},
 		{
 			name:           "Invalid pseudo-version",
 			version:        "v1.2.3",
+			expectedResult: false,
+		},
+		{
+			name:           "Valid pseudo-version with zero patch increment form",
+			version:        "v0.0.0-0.20230215024106-420ad0987b9b",
+			expectedResult: true,
+		},
+		{
+			name:           "Valid pseudo-version with prerelease form",
+			version:        "v0.0.0-beta.0.20230215024106-420ad0987b9b",
+			expectedResult: true,
+		},
+		{
+			name:           "Valid pseudo-version with incompatible suffix",
+			version:        "v0.0.0-20230215024106-420ad0987b9b+incompatible",
+			expectedResult: true,
+		},
+		{
+			name:           "Valid zero patch increment pseudo-version with incompatible suffix",
+			version:        "v1.2.4-0.20230215024106-420ad0987b9b+incompatible",
+			expectedResult: true,
+		},
+		{
+			name:           "Invalid pseudo-version with short timestamp",
+			version:        "v1.2.3-2023021502410-420ad0987b9b",
+			expectedResult: false,
+		},
+		{
+			name:           "Invalid pseudo-version with short hash",
+			version:        "v1.2.3-20230215024106-420ad0987b9",
 			expectedResult: false,
 		},
 	}

--- a/pkg/plugins/autodiscovery/golang/utils_test.go
+++ b/pkg/plugins/autodiscovery/golang/utils_test.go
@@ -20,6 +20,7 @@ func TestSearchGoModFiles(t *testing.T) {
 			expectedFoundFiles: []string{
 				"testdata/noModule/go.mod",
 				"testdata/noSumFile/go.mod",
+				"testdata/pseudoVersion/go.mod",
 				"testdata/replace/go.mod",
 			},
 		},
@@ -85,6 +86,32 @@ func TestGetGoModContent(t *testing.T) {
 			assert.Equal(t, d.expectedModules, foundGoModules)
 			assert.Equal(t, d.expectedReplaceModules, foundReplaceGoModules)
 			assert.Equal(t, d.expectedGoVersion, foundGoVersion)
+		})
+	}
+}
+
+func TestPseudoVersion(t *testing.T) {
+	dataset := []struct {
+		name           string
+		version        string
+		expectedResult bool
+	}{
+		{
+			name:           "Valid pseudo-version",
+			version:        "v1.2.3-20230215024106-420ad0987b9b",
+			expectedResult: true,
+		},
+		{
+			name:           "Invalid pseudo-version",
+			version:        "v1.2.3",
+			expectedResult: false,
+		},
+	}
+
+	for _, d := range dataset {
+		t.Run(d.name, func(t *testing.T) {
+			result := isPseudoVersion(d.version)
+			assert.Equal(t, d.expectedResult, result)
 		})
 	}
 }


### PR DESCRIPTION
Fix pseudo version in golang autodiscovery.

If a go module uses a pseudo version then Updatecli override the version filter to handle it.
A pseudo version looks like "v0.0.0-20260209031235-2402fdf4a9ed"


<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
cd pkg/plugins/autodiscovery/golang/
go test
```

## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via pull request in [website](https://github.com/updatecli/website) repository.

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
