### PR TITLE
fix: sanitize version when checking the latest Updatecli version available

### DIFF
--- a/pkg/core/engine/version.go
+++ b/pkg/core/engine/version.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"strings"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -11,15 +12,12 @@ import (
 	"github.com/updatecli/updatecli/pkg/core/version"
 )
 
-var (
-	// versionHTTPEndpoint is the URL to check for the latest version of updatecli
-	versionHTTPEndpoint string = "https://www.updatecli.io/changelogs/updatecli/_index.json"
-)
+// versionHTTPEndpoint is the URL to check for the latest version of updatecli
+var versionHTTPEndpoint string = "https://www.updatecli.io/changelogs/updatecli/_index.json"
 
 // CheckLatestPublishedVersion check if the currently used version is the latest version
 // available
 func CheckLatestPublishedVersion() error {
-
 	client := httpclient.NewThrottledRetryClient(1*time.Second, 1)
 
 	type versionData struct {
@@ -54,13 +52,20 @@ func CheckLatestPublishedVersion() error {
 		return fmt.Errorf("unable to parse the latest version of updatecli: %v", err)
 	}
 
+	sanitizeVersion := func(v string) string {
+		s := strings.TrimSpace(v)
+		s = strings.TrimPrefix(s, "v")
+
+		return s
+	}
+
 	if data.Latest.Tag == version.Version {
 		return nil
 	}
 
 	logrus.Infof("\n---")
-	logrus.Infof("A new version of updatecli is available: %s (current: %q)", data.Latest.Tag, version.Version)
-	logrus.Infof("Changelog available at: www.updatecli.io/changelogs/updatecli/changelogs/%s/", data.Latest.Tag)
+	logrus.Infof("A new version of updatecli is available: %s (current: %q)", sanitizeVersion(data.Latest.Tag), sanitizeVersion(version.Version))
+	logrus.Infof("Changelog available at: www.updatecli.io/changelsogs/updatecli/changelogs/%s/", data.Latest.Tag)
 	logrus.Infof("---")
 
 	return nil

--- a/pkg/core/engine/version.go
+++ b/pkg/core/engine/version.go
@@ -59,13 +59,13 @@ func CheckLatestPublishedVersion() error {
 		return s
 	}
 
-	if data.Latest.Tag == version.Version {
+	if sanitizeVersion(data.Latest.Tag) == sanitizeVersion(version.Version) {
 		return nil
 	}
 
 	logrus.Infof("\n---")
-	logrus.Infof("A new version of updatecli is available: %s (current: %q)", sanitizeVersion(data.Latest.Tag), sanitizeVersion(version.Version))
-	logrus.Infof("Changelog available at: www.updatecli.io/changelsogs/updatecli/changelogs/%s/", data.Latest.Tag)
+	logrus.Infof("A new version of updatecli is available: %s (current: %s)", data.Latest.Tag, version.Version)
+	logrus.Infof("Changelog available at: www.updatecli.io/changelogs/updatecli/changelogs/%s/", data.Latest.Tag)
 	logrus.Infof("---")
 
 	return nil


### PR DESCRIPTION
Fix minor issue when checking the latest version as the one retrieved from updatecli.io contains a `v` prefix while the embedded in the binary doesn't

The goal is to avoid the following issue
```
A new version of updatecli is available: v0.117.0 (current: "0.117.0")
Changelog available at: www.updatecli.io/changelogs/updatecli/changelogs/v0.117.0/
```

## Test

/

## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via pull request in [website](https://github.com/updatecli/website) repository.

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
