### PR TITLE
fix(terraform): include registry hostname in autodiscovery manifest

### DIFF
--- a/pkg/plugins/autodiscovery/terraform/manifest_template.go
+++ b/pkg/plugins/autodiscovery/terraform/manifest_template.go
@@ -15,6 +15,9 @@ sources:
       type: provider
       namespace: {{ .ProviderNamespace }}
       name: {{ .ProviderName }}
+      {{- if .ProviderHostname }}
+      hostname: {{ .ProviderHostname }}
+      {{- end }}
       versionfilter:
         kind: '{{ .VersionFilterKind }}'
         pattern: '{{ .VersionFilterPattern }}'

--- a/pkg/plugins/autodiscovery/terraform/providers.go
+++ b/pkg/plugins/autodiscovery/terraform/providers.go
@@ -94,11 +94,17 @@ func (t Terraform) getTerraformManifest(filename, provider, versionFilterPattern
 		return nil, err
 	}
 
+	var providerHostname string
+	if p.Hostname.String() != "registry.terraform.io" {
+		providerHostname = p.Hostname.String()
+	}
+
 	params := struct {
 		ActionID             string
 		TerraformLockFile    string
 		Platforms            []string
 		Provider             string
+		ProviderHostname     string
 		ProviderNamespace    string
 		ProviderName         string
 		VersionFilterKind    string
@@ -111,6 +117,7 @@ func (t Terraform) getTerraformManifest(filename, provider, versionFilterPattern
 		TerraformLockFile:    filename,
 		Platforms:            t.spec.Platforms,
 		Provider:             p.ForDisplay(),
+		ProviderHostname:     providerHostname,
 		ProviderNamespace:    p.Namespace,
 		ProviderName:         p.Type,
 		VersionFilterKind:    t.versionFilter.Kind,


### PR DESCRIPTION
This fixes an issue where the Terraform autodiscovery plugin drops the hostname for non-default registries (like OpenTofu) and falls back to registry.terraform.io.

Fix #9232

<!-- Describe the changes introduced by this pull request -->
When generating the updatecli manifest, the Terraform autodiscovery plugin was omitting the `hostname` field for the `terraform/registry` source configuration. Because of this, Updatecli would default to `registry.terraform.io`, causing it to throw a 404 error when trying to resolve providers hosted on alternative registries like `registry.opentofu.org`.

This PR uses the `terraformRegistryAddress` parser to extract the exact hostname from the provider string inside `.terraform.lock.hcl`. It then explicitly injects the `hostname` field into the generated manifest template if the hostname differs from the default `registry.terraform.io`.

## Test

To test this pull request, you can run the following commands:

```shell
cd pkg/plugins/autodiscovery/terraform
go test
