### PR TITLE
chore: add ci pipline job in global report

### DIFF
--- a/pkg/core/engine/run.go
+++ b/pkg/core/engine/run.go
@@ -78,6 +78,10 @@ func (e *Engine) Run(ctx context.Context) (err error) {
 
 	for i := range e.Pipelines {
 		pipeline := e.Pipelines[i]
+		err = pipeline.Report.UpdateCIJob()
+		if err != nil {
+			logrus.Debugf("updating CI job information: %s", err)
+		}
 		err = pipeline.Report.UpdateID()
 		if err != nil {
 			errs = append(errs, fmt.Errorf("updating report ID failed: %w", err))

--- a/pkg/core/reports/report.go
+++ b/pkg/core/reports/report.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/updatecli/updatecli/pkg/core/result"
+	"github.com/updatecli/updatecli/pkg/plugins/utils/ci"
 )
 
 const (
@@ -74,6 +75,12 @@ Report available on {{ .reportURL -}}{{"\n"}}
 `
 )
 
+// CIData contains information about the CI pipeline where the report is generated
+type CIData struct {
+	URL  string `json:",omitempty"`
+	Name string `json:",omitempty"`
+}
+
 // Report contains the result of the execution of a pipeline
 type Report struct {
 	Name   string
@@ -90,6 +97,7 @@ type Report struct {
 	Conditions map[string]*result.Condition
 	Targets    map[string]*result.Target
 	ReportURL  string
+	CI         CIData `json:",omitempty"`
 }
 
 // String returns a report as a string
@@ -120,6 +128,25 @@ func (r *Report) String(mode string) (report string, err error) {
 	report = buffer.String()
 
 	return report, nil
+}
+
+// UpdateCIJob updates the report with CI job information if available
+func (r *Report) UpdateCIJob() error {
+	detectedCi, err := ci.New()
+	if err != nil {
+		return err
+	}
+
+	if detectedCi == nil {
+		// No CI pipeline detected
+		return nil
+	}
+
+	r.CI = CIData{
+		Name: detectedCi.Name(),
+		URL:  detectedCi.URL(),
+	}
+	return nil
 }
 
 // UpdateID generates a unique ID for the report based on the content of the report

--- a/pkg/core/reports/report.go
+++ b/pkg/core/reports/report.go
@@ -97,7 +97,7 @@ type Report struct {
 	Conditions map[string]*result.Condition
 	Targets    map[string]*result.Target
 	ReportURL  string
-	CI         CIData `json:",omitempty"`
+	CI         *CIData
 }
 
 // String returns a report as a string
@@ -142,7 +142,7 @@ func (r *Report) UpdateCIJob() error {
 		return nil
 	}
 
-	r.CI = CIData{
+	r.CI = &CIData{
 		Name: detectedCi.Name(),
 		URL:  detectedCi.URL(),
 	}


### PR DESCRIPTION
Show ci job url where Updatecli was executed directly in the report data

## Test

Tested manually

## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via pull request in [website](https://github.com/updatecli/website) repository.

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
