### PR TITLE
chore: cleanup autodiscovery spec comment

### DIFF
--- a/pkg/plugins/autodiscovery/argocd/main.go
+++ b/pkg/plugins/autodiscovery/argocd/main.go
@@ -12,18 +12,18 @@ import (
 
 // Spec defines the parameters which can be provided to the argocd builder.
 type Spec struct {
-	// RootDir defines the root directory used to recursively search for ArgoCD manifest
+	// rootDir defines the root directory used to recursively search for ArgoCD manifest
 	RootDir string `yaml:",omitempty"`
-	// Ignore allows to specify rule to ignore autodiscovery a specific Argocd manifest based on a rule
+	// ignore allows to specify rule to ignore autodiscovery a specific Argocd manifest based on a rule
 	Ignore MatchingRules `yaml:",omitempty"`
-	// Only allows to specify rule to only autodiscover manifest for a specific ArgoCD manifest based on a rule
+	// only allows to specify rule to only autodiscover manifest for a specific ArgoCD manifest based on a rule
 	Only MatchingRules `yaml:",omitempty"`
-	//  versionfilter provides parameters to specify the version pattern used when generating manifest.
+	//  `versionfilter` provides parameters to specify the version pattern used when generating manifest.
 	//
 	//  kind - semver
 	//    versionfilter of kind `semver` uses semantic versioning as version filtering
 	//    pattern accepts one of:
-	//      `prerelease` - Updatecli tries to identify the latest "prerelease" whatever it means
+	//      `prerelease` - Updatecli tries to identify the latest prerelease whatever it means
 	//      `patch` - Updatecli only handles patch version update
 	//      `minor` - Updatecli handles patch AND minor version update
 	//      `minoronly` - Updatecli handles minor version only
@@ -37,12 +37,15 @@ type Spec struct {
 	//
 	//  example:
 	//  ```
-	//  	versionfilter:
-	//  		kind: semver
-	//  		pattern: minor
+	//    versionfilter:
+	//      kind: semver
+	//      pattern: minor
 	//  ```
 	//
-	//	and its type like regex, semver, or just latest.
+	//  and its type like regex, semver, or just latest.
+	//
+	//  More examples can be found at https://www.updatecli.io/docs/core/versionfilter/
+
 	VersionFilter version.Filter `yaml:",omitempty"`
 	// Auths holds a map of string to string where the key is the registry URL and the value the token used for authentication
 	//
@@ -50,7 +53,7 @@ type Spec struct {
 	//
 	// Example:
 	//
-	// ```yaml
+	// ```
 	// auths:
 	//   "my-helm-repo.com": "my-secret-token"
 	// ```

--- a/pkg/plugins/autodiscovery/bazel/main.go
+++ b/pkg/plugins/autodiscovery/bazel/main.go
@@ -23,7 +23,33 @@ type Bazel struct {
 	rootDir string
 	// scmID holds the scmID used by the newly generated manifest
 	scmID string
-	// versionFilter holds the "valid" version.filter, that might be different from the user-specified filter (Spec.VersionFilter)
+	//  `versionfilter` provides parameters to specify the version pattern used when generating manifest.
+	//
+	//  kind - semver
+	//    versionfilter of kind `semver` uses semantic versioning as version filtering
+	//    pattern accepts one of:
+	//      `prerelease` - Updatecli tries to identify the latest prerelease whatever it means
+	//      `patch` - Updatecli only handles patch version update
+	//      `minor` - Updatecli handles patch AND minor version update
+	//      `minoronly` - Updatecli handles minor version only
+	//      `major` - Updatecli handles patch, minor, AND major version update
+	//      `majoronly` - Updatecli only handles major version update
+	//      `a version constraint` such as `>= 1.0.0`
+	//
+	//  kind - regex
+	//    versionfilter of kind `regex` uses regular expression as version filtering
+	//    pattern accepts a valid regular expression
+	//
+	//  example:
+	//  ```
+	//    versionfilter:
+	//      kind: semver
+	//      pattern: minor
+	//  ```
+	//
+	//  and its type like regex, semver, or just latest.
+	//
+	//  More examples can be found at https://www.updatecli.io/docs/core/versionfilter/
 	versionFilter version.Filter
 }
 

--- a/pkg/plugins/autodiscovery/cargo/main.go
+++ b/pkg/plugins/autodiscovery/cargo/main.go
@@ -21,30 +21,33 @@ type Spec struct {
 	Only MatchingRules `yaml:",omitempty"`
 	// Auths provides a map of registry credentials where the key is the registry URL without scheme
 	Registries map[string]cargo.Registry `yaml:",omitempty"`
-	/*
-		`versionfilter` provides parameters to specify the version pattern to use when generating manifest.
-
-		kind - semver
-			versionfilter of kind `semver` uses semantic versioning as version filtering
-			pattern accepts one of:
-				`patch` - patch only update patch version
-				`minor` - minor only update minor version
-				`major` - major only update major versions
-				`a version constraint` such as `>= 1.0.0`
-
-		kind - regex
-			versionfilter of kind `regex` uses regular expression as version filtering
-			pattern accepts a valid regular expression
-
-		example:
-		```
-			versionfilter:
-				kind: semver
-				pattern: minor
-		```
-
-		and its type like regex, semver, or just latest.
-	*/
+	//  `versionfilter` provides parameters to specify the version pattern used when generating manifest.
+	//
+	//  kind - semver
+	//    versionfilter of kind `semver` uses semantic versioning as version filtering
+	//    pattern accepts one of:
+	//      `prerelease` - Updatecli tries to identify the latest prerelease whatever it means
+	//      `patch` - Updatecli only handles patch version update
+	//      `minor` - Updatecli handles patch AND minor version update
+	//      `minoronly` - Updatecli handles minor version only
+	//      `major` - Updatecli handles patch, minor, AND major version update
+	//      `majoronly` - Updatecli only handles major version update
+	//      `a version constraint` such as `>= 1.0.0`
+	//
+	//  kind - regex
+	//    versionfilter of kind `regex` uses regular expression as version filtering
+	//    pattern accepts a valid regular expression
+	//
+	//  example:
+	//  ```
+	//    versionfilter:
+	//      kind: semver
+	//      pattern: minor
+	//  ```
+	//
+	//  and its type like regex, semver, or just latest.
+	//
+	//  More examples can be found at https://www.updatecli.io/docs/core/versionfilter/
 	VersionFilter version.Filter `yaml:",omitempty"`
 }
 

--- a/pkg/plugins/autodiscovery/dockercompose/main.go
+++ b/pkg/plugins/autodiscovery/dockercompose/main.go
@@ -31,44 +31,45 @@ type Spec struct {
 	//
 	// example:
 	//
-	// ---
+	// ```
 	// auths:
 	//   "ghcr.io":
 	//     token: "xxx"
 	//   "index.docker.io":
 	//     username: "admin"
 	//     password: "password"
-	// ---
+	// ```
 	//
 	Auths map[string]docker.InlineKeyChain `yaml:",omitempty"`
-	// FileMatch allows to override default docker-compose.yaml file matching. Default ["compose.yaml", "compose.yml", "compose.*.yaml", "compose.*.yml", "docker-compose.yaml","docker-compose.yml","docker-compose.*.yaml","docker-compose.*.yml"]
+	// FileMatch allows to override default docker-compose.yaml file matching. Default `["compose.yaml", "compose.yml", "compose.*.yaml", "compose.*.yml", "docker-compose.yaml","docker-compose.yml","docker-compose.*.yaml","docker-compose.*.yml"]`
 	FileMatch []string `yaml:",omitempty"`
-	// versionfilter provides parameters to specify the version pattern used when generating manifest.
+	//  `versionfilter` provides parameters to specify the version pattern used when generating manifest.
 	//
-	// More information available at
-	// https://www.updatecli.io/docs/core/versionfilter/
+	//  kind - semver
+	//    versionfilter of kind `semver` uses semantic versioning as version filtering
+	//    pattern accepts one of:
+	//      `prerelease` - Updatecli tries to identify the latest prerelease whatever it means
+	//      `patch` - Updatecli only handles patch version update
+	//      `minor` - Updatecli handles patch AND minor version update
+	//      `minoronly` - Updatecli handles minor version only
+	//      `major` - Updatecli handles patch, minor, AND major version update
+	//      `majoronly` - Updatecli only handles major version update
+	//      `a version constraint` such as `>= 1.0.0`
 	//
-	// kind - semver
-	//   versionfilter of kind `semver` uses semantic versioning as version filtering
-	//   pattern accepts one of:
-	//     `patch` - patch only update patch version
-	//     `minor` - minor only update minor version
-	//     `major` - major only update major versions
-	//     `a version constraint` such as `>= 1.0.0`
+	//  kind - regex
+	//    versionfilter of kind `regex` uses regular expression as version filtering
+	//    pattern accepts a valid regular expression
 	//
-	// kind - regex
-	// versionfilter of kind `regex` uses regular expression as version filtering
-	// pattern accepts a valid regular expression
+	//  example:
+	//  ```
+	//    versionfilter:
+	//      kind: semver
+	//      pattern: minor
+	//  ```
 	//
-	// example:
-	// ```
-	//   versionfilter:
-	//   kind: semver
-	//   pattern: minor
-	//```
+	//  and its type like regex, semver, or just latest.
 	//
-	// More version filter available at https://www.updatecli.io/docs/core/versionfilter/
-	//
+	//  More examples can be found at https://www.updatecli.io/docs/core/versionfilter/
 	VersionFilter version.Filter `yaml:",omitempty"`
 }
 

--- a/pkg/plugins/autodiscovery/dockerfile/main.go
+++ b/pkg/plugins/autodiscovery/dockerfile/main.go
@@ -28,26 +28,29 @@ type Spec struct {
 	//
 	// example:
 	//
-	// ---
+	// ```
 	// auths:
 	//   "ghcr.io":
 	//     token: "xxx"
 	//   "index.docker.io":
 	//     username: "admin"
 	//     password: "password"
-	// ---
+	// ```
 	//
 	Auths map[string]docker.InlineKeyChain `yaml:",omitempty"`
-	// FileMatch allows to override default Dockerfile file matching. Default ["Dockerfile"]
+	// FileMatch allows to override default Dockerfile file matching. Default `["Dockerfile"]`
 	FileMatch []string `yaml:",omitempty"`
-	//  versionfilter provides parameters to specify the version pattern used when generating manifest.
+	//  `versionfilter` provides parameters to specify the version pattern used when generating manifest.
 	//
 	//  kind - semver
 	//    versionfilter of kind `semver` uses semantic versioning as version filtering
 	//    pattern accepts one of:
-	//      `patch` - patch only update patch version
-	//      `minor` - minor only update minor version
-	//      `major` - major only update major versions
+	//      `prerelease` - Updatecli tries to identify the latest prerelease whatever it means
+	//      `patch` - Updatecli only handles patch version update
+	//      `minor` - Updatecli handles patch AND minor version update
+	//      `minoronly` - Updatecli handles minor version only
+	//      `major` - Updatecli handles patch, minor, AND major version update
+	//      `majoronly` - Updatecli only handles major version update
 	//      `a version constraint` such as `>= 1.0.0`
 	//
 	//  kind - regex
@@ -55,15 +58,15 @@ type Spec struct {
 	//    pattern accepts a valid regular expression
 	//
 	//  example:
-	//
 	//  ```
-	//  versionfilter:
-	//    kind: semver
-	//    pattern: minor
+	//    versionfilter:
+	//      kind: semver
+	//      pattern: minor
 	//  ```
 	//
-	//  More version filter available at https://www.updatecli.io/docs/core/versionfilter/
+	//  and its type like regex, semver, or just latest.
 	//
+	//  More examples can be found at https://www.updatecli.io/docs/core/versionfilter/
 	VersionFilter version.Filter `yaml:",omitempty"`
 }
 

--- a/pkg/plugins/autodiscovery/fleet/main.go
+++ b/pkg/plugins/autodiscovery/fleet/main.go
@@ -18,7 +18,7 @@ type Spec struct {
 	//
 	// Example:
 	//
-	// ```yaml
+	// ```
 	// auths:
 	//   "my-helm-repo.com": "my-secret-token"
 	// ```
@@ -29,30 +29,33 @@ type Spec struct {
 	Ignore MatchingRules `yaml:",omitempty"`
 	// Only allows to specify rule to only autodiscover manifest for a specific Fleet bundle based on a rule
 	Only MatchingRules `yaml:",omitempty"`
-	/*
-		versionfilter provides parameters to specify the version pattern used when generating manifest.
-
-		kind - semver
-			versionfilter of kind `semver` uses semantic versioning as version filtering
-			pattern accepts one of:
-				`patch` - patch only update patch version
-				`minor` - minor only update minor version
-				`major` - major only update major versions
-				`a version constraint` such as `>= 1.0.0`
-
-		kind - regex
-			versionfilter of kind `regex` uses regular expression as version filtering
-			pattern accepts a valid regular expression
-
-		example:
-		```
-			versionfilter:
-				kind: semver
-				pattern: minor
-		```
-
-		and its type like regex, semver, or just latest.
-	*/
+	//  `versionfilter` provides parameters to specify the version pattern used when generating manifest.
+	//
+	//  kind - semver
+	//    versionfilter of kind `semver` uses semantic versioning as version filtering
+	//    pattern accepts one of:
+	//      `prerelease` - Updatecli tries to identify the latest prerelease whatever it means
+	//      `patch` - Updatecli only handles patch version update
+	//      `minor` - Updatecli handles patch AND minor version update
+	//      `minoronly` - Updatecli handles minor version only
+	//      `major` - Updatecli handles patch, minor, AND major version update
+	//      `majoronly` - Updatecli only handles major version update
+	//      `a version constraint` such as `>= 1.0.0`
+	//
+	//  kind - regex
+	//    versionfilter of kind `regex` uses regular expression as version filtering
+	//    pattern accepts a valid regular expression
+	//
+	//  example:
+	//  ```
+	//    versionfilter:
+	//      kind: semver
+	//      pattern: minor
+	//  ```
+	//
+	//  and its type like regex, semver, or just latest.
+	//
+	//  More examples can be found at https://www.updatecli.io/docs/core/versionfilter/
 	VersionFilter version.Filter `yaml:",omitempty"`
 }
 

--- a/pkg/plugins/autodiscovery/flux/main.go
+++ b/pkg/plugins/autodiscovery/flux/main.go
@@ -36,7 +36,7 @@ type Spec struct {
 	HelmRelease *bool `yaml:",omitempty"`
 	// files allows to override default flux files
 	//
-	// default: ["*.yaml", "*.yml"]
+	// default: `["*.yaml", "*.yml"]`
 	Files []string `yaml:",omitempty"`
 	// ignore allows to specify rule to ignore autodiscovery a specific Flux helmrelease based on a rule
 	//
@@ -57,31 +57,33 @@ type Spec struct {
 	// default: . (current working directory) or scm root directory
 	//
 	RootDir string `yaml:",omitempty"`
-	// versionfilter provides parameters to specify the version pattern used when generating manifest.
+	//  `versionfilter` provides parameters to specify the version pattern used when generating manifest.
 	//
-	// More information available at
-	// https://www.updatecli.io/docs/core/versionfilter/
+	//  kind - semver
+	//    versionfilter of kind `semver` uses semantic versioning as version filtering
+	//    pattern accepts one of:
+	//      `prerelease` - Updatecli tries to identify the latest prerelease whatever it means
+	//      `patch` - Updatecli only handles patch version update
+	//      `minor` - Updatecli handles patch AND minor version update
+	//      `minoronly` - Updatecli handles minor version only
+	//      `major` - Updatecli handles patch, minor, AND major version update
+	//      `majoronly` - Updatecli only handles major version update
+	//      `a version constraint` such as `>= 1.0.0`
 	//
-	// kind - semver
-	//   versionfilter of kind `semver` uses semantic versioning as version filtering
-	//   pattern accepts one of:
-	//     `patch` - patch only update patch version
-	//     `minor` - minor only update minor version
-	//     `major` - major only update major versions
-	//     `a version constraint` such as `>= 1.0.0`
+	//  kind - regex
+	//    versionfilter of kind `regex` uses regular expression as version filtering
+	//    pattern accepts a valid regular expression
 	//
-	// kind - regex
-	// versionfilter of kind `regex` uses regular expression as version filtering
-	// pattern accepts a valid regular expression
+	//  example:
+	//  ```
+	//    versionfilter:
+	//      kind: semver
+	//      pattern: minor
+	//  ```
 	//
-	// example:
-	// ```
-	//   versionfilter:
-	//   kind: semver
-	//   pattern: minor
-	// ```
+	//  and its type like regex, semver, or just latest.
 	//
-	// More version filter available at https://www.updatecli.io/docs/core/versionfilter/
+	//  More examples can be found at https://www.updatecli.io/docs/core/versionfilter/
 	VersionFilter version.Filter `yaml:",omitempty"`
 }
 

--- a/pkg/plugins/autodiscovery/githubaction/main.go
+++ b/pkg/plugins/autodiscovery/githubaction/main.go
@@ -31,17 +31,21 @@ type Spec struct {
 	// files allows to specify the accepted Action workflow file name
 	//
 	// default:
+	// ```
 	//   - ".github/workflows/*.yaml",
 	//   - ".github/workflows/*.yml",
 	//   - ".gitea/workflows/*.yaml",
 	//   - ".gitea/workflows/*.yml",
 	//   - ".forgejo/workflows/*.yaml",
 	//   - ".forgejo/workflows/*.yml",
+	// ```
 	Files []string `yaml:",omitempty"`
 	// actions allows to specify the accepted Composite Action names
 	//
 	// default:
+	// ```
 	//   - "*",
+	// ```
 	Actions []string `yaml:",omitempty"`
 
 	// ignore allows to specify rule to ignore autodiscovery a specific GitHub action based on a rule
@@ -58,29 +62,33 @@ type Spec struct {
 	//
 	// default: empty
 	RootDir string `yaml:",omitempty"`
-	// versionfilter provides parameters to specify the version pattern used when generating manifest.
+	//  `versionfilter` provides parameters to specify the version pattern used when generating manifest.
 	//
-	// kind - semver
-	//		versionfilter of kind `semver` uses semantic versioning as version filtering
-	//		pattern accepts one of:
-	//			`patch` - patch only update patch version
-	//			`minor` - minor only update minor version
-	//			`major` - major only update major versions
-	//			`a version constraint` such as `>= 1.0.0`
+	//  kind - semver
+	//    versionfilter of kind `semver` uses semantic versioning as version filtering
+	//    pattern accepts one of:
+	//      `prerelease` - Updatecli tries to identify the latest prerelease whatever it means
+	//      `patch` - Updatecli only handles patch version update
+	//      `minor` - Updatecli handles patch AND minor version update
+	//      `minoronly` - Updatecli handles minor version only
+	//      `major` - Updatecli handles patch, minor, AND major version update
+	//      `majoronly` - Updatecli only handles major version update
+	//      `a version constraint` such as `>= 1.0.0`
 	//
-	//	kind - regex
-	//		versionfilter of kind `regex` uses regular expression as version filtering
-	//		pattern accepts a valid regular expression
+	//  kind - regex
+	//    versionfilter of kind `regex` uses regular expression as version filtering
+	//    pattern accepts a valid regular expression
 	//
-	//	example:
-	//	```
-	//		versionfilter:
-	//			kind: semver
-	//			pattern: minor
-	//	```
+	//  example:
+	//  ```
+	//    versionfilter:
+	//      kind: semver
+	//      pattern: minor
+	//  ```
 	//
-	//	and its type like regex, semver, or just latest.
+	//  and its type like regex, semver, or just latest.
 	//
+	//  More examples can be found at https://www.updatecli.io/docs/core/versionfilter/
 	VersionFilter version.Filter `yaml:",omitempty"`
 	// Credentials allows to specify the credentials to use to authenticate to the git provider
 	// The ID of the credential must be the domain of the git provider to configure
@@ -140,21 +148,21 @@ type GitHubAction struct {
 type gitProviderToken struct {
 	// Kind defines the Kind of git provider to use
 	//
-	// accepted values: ['github','gitea','forgejo']
+	// accepted values: `['github','gitea','forgejo']`
 	Kind string `yaml:",omitempty"`
 	// Token defines the Token to use to authenticate to the git provider
 	//
 	// The default value depends on the action domain
-	// For 'github.com', the default value is set to first environment detected
-	//  1. "UPDATECLI_GITHUB_TOKEN"
-	//  2. "GITHUB_TOKEN"
+	// For `github.com`, the default value is set to first environment detected
+	//  1. `UPDATECLI_GITHUB_TOKEN`
+	//  2. `GITHUB_TOKEN`
 	//
-	// For 'gitea.com' and 'codeberg.org', the default value is set to first environment detected
-	//  1. "UPDATECLI_GITHUB_TOKEN"
-	//  1. "GITEA_TOKEN"
+	// For `gitea.com` and `codeberg.org`, the default value is set to first environment detected
+	//  1. `UPDATECLI_GITHUB_TOKEN`
+	//  1. `GITEA_TOKEN`
 	Token string `yaml:",omitempty"`
 	// App defines the GitHub App credentials used to authenticate with GitHub API.
-	// It is not compatible with the "token" field.
+	// It is not compatible with the `token` field.
 	// It is recommended to use the GitHub App authentication method for better security and granular permissions.
 	// For more information, please refer to the following documentation:
 	// https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/authenticating-as-a-github-app-installation

--- a/pkg/plugins/autodiscovery/golang/main.go
+++ b/pkg/plugins/autodiscovery/golang/main.go
@@ -19,36 +19,40 @@ type Spec struct {
 	OnlyGoVersion *bool `yaml:",omitempty"`
 	// OnlyGoModule allows to specify if the autodiscovery should only handle Go module specified in go.mod
 	OnlyGoModule *bool `yaml:",omitempty"`
-	// ignore allows to specify "rule" to ignore autodiscovery a specific go.mod rule
+	// ignore allows to specify `rule` to ignore autodiscovery a specific go.mod rule
 	Ignore MatchingRules `yaml:",omitempty"`
-	// `only` allows to specify rule to "only" autodiscover manifest for a specific golang rule
+	// `only` allows to specify rule to `only` autodiscover manifest for a specific golang rule
 	Only MatchingRules `yaml:",omitempty"`
-	// `versionfilter` provides parameters to specify the version pattern to use when generating manifest.
+	//  `versionfilter` provides parameters to specify the version pattern used when generating manifest.
 	//
-	// kind - semver
-	// 	versionfilter of kind `semver` uses semantic versioning as version filtering
-	// 	pattern accepts one of:
-	// 	  `patch` - patch only update patch version
-	// 	  `minor` - minor only update minor version
-	// 	  `major` - major only update major versions
-	// 	  `a version constraint` such as `>= 1.0.0`
+	//  kind - semver
+	//    versionfilter of kind `semver` uses semantic versioning as version filtering
+	//    pattern accepts one of:
+	//      `prerelease` - Updatecli tries to identify the latest prerelease whatever it means
+	//      `patch` - Updatecli only handles patch version update
+	//      `minor` - Updatecli handles patch AND minor version update
+	//      `minoronly` - Updatecli handles minor version only
+	//      `major` - Updatecli handles patch, minor, AND major version update
+	//      `majoronly` - Updatecli only handles major version update
+	//      `a version constraint` such as `>= 1.0.0`
 	//
-	// kind - regex
-	// 	versionfilter of kind `regex` uses regular expression as version filtering
-	// 	pattern accepts a valid regular expression
+	//  kind - regex
+	//    versionfilter of kind `regex` uses regular expression as version filtering
+	//    pattern accepts a valid regular expression
 	//
-	// example:
-	// ```
-	// 	versionfilter:
-	// 		kind: semver
-	// 		pattern: minor
-	// ```
+	//  example:
+	//  ```
+	//    versionfilter:
+	//      kind: semver
+	//      pattern: minor
+	//  ```
 	//
-	// and its type like regex, semver, or just latest.
+	//  and its type like regex, semver, or just latest.
 	//
+	//  More examples can be found at https://www.updatecli.io/docs/core/versionfilter/
 	VersionFilter version.Filter `yaml:",omitempty"`
 	// Age defines the minimum or maximum age of a release to be considered valid.
-	// It accepts a duration string (e.g., "24h", "7d", "1w").
+	// It accepts a duration string (e.g., `24h`, `7d`, `1w`).
 	Age age.Spec `yaml:",omitempty"`
 }
 

--- a/pkg/plugins/autodiscovery/helm/main.go
+++ b/pkg/plugins/autodiscovery/helm/main.go
@@ -18,14 +18,14 @@ type Spec struct {
 	//
 	// example:
 	//
-	// ---
+	// ```
 	// auths:
 	//   "ghcr.io":
 	//     token: "xxx"
 	//   "index.docker.io":
 	//     username: "admin"
 	//     password: "password"
-	// ---
+	// ```
 	//
 	Auths map[string]docker.InlineKeyChain `yaml:",omitempty"`
 	// digest provides a parameter to specify if the generated manifest should use a digest on top of the tag when updating container.
@@ -40,36 +40,37 @@ type Spec struct {
 	RootDir string `yaml:",omitempty"`
 	// only specify required rule(s) to restrict Helm chart update.
 	Only MatchingRules `yaml:",omitempty"`
-	// versionfilter provides parameters to specify the version pattern used when generating manifest.
+	//  `versionfilter` provides parameters to specify the version pattern used when generating manifest.
 	//
-	// More information available at
-	// https://www.updatecli.io/docs/core/versionfilter/
+	//  kind - semver
+	//    versionfilter of kind `semver` uses semantic versioning as version filtering
+	//    pattern accepts one of:
+	//      `prerelease` - Updatecli tries to identify the latest prerelease whatever it means
+	//      `patch` - Updatecli only handles patch version update
+	//      `minor` - Updatecli handles patch AND minor version update
+	//      `minoronly` - Updatecli handles minor version only
+	//      `major` - Updatecli handles patch, minor, AND major version update
+	//      `majoronly` - Updatecli only handles major version update
+	//      `a version constraint` such as `>= 1.0.0`
 	//
-	// kind - semver
-	//   versionfilter of kind `semver` uses semantic versioning as version filtering
-	//   pattern accepts one of:
-	//     `patch` - patch only update patch version
-	//     `minor` - minor only update minor version
-	//     `major` - major only update major versions
-	//     `a version constraint` such as `>= 1.0.0`
+	//  kind - regex
+	//    versionfilter of kind `regex` uses regular expression as version filtering
+	//    pattern accepts a valid regular expression
 	//
-	// kind - regex
-	// versionfilter of kind `regex` uses regular expression as version filtering
-	// pattern accepts a valid regular expression
+	//  example:
+	//  ```
+	//    versionfilter:
+	//      kind: semver
+	//      pattern: minor
+	//  ```
 	//
-	// example:
-	// ```
-	//   versionfilter:
-	//   kind: semver
-	//   pattern: minor
-	// ```
+	//  and its type like regex, semver, or just latest.
 	//
-	// More version filter available at https://www.updatecli.io/docs/core/versionfilter/
-	//
+	//  More examples can be found at https://www.updatecli.io/docs/core/versionfilter/
 	VersionFilter version.Filter `yaml:",omitempty"`
 	// [target] Defines if a Chart should be packaged or not.
 	SkipPackaging bool `yaml:",omitempty"`
-	// [target] Defines if a Chart changes, triggers, or not, a Chart version update, accepted values is a comma separated list of "none,major,minor,patch"
+	// [target] Defines if a Chart changes, triggers, or not, a Chart version update, accepted values is a comma separated list of `none,major,minor,patch`
 	VersionIncrement string `yaml:",omitempty"`
 }
 

--- a/pkg/plugins/autodiscovery/helmfile/main.go
+++ b/pkg/plugins/autodiscovery/helmfile/main.go
@@ -15,36 +15,39 @@ import (
 type Spec struct {
 	// rootdir defines the root directory used to recursively search for Helmfile manifest
 	RootDir string `yaml:",omitempty"`
-	// Ignore allows to specify rule to ignore "autodiscovery" a specific Helmfile based on a rule
+	// Ignore allows to specify rule to ignore `autodiscovery` a specific Helmfile based on a rule
 	Ignore MatchingRules `yaml:",omitempty"`
-	// Only allows to specify rule to only "autodiscovery" manifest for a specific Helmfile based on a rule
+	// Only allows to specify rule to only `autodiscovery` manifest for a specific Helmfile based on a rule
 	Only MatchingRules `yaml:",omitempty"`
 	// Auths provides a map of registry credentials where the key is the registry URL without scheme
 	Auths map[string]docker.InlineKeyChain `yaml:",omitempty"`
-	/*
-		versionfilter provides parameters to specify the version pattern used when generating manifest.
-
-		kind - semver
-			versionfilter of kind `semver` uses semantic versioning as version filtering
-			pattern accepts one of:
-				`patch` - patch only update patch version
-				`minor` - minor only update minor version
-				`major` - major only update major versions
-				`a version constraint` such as `>= 1.0.0`
-
-		kind - regex
-			versionfilter of kind `regex` uses regular expression as version filtering
-			pattern accepts a valid regular expression
-
-		example:
-		```
-			versionfilter:
-				kind: semver
-				pattern: minor
-		```
-
-		and its type like regex, semver, or just latest.
-	*/
+	//  `versionfilter` provides parameters to specify the version pattern used when generating manifest.
+	//
+	//  kind - semver
+	//    versionfilter of kind `semver` uses semantic versioning as version filtering
+	//    pattern accepts one of:
+	//      `prerelease` - Updatecli tries to identify the latest prerelease whatever it means
+	//      `patch` - Updatecli only handles patch version update
+	//      `minor` - Updatecli handles patch AND minor version update
+	//      `minoronly` - Updatecli handles minor version only
+	//      `major` - Updatecli handles patch, minor, AND major version update
+	//      `majoronly` - Updatecli only handles major version update
+	//      `a version constraint` such as `>= 1.0.0`
+	//
+	//  kind - regex
+	//    versionfilter of kind `regex` uses regular expression as version filtering
+	//    pattern accepts a valid regular expression
+	//
+	//  example:
+	//  ```
+	//    versionfilter:
+	//      kind: semver
+	//      pattern: minor
+	//  ```
+	//
+	//  and its type like regex, semver, or just latest.
+	//
+	//  More examples can be found at https://www.updatecli.io/docs/core/versionfilter/
 	VersionFilter version.Filter `yaml:",omitempty"`
 }
 

--- a/pkg/plugins/autodiscovery/ko/main.go
+++ b/pkg/plugins/autodiscovery/ko/main.go
@@ -15,34 +15,34 @@ import (
 type Spec struct {
 	// Auths provides a map of registry credentials where the key is the registry URL without scheme
 	Auths map[string]docker.InlineKeyChain `yaml:",omitempty"`
-	/*
-		digest provides parameters to specify if the generated manifest should use a digest on top of the tag.
-	*/
+	//	Digest provides parameters to specify if the generated manifest should use a digest on top of the tag.
 	Digest *bool `yaml:",omitempty"`
-	/* Files allows to specify a list of Files to analyze.
-
-	    The pattern syntax is:
-	       pattern:
-	         { term }
-	       term:
-	         '*'         matches any sequence of non-Separator characters
-	         '?'         matches any single non-Separator character
-	         '[' [ '^' ] { character-range } ']' character class (must be non-empty)
-	         c           matches character c (c != '*', '?', '\\', '[')
-	         '\\' c      matches character c
-
-		    character-range:
-		    	c           matches character c (c != '\\', '-', ']')
-	         '\\' c      matches character c
-	         lo '-' hi   matches character c for lo <= c <= hi
-
-	        Match requires pattern to match all of name, not just a substring.
-	        The only possible returned error is ErrBadPattern, when pattern
-	        is malformed.
-
-	        On Windows, escaping is disabled. Instead, '\\' is treated as
-	        path separator.
-	*/
+	// Files allows to specify a list of Files to analyze.
+	//
+	//  The pattern syntax is:
+	// ```
+	//     pattern:
+	//       { term }
+	//     term:
+	//       '*'         matches any sequence of non-Separator characters
+	//       '?'         matches any single non-Separator character
+	//       '[' [ '^' ] { character-range } ']' character class (must be non-empty)
+	//       c           matches character c (c != '*', '?', '\\', '[')
+	//       '\\' c      matches character c
+	//
+	//   character-range:
+	//   	c           matches character c (c != '\\', '-', ']')
+	//       '\\' c      matches character c
+	//       lo '-' hi   matches character c for lo <= c <= hi
+	// ```
+	//
+	//      Match requires pattern to match all of name, not just a substring.
+	//      The only possible returned error is ErrBadPattern, when pattern
+	//      is malformed.
+	//
+	//      On Windows, escaping is disabled. Instead, `\\` is treated as
+	//      path separator.
+	//
 	Files []string `yaml:",omitempty"`
 	// RootDir defines the root directory used to recursively search for Kubernetes files
 	RootDir string `yaml:",omitempty"`
@@ -50,30 +50,33 @@ type Spec struct {
 	Ignore MatchingRules `yaml:",omitempty"`
 	// Only allows to specify rule to only autodiscover manifest for a specific Kubernetes manifest based on a rule
 	Only MatchingRules `yaml:",omitempty"`
-	/*
-		versionfilter provides parameters to specify the version pattern used when generating manifest.
-
-		kind - semver
-			versionfilter of kind `semver` uses semantic versioning as version filtering
-			pattern accepts one of:
-				`patch` - patch only update patch version
-				`minor` - minor only update minor version
-				`major` - major only update major versions
-				`a version constraint` such as `>= 1.0.0`
-
-		kind - regex
-			versionfilter of kind `regex` uses regular expression as version filtering
-			pattern accepts a valid regular expression
-
-		example:
-		```
-			versionfilter:
-				kind: semver
-				pattern: minor
-		```
-
-		and its type like regex, semver, or just latest.
-	*/
+	//  `versionfilter` provides parameters to specify the version pattern used when generating manifest.
+	//
+	//  kind - semver
+	//    versionfilter of kind `semver` uses semantic versioning as version filtering
+	//    pattern accepts one of:
+	//      `prerelease` - Updatecli tries to identify the latest prerelease whatever it means
+	//      `patch` - Updatecli only handles patch version update
+	//      `minor` - Updatecli handles patch AND minor version update
+	//      `minoronly` - Updatecli handles minor version only
+	//      `major` - Updatecli handles patch, minor, AND major version update
+	//      `majoronly` - Updatecli only handles major version update
+	//      `a version constraint` such as `>= 1.0.0`
+	//
+	//  kind - regex
+	//    versionfilter of kind `regex` uses regular expression as version filtering
+	//    pattern accepts a valid regular expression
+	//
+	//  example:
+	//  ```
+	//    versionfilter:
+	//      kind: semver
+	//      pattern: minor
+	//  ```
+	//
+	//  and its type like regex, semver, or just latest.
+	//
+	//  More examples can be found at https://www.updatecli.io/docs/core/versionfilter/
 	VersionFilter version.Filter `yaml:",omitempty"`
 }
 

--- a/pkg/plugins/autodiscovery/kubernetes/main.go
+++ b/pkg/plugins/autodiscovery/kubernetes/main.go
@@ -23,14 +23,14 @@ type Spec struct {
 	//
 	// example:
 	//
-	// ---
+	// ```
 	// auths:
 	//   "ghcr.io":
 	//     token: "xxx"
 	//   "index.docker.io":
 	//     username: "admin"
 	//     password: "password"
-	// ---
+	// ```
 	//
 	Auths map[string]docker.InlineKeyChain `yaml:",omitempty"`
 	//	digest provides parameters to specify if the generated manifest should use a digest on top of the tag.
@@ -39,6 +39,7 @@ type Spec struct {
 	// Files allows to specify a list of Files to analyze.
 	//
 	// The pattern syntax is:
+	// ```
 	//   pattern:
 	//    { term }
 	//    term:
@@ -52,12 +53,13 @@ type Spec struct {
 	//   c         matches character c (c != '\\', '-', ']')
 	//   '\\' c    matches character c
 	//   lo '-' hi matches character c for lo <= c <= hi
+	// ```
 	//
 	// Match requires pattern to match all of name, not just a substring.
 	// The only possible returned error is ErrBadPattern, when pattern
 	// is malformed.
 	//
-	// On Windows, escaping is disabled. Instead, '\\' is treated as
+	// On Windows, escaping is disabled. Instead, `\\` is treated as
 	// path separator.
 	//
 	Files []string `yaml:",omitempty"`
@@ -67,32 +69,33 @@ type Spec struct {
 	Ignore MatchingRules `yaml:",omitempty"`
 	// Only allows to specify rule to only autodiscover manifest for a specific Kubernetes manifest based on a rule
 	Only MatchingRules `yaml:",omitempty"`
-	// versionfilter provides parameters to specify the version pattern used when generating manifest.
+	//  `versionfilter` provides parameters to specify the version pattern used when generating manifest.
 	//
-	// More information available at
-	// https://www.updatecli.io/docs/core/versionfilter/
+	//  kind - semver
+	//    versionfilter of kind `semver` uses semantic versioning as version filtering
+	//    pattern accepts one of:
+	//      `prerelease` - Updatecli tries to identify the latest prerelease whatever it means
+	//      `patch` - Updatecli only handles patch version update
+	//      `minor` - Updatecli handles patch AND minor version update
+	//      `minoronly` - Updatecli handles minor version only
+	//      `major` - Updatecli handles patch, minor, AND major version update
+	//      `majoronly` - Updatecli only handles major version update
+	//      `a version constraint` such as `>= 1.0.0`
 	//
-	// kind - semver
-	//   versionfilter of kind `semver` uses semantic versioning as version filtering
-	//   pattern accepts one of:
-	//     `patch` - patch only update patch version
-	//     `minor` - minor only update minor version
-	//     `major` - major only update major versions
-	//     `a version constraint` such as `>= 1.0.0`
+	//  kind - regex
+	//    versionfilter of kind `regex` uses regular expression as version filtering
+	//    pattern accepts a valid regular expression
 	//
-	// kind - regex
-	// versionfilter of kind `regex` uses regular expression as version filtering
-	// pattern accepts a valid regular expression
+	//  example:
+	//  ```
+	//    versionfilter:
+	//      kind: semver
+	//      pattern: minor
+	//  ```
 	//
-	// example:
-	// ```
-	//   versionfilter:
-	//   kind: semver
-	//   pattern: minor
-	// ```
+	//  and its type like regex, semver, or just latest.
 	//
-	// More version filter available at https://www.updatecli.io/docs/core/versionfilter/
-	//
+	//  More examples can be found at https://www.updatecli.io/docs/core/versionfilter/
 	VersionFilter version.Filter `yaml:",omitempty"`
 }
 

--- a/pkg/plugins/autodiscovery/maven/main.go
+++ b/pkg/plugins/autodiscovery/maven/main.go
@@ -18,30 +18,33 @@ type Spec struct {
 	Ignore MatchingRules `yaml:",omitempty"`
 	// Only allows to specify rule to only autodiscover manifest for a specific Helm based on a rule
 	Only MatchingRules `yaml:",omitempty"`
-	/*
-		versionfilter provides parameters to specify the version pattern used when generating manifest.
-
-		kind - semver
-			versionfilter of kind `semver` uses semantic versioning as version filtering
-			pattern accepts one of:
-				`patch` - patch only update patch version
-				`minor` - minor only update minor version
-				`major` - major only update major versions
-				`a version constraint` such as `>= 1.0.0`
-
-		kind - regex
-			versionfilter of kind `regex` uses regular expression as version filtering
-			pattern accepts a valid regular expression
-
-		example:
-		```
-			versionfilter:
-				kind: semver
-				pattern: minor
-		```
-
-		and its type like regex, semver, or just latest.
-	*/
+	//  `versionfilter` provides parameters to specify the version pattern used when generating manifest.
+	//
+	//  kind - semver
+	//    versionfilter of kind `semver` uses semantic versioning as version filtering
+	//    pattern accepts one of:
+	//      `prerelease` - Updatecli tries to identify the latest prerelease whatever it means
+	//      `patch` - Updatecli only handles patch version update
+	//      `minor` - Updatecli handles patch AND minor version update
+	//      `minoronly` - Updatecli handles minor version only
+	//      `major` - Updatecli handles patch, minor, AND major version update
+	//      `majoronly` - Updatecli only handles major version update
+	//      `a version constraint` such as `>= 1.0.0`
+	//
+	//  kind - regex
+	//    versionfilter of kind `regex` uses regular expression as version filtering
+	//    pattern accepts a valid regular expression
+	//
+	//  example:
+	//  ```
+	//    versionfilter:
+	//      kind: semver
+	//      pattern: minor
+	//  ```
+	//
+	//  and its type like regex, semver, or just latest.
+	//
+	//  More examples can be found at https://www.updatecli.io/docs/core/versionfilter/
 	VersionFilter version.Filter `yaml:",omitempty"`
 }
 

--- a/pkg/plugins/autodiscovery/nomad/main.go
+++ b/pkg/plugins/autodiscovery/nomad/main.go
@@ -31,44 +31,45 @@ type Spec struct {
 	//
 	// example:
 	//
-	// ---
+	// ```
 	// auths:
 	//   "ghcr.io":
 	//     token: "xxx"
 	//   "index.docker.io":
 	//     username: "admin"
 	//     password: "password"
-	// ---
+	// ```
 	//
 	Auths map[string]docker.InlineKeyChain `yaml:",omitempty"`
-	// FileMatch allows to override default docker-compose.yaml file matching. Default ["docker-compose.yaml","docker-compose.yml","docker-compose.*.yaml","docker-compose.*.yml"]
+	// FileMatch allows to override default docker-compose.yaml file matching. Default `["docker-compose.yaml","docker-compose.yml","docker-compose.*.yaml","docker-compose.*.yml"]`
 	FileMatch []string `yaml:",omitempty"`
-	// versionfilter provides parameters to specify the version pattern used when generating manifest.
+	//  `versionfilter` provides parameters to specify the version pattern used when generating manifest.
 	//
-	// More information available at
-	// https://www.updatecli.io/docs/core/versionfilter/
+	//  kind - semver
+	//    versionfilter of kind `semver` uses semantic versioning as version filtering
+	//    pattern accepts one of:
+	//      `prerelease` - Updatecli tries to identify the latest prerelease whatever it means
+	//      `patch` - Updatecli only handles patch version update
+	//      `minor` - Updatecli handles patch AND minor version update
+	//      `minoronly` - Updatecli handles minor version only
+	//      `major` - Updatecli handles patch, minor, AND major version update
+	//      `majoronly` - Updatecli only handles major version update
+	//      `a version constraint` such as `>= 1.0.0`
 	//
-	// kind - semver
-	//   versionfilter of kind `semver` uses semantic versioning as version filtering
-	//   pattern accepts one of:
-	//     `patch` - patch only update patch version
-	//     `minor` - minor only update minor version
-	//     `major` - major only update major versions
-	//     `a version constraint` such as `>= 1.0.0`
+	//  kind - regex
+	//    versionfilter of kind `regex` uses regular expression as version filtering
+	//    pattern accepts a valid regular expression
 	//
-	// kind - regex
-	// versionfilter of kind `regex` uses regular expression as version filtering
-	// pattern accepts a valid regular expression
+	//  example:
+	//  ```
+	//    versionfilter:
+	//      kind: semver
+	//      pattern: minor
+	//  ```
 	//
-	// example:
-	// ```
-	//   versionfilter:
-	//   kind: semver
-	//   pattern: minor
-	//```
+	//  and its type like regex, semver, or just latest.
 	//
-	// More version filter available at https://www.updatecli.io/docs/core/versionfilter/
-	//
+	//  More examples can be found at https://www.updatecli.io/docs/core/versionfilter/
 	VersionFilter version.Filter `yaml:",omitempty"`
 }
 

--- a/pkg/plugins/autodiscovery/npm/main.go
+++ b/pkg/plugins/autodiscovery/npm/main.go
@@ -18,30 +18,33 @@ type Spec struct {
 	Ignore MatchingRules `yaml:",omitempty"`
 	// Only allows to specify rule to only autodiscover manifest for a specific NPM based on a rule
 	Only MatchingRules `yaml:",omitempty"`
-	/*
-		versionfilter provides parameters to specify the version pattern used when generating manifest.
-
-		kind - semver
-			versionfilter of kind `semver` uses semantic versioning as version filtering
-			pattern accepts one of:
-				`patch` - patch only update patch version
-				`minor` - minor only update minor version
-				`major` - major only update major versions
-				`a version constraint` such as `>= 1.0.0`
-
-		kind - regex
-			versionfilter of kind `regex` uses regular expression as version filtering
-			pattern accepts a valid regular expression
-
-		example:
-		```
-			versionfilter:
-				kind: semver
-				pattern: minor
-		```
-
-		and its type like regex, semver, or just latest.
-	*/
+	//  `versionfilter` provides parameters to specify the version pattern used when generating manifest.
+	//
+	//  kind - semver
+	//    versionfilter of kind `semver` uses semantic versioning as version filtering
+	//    pattern accepts one of:
+	//      `prerelease` - Updatecli tries to identify the latest prerelease whatever it means
+	//      `patch` - Updatecli only handles patch version update
+	//      `minor` - Updatecli handles patch AND minor version update
+	//      `minoronly` - Updatecli handles minor version only
+	//      `major` - Updatecli handles patch, minor, AND major version update
+	//      `majoronly` - Updatecli only handles major version update
+	//      `a version constraint` such as `>= 1.0.0`
+	//
+	//  kind - regex
+	//    versionfilter of kind `regex` uses regular expression as version filtering
+	//    pattern accepts a valid regular expression
+	//
+	//  example:
+	//  ```
+	//    versionfilter:
+	//      kind: semver
+	//      pattern: minor
+	//  ```
+	//
+	//  and its type like regex, semver, or just latest.
+	//
+	//  More examples can be found at https://www.updatecli.io/docs/core/versionfilter/
 	VersionFilter version.Filter `yaml:",omitempty"`
 	// IgnoreVersionConstraints indicates whether to respect version constraints defined in package.json or not.
 	// When set to true, Updatecli will ignore version constraints and update to the latest version available
@@ -50,7 +53,7 @@ type Spec struct {
 	//
 	// Remark:
 	//  * If set to false, Updatecli will try to convert version constrains to valid semantic version
-	//    so we can use versionFilter to retrieve the last Major/Minor/Patch version but in case of complex version constraints, such as ">=1.0.0 <2.0.0",
+	//    so we can use versionFilter to retrieve the last Major/Minor/Patch version but in case of complex version constraints, such as `>=1.0.0 <2.0.0`,
 	//    Updatecli will convert it to the first version it detects such as 1.0.0 in our example
 	IgnoreVersionConstraints *bool `yaml:",omitempty"`
 	// NpmrcPath defines the path to the .npmrc file to use for all discovered packages.

--- a/pkg/plugins/autodiscovery/precommit/main.go
+++ b/pkg/plugins/autodiscovery/precommit/main.go
@@ -18,30 +18,33 @@ type Spec struct {
 	Ignore MatchingRules `yaml:",omitempty"`
 	// Only allows to specify rule to only autodiscover manifest for a specific NPM based on a rule
 	Only MatchingRules `yaml:",omitempty"`
-	/*
-		versionfilter provides parameters to specify the version pattern used when generating manifest.
-
-		kind - semver
-			versionfilter of kind `semver` uses semantic versioning as version filtering
-			pattern accepts one of:
-				`patch` - patch only update patch version
-				`minor` - minor only update minor version
-				`major` - major only update major versions
-				`a version constraint` such as `>= 1.0.0`
-
-		kind - regex
-			versionfilter of kind `regex` uses regular expression as version filtering
-			pattern accepts a valid regular expression
-
-		example:
-		```
-			versionfilter:
-				kind: semver
-				pattern: minor
-		```
-
-		and its type like regex, semver, or just latest.
-	*/
+	//  `versionfilter` provides parameters to specify the version pattern used when generating manifest.
+	//
+	//  kind - semver
+	//    versionfilter of kind `semver` uses semantic versioning as version filtering
+	//    pattern accepts one of:
+	//      `prerelease` - Updatecli tries to identify the latest prerelease whatever it means
+	//      `patch` - Updatecli only handles patch version update
+	//      `minor` - Updatecli handles patch AND minor version update
+	//      `minoronly` - Updatecli handles minor version only
+	//      `major` - Updatecli handles patch, minor, AND major version update
+	//      `majoronly` - Updatecli only handles major version update
+	//      `a version constraint` such as `>= 1.0.0`
+	//
+	//  kind - regex
+	//    versionfilter of kind `regex` uses regular expression as version filtering
+	//    pattern accepts a valid regular expression
+	//
+	//  example:
+	//  ```
+	//    versionfilter:
+	//      kind: semver
+	//      pattern: minor
+	//  ```
+	//
+	//  and its type like regex, semver, or just latest.
+	//
+	//  More examples can be found at https://www.updatecli.io/docs/core/versionfilter/
 	VersionFilter version.Filter `yaml:",omitempty"`
 	// Digest provides parameters to specify if the generated manifest should use a digest instead of the branch or tag.
 	// This is equivalent to using the [`--freeze`](https://pre-commit.com/#pre-commit-autoupdate) option of precommit

--- a/pkg/plugins/autodiscovery/pyproject/main.go
+++ b/pkg/plugins/autodiscovery/pyproject/main.go
@@ -18,32 +18,33 @@ type Spec struct {
 	Ignore MatchingRules `yaml:",omitempty"`
 	// Only specifies rules to restrict autodiscovery to matching pyproject.toml dependencies.
 	Only MatchingRules `yaml:",omitempty"`
-	/*
-		versionfilter provides parameters to specify the version pattern used when generating manifests.
-
-		kind - pep440 (default)
-			versionfilter of kind `pep440` uses PEP 440 version specifiers natively.
-			pattern accepts a PEP 440 version specifier such as `>=2.28`, `>=1.0,<3.0`, or `*` (any).
-
-		kind - semver
-			versionfilter of kind `semver` uses semantic versioning as version filtering.
-			pattern accepts one of:
-				`patch` - update patch version only
-				`minor` - update minor version only
-				`major` - update major versions only
-				`a version constraint` such as `>= 1.0.0`
-
-		kind - regex
-			versionfilter of kind `regex` uses regular expression as version filtering.
-			pattern accepts a valid regular expression.
-
-		example:
-		```
-			versionfilter:
-				kind: pep440
-				pattern: ">=2.28"
-		```
-	*/
+	//  `versionfilter` provides parameters to specify the version pattern used when generating manifest.
+	//
+	//  kind - semver
+	//    versionfilter of kind `semver` uses semantic versioning as version filtering
+	//    pattern accepts one of:
+	//      `prerelease` - Updatecli tries to identify the latest prerelease whatever it means
+	//      `patch` - Updatecli only handles patch version update
+	//      `minor` - Updatecli handles patch AND minor version update
+	//      `minoronly` - Updatecli handles minor version only
+	//      `major` - Updatecli handles patch, minor, AND major version update
+	//      `majoronly` - Updatecli only handles major version update
+	//      `a version constraint` such as `>= 1.0.0`
+	//
+	//  kind - regex
+	//    versionfilter of kind `regex` uses regular expression as version filtering
+	//    pattern accepts a valid regular expression
+	//
+	//  example:
+	//  ```
+	//    versionfilter:
+	//      kind: semver
+	//      pattern: minor
+	//  ```
+	//
+	//  and its type like regex, semver, or just latest.
+	//
+	//  More examples can be found at https://www.updatecli.io/docs/core/versionfilter/
 	VersionFilter version.Filter `yaml:",omitempty"`
 	// IndexURL specifies a custom PyPI index URL propagated to all generated source specs.
 	IndexURL string `yaml:",omitempty"`

--- a/pkg/plugins/autodiscovery/terraform/main.go
+++ b/pkg/plugins/autodiscovery/terraform/main.go
@@ -19,7 +19,33 @@ type Terraform struct {
 	rootDir string
 	// scmID holds the scmID used by the newly generated manifest
 	scmID string
-	// versionFilter holds the "valid" version.filter, that might be different from the user-specified filter (Spec.VersionFilter)
+	//  `versionfilter` provides parameters to specify the version pattern used when generating manifest.
+	//
+	//  kind - semver
+	//    versionfilter of kind `semver` uses semantic versioning as version filtering
+	//    pattern accepts one of:
+	//      `prerelease` - Updatecli tries to identify the latest prerelease whatever it means
+	//      `patch` - Updatecli only handles patch version update
+	//      `minor` - Updatecli handles patch AND minor version update
+	//      `minoronly` - Updatecli handles minor version only
+	//      `major` - Updatecli handles patch, minor, AND major version update
+	//      `majoronly` - Updatecli only handles major version update
+	//      `a version constraint` such as `>= 1.0.0`
+	//
+	//  kind - regex
+	//    versionfilter of kind `regex` uses regular expression as version filtering
+	//    pattern accepts a valid regular expression
+	//
+	//  example:
+	//  ```
+	//    versionfilter:
+	//      kind: semver
+	//      pattern: minor
+	//  ```
+	//
+	//  and its type like regex, semver, or just latest.
+	//
+	//  More examples can be found at https://www.updatecli.io/docs/core/versionfilter/
 	versionFilter version.Filter
 }
 

--- a/pkg/plugins/autodiscovery/terragrunt/main.go
+++ b/pkg/plugins/autodiscovery/terragrunt/main.go
@@ -19,7 +19,33 @@ type Terragrunt struct {
 	rootDir string
 	// `scmID` holds the scmID used by the newly generated manifest
 	scmID string
-	// `versionFilter` holds the "valid" version.filter, that might be different from the user-specified filter (Spec.VersionFilter)
+	//  `versionfilter` provides parameters to specify the version pattern used when generating manifest.
+	//
+	//  kind - semver
+	//    versionfilter of kind `semver` uses semantic versioning as version filtering
+	//    pattern accepts one of:
+	//      `prerelease` - Updatecli tries to identify the latest prerelease whatever it means
+	//      `patch` - Updatecli only handles patch version update
+	//      `minor` - Updatecli handles patch AND minor version update
+	//      `minoronly` - Updatecli handles minor version only
+	//      `major` - Updatecli handles patch, minor, AND major version update
+	//      `majoronly` - Updatecli only handles major version update
+	//      `a version constraint` such as `>= 1.0.0`
+	//
+	//  kind - regex
+	//    versionfilter of kind `regex` uses regular expression as version filtering
+	//    pattern accepts a valid regular expression
+	//
+	//  example:
+	//  ```
+	//    versionfilter:
+	//      kind: semver
+	//      pattern: minor
+	//  ```
+	//
+	//  and its type like regex, semver, or just latest.
+	//
+	//  More examples can be found at https://www.updatecli.io/docs/core/versionfilter/
 	versionFilter version.Filter
 }
 

--- a/pkg/plugins/autodiscovery/updatecli/main.go
+++ b/pkg/plugins/autodiscovery/updatecli/main.go
@@ -15,61 +15,66 @@ import (
 type Spec struct {
 	// rootdir defines the root directory used to recursively search for Updatecli manifest
 	RootDir string `yaml:",omitempty"`
-	// Ignore allows to specify rule to ignore "autodiscovery" a specific Updatecli based on a rule
+	// Ignore allows to specify rule to ignore `autodiscovery` a specific Updatecli based on a rule
 	Ignore MatchingRules `yaml:",omitempty"`
-	// Only allows to specify rule to only "autodiscovery" manifest for a specific Updatecli based on a rule
+	// Only allows to specify rule to only `autodiscovery` manifest for a specific Updatecli based on a rule
 	Only MatchingRules `yaml:",omitempty"`
-	/* Files allows to specify a list of Files to analyze.
-
-	    The pattern syntax is:
-	       pattern:
-	         { term }
-	       term:
-	         '*'         matches any sequence of non-Separator characters
-	         '?'         matches any single non-Separator character
-	         '[' [ '^' ] { character-range } ']' character class (must be non-empty)
-	         c           matches character c (c != '*', '?', '\\', '[')
-	         '\\' c      matches character c
-
-		    character-range:
-		    	c           matches character c (c != '\\', '-', ']')
-	         '\\' c      matches character c
-	         lo '-' hi   matches character c for lo <= c <= hi
-
-	        Match requires pattern to match all of name, not just a substring.
-	        The only possible returned error is ErrBadPattern, when pattern
-	        is malformed.
-
-	        On Windows, escaping is disabled. Instead, '\\' is treated as
-	        path separator.
-	*/
+	// Files allows to specify a list of Files to analyze.
+	//
+	//  The pattern syntax is:
+	// ```
+	//     pattern:
+	//       { term }
+	//     term:
+	//       '*'         matches any sequence of non-Separator characters
+	//       '?'         matches any single non-Separator character
+	//       '[' [ '^' ] { character-range } ']' character class (must be non-empty)
+	//       c           matches character c (c != '*', '?', '\\', '[')
+	//       '\\' c      matches character c
+	//
+	//   character-range:
+	//   	c           matches character c (c != '\\', '-', ']')
+	//       '\\' c      matches character c
+	//       lo '-' hi   matches character c for lo <= c <= hi
+	// ```
+	//
+	//      Match requires pattern to match all of name, not just a substring.
+	//      The only possible returned error is ErrBadPattern, when pattern
+	//      is malformed.
+	//
+	//      On Windows, escaping is disabled. Instead, `\\` is treated as
+	//      path separator.
+	//
 	Files []string `yaml:",omitempty"`
 	// Auths provides a map of registry credentials where the key is the registry URL without scheme
 	Auths map[string]docker.InlineKeyChain `yaml:",omitempty"`
-	/*
-		versionfilter provides parameters to specify the version pattern used when generating manifest.
-
-		kind - semver
-			versionfilter of kind `semver` uses semantic versioning as version filtering
-			pattern accepts one of:
-				`patch` - patch only update patch version
-				`minor` - minor only update minor version
-				`major` - major only update major versions
-				`a version constraint` such as `>= 1.0.0`
-
-		kind - regex
-			versionfilter of kind `regex` uses regular expression as version filtering
-			pattern accepts a valid regular expression
-
-		example:
-		```
-			versionfilter:
-				kind: semver
-				pattern: minor
-		```
-
-		and its type like regex, semver, or just latest.
-	*/
+	//  `versionfilter` provides parameters to specify the version pattern used when generating manifest.
+	//
+	//  kind - semver
+	//    versionfilter of kind `semver` uses semantic versioning as version filtering
+	//    pattern accepts one of:
+	//      `prerelease` - Updatecli tries to identify the latest prerelease whatever it means
+	//      `patch` - Updatecli only handles patch version update
+	//      `minor` - Updatecli handles patch AND minor version update
+	//      `minoronly` - Updatecli handles minor version only
+	//      `major` - Updatecli handles patch, minor, AND major version update
+	//      `majoronly` - Updatecli only handles major version update
+	//      `a version constraint` such as `>= 1.0.0`
+	//
+	//  kind - regex
+	//    versionfilter of kind `regex` uses regular expression as version filtering
+	//    pattern accepts a valid regular expression
+	//
+	//  example:
+	//  ```
+	//    versionfilter:
+	//      kind: semver
+	//      pattern: minor
+	//  ```
+	//
+	//  and its type like regex, semver, or just latest.
+	//
+	//  More examples can be found at https://www.updatecli.io/docs/core/versionfilter/
 	VersionFilter version.Filter `yaml:",omitempty"`
 }
 

--- a/pkg/plugins/autodiscovery/woodpecker/main.go
+++ b/pkg/plugins/autodiscovery/woodpecker/main.go
@@ -31,45 +31,46 @@ type Spec struct {
 	//
 	// example:
 	//
-	// ---
+	// ```
 	// auths:
 	//   "ghcr.io":
 	//     token: "xxx"
 	//   "index.docker.io":
 	//     username: "admin"
 	//     password: "password"
-	// ---
+	// ```
 	//
 	Auths map[string]docker.InlineKeyChain `yaml:",omitempty"`
 	// FileMatch allows to override default Woodpecker workflow file matching.
-	// Default [".woodpecker.yml", ".woodpecker.yaml", ".woodpecker/*.yml", ".woodpecker/*.yaml", ".woodpecker/**/*.yml", ".woodpecker/**/*.yaml"]
+	// Default `[".woodpecker.yml", ".woodpecker.yaml", ".woodpecker/*.yml", ".woodpecker/*.yaml", ".woodpecker/**/*.yml", ".woodpecker/**/*.yaml"]`
 	FileMatch []string `yaml:",omitempty"`
-	// versionfilter provides parameters to specify the version pattern used when generating manifest.
+	//  `versionfilter` provides parameters to specify the version pattern used when generating manifest.
 	//
-	// More information available at
-	// https://www.updatecli.io/docs/core/versionfilter/
+	//  kind - semver
+	//    versionfilter of kind `semver` uses semantic versioning as version filtering
+	//    pattern accepts one of:
+	//      `prerelease` - Updatecli tries to identify the latest prerelease whatever it means
+	//      `patch` - Updatecli only handles patch version update
+	//      `minor` - Updatecli handles patch AND minor version update
+	//      `minoronly` - Updatecli handles minor version only
+	//      `major` - Updatecli handles patch, minor, AND major version update
+	//      `majoronly` - Updatecli only handles major version update
+	//      `a version constraint` such as `>= 1.0.0`
 	//
-	// kind - semver
-	//   versionfilter of kind `semver` uses semantic versioning as version filtering
-	//   pattern accepts one of:
-	//     `patch` - patch only update patch version
-	//     `minor` - minor only update minor version
-	//     `major` - major only update major versions
-	//     `a version constraint` such as `>= 1.0.0`
+	//  kind - regex
+	//    versionfilter of kind `regex` uses regular expression as version filtering
+	//    pattern accepts a valid regular expression
 	//
-	// kind - regex
-	// versionfilter of kind `regex` uses regular expression as version filtering
-	// pattern accepts a valid regular expression
+	//  example:
+	//  ```
+	//    versionfilter:
+	//      kind: semver
+	//      pattern: minor
+	//  ```
 	//
-	// example:
-	// ```
-	//   versionfilter:
-	//   kind: semver
-	//   pattern: minor
-	//```
+	//  and its type like regex, semver, or just latest.
 	//
-	// More version filter available at https://www.updatecli.io/docs/core/versionfilter/
-	//
+	//  More examples can be found at https://www.updatecli.io/docs/core/versionfilter/
 	VersionFilter version.Filter `yaml:",omitempty"`
 }
 


### PR DESCRIPTION
This pullrequest is an attempt to fix the comment used to generate the jsonschame then used by the documentation website.
Especially `pkg/plugins/autodiscovery/golang/` and `pkg/plugins/autodiscovery/dockerfile/` seems problematic
Hugo doesn't seem to like single and double quotes