### PR TITLE
fix: guard against short paths in changelog GitHub URL redirect

### DIFF
--- a/pkg/plugins/resources/dockerimage/changelog.go
+++ b/pkg/plugins/resources/dockerimage/changelog.go
@@ -112,8 +112,13 @@ func getChangelogAnnotation(desc v1.Descriptor) string {
 // redirectToGitHubRawContent tries to redirect a github url to its associated file raw content
 func redirectToGitHubRawContent(u *url.URL) {
 	beforePath := u.Path
-	if strings.Split(u.Path, "/")[3] == "tree" {
-		s := strings.Split(u.Path, "/")
+
+	s := strings.Split(u.Path, "/")
+	// A github.com URL shorter than /owner/repo/path (e.g. a changelog living
+	// at the repository root like https://github.com/owner/repo/CHANGELOG.md)
+	// does not have a "tree"/"blob" segment at index 3, so leave it untouched
+	// instead of panicking on an out of range index.
+	if len(s) > 3 && s[3] == "tree" {
 		s[3] = "blob"
 		u.Path = strings.Join(s, "/")
 	}

--- a/pkg/plugins/resources/dockerimage/changelog_redirect_test.go
+++ b/pkg/plugins/resources/dockerimage/changelog_redirect_test.go
@@ -1,0 +1,47 @@
+package dockerimage
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRedirectToGitHubRawContent(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "rewrites tree to blob",
+			input:    "https://github.com/updatecli/policies/tree/main/CHANGELOG.md",
+			expected: "https://github.com/updatecli/policies/blob/main/CHANGELOG.md?raw=true",
+		},
+		{
+			name:     "leaves short root-level changelog path untouched",
+			input:    "https://github.com/CHANGELOG.md",
+			expected: "https://github.com/CHANGELOG.md?raw=true",
+		},
+		{
+			name:     "leaves blob path and adds raw query",
+			input:    "https://github.com/updatecli/policies/blob/main/CHANGELOG.md",
+			expected: "https://github.com/updatecli/policies/blob/main/CHANGELOG.md?raw=true",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			u, err := url.Parse(tt.input)
+			require.NoError(t, err)
+
+			// Must not panic on short paths.
+			assert.NotPanics(t, func() {
+				redirectToGitHubRawContent(u)
+			})
+
+			assert.Equal(t, tt.expected, u.String())
+		})
+	}
+}


### PR DESCRIPTION
redirectToGitHubRawContent indexed strings.Split(u.Path, "/")[3] without checking the slice length. A github.com changelog URL with fewer than four path segments (e.g. an annotation pointing at https://github.com/CHANGELOG.md) panicked with index out of range and aborted the whole run, since Changelog() calls it for every image advertising such an annotation.

Split once and only rewrite the segment when it exists, leaving short paths untouched. Added a unit test covering the short path and the tree->blob rewrite.

Fixes #9688