### PR TITLE
fix(pyproject): track uv.lock relative to target workdir

### DIFF
--- a/pkg/plugins/autodiscovery/pyproject/dependencies.go
+++ b/pkg/plugins/autodiscovery/pyproject/dependencies.go
@@ -198,8 +198,6 @@ func (p Pyproject) buildTemplateParams(
 		}
 	}
 
-	relLockFile := filepath.Join(workdir, "uv.lock")
-
 	return manifestTemplateParams{
 		ManifestName:               manifestName,
 		ActionID:                   p.actionID,
@@ -214,7 +212,7 @@ func (p Pyproject) buildTemplateParams(
 		TargetName:                 fmt.Sprintf("deps(pypi): bump %q to {{ source %q }}", dep.Name, dep.Name),
 		ScmID:                      p.scmID,
 		UvEnabled:                  lockSupport.uv,
-		LockFile:                   relLockFile,
+		LockFile:                   "uv.lock",
 		Workdir:                    workdir,
 	}
 }

--- a/pkg/plugins/autodiscovery/pyproject/main_test.go
+++ b/pkg/plugins/autodiscovery/pyproject/main_test.go
@@ -547,6 +547,39 @@ targets:
 `,
 			},
 		},
+		{
+			name:        "Scenario 12 -- nested subdirectory project tracks uv.lock relative to its workdir",
+			rootDir:     "testdata/subdir_project",
+			uvAvailable: true,
+			expectedPipelines: []string{
+				`name: 'deps(pypi): bump "requests" for "nested-project" project'
+sources:
+  requests:
+    name: 'Get latest "requests" package version'
+    kind: 'pypi'
+    spec:
+      name: 'requests'
+      versionfilter:
+        kind: 'pep440'
+        pattern: '>=2.28'
+targets:
+  requests:
+    name: 'deps(pypi): bump "requests" to {{ source "requests" }}'
+    kind: 'shell'
+    spec:
+      command: 'uv lock --upgrade-package requests=={{ source "requests" }}'
+      changedif:
+        kind: file/checksum
+        spec:
+          files:
+            - "uv.lock"
+      environments:
+        - name: PATH
+      workdir: 'foo/bar'
+    disablesourceinput: true
+`,
+			},
+		},
 	}
 
 	for _, tt := range testdata {

--- a/pkg/plugins/autodiscovery/pyproject/testdata/subdir_project/foo/bar/pyproject.toml
+++ b/pkg/plugins/autodiscovery/pyproject/testdata/subdir_project/foo/bar/pyproject.toml
@@ -1,0 +1,6 @@
+[project]
+name = "nested-project"
+requires-python = ">=3.12"
+dependencies = [
+    "requests>=2.28",
+]

--- a/pkg/plugins/autodiscovery/pyproject/testdata/subdir_project/foo/bar/uv.lock
+++ b/pkg/plugins/autodiscovery/pyproject/testdata/subdir_project/foo/bar/uv.lock
@@ -1,0 +1,5 @@
+version = 1
+requires-python = ">=3.12"
+
+[[package]]
+name = "nested-project"


### PR DESCRIPTION
## Current Behavior

The pyproject autodiscovery crawler generates a broken `shell` target for any `pyproject.toml` discovered in a **subdirectory**. The generated target sets:

- `workdir: <subdir>` — the `uv lock` command runs here and succeeds, and
- a `changedif` (`file/checksum`) tracking `<subdir>/uv.lock`.

Because the shell resource resolves `changedif` files **relative to `workdir`**, the path doubles (e.g. `foo/bar/foo/bar/uv.lock`). That path doesn't exist, so the post-command file check reports `Missing files` and the target fails — even though `uv lock` succeeded. Projects at the scan root are unaffected because `workdir` is `.`.

## Fix

Record the lockfile path relative to the target's own `workdir` (just `uv.lock`) instead of joining `workdir` into it. The `workdir` is already emitted into the target, and the shell resource prepends it, so joining it twice was the bug. This also matches how sibling crawlers (`golang`, `npm`, `cargo`) reference their lock files as plain literals.

```diff
-	relLockFile := filepath.Join(workdir, "uv.lock")
-	...
-		LockFile:                   relLockFile,
+		LockFile:                   "uv.lock",
```

## Tests

Added a regression scenario (`Scenario 12`) using a nested subdirectory project (`testdata/subdir_project/foo/bar`) to prove the fix holds at arbitrary depth. With the bug present this scenario fails (`files: - "foo/bar/uv.lock"`); with the fix it passes (`files: - "uv.lock"`, `workdir: 'foo/bar'`). Existing scan-root scenarios are unchanged.

Verified end-to-end against a real subdirectory project: `updatecli apply` runs `uv lock` in the subdir and rewrites `<subdir>/uv.lock` correctly, with no `<subdir>/<subdir>/` ever created.

Fixes #9265

🤖 Generated with [Claude Code](https://claude.com/claude-code)