### PR TITLE
chore: updatecli docs handle different exit code

### DIFF
--- a/cmd/docs.go
+++ b/cmd/docs.go
@@ -1,10 +1,14 @@
 package cmd
 
 import (
+	"crypto/sha256"
 	"fmt"
+	"io"
+	"os"
 	"path/filepath"
 	"strings"
 
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
 )
@@ -47,20 +51,76 @@ var (
 		Use:    "docs",
 		Hidden: true,
 		Short:  "Generate updatecli documentation",
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			rootCmd.DisableAutoGenTag = true
-			err := doc.GenMarkdownTreeCustom(
-				rootCmd,
-				docsDir,
-				docPrepender,
-				linkhandler)
+
+			before, err := snapshotDir(docsDir)
 			if err != nil {
-				panic(err)
+				return err
 			}
+
+			if err = doc.GenMarkdownTreeCustom(rootCmd, docsDir, docPrepender, linkhandler); err != nil {
+				return err
+			}
+
+			after, err := snapshotDir(docsDir)
+			if err != nil {
+				return err
+			}
+
+			for path, hash := range after {
+				if prev, exists := before[path]; !exists || prev != hash {
+					logrus.Infof("Documentation files updated in %q", docsDir)
+					os.Exit(2)
+				}
+			}
+
+			logrus.Infof("Documentation files already up to date in %q", docsDir)
+			return nil
 		},
 	}
 )
 
 func init() {
 	docsCmd.Flags().StringVarP(&docsDir, "docs", "d", "./docs", "Specify the directory where to generate documentation files")
+}
+
+// snapshotDir returns a map of file paths (relative to dir) to their SHA-256 hash.
+// If the directory does not exist yet, an empty map is returned.
+func snapshotDir(dir string) (map[string][sha256.Size]byte, error) {
+	hashes := make(map[string][sha256.Size]byte)
+
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		return hashes, nil
+	}
+
+	err := filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+
+		f, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+
+		h := sha256.New()
+		if _, err = io.Copy(h, f); err != nil {
+			return err
+		}
+
+		rel, err := filepath.Rel(dir, path)
+		if err != nil {
+			return err
+		}
+
+		hashes[rel] = [sha256.Size]byte(h.Sum(nil))
+		return nil
+	})
+
+	return hashes, err
 }


### PR DESCRIPTION
This change will simplify the updatecli manifest from [here](https://github.com/updatecli/website/blob/master/updatecli/updatecli.d/docs.yaml) as we'll be able to detect if something changed or not
<!-- Describe the changes introduced by this pull request -->

## Test

Tested manually

## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via pull request in [website](https://github.com/updatecli/website) repository.

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
