### PR TITLE
fix(dockerdigest): include HideTag in ReportConfig to prevent source cache collision

### DIFF
--- a/pkg/plugins/resources/dockerdigest/main.go
+++ b/pkg/plugins/resources/dockerdigest/main.go
@@ -139,5 +139,6 @@ func (d *DockerDigest) ReportConfig() interface{} {
 		Tag:          d.spec.Tag,
 		Digest:       d.spec.Digest,
 		Architecture: d.spec.Architecture,
+		HideTag:      d.spec.HideTag,
 	}
 }

--- a/pkg/plugins/resources/dockerdigest/reportconfig_test.go
+++ b/pkg/plugins/resources/dockerdigest/reportconfig_test.go
@@ -1,0 +1,69 @@
+package dockerdigest
+
+// TestReportConfigCacheKey proves that ReportConfig() must include HideTag in
+// its output so that two sources sharing the same image+tag but differing only
+// in hidetag receive distinct cache keys.
+//
+// RED (bug):  HideTag absent  → identical JSON → same key → cache collision
+// GREEN (fix): HideTag present → different JSON → different keys → no collision
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func cacheKeyFromSpec(spec interface{}) string {
+	payload, _ := json.Marshal(struct {
+		Kind string      `json:"Kind"`
+		Spec interface{} `json:"Spec"`
+	}{Kind: "dockerdigest", Spec: spec})
+	h := sha256.Sum256(payload)
+	return fmt.Sprintf("%x", h)
+}
+
+func TestReportConfig_HideTagIncluded(t *testing.T) {
+	const image = "registry.example.com/myapp"
+	const tag = "v1.0.0"
+
+	versionSource := &DockerDigest{spec: Spec{
+		Image:   image,
+		Tag:     tag,
+		HideTag: false,
+	}}
+	appVersionSource := &DockerDigest{spec: Spec{
+		Image:   image,
+		Tag:     tag,
+		HideTag: true,
+	}}
+
+	rcVersion := versionSource.ReportConfig()
+	rcAppVersion := appVersionSource.ReportConfig()
+
+	keyVersion := cacheKeyFromSpec(rcVersion)
+	keyAppVersion := cacheKeyFromSpec(rcAppVersion)
+
+	// Marshal both to inspect what fields are actually present.
+	jsonVersion, err := json.Marshal(rcVersion)
+	require.NoError(t, err)
+	jsonAppVersion, err := json.Marshal(rcAppVersion)
+	require.NoError(t, err)
+
+	t.Logf("latestVersion    ReportConfig JSON: %s", jsonVersion)
+	t.Logf("latestAppVersion ReportConfig JSON: %s", jsonAppVersion)
+	t.Logf("latestVersion    cache key: %s", keyVersion)
+	t.Logf("latestAppVersion cache key: %s", keyAppVersion)
+
+	// GREEN: keys must differ so each source executes independently.
+	assert.NotEqual(t, keyVersion, keyAppVersion,
+		"cache key collision: HideTag must be included in ReportConfig() output "+
+			"so latestVersion and latestAppVersion receive distinct cache keys")
+
+	// Verify HideTag is actually present in the appVersion JSON.
+	assert.Contains(t, string(jsonAppVersion), "HideTag",
+		"ReportConfig() must include HideTag field")
+}

--- a/pkg/plugins/resources/dockerdigest/reportconfig_test.go
+++ b/pkg/plugins/resources/dockerdigest/reportconfig_test.go
@@ -1,69 +1,22 @@
 package dockerdigest
 
-// TestReportConfigCacheKey proves that ReportConfig() must include HideTag in
-// its output so that two sources sharing the same image+tag but differing only
-// in hidetag receive distinct cache keys.
-//
-// RED (bug):  HideTag absent  → identical JSON → same key → cache collision
-// GREEN (fix): HideTag present → different JSON → different keys → no collision
-
 import (
-	"crypto/sha256"
 	"encoding/json"
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func cacheKeyFromSpec(spec interface{}) string {
-	payload, _ := json.Marshal(struct {
-		Kind string      `json:"Kind"`
-		Spec interface{} `json:"Spec"`
-	}{Kind: "dockerdigest", Spec: spec})
-	h := sha256.Sum256(payload)
-	return fmt.Sprintf("%x", h)
-}
-
-func TestReportConfig_HideTagIncluded(t *testing.T) {
-	const image = "registry.example.com/myapp"
-	const tag = "v1.0.0"
-
-	versionSource := &DockerDigest{spec: Spec{
-		Image:   image,
-		Tag:     tag,
-		HideTag: false,
-	}}
-	appVersionSource := &DockerDigest{spec: Spec{
-		Image:   image,
-		Tag:     tag,
+func TestReportConfig_IncludesHideTag(t *testing.T) {
+	source := &DockerDigest{spec: Spec{
+		Image:   "registry.example.com/myapp",
+		Tag:     "v1.0.0",
 		HideTag: true,
 	}}
 
-	rcVersion := versionSource.ReportConfig()
-	rcAppVersion := appVersionSource.ReportConfig()
-
-	keyVersion := cacheKeyFromSpec(rcVersion)
-	keyAppVersion := cacheKeyFromSpec(rcAppVersion)
-
-	// Marshal both to inspect what fields are actually present.
-	jsonVersion, err := json.Marshal(rcVersion)
+	data, err := json.Marshal(source.ReportConfig())
 	require.NoError(t, err)
-	jsonAppVersion, err := json.Marshal(rcAppVersion)
-	require.NoError(t, err)
-
-	t.Logf("latestVersion    ReportConfig JSON: %s", jsonVersion)
-	t.Logf("latestAppVersion ReportConfig JSON: %s", jsonAppVersion)
-	t.Logf("latestVersion    cache key: %s", keyVersion)
-	t.Logf("latestAppVersion cache key: %s", keyAppVersion)
-
-	// GREEN: keys must differ so each source executes independently.
-	assert.NotEqual(t, keyVersion, keyAppVersion,
-		"cache key collision: HideTag must be included in ReportConfig() output "+
-			"so latestVersion and latestAppVersion receive distinct cache keys")
-
-	// Verify HideTag is actually present in the appVersion JSON.
-	assert.Contains(t, string(jsonAppVersion), "HideTag",
-		"ReportConfig() must include HideTag field")
+	assert.Contains(t, string(data), `"HideTag":true`,
+		"ReportConfig() must include HideTag so sources differing only in hidetag get distinct cache keys")
 }


### PR DESCRIPTION
It's common to pair two `dockerdigest` sources against the same image and tag: one with `hidetag: false` for `image.tag` and one with `hidetag: true` for `appVersion`. This worked correctly for years until the source cache introduced in v0.116.0 started treating them as identical — `ReportConfig()` omits `HideTag` from its output, so both sources hash to the same cache key. Whichever runs first populates the cache; the other receives a stale hit and produces the wrong result without any error — updatecli reports `✔` for both.

This PR adds `HideTag` to the struct returned by `ReportConfig()` so each source gets a distinct cache key and executes independently.

Because source execution order is non-deterministic, the failure shows up differently depending on which source wins the race:

| Ordering | Source | v0.115.x | v0.116.0+ |
|---|---|---|---|
| version first | `version` (hidetag=false) | `tag@sha256:…` ✓ | `tag@sha256:…` ✓ |
| version first | `appversion` (hidetag=true) | short hash ✓ | `""` ✗ — transformer receives `tag@sha256:…`; `trimprefix` is a no-op |
| appversion first | `appversion` (hidetag=true) | short hash ✓ | short hash ✓ |
| appversion first | `version` (hidetag=false) | `tag@sha256:…` ✓ | `@sha256:…` ✗ — cache hit, no transformer on version source |

## Test

To test this pull request, you can run the following commands:

```shell
cd pkg/plugins/resources/dockerdigest
go test -run TestReportConfig_HideTagIncluded -v
```

The test calls `ReportConfig()` on a source with `hidetag: true` and asserts the returned JSON contains `"HideTag":true` — confirming the field is present and carries the correct value.

To reproduce against a live registry, save as `reproduce.yaml` and run `updatecli apply -c reproduce.yaml`:

<details>
<summary>reproduce.yaml</summary>

```yaml
sources:

  # ── Ordering A: version runs first ──────────────────────────────────────
  # v0.116.0+: version caches "stable@sha256:…"; appversion gets stale hit.

  ord_a_version:
    name: "[Ord A] version — runs first — v0.115 ✓  v0.116 ✓"
    kind: dockerdigest
    spec:
      image: "nginx"
      tag: "stable"

  ord_a_appversion:
    name: "[Ord A] appversion — cache hit → trimprefix no-op → regex fails — v0.115 ✓  v0.116 ✗ (empty)"
    kind: dockerdigest
    spec:
      image: "nginx"
      tag: "stable"
      hidetag: true
    dependson:
      - ord_a_version
    transformers:
      - trimprefix: "@sha256:"
      - findsubmatch:
          pattern: "^([0-9a-f]{8})"

  # ── Ordering B: appversion runs first ───────────────────────────────────
  # v0.116.0+: appversion caches "@sha256:…"; version gets stale hit.
  # Uses a different tag to isolate this pair's cache key from Ordering A.

  ord_b_appversion:
    name: "[Ord B] appversion — runs first — v0.115 ✓  v0.116 ✓"
    kind: dockerdigest
    spec:
      image: "nginx"
      tag: "mainline"
      hidetag: true
    transformers:
      - trimprefix: "@sha256:"
      - findsubmatch:
          pattern: "^([0-9a-f]{8})"

  ord_b_version:
    name: "[Ord B] version — cache hit → @sha256:… with no transformer — v0.115 ✓  v0.116 ✗ (wrong format)"
    kind: dockerdigest
    spec:
      image: "nginx"
      tag: "mainline"
    dependson:
      - ord_b_appversion
```

</details>

On v0.116.0: `ord_a_appversion` → `""`, `ord_b_version` → `@sha256:…`. On a patched build all four sources resolve correctly.

## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via pull request in [website](https://github.com/updatecli/website) repository.

### Tradeoff

`HideTag: false` (the default) now serializes as `"HideTag":false` in the cache key JSON where it was previously absent. Users with `hidetag` unset will see a one-time cache miss on first run after upgrade — a fresh registry call with the correct result. No functional regression.

### Potential improvement

Other fields that affect the `dockerdigest` output format, and any plugin added after #8291, should be audited to confirm `ReportConfig()` is a complete identity function for the source's output.
