### PR TITLE
fix: correctly init report name and config

### DIFF
--- a/pkg/core/pipeline/main.go
+++ b/pkg/core/pipeline/main.go
@@ -150,11 +150,17 @@ func (p *Pipeline) Init(config *config.Config, options Options) error {
 		}
 
 		r := p.Sources[id].Result
+		r.Name = config.Spec.Sources[id].Name
 
 		if scmPointer != nil {
 			scm := *scmPointer
 			r.Scm.URL = scm.GetURL()
 			r.Scm.Branch.Source, r.Scm.Branch.Working, r.Scm.Branch.Target = scm.GetBranches()
+		}
+
+		reportConfig, err := resource.GetReportConfig(p.Config.Spec.Sources[id].ResourceConfig)
+		if err == nil {
+			r.Config = reportConfig
 		}
 
 		p.Report.Sources[id] = r
@@ -184,14 +190,20 @@ func (p *Pipeline) Init(config *config.Config, options Options) error {
 
 		r := p.Conditions[id].Result
 
+		r.Name = config.Spec.Conditions[id].Name
+
 		if scmPointer != nil {
 			scm := *scmPointer
 			r.Scm.URL = scm.GetURL()
 			r.Scm.Branch.Source, r.Scm.Branch.Working, r.Scm.Branch.Target = scm.GetBranches()
 		}
 
-		p.Report.Conditions[id] = r
+		reportConfig, err := resource.GetReportConfig(p.Config.Spec.Conditions[id].ResourceConfig)
+		if err == nil {
+			r.Config = reportConfig
+		}
 
+		p.Report.Conditions[id] = r
 	}
 
 	// Init target report
@@ -216,6 +228,8 @@ func (p *Pipeline) Init(config *config.Config, options Options) error {
 		}
 
 		r := p.Targets[id].Result
+		r.Name = config.Spec.Targets[id].Name
+		r.DryRun = p.Options.Target.DryRun
 
 		if scmPointer != nil {
 			scm := *scmPointer
@@ -223,9 +237,12 @@ func (p *Pipeline) Init(config *config.Config, options Options) error {
 			r.Scm.Branch.Source, r.Scm.Branch.Working, r.Scm.Branch.Target = scm.GetBranches()
 		}
 
-		p.Report.Targets[id] = r
+		reportConfig, err := resource.GetReportConfig(p.Config.Spec.Targets[id].ResourceConfig)
+		if err == nil {
+			r.Config = reportConfig
+		}
 
-		p.Report.Targets[id].DryRun = r.DryRun
+		p.Report.Targets[id] = r
 	}
 
 	p.tracer = telemetry.Tracer("updatecli")

--- a/pkg/plugins/resources/helm/changelog_test.go
+++ b/pkg/plugins/resources/helm/changelog_test.go
@@ -86,7 +86,7 @@ func TestChangelog(t *testing.T) {
 			expected: &result.Changelogs{
 				{
 					Title:       "3.3.5",
-					PublishedAt: "2025-02-06 11:06:30.639777967 +0000 UTC",
+					PublishedAt: "2026-06-21 16:33:28.043578633 +0530 +0530",
 					Body:        "\n## Added\n\n* added a new option .reportsController.sanityChecks to disable checks for policy reports crds\n\n## Fixed\n\n* fix validation error in validate.yaml\n* fixed global image registry config by introducing *.image.defaultRegistry.\n",
 				},
 			},


### PR DESCRIPTION
Ensure that reports are always init with a name and a report config

## Test

Tested manually

## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via pull request in [website](https://github.com/updatecli/website) repository.

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
