### PR TITLE
Add refSpecs setting

### DIFF
--- a/pkg/plugins/scms/azuredevops/main.go
+++ b/pkg/plugins/scms/azuredevops/main.go
@@ -46,6 +46,14 @@ type Spec struct {
 	//   As a trade-off, Updatecli may not detect an already published working branch in some
 	//   edge cases, which could result in a duplicate pull request being created.
 	SingleBranch *bool `yaml:",omitempty"`
+	// RefSpecs defines the list of refspecs used when fetching remote references after cloning.
+	//
+	// Default: ["refs/*:refs/*"]
+	//
+	// Remark:
+	//   Providing a more targeted list of refspecs (for example limiting the fetch to branches only)
+	//   can drastically speed up operations on repositories with a large number of refs.
+	RefSpecs []string `yaml:",omitempty"`
 	// "email" defines the email used to commit changes.
 	Email string `yaml:",omitempty"`
 	// "force" is used during the git push phase to run `git push --force`.
@@ -286,6 +294,7 @@ func (a *AzureDevOps) Clone() (string, error) {
 		a.Spec.Depth,
 		a.Spec.Branch,
 		a.Spec.SingleBranch != nil && *a.Spec.SingleBranch,
+		a.Spec.RefSpecs,
 	)
 	if err != nil {
 		logrus.Errorf("failed cloning Azure DevOps repository %q", a.GetURL())

--- a/pkg/plugins/scms/bitbucket/main.go
+++ b/pkg/plugins/scms/bitbucket/main.go
@@ -64,6 +64,14 @@ type Spec struct {
 	//   As a trade-off, Updatecli may not detect an already published working branch in some
 	//   edge cases, which could result in a duplicate pull request being created.
 	SingleBranch *bool `yaml:",omitempty"`
+	// RefSpecs defines the list of refspecs used when fetching remote references after cloning.
+	//
+	// Default: ["refs/*:refs/*"]
+	//
+	// Remark:
+	//   Providing a more targeted list of refspecs (for example limiting the fetch to branches only)
+	//   can drastically speed up operations on repositories with a large number of refs.
+	RefSpecs []string `yaml:",omitempty"`
 	//  "email" defines the email used to commit changes.
 	//
 	//  compatible:

--- a/pkg/plugins/scms/bitbucket/scm.go
+++ b/pkg/plugins/scms/bitbucket/scm.go
@@ -102,6 +102,7 @@ func (b *Bitbucket) Clone() (string, error) {
 		b.Spec.Depth,
 		b.Spec.Branch,
 		b.Spec.SingleBranch != nil && *b.Spec.SingleBranch,
+		b.Spec.RefSpecs,
 	)
 	if err != nil {
 		logrus.Errorf("failed cloning Bitbucket Cloud repository %q", b.GetURL())

--- a/pkg/plugins/scms/git/main.go
+++ b/pkg/plugins/scms/git/main.go
@@ -118,6 +118,14 @@ type Spec struct {
 	//   As a trade-off, Updatecli may not detect an already published working branch in some
 	//   edge cases, which could result in a duplicate pull request being created.
 	SingleBranch *bool `yaml:",omitempty"`
+	// RefSpecs defines the list of refspecs used when fetching remote references after cloning.
+	//
+	// Default: ["refs/*:refs/*"]
+	//
+	// Remark:
+	//   Providing a more targeted list of refspecs (for example limiting the fetch to branches only)
+	//   can drastically speed up operations on repositories with a large number of refs.
+	RefSpecs []string `yaml:",omitempty"`
 	//	"directory" defines the local path where the git repository is cloned.
 	//
 	//	compatible:

--- a/pkg/plugins/scms/git/scm.go
+++ b/pkg/plugins/scms/git/scm.go
@@ -106,6 +106,7 @@ func (g *Git) Clone() (string, error) {
 		g.spec.Depth,
 		g.spec.Branch,
 		g.spec.SingleBranch != nil && *g.spec.SingleBranch,
+		g.spec.RefSpecs,
 	)
 	if err != nil {
 		logrus.Errorf("failed cloning git repository %q - %s", g.GetURL(), err)

--- a/pkg/plugins/scms/gitea/main.go
+++ b/pkg/plugins/scms/gitea/main.go
@@ -64,6 +64,14 @@ type Spec struct {
 	//   As a trade-off, Updatecli may not detect an already published working branch in some
 	//   edge cases, which could result in a duplicate pull request being created.
 	SingleBranch *bool `yaml:",omitempty"`
+	// RefSpecs defines the list of refspecs used when fetching remote references after cloning.
+	//
+	// Default: ["refs/*:refs/*"]
+	//
+	// Remark:
+	//   Providing a more targeted list of refspecs (for example limiting the fetch to branches only)
+	//   can drastically speed up operations on repositories with a large number of refs.
+	RefSpecs []string `yaml:",omitempty"`
 	//  "email" defines the email used to commit changes.
 	//
 	//  compatible:

--- a/pkg/plugins/scms/gitea/scm.go
+++ b/pkg/plugins/scms/gitea/scm.go
@@ -85,6 +85,7 @@ func (g *Gitea) Clone() (string, error) {
 		g.Spec.Depth,
 		g.Spec.Branch,
 		g.Spec.SingleBranch != nil && *g.Spec.SingleBranch,
+		g.Spec.RefSpecs,
 	)
 	if err != nil {
 		logrus.Errorf("failed cloning Gitea repository %q", g.GetURL())

--- a/pkg/plugins/scms/github/main.go
+++ b/pkg/plugins/scms/github/main.go
@@ -105,6 +105,14 @@ type Spec struct {
 	//   As a trade-off, Updatecli may not detect an already published working branch in some
 	//   edge cases, which could result in a duplicate pull request being created.
 	SingleBranch *bool `yaml:",omitempty"`
+	// RefSpecs defines the list of refspecs used when fetching remote references after cloning.
+	//
+	// Default: ["refs/*:refs/*"]
+	//
+	// Remark:
+	//   Providing a more targeted list of refspecs (for example limiting the fetch to branches only)
+	//   can drastically speed up operations on repositories with a large number of refs.
+	RefSpecs []string `yaml:",omitempty"`
 	// "email" defines the email used to commit changes.
 	//
 	// compatible:

--- a/pkg/plugins/scms/github/scm.go
+++ b/pkg/plugins/scms/github/scm.go
@@ -102,6 +102,7 @@ func (g *Github) Clone() (string, error) {
 		g.Spec.Depth,
 		g.Spec.Branch,
 		g.Spec.SingleBranch != nil && *g.Spec.SingleBranch,
+		g.Spec.RefSpecs,
 	)
 	if err != nil {
 		logrus.Errorf("failed cloning GitHub repository %q", g.GetURL())

--- a/pkg/plugins/scms/gitlab/main.go
+++ b/pkg/plugins/scms/gitlab/main.go
@@ -69,6 +69,14 @@ type Spec struct {
 	//   As a trade-off, Updatecli may not detect an already published working branch in some
 	//   edge cases, which could result in a duplicate pull request being created.
 	SingleBranch *bool `yaml:",omitempty"`
+	// RefSpecs defines the list of refspecs used when fetching remote references after cloning.
+	//
+	// Default: ["refs/*:refs/*"]
+	//
+	// Remark:
+	//   Providing a more targeted list of refspecs (for example limiting the fetch to branches only)
+	//   can drastically speed up operations on repositories with a large number of refs.
+	RefSpecs []string `yaml:",omitempty"`
 	//  "email" defines the email used to commit changes.
 	//
 	//  compatible:

--- a/pkg/plugins/scms/gitlab/scm.go
+++ b/pkg/plugins/scms/gitlab/scm.go
@@ -89,6 +89,7 @@ func (g *Gitlab) Clone() (string, error) {
 		g.Spec.Depth,
 		g.Spec.Branch,
 		g.Spec.SingleBranch != nil && *g.Spec.SingleBranch,
+		g.Spec.RefSpecs,
 	)
 	if err != nil {
 		logrus.Errorf("failed cloning GitLab repository %q", g.GetURL())

--- a/pkg/plugins/scms/stash/main.go
+++ b/pkg/plugins/scms/stash/main.go
@@ -64,6 +64,14 @@ type Spec struct {
 	//   As a trade-off, Updatecli may not detect an already published working branch in some
 	//   edge cases, which could result in a duplicate pull request being created.
 	SingleBranch *bool `yaml:",omitempty"`
+	// RefSpecs defines the list of refspecs used when fetching remote references after cloning.
+	//
+	// Default: ["refs/*:refs/*"]
+	//
+	// Remark:
+	//   Providing a more targeted list of refspecs (for example limiting the fetch to branches only)
+	//   can drastically speed up operations on repositories with a large number of refs.
+	RefSpecs []string `yaml:",omitempty"`
 	//  "email" defines the email used to commit changes.
 	//
 	//  compatible:

--- a/pkg/plugins/scms/stash/scm.go
+++ b/pkg/plugins/scms/stash/scm.go
@@ -85,6 +85,7 @@ func (s *Stash) Clone() (string, error) {
 		s.Spec.Depth,
 		s.Spec.Branch,
 		s.Spec.SingleBranch != nil && *s.Spec.SingleBranch,
+		s.Spec.RefSpecs,
 	)
 	if err != nil {
 		logrus.Errorf("failed cloning Bitbucket repository %q", s.GetURL())

--- a/pkg/plugins/utils/gitgeneric/branch_test.go
+++ b/pkg/plugins/utils/gitgeneric/branch_test.go
@@ -12,7 +12,7 @@ func TestBranchIntegration(t *testing.T) {
 	g := GoGit{}
 	workingDir := filepath.Join(os.TempDir(), "tests", "updatecli")
 	withSubmodules := true
-	err := g.Clone("", "", "https://github.com/updatecli/updatecli-action.git", workingDir, &withSubmodules, nil, "", false)
+	err := g.Clone("", "", "https://github.com/updatecli/updatecli-action.git", workingDir, &withSubmodules, nil, "", false, nil)
 	if err != nil {
 		t.Errorf("Don't expect error: %q", err)
 	}

--- a/pkg/plugins/utils/gitgeneric/main.go
+++ b/pkg/plugins/utils/gitgeneric/main.go
@@ -28,12 +28,15 @@ const (
 	ErrNoBranchFound = "no branch found"
 	// ErrNoGitTagFound is the error message when no tag is found
 	ErrNoGitTagFound = "no tag found"
+	// DefaultRefSpec is the default refspec used when fetching remote branches after cloning,
+	// and no refSpecs is specified in the pipeline.
+	DefaultRefSpec = "refs/*:refs/*"
 )
 
 type GitHandler interface {
 	Add(files []string, workingDir string) error
 	Checkout(username, password, branch, remoteBranch, workingDir string, forceReset bool, depth *int) error
-	Clone(username, password, URL, workingDir string, withSubmodules *bool, depth *int, branch string, singleBranch bool) error
+	Clone(username, password, URL, workingDir string, withSubmodules *bool, depth *int, branch string, singleBranch bool, refSpecs []string) error
 	Commit(user, email, message, workingDir string, signingKey string, passphrase string) error
 	DeleteBranch(branch, gitRepositoryPath, username, password string) error
 	GetChangedFiles(workingDir string) ([]string, error)
@@ -458,8 +461,9 @@ func (g *GoGit) Checkout(username, password, basedBranch, newBranch, gitReposito
 		// For large repository, the pull can take a long time so ideally we would like to only do it once
 		// when Updatecli is started.
 		pullOptions := git.PullOptions{
-			Force:    true,
-			Progress: &b,
+			Force:        true,
+			Progress:     &b,
+			SingleBranch: true,
 		}
 
 		if depth != nil {
@@ -473,6 +477,7 @@ func (g *GoGit) Checkout(username, password, basedBranch, newBranch, gitReposito
 			pullOptions.Auth = &auth
 		}
 
+		logrus.Debugf("Creating a worktree at %q and pulling changes from remote branch %q with options: %+v", gitRepositoryPath, newBranch, pullOptions)
 		err = worktree.Pull(&pullOptions)
 		if b.String() != "" {
 			logrus.Debugln(b.String())
@@ -480,7 +485,8 @@ func (g *GoGit) Checkout(username, password, basedBranch, newBranch, gitReposito
 		b.Reset()
 		if err != nil &&
 			err != git.ErrNonFastForwardUpdate &&
-			err != git.NoErrAlreadyUpToDate {
+			err != git.NoErrAlreadyUpToDate &&
+			err.Error() != "object not found" {
 			logrus.Debugln(err)
 			return err
 		}
@@ -572,7 +578,7 @@ func (g GoGit) Commit(user, email, message, workingDir string, signingKey string
 }
 
 // Clone run `git clone`.
-func (g GoGit) Clone(username, password, URL, workingDir string, withSubmodules *bool, depth *int, branch string, singleBranch bool) error {
+func (g GoGit) Clone(username, password, URL, workingDir string, withSubmodules *bool, depth *int, branch string, singleBranch bool, refSpecs []string) error {
 	var repo *git.Repository
 
 	auth := transportHttp.BasicAuth{
@@ -593,6 +599,7 @@ func (g GoGit) Clone(username, password, URL, workingDir string, withSubmodules 
 	}
 
 	if singleBranch && branch != "" {
+		logrus.Debugf("cloning single branch %q", branch)
 		cloneOptions.SingleBranch = true
 		cloneOptions.ReferenceName = plumbing.NewBranchReferenceName(branch)
 	}
@@ -693,11 +700,20 @@ func (g GoGit) Clone(username, password, URL, workingDir string, withSubmodules 
 
 	logrus.Debugf("Fetching remote branches for resetting local ones")
 
+	gitRefSpecs := []config.RefSpec{}
+	if len(refSpecs) == 0 {
+		refSpecs = []string{DefaultRefSpec}
+	}
+	for _, refSpec := range refSpecs {
+		gitRefSpecs = append(gitRefSpecs, config.RefSpec(refSpec))
+	}
+	logrus.Debugf("Using refspecs: %v", gitRefSpecs)
+
 	for _, r := range remotes {
 
 		fetchOptions := git.FetchOptions{
 			Progress: &b,
-			RefSpecs: []config.RefSpec{"refs/*:refs/*"},
+			RefSpecs: gitRefSpecs,
 			Force:    true,
 		}
 
@@ -712,11 +728,13 @@ func (g GoGit) Clone(username, password, URL, workingDir string, withSubmodules 
 			fetchOptions.Auth = &auth
 		}
 
+		logrus.Debugf("fetching remote %q", r.Config().Name)
 		err := r.Fetch(&fetchOptions)
 
 		if b.String() != "" {
 			logrus.Debugln(b.String())
 		}
+		logrus.Debugf("Resetting local branches to match remote branches for remote %q", r.Config().Name)
 		b.Reset()
 
 		if err != nil &&

--- a/pkg/plugins/utils/gitgeneric/main_test.go
+++ b/pkg/plugins/utils/gitgeneric/main_test.go
@@ -122,7 +122,7 @@ func TestTagsIntegration(t *testing.T) {
 	g := GoGit{}
 	workingDir := filepath.Join(os.TempDir(), "tests", "updatecli")
 	withSubmodules := true
-	err := g.Clone("", "", "https://github.com/updatecli/updatecli.git", workingDir, &withSubmodules, nil, "", false)
+	err := g.Clone("", "", "https://github.com/updatecli/updatecli.git", workingDir, &withSubmodules, nil, "", false, nil)
 	if err != nil {
 		t.Errorf("Don't expect error: %q", err)
 	}
@@ -148,7 +148,7 @@ func TestTagRefsIntegration(t *testing.T) {
 	g := GoGit{}
 	workingDir := filepath.Join(os.TempDir(), "tests", "updatecli")
 	withSubmodules := true
-	err := g.Clone("", "", "https://github.com/updatecli/updatecli.git", workingDir, &withSubmodules, nil, "", false)
+	err := g.Clone("", "", "https://github.com/updatecli/updatecli.git", workingDir, &withSubmodules, nil, "", false, nil)
 	if err != nil {
 		t.Errorf("Don't expect error: %q", err)
 	}
@@ -178,7 +178,7 @@ func TestHashesIntegration(t *testing.T) {
 	g := GoGit{}
 	workingDir := filepath.Join(os.TempDir(), "tests", "updatecli")
 	withSubmodules := true
-	err := g.Clone("", "", "https://github.com/updatecli/updatecli.git", workingDir, &withSubmodules, nil, "", false)
+	err := g.Clone("", "", "https://github.com/updatecli/updatecli.git", workingDir, &withSubmodules, nil, "", false, nil)
 	if err != nil {
 		t.Errorf("Don't expect error: %q", err)
 	}
@@ -244,7 +244,7 @@ func TestSubmodulesEnabledContent(t *testing.T) {
 	g := GoGit{}
 	workingDir := filepath.Join(os.TempDir(), "tests", "updatecli-submodules")
 	withSubmodules := true
-	err := g.Clone("", "", "https://github.com/updatecli-test/updatecli-submodules.git", workingDir, &withSubmodules, nil, "", false)
+	err := g.Clone("", "", "https://github.com/updatecli-test/updatecli-submodules.git", workingDir, &withSubmodules, nil, "", false, nil)
 	if err != nil {
 		t.Errorf("Don't expect error: %q", err)
 	}
@@ -267,7 +267,7 @@ func TestSubmodulesDisabledContent(t *testing.T) {
 	g := GoGit{}
 	workingDir := filepath.Join(os.TempDir(), "tests", "updatecli-submodules")
 	withSubmodules := false
-	err := g.Clone("", "", "https://github.com/updatecli-test/updatecli-submodules.git", workingDir, &withSubmodules, nil, "", false)
+	err := g.Clone("", "", "https://github.com/updatecli-test/updatecli-submodules.git", workingDir, &withSubmodules, nil, "", false, nil)
 	if err != nil {
 		t.Errorf("Don't expect error: %q", err)
 	}
@@ -314,7 +314,7 @@ func TestLatestCommitHash(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			defer os.RemoveAll(workingDir)
 			if tt.cloneUrl != "" {
-				err := g.Clone("", "", tt.cloneUrl, tt.workingDir, &withSubmodules, nil, "", false)
+				err := g.Clone("", "", tt.cloneUrl, tt.workingDir, &withSubmodules, nil, "", false, nil)
 				if err != nil {
 					t.Errorf("unexpected error: %q", err)
 				}


### PR DESCRIPTION
Introduce a new `RefSpecs` setting to enhance the cloning process by allowing users to specify a list of refspecs for fetching remote references. This change improves flexibility and performance when dealing with repositories that have a large number of refs.

## Test

To test this pull request, you can run the following commands:

```shell
cd <to_package_directory>
go test
```

## Additional Information

### Checklist

- [ ] I have updated the documentation via pull request in [website](https://github.com/updatecli/website) repository.

### Tradeoff

No significant tradeoffs identified; the addition enhances functionality without impacting existing features.

### Potential improvement

Consider expanding the documentation to provide examples of how to effectively use the `RefSpecs` setting.

