### PR TITLE
fix: guard against short paths in changelog GitHub URL redirect

### DIFF
--- a/pkg/plugins/resources/dockerimage/changelog.go
+++ b/pkg/plugins/resources/dockerimage/changelog.go
@@ -112,8 +112,8 @@ func getChangelogAnnotation(desc v1.Descriptor) string {
 // redirectToGitHubRawContent tries to redirect a github url to its associated file raw content
 func redirectToGitHubRawContent(u *url.URL) {
 	beforePath := u.Path
-	if strings.Split(u.Path, "/")[3] == "tree" {
-		s := strings.Split(u.Path, "/")
+	s := strings.Split(u.Path, "/")
+	if len(s) > 3 && s[3] == "tree" {
 		s[3] = "blob"
 		u.Path = strings.Join(s, "/")
 	}

--- a/pkg/plugins/resources/dockerimage/changelog_redirect_test.go
+++ b/pkg/plugins/resources/dockerimage/changelog_redirect_test.go
@@ -1,0 +1,45 @@
+package dockerimage
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRedirectToGitHubRawContent(t *testing.T) {
+	testdata := []struct {
+		name         string
+		input        string
+		expectedPath string
+	}{
+		{
+			name:         "tree url is rewritten to blob",
+			input:        "https://github.com/updatecli/policies/tree/main/CHANGELOG.md",
+			expectedPath: "/updatecli/policies/blob/main/CHANGELOG.md",
+		},
+		{
+			name:         "short path without enough segments is left untouched",
+			input:        "https://github.com/CHANGELOG.md",
+			expectedPath: "/CHANGELOG.md",
+		},
+		{
+			name:         "owner and repo only path is left untouched",
+			input:        "https://github.com/updatecli/policies",
+			expectedPath: "/updatecli/policies",
+		},
+	}
+
+	for _, tt := range testdata {
+		t.Run(tt.name, func(t *testing.T) {
+			u, err := url.Parse(tt.input)
+			require.NoError(t, err)
+
+			redirectToGitHubRawContent(u)
+
+			assert.Equal(t, tt.expectedPath, u.Path)
+			assert.Equal(t, "true", u.Query().Get("raw"))
+		})
+	}
+}


### PR DESCRIPTION
redirectToGitHubRawContent splits the changelog URL path on "/" and reads index 3 without checking the length, so a github.com changelog URL with fewer than four path segments panics with index out of range. Since the URL comes from the org.opencontainers.image.changelog image annotation, a short value like https://github.com/CHANGELOG.md crashes the run.

Split once, check the slice has more than three elements before touching index 3, and leave short paths unchanged.