### PR TITLE
fix: skip version check for generator commands

### DIFF
--- a/cmd/env.go
+++ b/cmd/env.go
@@ -10,6 +10,8 @@ import (
 
 const DisableChangelogEnvVar = "UPDATECLI_DISABLE_CHANGELOG"
 
+const DisableVersionCheckEnvVar = "UPDATECLI_DISABLE_VERSION_CHECK"
+
 // getEnvBoolOrDefault reads a boolean environment variable.
 // It returns defaultValue when the variable is unset or invalid.
 func getEnvBoolOrDefault(envVar string, defaultValue bool) bool {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -87,9 +87,10 @@ func init() {
 		if disableVersionCheck {
 			return
 		}
-		cmdName := cmd.Name()
-		if slices.Contains(skipVersionCheckCommands, cmdName) {
-			return
+		for c := cmd; c != nil; c = c.Parent() {
+			if slices.Contains(skipVersionCheckCommands, c.Name()) {
+				return
+			}
 		}
 		err := engine.CheckLatestPublishedVersion()
 		if err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -27,20 +27,20 @@ import (
 )
 
 var (
-	pipelineIds      []string
-	labels           []string
-	manifestFiles    []string
-	valuesFiles      []string
-	valuesInline     []string
-	secretsFiles     []string
-	policyReferences []string
-	e                engine.Engine
-	verbose          bool
-	experimental     bool
-	disableTLS       bool
-	disableChangelog     bool
-	uniqueTmpDir         bool
-	disableVersionCheck  bool
+	pipelineIds         []string
+	labels              []string
+	manifestFiles       []string
+	valuesFiles         []string
+	valuesInline        []string
+	secretsFiles        []string
+	policyReferences    []string
+	e                   engine.Engine
+	verbose             bool
+	experimental        bool
+	disableTLS          bool
+	disableChangelog    bool
+	uniqueTmpDir        bool
+	disableVersionCheck bool
 
 	rootCmd = &cobra.Command{
 		Use:   "updatecli",

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -38,8 +38,9 @@ var (
 	verbose          bool
 	experimental     bool
 	disableTLS       bool
-	disableChangelog bool
-	uniqueTmpDir     bool
+	disableChangelog     bool
+	uniqueTmpDir         bool
+	disableVersionCheck  bool
 
 	rootCmd = &cobra.Command{
 		Use:   "updatecli",
@@ -66,11 +67,30 @@ func Execute() {
 	}
 }
 
+// skipVersionCheckCommands lists commands where the version check is skipped
+// to avoid unnecessary network requests and prevent banner output from
+// corrupting generated content.
+var skipVersionCheckCommands = []string{
+	"completion",
+	"__complete",
+	"__completeNoDesc",
+	"docs",
+	"man",
+	"jsonschema",
+}
+
 func init() {
 
 	logrus.SetOutput(os.Stdout)
 
 	rootCmd.PersistentPostRun = func(cmd *cobra.Command, args []string) {
+		if disableVersionCheck {
+			return
+		}
+		cmdName := cmd.Name()
+		if slices.Contains(skipVersionCheckCommands, cmdName) {
+			return
+		}
 		err := engine.CheckLatestPublishedVersion()
 		if err != nil {
 			logrus.Debugf("Unable to check for the latest version of updatecli: %v", err)
@@ -80,6 +100,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "debug", "", false, "Debug Output")
 	rootCmd.PersistentFlags().BoolVarP(&experimental, "experimental", "", false, "Enable Experimental mode")
 	rootCmd.PersistentFlags().BoolVar(&uniqueTmpDir, "unique-tmp-dir", false, "Use a unique temporary directory to allow running multiple Updatecli instances in parallel")
+	rootCmd.PersistentFlags().BoolVar(&disableVersionCheck, "disable-version-check", getEnvBoolOrDefault(DisableVersionCheckEnvVar, false), "Disable version check (env: "+DisableVersionCheckEnvVar+")")
 	rootCmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
 		if verbose {
 			logrus.SetLevel(logrus.DebugLevel)

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,132 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestDisableVersionCheckFlagRegistration(t *testing.T) {
+	t.Setenv(DisableVersionCheckEnvVar, "false")
+
+	flag := rootCmd.PersistentFlags().Lookup("disable-version-check")
+	if flag == nil {
+		t.Fatal("flag not registered")
+	}
+
+	if flag.Usage == "" {
+		t.Error("flag help text is empty")
+	}
+
+	if !strings.Contains(flag.Usage, DisableVersionCheckEnvVar) {
+		t.Errorf(
+			"flag help text does not mention env var %q: help text is %q",
+			DisableVersionCheckEnvVar,
+			flag.Usage,
+		)
+	}
+}
+
+func TestDisableVersionCheckFlagUsesEnvDefault(t *testing.T) {
+	tests := []struct {
+		name        string
+		envValue    string
+		expectedDef string
+	}{
+		{
+			name:        "env_var_true",
+			envValue:    "true",
+			expectedDef: "true",
+		},
+		{
+			name:        "env_var_false",
+			envValue:    "false",
+			expectedDef: "false",
+		},
+		{
+			name:        "env_var_1",
+			envValue:    "1",
+			expectedDef: "true",
+		},
+		{
+			name:        "env_var_0",
+			envValue:    "0",
+			expectedDef: "false",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(DisableVersionCheckEnvVar, tt.envValue)
+
+			cmd := &cobra.Command{Use: "test"}
+			var val bool
+			cmd.PersistentFlags().BoolVar(
+				&val,
+				"disable-version-check",
+				getEnvBoolOrDefault(DisableVersionCheckEnvVar, false),
+				"Disable version check",
+			)
+
+			flag := cmd.PersistentFlags().Lookup("disable-version-check")
+			if flag == nil {
+				t.Fatal("flag not registered")
+			}
+
+			if flag.DefValue != tt.expectedDef {
+				t.Errorf(
+					"flag default value: got %q, expected %q",
+					flag.DefValue,
+					tt.expectedDef,
+				)
+			}
+		})
+	}
+}
+
+func TestDisableVersionCheckFlagOverridesEnv(t *testing.T) {
+	t.Setenv(DisableVersionCheckEnvVar, "true")
+
+	cmd := &cobra.Command{
+		Use: "test",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return nil
+		},
+	}
+
+	var val bool
+	cmd.PersistentFlags().BoolVar(
+		&val,
+		"disable-version-check",
+		getEnvBoolOrDefault(DisableVersionCheckEnvVar, false),
+		"Disable version check",
+	)
+
+	cmd.SetArgs([]string{"--disable-version-check=false"})
+
+	err := cmd.Execute()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if val {
+		t.Error("expected flag to override env var")
+	}
+}
+
+func TestSkipVersionCheckCommandsContainsExpectedCommands(t *testing.T) {
+	expected := []string{"completion", "__complete", "__completeNoDesc", "docs", "man", "jsonschema"}
+	for _, name := range expected {
+		found := false
+		for _, s := range skipVersionCheckCommands {
+			if s == name {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("skipVersionCheckCommands missing %q", name)
+		}
+	}
+}


### PR DESCRIPTION
Fix #9028

## Summary

The version check in `PersistentPostRun` runs for every subcommand, including `completion`. Since `logrus` output goes to stdout, the "new release available" banner gets captured into generated shell completion scripts, producing an invalid file that breaks the user shell on startup.

This hits Homebrew users especially hard since completions are generated at install time, so every new shell gets a syntax error.

## What changed

- Added `--disable-version-check` flag and `UPDATECLI_DISABLE_VERSION_CHECK` env var (same pattern as `--disable-changelog`)
- Skip version check for generator commands: `completion`, `__complete`, `__completeNoDesc`, `docs`, `man`, `jsonschema`
- Walk up the command tree with `cmd.Parent()` so nested subcommands like `completion bash` are also correctly skipped
- Added tests for flag registration, env var defaults, flag override, and skip list contents

## Test

```shell
go test ./cmd/...
go build -o /tmp/updatecli . && /tmp/updatecli completion bash > test.bash && bash -n test.bash
```

Note: `bash -n` only catches the issue if a newer version of updatecli is available (which is what triggers the banner). If you are already on the latest version, no banner is emitted so the test passes regardless.

## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via pull request in [website](https://github.com/updatecli/website) repository.

### Tradeoff

- The version check is skipped entirely for generator commands rather than routing the banner to stderr. This avoids the corruption but means users will not see version notifications when running these commands.
- New generator commands added in the future need to be added to the skip list.
- The root cause (`logrus.SetOutput(os.Stdout)` sending diagnostic output to stdout) is not addressed here. A follow-up could route the banner to stderr as a more general fix.