### PR TITLE
deps: fix default golang update

### DIFF
--- a/updatecli/updatecli-compose.d/golang/major.yaml
+++ b/updatecli/updatecli-compose.d/golang/major.yaml
@@ -16,8 +16,12 @@ policies:
     policy: ghcr.io/updatecli/policies/autodiscovery/golang:0.13.1@sha256:85a008b9760fc02b05f68f4047d53b7c05f7250d5a8e8e7da33e925c72c885e0
     valuesinline:
       name: "deps(golang): Bump Major version for Golang module"
-      pipelineid: "golang/gomod/major"
+      pipelineid: "golang/gomod/major/default"
+      groupby: individual
       spec:
+        onlygomodule: true
+        only:
+          - path: "go.mod"
         ignore:
           - path: "go.mod"
             modules:

--- a/updatecli/updatecli-compose.d/golang/minor.yaml
+++ b/updatecli/updatecli-compose.d/golang/minor.yaml
@@ -16,8 +16,12 @@ policies:
     policy: ghcr.io/updatecli/policies/autodiscovery/golang:0.13.1@sha256:85a008b9760fc02b05f68f4047d53b7c05f7250d5a8e8e7da33e925c72c885e0
     valuesinline:
       name: "deps(golang): Bump minor version for Golang module"
-      pipelineid: "golang/gomod/minor"
+      pipelineid: "golang/gomod/minor/default"
+      groupby: individual
       spec:
+        onlygomodule: true
+        only:
+          - path: "go.mod"
         ignore:
           - path: "go.mod"
             modules:


### PR DESCRIPTION
Fixing Updatecli configuration that automate golang update