### PR TITLE
chore: update pnpm/action-setup version in workflows

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -48,7 +48,7 @@ jobs:
           # we always use the latest patch version.
           version: v2.9.0
           install-mode: "binary"
-      - uses: "pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061" # v4.2.2
+      - uses: "pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093" # v6.0.8
         with:
           version: "10.33.0"
           run_install: false


### PR DESCRIPTION
For some reason the v4.2.2 doesn't exist anymore so Updatecli can't decide what to use

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
cd <to_package_directory>
go test
```

## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via pull request in [website](https://github.com/updatecli/website) repository.

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
