### PR TITLE
feat(csv/json/toml): add Dasel v3 support

### DIFF
--- a/e2e/updatecli.d/success.d/csv.yaml
+++ b/e2e/updatecli.d/success.d/csv.yaml
@@ -8,17 +8,20 @@ sources:
     spec:
       files:
         - pkg/plugins/resources/csv/testdata/data.csv
-      key: .[0].firstname
+      key: "$this[0].firstname"
+      engine: dasel/v3
+
   versionfilter:
     name: Test Version filter`
     kind: csv
     spec:
-      files: 
+      files:
         - pkg/plugins/resources/csv/testdata/data.csv
-      query: ".[*].firstname"
+      key: "map(firstname)..."
       versionfilter:
         kind: regex
         pattern: "^Jo"
+      engine: dasel/v3
 
 conditions:
   single:
@@ -29,8 +32,9 @@ conditions:
       files:
         - pkg/plugins/resources/csv/testdata/data.csv
         - pkg/plugins/resources/csv/testdata/data.csv
-      key: .[0].firstname
+      key: $this[0].firstname
       value: John
+      engine: dasel/v3
 
 targets:
   single:
@@ -38,11 +42,12 @@ targets:
     kind: csv
     sourceid: default
     spec:
-      files: 
+      files:
         - pkg/plugins/resources/csv/testdata/data.csv
         - pkg/plugins/resources/csv/testdata/data.csv
-      query: .[1].firstname
+      key: $this[1].firstname
       value: John
+      engine: dasel/v3
 
   multiple:
     name: Multiple target update
@@ -52,4 +57,5 @@ targets:
       files:
         - pkg/plugins/resources/csv/testdata/data.csv
         - pkg/plugins/resources/csv/testdata/data.csv
-      query: .[*].firstname
+      key: "map(firstname)..."
+      engine: dasel/v3

--- a/e2e/updatecli.d/success.d/json.yaml
+++ b/e2e/updatecli.d/success.d/json.yaml
@@ -13,7 +13,7 @@ sources:
     kind: json
     spec:
       file: https://www.updatecli.io/schema/latest/config.json
-      key: $id
+      key: additionalProperties
       engine: dasel/v3
   localdasel:
     name: Get value from json
@@ -27,9 +27,15 @@ sources:
     kind: json
     spec:
       file: https://www.updatecli.io/schema/latest/config.json
-      key: $id
+      key: additionalProperties
       engine: dasel
-
+  httpdasel2:
+    name: Get value from json
+    kind: json
+    spec:
+      file: https://www.updatecli.io/schema/latest/config.json
+      key: '["$id"]'
+      engine: dasel
 conditions:
   local:
     name: Test value from json
@@ -47,8 +53,8 @@ conditions:
     disablesourceinput: true
     spec:
       file: https://www.updatecli.io/schema/latest/config.json
-      key: $schema
-      value: http://json-schema.org/draft-04/schema
+      key: additionalProperties
+      value: "false"
       engine: dasel/v3
   localdasel:
     name: Test value from json
@@ -66,14 +72,15 @@ conditions:
     disablesourceinput: true
     spec:
       file: https://www.updatecli.io/schema/latest/config.json
-      key: $schema
-      value: http://json-schema.org/draft-04/schema
+      value: "false"
+      key: additionalProperties
       engine: dasel
 
 targets:
   local:
     name: Test value from json
     kind: json
+    disableconditions: true
     sourceid: local
     spec:
       file: pkg/plugins/resources/json/testdata/data.json
@@ -83,6 +90,7 @@ targets:
 
   local2:
     name: Test value from json
+    disableconditions: true
     kind: json
     sourceid: local
     spec:
@@ -94,6 +102,7 @@ targets:
       engine: dasel/v3
   localdasel:
     name: Test value from json
+    disableconditions: true
     kind: json
     sourceid: local
     spec:
@@ -105,6 +114,7 @@ targets:
   local2dasel:
     name: Test value from json
     kind: json
+    disableconditions: true
     sourceid: local
     spec:
       files:

--- a/e2e/updatecli.d/success.d/json.yaml
+++ b/e2e/updatecli.d/success.d/json.yaml
@@ -7,14 +7,28 @@ sources:
     spec:
       file: pkg/plugins/resources/json/testdata/data.json
       key: firstName
-      engine: dasel/v2
+      engine: dasel/v3
   http:
     name: Get value from json
     kind: json
     spec:
       file: https://www.updatecli.io/schema/latest/config.json
       key: $id
-      engine: dasel/v2
+      engine: dasel/v3
+  localdasel:
+    name: Get value from json
+    kind: json
+    spec:
+      file: pkg/plugins/resources/json/testdata/data.json
+      key: firstName
+      engine: dasel
+  httpdasel:
+    name: Get value from json
+    kind: json
+    spec:
+      file: https://www.updatecli.io/schema/latest/config.json
+      key: $id
+      engine: dasel
 
 conditions:
   local:
@@ -26,7 +40,7 @@ conditions:
         - pkg/plugins/resources/json/testdata/data.json
         - pkg/plugins/resources/json/testdata/data.2.json
       key: firstName
-      engine: dasel/v2
+      engine: dasel/v3
   http:
     name: Test value from json
     kind: json
@@ -35,7 +49,26 @@ conditions:
       file: https://www.updatecli.io/schema/latest/config.json
       key: $schema
       value: http://json-schema.org/draft-04/schema
-      engine: dasel/v2
+      engine: dasel/v3
+  localdasel:
+    name: Test value from json
+    kind: json
+    sourceid: local
+    spec:
+      files:
+        - pkg/plugins/resources/json/testdata/data.json
+        - pkg/plugins/resources/json/testdata/data.2.json
+      key: firstName
+      engine: dasel
+  httpdasel:
+    name: Test value from json
+    kind: json
+    disablesourceinput: true
+    spec:
+      file: https://www.updatecli.io/schema/latest/config.json
+      key: $schema
+      value: http://json-schema.org/draft-04/schema
+      engine: dasel
 
 targets:
   local:
@@ -46,7 +79,7 @@ targets:
       file: pkg/plugins/resources/json/testdata/data.json
       key: firstName
       value: John
-      engine: dasel/v2
+      engine: dasel/v3
 
   local2:
     name: Test value from json
@@ -58,4 +91,25 @@ targets:
         - pkg/plugins/resources/json/testdata/data.2.json
       key: firstName
       value: John
-      engine: dasel/v2
+      engine: dasel/v3
+  localdasel:
+    name: Test value from json
+    kind: json
+    sourceid: local
+    spec:
+      file: pkg/plugins/resources/json/testdata/data.json
+      key: firstName
+      value: John
+      engine: dasel
+
+  local2dasel:
+    name: Test value from json
+    kind: json
+    sourceid: local
+    spec:
+      files:
+        - pkg/plugins/resources/json/testdata/data.json
+        - pkg/plugins/resources/json/testdata/data.2.json
+      key: firstName
+      value: John
+      engine: dasel

--- a/e2e/updatecli.d/success.d/toml.yaml
+++ b/e2e/updatecli.d/success.d/toml.yaml
@@ -7,14 +7,7 @@ sources:
     spec:
       file: pkg/plugins/resources/toml/testdata/data.toml
       key: owner.firstName
-  ports:
-    name: Get sorted ports
-    kind: toml
-    spec:
-      file: pkg/plugins/resources/toml/testdata/data.toml
-      query: database.ports.[*]
-      versionfilter:
-        kind: semver
+      engine: dasel/v3
 
 conditions:
   local:
@@ -24,22 +17,7 @@ conditions:
     spec:
       file: pkg/plugins/resources/toml/testdata/data.toml
       key: owner.firstName
-  multiple:
-    name: Test multiple value from toml
-    kind: toml
-    disablesourceinput: true
-    spec:
-      file: pkg/plugins/resources/toml/testdata/data.toml
-      key: ".employees.(address=AU).role"
-      value: "M"
-  ports:
-    name: Get sorted ports
-    kind: toml
-    disablesourceinput: true
-    spec:
-      file: pkg/plugins/resources/toml/testdata/data.toml
-      query: ".employees.(address=AU).role"
-      value: "M"
+      engine: dasel/v3
 
 targets:
   local:
@@ -50,4 +28,4 @@ targets:
       file: pkg/plugins/resources/toml/testdata/data.toml
       key: owner.firstName
       value: John
-
+      engine: dasel/v3

--- a/e2e/updatecli.d/warning.d/jsonv2.yaml
+++ b/e2e/updatecli.d/warning.d/jsonv2.yaml
@@ -1,0 +1,61 @@
+name: Basic Json Example
+
+sources:
+  local:
+    name: Get value from json
+    kind: json
+    spec:
+      file: pkg/plugins/resources/json/testdata/data.json
+      key: firstName
+      engine: dasel/v2
+  http:
+    name: Get value from json
+    kind: json
+    spec:
+      file: https://www.updatecli.io/schema/latest/config.json
+      key: $id
+      engine: dasel/v2
+
+conditions:
+  local:
+    name: Test value from json
+    kind: json
+    sourceid: local
+    spec:
+      files:
+        - pkg/plugins/resources/json/testdata/data.json
+        - pkg/plugins/resources/json/testdata/data.2.json
+      key: firstName
+      engine: dasel/v2
+  http:
+    name: Test value from json
+    kind: json
+    disablesourceinput: true
+    spec:
+      file: https://www.updatecli.io/schema/latest/config.json
+      key: $schema
+      value: http://json-schema.org/draft-04/schema
+      engine: dasel/v2
+
+targets:
+  local:
+    name: Test value from json
+    kind: json
+    sourceid: local
+    spec:
+      file: pkg/plugins/resources/json/testdata/data.json
+      key: firstName
+      value: John
+      engine: dasel/v2
+
+  local2:
+    name: Test value from json
+    kind: json
+    sourceid: local
+    spec:
+      files:
+        - pkg/plugins/resources/json/testdata/data.json
+        - pkg/plugins/resources/json/testdata/data.2.json
+      key: firstName
+      value: John
+      engine: dasel/v2

--- a/go.mod
+++ b/go.mod
@@ -68,6 +68,7 @@ require (
 	github.com/tetratelabs/wazero v1.12.0
 	github.com/tomwright/dasel v1.27.3
 	github.com/tomwright/dasel/v2 v2.8.1
+	github.com/tomwright/dasel/v3 v3.11.2
 	github.com/vmware-labs/yaml-jsonpath v0.3.2
 	github.com/yuin/goldmark v1.8.4
 	github.com/zclconf/go-cty v1.19.0
@@ -137,6 +138,8 @@ require (
 	github.com/buger/jsonparser v1.1.2 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
+	github.com/clipperhouse/stringish v0.1.1 // indirect
+	github.com/clipperhouse/uax29/v2 v2.5.0 // indirect
 	github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2 // indirect
 	github.com/cockroachdb/apd/v3 v3.2.3 // indirect
 	github.com/containerd/errdefs v1.0.0 // indirect
@@ -201,7 +204,6 @@ require (
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
 	github.com/protocolbuffers/txtpbfmt v0.0.0-20260420112717-c39628bde8b5 // indirect
-	github.com/rivo/uniseg v0.4.4 // indirect
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 	github.com/shirou/gopsutil/v4 v4.26.5 // indirect
 	github.com/spiffe/go-spiffe/v2 v2.8.1 // indirect
@@ -303,7 +305,7 @@ require (
 	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de // indirect
 	github.com/mattn/go-colorable v0.1.15 // indirect
 	github.com/mattn/go-isatty v0.0.22 // indirect
-	github.com/mattn/go-runewidth v0.0.15 // indirect
+	github.com/mattn/go-runewidth v0.0.19 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -196,6 +196,10 @@ github.com/chai2010/gettext-go v1.0.2/go.mod h1:y+wnP2cHYaVj19NZhYKAwEMH2CI1gNHe
 github.com/clbanning/mxj/v2 v2.7.0 h1:WA/La7UGCanFe5NpHF0Q3DNtnCsVoxbPKuyBNHWRyME=
 github.com/clbanning/mxj/v2 v2.7.0/go.mod h1:hNiWqW14h+kc+MdF9C6/YoRfjEJoR3ou6tn/Qo+ve2s=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
+github.com/clipperhouse/stringish v0.1.1 h1:+NSqMOr3GR6k1FdRhhnXrLfztGzuG+VuFDfatpWHKCs=
+github.com/clipperhouse/stringish v0.1.1/go.mod h1:v/WhFtE1q0ovMta2+m+UbpZ+2/HEXNWYXQgCt4hdOzA=
+github.com/clipperhouse/uax29/v2 v2.5.0 h1:x7T0T4eTHDONxFJsL94uKNKPHrclyFI0lm7+w94cO8U=
+github.com/clipperhouse/uax29/v2 v2.5.0/go.mod h1:Wn1g7MK6OoeDT0vL+Q0SQLDz/KpfsVRgg6W7ihQeh4g=
 github.com/cloudflare/circl v1.6.4 h1:pOXuDTCEYyzydgUpQ0CQz3LsinKjiSk6nNP5Lt5K64U=
 github.com/cloudflare/circl v1.6.4/go.mod h1:YxarevkLlbaHuWsxG6vmYNWBEsSp4pnp7j+4VljMavY=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
@@ -387,6 +391,8 @@ github.com/go-viper/mapstructure/v2 v2.5.0 h1:vM5IJoUAy3d7zRSVtIwQgBj7BiWtMPfmPE
 github.com/go-viper/mapstructure/v2 v2.5.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
+github.com/goccy/go-json v0.10.6 h1:p8HrPJzOakx/mn/bQtjgNjdTcN+/S6FcG2CTtQOrHVU=
+github.com/goccy/go-json v0.10.6/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
 github.com/goccy/go-yaml v1.9.8/go.mod h1:JubOolP3gh0HpiBc4BLRD4YmjEjHAmIIB2aaXKkTfoE=
 github.com/goccy/go-yaml v1.19.2 h1:PmFC1S6h8ljIz6gMRBopkjP1TVT7xuwrButHID66PoM=
 github.com/goccy/go-yaml v1.19.2/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=
@@ -564,8 +570,8 @@ github.com/mattn/go-colorable v0.1.15/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stg
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-isatty v0.0.22 h1:j8l17JJ9i6VGPUFUYoTUKPSgKe/83EYU2zBC7YNKMw4=
 github.com/mattn/go-isatty v0.0.22/go.mod h1:ZXfXG4SQHsB/w3ZeOYbR0PrPwLy+n6xiMrJlRFqopa4=
-github.com/mattn/go-runewidth v0.0.15 h1:UNAjwbU9l54TA3KzvqLGxwWjHmMgBUVhBiTjelZgg3U=
-github.com/mattn/go-runewidth v0.0.15/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
+github.com/mattn/go-runewidth v0.0.19 h1:v++JhqYnZuu5jSKrk9RbgF5v4CGUjqRfBm05byFGLdw=
+github.com/mattn/go-runewidth v0.0.19/go.mod h1:XBkDxAl56ILZc9knddidhrOlY5R/pDhgLpndooCuJAs=
 github.com/mattn/go-sqlite3 v1.14.22 h1:2gZY6PC6kBnID23Tichd1K+Z0oS6nE/XwU+Vz/5o4kU=
 github.com/mattn/go-sqlite3 v1.14.22/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/microsoft/azure-devops-go-api/azuredevops/v7 v7.1.0 h1:mmJCWLe63QvybxhW1iBmQWEaCKdc4SKgALfTNZ+OphU=
@@ -687,9 +693,6 @@ github.com/redis/go-redis/extra/redisotel/v9 v9.0.5 h1:EfpWLLCyXw8PSM2/XNJLjI3Pb
 github.com/redis/go-redis/extra/redisotel/v9 v9.0.5/go.mod h1:WZjPDy7VNzn77AAfnAfVjZNvfJTYfPetfZk5yoSTLaQ=
 github.com/redis/go-redis/v9 v9.7.3 h1:YpPyAayJV+XErNsatSElgRZZVCwXX9QzkKYNvO7x0wM=
 github.com/redis/go-redis/v9 v9.7.3/go.mod h1:bGUrSggJ9X9GUmZpZNEOQKaANxSGgOEBRltRTZHSvrA=
-github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
-github.com/rivo/uniseg v0.4.4 h1:8TfxU8dW6PdqD27gjM8MVNuicgxIjxpm4K7x4jp8sis=
-github.com/rivo/uniseg v0.4.4/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/rogpeppe/go-internal v1.15.0 h1:D0RCU5rMAp+SpgkiNdrjfJ+LX4J1M32V2NeCY7EJ6hc=
 github.com/rogpeppe/go-internal v1.15.0/go.mod h1:DrUVZyrJU+txYW5/1kwtXQSMFio52ZOxX7yM1VHvnxs=
 github.com/rubenv/sql-migrate v1.8.1 h1:EPNwCvjAowHI3TnZ+4fQu3a915OpnQoPAjTXCGOy2U0=
@@ -766,6 +769,8 @@ github.com/tomwright/dasel v1.27.3 h1:vnoaZsG8hbubcdh2IioRVjOt2DTg+txLtDGKQn1cdA
 github.com/tomwright/dasel v1.27.3/go.mod h1:/rESPoTvQxRkrtEH8lhSU8CB2UWPh/bM0kDrKVGf1kQ=
 github.com/tomwright/dasel/v2 v2.8.1 h1:mo5SlL0V2d3a0uPsD9Rrndn0cHWpbNDheB4+Fm++z8k=
 github.com/tomwright/dasel/v2 v2.8.1/go.mod h1:6bNDNAnmGEtGpuIvksuQwiNcAgQ87pmzndynsqTNglc=
+github.com/tomwright/dasel/v3 v3.11.2 h1:rrvsZv0w4M7sEJ4inuORr7AD7KPG6CbgL3fHHpAcvNE=
+github.com/tomwright/dasel/v3 v3.11.2/go.mod h1:NMZl2F0lmpBnSsBg1rYUqGwwiLsB8SIWuqTVnT6wpfg=
 github.com/urfave/cli v1.22.17 h1:SYzXoiPfQjHBbkYxbew5prZHS1TOLT3ierW8SYLqtVQ=
 github.com/urfave/cli v1.22.17/go.mod h1:b0ht0aqgH/6pBYzzxURyrM4xXNgsoT/n2ZzwQiEhNVo=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=

--- a/pkg/plugins/autodiscovery/cargo/dependencies.go
+++ b/pkg/plugins/autodiscovery/cargo/dependencies.go
@@ -55,21 +55,21 @@ func (c Cargo) generateManifest(
 	}
 	var existingSourceKey string
 	if dependency.Inlined {
-		existingSourceKey = fmt.Sprintf("%s.%s", dependencyType, dependency.Name)
+		existingSourceKey = fmt.Sprintf("get(%q).get(%q)", dependencyType, dependency.Name)
 	} else {
-		existingSourceKey = fmt.Sprintf("%s.%s.version", dependencyType, dependency.Name)
+		existingSourceKey = fmt.Sprintf("get(%q).get(%q).version", dependencyType, dependency.Name)
 	}
 	var ConditionQuery string
 	if dependency.Inlined {
-		ConditionQuery = fmt.Sprintf("%s.(?:-=%s)", dependencyType, dependency.Name)
+		ConditionQuery = fmt.Sprintf("get(%q).(?:-=%q)", dependencyType, dependency.Name)
 	} else {
-		ConditionQuery = fmt.Sprintf("%s.(?:-=%s).version", dependencyType, dependency.Name)
+		ConditionQuery = fmt.Sprintf("get(%q).(?:-=%q).version", dependencyType, dependency.Name)
 	}
 	var TargetKey string
 	if dependency.Inlined {
-		TargetKey = fmt.Sprintf("%s.%s", dependencyType, dependency.Name)
+		TargetKey = fmt.Sprintf("get(%q).get(%q)", dependencyType, dependency.Name)
 	} else {
-		TargetKey = fmt.Sprintf("%s.%s.version", dependencyType, dependency.Name)
+		TargetKey = fmt.Sprintf("get(%q).get(%q).version", dependencyType, dependency.Name)
 	}
 	var Registry cargo.Registry
 	if dependency.Registry != "" {

--- a/pkg/plugins/autodiscovery/cargo/dependencyManifest.go
+++ b/pkg/plugins/autodiscovery/cargo/dependencyManifest.go
@@ -40,7 +40,8 @@ sources:
 {{- end }}
     spec:
       file: '{{ .CargoFile }}'
-      Key: '{{ .ExistingSourceKey }}'
+      key: '{{ .ExistingSourceKey }}'
+      engine: 'dasel'
 conditions:
   {{ .ConditionID }}:
     name: 'Test if version of "{{ .DependencyName }}" {{"{{"}} source "{{ .ExistingSourceID }}" {{"}}"}} differs from {{"{{"}} source "{{ .SourceID }}" {{"}}"}}'
@@ -80,6 +81,7 @@ targets:
     spec:
       file: '{{ .CargoFile }}'
       key: '{{ .TargetKey }}'
+      engine: 'dasel'
     sourceid: '{{ .SourceID }}'
 {{- if .CargoLockFile }}
   lockfile:

--- a/pkg/plugins/autodiscovery/cargo/main_test.go
+++ b/pkg/plugins/autodiscovery/cargo/main_test.go
@@ -42,7 +42,8 @@ sources:
     kind: 'toml'
     spec:
       file: 'Cargo.toml'
-      Key: 'dependencies.anyhow'
+      key: 'get("dependencies").get("anyhow")'
+      engine: 'dasel'
 conditions:
   anyhow:
     name: 'Test if version of "anyhow" {{ source "anyhow-current-version" }} differs from {{ source "anyhow" }}'
@@ -56,7 +57,8 @@ targets:
     kind: 'toml'
     spec:
       file: 'Cargo.toml'
-      key: 'dependencies.anyhow'
+      key: 'get("dependencies").get("anyhow")'
+      engine: 'dasel'
     sourceid: 'anyhow'
 `, `name: 'deps(cargo): bump dependency "rand" for "test-crate" crate'
 sources:
@@ -73,7 +75,8 @@ sources:
     kind: 'toml'
     spec:
       file: 'Cargo.toml'
-      Key: 'dependencies.rand.version'
+      key: 'get("dependencies").get("rand").version'
+      engine: 'dasel'
 conditions:
   rand:
     name: 'Test if version of "rand" {{ source "rand-current-version" }} differs from {{ source "rand" }}'
@@ -87,7 +90,8 @@ targets:
     kind: 'toml'
     spec:
       file: 'Cargo.toml'
-      key: 'dependencies.rand.version'
+      key: 'get("dependencies").get("rand").version'
+      engine: 'dasel'
     sourceid: 'rand'
 `, `name: 'deps(cargo): bump build dependency "built" for "test-crate" crate'
 sources:
@@ -104,7 +108,8 @@ sources:
     kind: 'toml'
     spec:
       file: 'Cargo.toml'
-      Key: 'build-dependencies.built'
+      key: 'get("build-dependencies").get("built")'
+      engine: 'dasel'
 conditions:
   built:
     name: 'Test if version of "built" {{ source "built-current-version" }} differs from {{ source "built" }}'
@@ -118,7 +123,8 @@ targets:
     kind: 'toml'
     spec:
       file: 'Cargo.toml'
-      key: 'build-dependencies.built'
+      key: 'get("build-dependencies").get("built")'
+      engine: 'dasel'
     sourceid: 'built'
 `, `name: 'deps(cargo): bump dev dependency "futures" for "test-crate" crate'
 sources:
@@ -135,7 +141,8 @@ sources:
     kind: 'toml'
     spec:
       file: 'Cargo.toml'
-      Key: 'dev-dependencies.futures.version'
+      key: 'get("dev-dependencies").get("futures").version'
+      engine: 'dasel'
 conditions:
   futures:
     name: 'Test if version of "futures" {{ source "futures-current-version" }} differs from {{ source "futures" }}'
@@ -149,7 +156,8 @@ targets:
     kind: 'toml'
     spec:
       file: 'Cargo.toml'
-      key: 'dev-dependencies.futures.version'
+      key: 'get("dev-dependencies").get("futures").version'
+      engine: 'dasel'
     sourceid: 'futures'
 `},
 		},
@@ -173,7 +181,8 @@ sources:
     kind: 'toml'
     spec:
       file: 'Cargo.toml'
-      Key: 'dependencies.anyhow'
+      key: 'get("dependencies").get("anyhow")'
+      engine: 'dasel'
 conditions:
   anyhow:
     name: 'Test if version of "anyhow" {{ source "anyhow-current-version" }} differs from {{ source "anyhow" }}'
@@ -187,7 +196,8 @@ targets:
     kind: 'toml'
     spec:
       file: 'Cargo.toml'
-      key: 'dependencies.anyhow'
+      key: 'get("dependencies").get("anyhow")'
+      engine: 'dasel'
     sourceid: 'anyhow'
 `, `name: 'deps(cargo): bump dependency "rand" for "test-crate" crate'
 sources:
@@ -204,7 +214,8 @@ sources:
     kind: 'toml'
     spec:
       file: 'Cargo.toml'
-      Key: 'dependencies.rand.version'
+      key: 'get("dependencies").get("rand").version'
+      engine: 'dasel'
 conditions:
   rand:
     name: 'Test if version of "rand" {{ source "rand-current-version" }} differs from {{ source "rand" }}'
@@ -218,7 +229,8 @@ targets:
     kind: 'toml'
     spec:
       file: 'Cargo.toml'
-      key: 'dependencies.rand.version'
+      key: 'get("dependencies").get("rand").version'
+      engine: 'dasel'
     sourceid: 'rand'
 `, `name: 'deps(cargo): bump build dependency "built" for "test-crate" crate'
 sources:
@@ -235,7 +247,8 @@ sources:
     kind: 'toml'
     spec:
       file: 'Cargo.toml'
-      Key: 'build-dependencies.built'
+      key: 'get("build-dependencies").get("built")'
+      engine: 'dasel'
 conditions:
   built:
     name: 'Test if version of "built" {{ source "built-current-version" }} differs from {{ source "built" }}'
@@ -249,7 +262,8 @@ targets:
     kind: 'toml'
     spec:
       file: 'Cargo.toml'
-      key: 'build-dependencies.built'
+      key: 'get("build-dependencies").get("built")'
+      engine: 'dasel'
     sourceid: 'built'
 `, `name: 'deps(cargo): bump dev dependency "futures" for "test-crate" crate'
 sources:
@@ -266,7 +280,8 @@ sources:
     kind: 'toml'
     spec:
       file: 'Cargo.toml'
-      Key: 'dev-dependencies.futures.version'
+      key: 'get("dev-dependencies").get("futures").version'
+      engine: 'dasel'
 conditions:
   futures:
     name: 'Test if version of "futures" {{ source "futures-current-version" }} differs from {{ source "futures" }}'
@@ -280,7 +295,8 @@ targets:
     kind: 'toml'
     spec:
       file: 'Cargo.toml'
-      key: 'dev-dependencies.futures.version'
+      key: 'get("dev-dependencies").get("futures").version'
+      engine: 'dasel'
     sourceid: 'futures'
 `},
 		},
@@ -304,7 +320,8 @@ sources:
     kind: 'toml'
     spec:
       file: 'Cargo.toml'
-      Key: 'dependencies.anyhow'
+      key: 'get("dependencies").get("anyhow")'
+      engine: 'dasel'
 conditions:
   anyhow:
     name: 'Test if version of "anyhow" {{ source "anyhow-current-version" }} differs from {{ source "anyhow" }}'
@@ -344,7 +361,8 @@ sources:
     kind: 'toml'
     spec:
       file: 'Cargo.toml'
-      Key: 'dependencies.rand.version'
+      key: 'get("dependencies").get("rand").version'
+      engine: 'dasel'
 conditions:
   rand:
     name: 'Test if version of "rand" {{ source "rand-current-version" }} differs from {{ source "rand" }}'
@@ -384,7 +402,8 @@ sources:
     kind: 'toml'
     spec:
       file: 'Cargo.toml'
-      Key: 'build-dependencies.built'
+      key: 'get("build-dependencies").get("built")'
+      engine: 'dasel'
 conditions:
   built:
     name: 'Test if version of "built" {{ source "built-current-version" }} differs from {{ source "built" }}'
@@ -424,7 +443,8 @@ sources:
     kind: 'toml'
     spec:
       file: 'Cargo.toml'
-      Key: 'dev-dependencies.futures.version'
+      key: 'get("dev-dependencies").get("futures").version'
+      engine: 'dasel'
 conditions:
   futures:
     name: 'Test if version of "futures" {{ source "futures-current-version" }} differs from {{ source "futures" }}'
@@ -478,7 +498,8 @@ sources:
     kind: 'toml'
     spec:
       file: 'Cargo.toml'
-      Key: 'dependencies.anyhow'
+      key: 'get("dependencies").get("anyhow")'
+      engine: 'dasel'
 conditions:
   anyhow:
     name: 'Test if version of "anyhow" {{ source "anyhow-current-version" }} differs from {{ source "anyhow" }}'
@@ -492,7 +513,8 @@ targets:
     kind: 'toml'
     spec:
       file: 'Cargo.toml'
-      key: 'dependencies.anyhow'
+      key: 'get("dependencies").get("anyhow")'
+      engine: 'dasel'
     sourceid: 'anyhow'
   lockfile:
     name: 'deps(cargo): update Cargo.lock following bump crate dependency "anyhow" to {{ source "anyhow" }}'
@@ -527,7 +549,8 @@ sources:
     kind: 'toml'
     spec:
       file: 'Cargo.toml'
-      Key: 'dependencies.rand.version'
+      key: 'get("dependencies").get("rand").version'
+      engine: 'dasel'
 conditions:
   rand:
     name: 'Test if version of "rand" {{ source "rand-current-version" }} differs from {{ source "rand" }}'
@@ -541,7 +564,8 @@ targets:
     kind: 'toml'
     spec:
       file: 'Cargo.toml'
-      key: 'dependencies.rand.version'
+      key: 'get("dependencies").get("rand").version'
+      engine: 'dasel'
     sourceid: 'rand'
   lockfile:
     name: 'deps(cargo): update Cargo.lock following bump crate dependency "rand" to {{ source "rand" }}'
@@ -576,7 +600,8 @@ sources:
     kind: 'toml'
     spec:
       file: 'Cargo.toml'
-      Key: 'dev-dependencies.futures.version'
+      key: 'get("dev-dependencies").get("futures").version'
+      engine: 'dasel'
 conditions:
   futures:
     name: 'Test if version of "futures" {{ source "futures-current-version" }} differs from {{ source "futures" }}'
@@ -590,7 +615,8 @@ targets:
     kind: 'toml'
     spec:
       file: 'Cargo.toml'
-      key: 'dev-dependencies.futures.version'
+      key: 'get("dev-dependencies").get("futures").version'
+      engine: 'dasel'
     sourceid: 'futures'
   lockfile:
     name: 'deps(cargo): update Cargo.lock following bump crate dev dependency "futures" to {{ source "futures" }}'
@@ -632,7 +658,8 @@ sources:
     kind: 'toml'
     spec:
       file: 'Cargo.toml'
-      Key: 'dependencies.anyhow'
+      key: 'get("dependencies").get("anyhow")'
+      engine: 'dasel'
 conditions:
   anyhow:
     name: 'Test if version of "anyhow" {{ source "anyhow-current-version" }} differs from {{ source "anyhow" }}'
@@ -674,7 +701,8 @@ sources:
     kind: 'toml'
     spec:
       file: 'Cargo.toml'
-      Key: 'dependencies.rand.version'
+      key: 'get("dependencies").get("rand").version'
+      engine: 'dasel'
 conditions:
   rand:
     name: 'Test if version of "rand" {{ source "rand-current-version" }} differs from {{ source "rand" }}'
@@ -716,7 +744,8 @@ sources:
     kind: 'toml'
     spec:
       file: 'Cargo.toml'
-      Key: 'dev-dependencies.futures.version'
+      key: 'get("dev-dependencies").get("futures").version'
+      engine: 'dasel'
 conditions:
   futures:
     name: 'Test if version of "futures" {{ source "futures-current-version" }} differs from {{ source "futures" }}'
@@ -765,7 +794,8 @@ sources:
     kind: 'toml'
     spec:
       file: 'Cargo.toml'
-      Key: 'workspace.dependencies.anyhow'
+      key: 'get("workspace.dependencies").get("anyhow")'
+      engine: 'dasel'
 conditions:
   anyhow:
     name: 'Test if version of "anyhow" {{ source "anyhow-current-version" }} differs from {{ source "anyhow" }}'
@@ -779,7 +809,8 @@ targets:
     kind: 'toml'
     spec:
       file: 'Cargo.toml'
-      key: 'workspace.dependencies.anyhow'
+      key: 'get("workspace.dependencies").get("anyhow")'
+      engine: 'dasel'
     sourceid: 'anyhow'
 `, `name: 'deps(cargo): bump workspace build dependency "built"'
 sources:
@@ -796,7 +827,8 @@ sources:
     kind: 'toml'
     spec:
       file: 'Cargo.toml'
-      Key: 'workspace.build-dependencies.built'
+      key: 'get("workspace.build-dependencies").get("built")'
+      engine: 'dasel'
 conditions:
   built:
     name: 'Test if version of "built" {{ source "built-current-version" }} differs from {{ source "built" }}'
@@ -810,7 +842,8 @@ targets:
     kind: 'toml'
     spec:
       file: 'Cargo.toml'
-      key: 'workspace.build-dependencies.built'
+      key: 'get("workspace.build-dependencies").get("built")'
+      engine: 'dasel'
     sourceid: 'built'
 `,
 				`name: 'deps(cargo): bump dependency "rand" for "simple_crate" crate'
@@ -828,7 +861,8 @@ sources:
     kind: 'toml'
     spec:
       file: 'crates/simple_crate/Cargo.toml'
-      Key: 'dependencies.rand.version'
+      key: 'get("dependencies").get("rand").version'
+      engine: 'dasel'
 conditions:
   rand:
     name: 'Test if version of "rand" {{ source "rand-current-version" }} differs from {{ source "rand" }}'
@@ -842,7 +876,8 @@ targets:
     kind: 'toml'
     spec:
       file: 'crates/simple_crate/Cargo.toml'
-      key: 'dependencies.rand.version'
+      key: 'get("dependencies").get("rand").version'
+      engine: 'dasel'
     sourceid: 'rand'
 `, `name: 'deps(cargo): bump dev dependency "futures" for "simple_crate" crate'
 sources:
@@ -859,7 +894,8 @@ sources:
     kind: 'toml'
     spec:
       file: 'crates/simple_crate/Cargo.toml'
-      Key: 'dev-dependencies.futures.version'
+      key: 'get("dev-dependencies").get("futures").version'
+      engine: 'dasel'
 conditions:
   futures:
     name: 'Test if version of "futures" {{ source "futures-current-version" }} differs from {{ source "futures" }}'
@@ -873,7 +909,8 @@ targets:
     kind: 'toml'
     spec:
       file: 'crates/simple_crate/Cargo.toml'
-      key: 'dev-dependencies.futures.version'
+      key: 'get("dev-dependencies").get("futures").version'
+      engine: 'dasel'
     sourceid: 'futures'
 `},
 		}, {
@@ -897,7 +934,8 @@ sources:
     kind: 'toml'
     spec:
       file: 'Cargo.toml'
-      Key: 'workspace.dependencies.anyhow'
+      key: 'get("workspace.dependencies").get("anyhow")'
+      engine: 'dasel'
 conditions:
   anyhow:
     name: 'Test if version of "anyhow" {{ source "anyhow-current-version" }} differs from {{ source "anyhow" }}'
@@ -911,7 +949,8 @@ targets:
     kind: 'toml'
     spec:
       file: 'Cargo.toml'
-      key: 'workspace.dependencies.anyhow'
+      key: 'get("workspace.dependencies").get("anyhow")'
+      engine: 'dasel'
     sourceid: 'anyhow'
 `, `name: 'deps(cargo): bump workspace build dependency "built"'
 sources:
@@ -928,7 +967,8 @@ sources:
     kind: 'toml'
     spec:
       file: 'Cargo.toml'
-      Key: 'workspace.build-dependencies.built'
+      key: 'get("workspace.build-dependencies").get("built")'
+      engine: 'dasel'
 conditions:
   built:
     name: 'Test if version of "built" {{ source "built-current-version" }} differs from {{ source "built" }}'
@@ -942,7 +982,8 @@ targets:
     kind: 'toml'
     spec:
       file: 'Cargo.toml'
-      key: 'workspace.build-dependencies.built'
+      key: 'get("workspace.build-dependencies").get("built")'
+      engine: 'dasel'
     sourceid: 'built'
 `,
 				`name: 'deps(cargo): bump dependency "rand" for "simple_crate" crate'
@@ -960,7 +1001,8 @@ sources:
     kind: 'toml'
     spec:
       file: 'crates/simple_crate/Cargo.toml'
-      Key: 'dependencies.rand.version'
+      key: 'get("dependencies").get("rand").version'
+      engine: 'dasel'
 conditions:
   rand:
     name: 'Test if version of "rand" {{ source "rand-current-version" }} differs from {{ source "rand" }}'
@@ -974,7 +1016,8 @@ targets:
     kind: 'toml'
     spec:
       file: 'crates/simple_crate/Cargo.toml'
-      key: 'dependencies.rand.version'
+      key: 'get("dependencies").get("rand").version'
+      engine: 'dasel'
     sourceid: 'rand'
 `, `name: 'deps(cargo): bump dev dependency "futures" for "simple_crate" crate'
 sources:
@@ -991,7 +1034,8 @@ sources:
     kind: 'toml'
     spec:
       file: 'crates/simple_crate/Cargo.toml'
-      Key: 'dev-dependencies.futures.version'
+      key: 'get("dev-dependencies").get("futures").version'
+      engine: 'dasel'
 conditions:
   futures:
     name: 'Test if version of "futures" {{ source "futures-current-version" }} differs from {{ source "futures" }}'
@@ -1005,7 +1049,8 @@ targets:
     kind: 'toml'
     spec:
       file: 'crates/simple_crate/Cargo.toml'
-      key: 'dev-dependencies.futures.version'
+      key: 'get("dev-dependencies").get("futures").version'
+      engine: 'dasel'
     sourceid: 'futures'
 `},
 		}, {
@@ -1028,7 +1073,8 @@ sources:
     kind: 'toml'
     spec:
       file: 'Cargo.toml'
-      Key: 'workspace.dependencies.anyhow'
+      key: 'get("workspace.dependencies").get("anyhow")'
+      engine: 'dasel'
 conditions:
   anyhow:
     name: 'Test if version of "anyhow" {{ source "anyhow-current-version" }} differs from {{ source "anyhow" }}'
@@ -1068,7 +1114,8 @@ sources:
     kind: 'toml'
     spec:
       file: 'Cargo.toml'
-      Key: 'workspace.build-dependencies.built'
+      key: 'get("workspace.build-dependencies").get("built")'
+      engine: 'dasel'
 conditions:
   built:
     name: 'Test if version of "built" {{ source "built-current-version" }} differs from {{ source "built" }}'
@@ -1108,7 +1155,8 @@ sources:
     kind: 'toml'
     spec:
       file: 'crates/simple_crate/Cargo.toml'
-      Key: 'dependencies.rand.version'
+      key: 'get("dependencies").get("rand").version'
+      engine: 'dasel'
 conditions:
   rand:
     name: 'Test if version of "rand" {{ source "rand-current-version" }} differs from {{ source "rand" }}'
@@ -1148,7 +1196,8 @@ sources:
     kind: 'toml'
     spec:
       file: 'crates/simple_crate/Cargo.toml'
-      Key: 'dev-dependencies.futures.version'
+      key: 'get("dev-dependencies").get("futures").version'
+      engine: 'dasel'
 conditions:
   futures:
     name: 'Test if version of "futures" {{ source "futures-current-version" }} differs from {{ source "futures" }}'
@@ -1202,7 +1251,8 @@ sources:
     kind: 'toml'
     spec:
       file: 'Cargo.toml'
-      Key: 'workspace.dependencies.anyhow'
+      key: 'get("workspace.dependencies").get("anyhow")'
+      engine: 'dasel'
 conditions:
   anyhow:
     name: 'Test if version of "anyhow" {{ source "anyhow-current-version" }} differs from {{ source "anyhow" }}'
@@ -1216,7 +1266,8 @@ targets:
     kind: 'toml'
     spec:
       file: 'Cargo.toml'
-      key: 'workspace.dependencies.anyhow'
+      key: 'get("workspace.dependencies").get("anyhow")'
+      engine: 'dasel'
     sourceid: 'anyhow'
   lockfile:
     name: 'deps(cargo): update Cargo.lock following bump workspace dependency "anyhow" to {{ source "anyhow" }}'
@@ -1252,7 +1303,8 @@ sources:
     kind: 'toml'
     spec:
       file: 'crates/simple_crate/Cargo.toml'
-      Key: 'dependencies.rand.version'
+      key: 'get("dependencies").get("rand").version'
+      engine: 'dasel'
 conditions:
   rand:
     name: 'Test if version of "rand" {{ source "rand-current-version" }} differs from {{ source "rand" }}'
@@ -1266,7 +1318,8 @@ targets:
     kind: 'toml'
     spec:
       file: 'crates/simple_crate/Cargo.toml'
-      key: 'dependencies.rand.version'
+      key: 'get("dependencies").get("rand").version'
+      engine: 'dasel'
     sourceid: 'rand'
   lockfile:
     name: 'deps(cargo): update Cargo.lock following bump crate dependency "rand" to {{ source "rand" }}'
@@ -1301,7 +1354,8 @@ sources:
     kind: 'toml'
     spec:
       file: 'crates/simple_crate/Cargo.toml'
-      Key: 'dev-dependencies.futures.version'
+      key: 'get("dev-dependencies").get("futures").version'
+      engine: 'dasel'
 conditions:
   futures:
     name: 'Test if version of "futures" {{ source "futures-current-version" }} differs from {{ source "futures" }}'
@@ -1315,7 +1369,8 @@ targets:
     kind: 'toml'
     spec:
       file: 'crates/simple_crate/Cargo.toml'
-      key: 'dev-dependencies.futures.version'
+      key: 'get("dev-dependencies").get("futures").version'
+      engine: 'dasel'
     sourceid: 'futures'
   lockfile:
     name: 'deps(cargo): update Cargo.lock following bump crate dev dependency "futures" to {{ source "futures" }}'
@@ -1363,7 +1418,8 @@ sources:
     scmid: 'git'
     spec:
       file: 'Cargo.toml'
-      Key: 'workspace.dependencies.anyhow'
+      key: 'get("workspace.dependencies").get("anyhow")'
+      engine: 'dasel'
 conditions:
   anyhow:
     name: 'Test if version of "anyhow" {{ source "anyhow-current-version" }} differs from {{ source "anyhow" }}'
@@ -1411,7 +1467,8 @@ sources:
     scmid: 'git'
     spec:
       file: 'crates/simple_crate/Cargo.toml'
-      Key: 'dependencies.rand.version'
+      key: 'get("dependencies").get("rand").version'
+      engine: 'dasel'
 conditions:
   rand:
     name: 'Test if version of "rand" {{ source "rand-current-version" }} differs from {{ source "rand" }}'
@@ -1459,7 +1516,8 @@ sources:
     scmid: 'git'
     spec:
       file: 'crates/simple_crate/Cargo.toml'
-      Key: 'dev-dependencies.futures.version'
+      key: 'get("dev-dependencies").get("futures").version'
+      engine: 'dasel'
 conditions:
   futures:
     name: 'Test if version of "futures" {{ source "futures-current-version" }} differs from {{ source "futures" }}'

--- a/pkg/plugins/resources/csv/condition.go
+++ b/pkg/plugins/resources/csv/condition.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/sirupsen/logrus"
 	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
 )
 
@@ -32,20 +33,41 @@ func (c *CSV) Condition(_ context.Context, source string, scm scm.ScmHandler) (p
 		var queryResults []string
 		var err error
 
-		switch len(c.spec.Query) > 0 {
-		case true:
-			queryResults, err = c.contents[i].MultipleQuery(c.spec.Query)
-			if err != nil {
-				return false, "", fmt.Errorf("running queries: %w", err)
+		switch c.engine {
+		case ENGINEDASEL_V1:
+			logrus.Debugf("Using engine %q", c.engine)
+			switch len(c.spec.Query) > 0 {
+			case true:
+				queryResults, err = c.contents[i].MultipleQuery(c.spec.Query)
+				if err != nil {
+					return false, "", fmt.Errorf("running queries: %w", err)
+				}
+
+			case false:
+				queryResult, err := c.contents[i].Query(c.spec.Key)
+				if err != nil {
+					return false, "", fmt.Errorf("running query: %w", err)
+				}
+
+				queryResults = []string{queryResult}
 			}
 
-		case false:
-			queryResult, err := c.contents[i].Query(c.spec.Key)
+		case ENGINEDASEL_V2:
+			logrus.Debugf("Using engine %q", c.engine)
+			queryResults, err = c.contents[i].QueryV2(c.spec.Key)
 			if err != nil {
-				return false, "", fmt.Errorf("running query: %w", err)
+				return false, "", fmt.Errorf("querying file %q: %w", c.contents[i].FilePath, err)
 			}
 
-			queryResults = []string{queryResult}
+		case ENGINEDASEL_V3:
+			logrus.Debugf("Using engine %q", c.engine)
+			queryResults, err = c.contents[i].QueryV3(c.spec.Key)
+			if err != nil {
+				return false, "", fmt.Errorf("querying file %q: %w", c.contents[i].FilePath, err)
+			}
+
+		default:
+			return false, "", fmt.Errorf("engine %q is not supported", c.engine)
 		}
 
 		for _, queryResult := range queryResults {

--- a/pkg/plugins/resources/csv/condition_test.go
+++ b/pkg/plugins/resources/csv/condition_test.go
@@ -75,6 +75,36 @@ func TestCondition(t *testing.T) {
 			expectedResult: true,
 		},
 		{
+			name: "Default scenario with Dasel v2",
+			spec: Spec{
+				File:   "testdata/data.csv",
+				Key:    ".[0].firstname",
+				Value:  "John",
+				Engine: strPtr(ENGINEDASEL_V2),
+			},
+			expectedResult: true,
+		},
+		{
+			name: "Default scenario with Dasel v3",
+			spec: Spec{
+				File:   "testdata/data.csv",
+				Key:    "$this[0].firstname",
+				Value:  "John",
+				Engine: strPtr(ENGINEDASEL_V3),
+			},
+			expectedResult: true,
+		},
+		{
+			name: "Mismatching value with Dasel v3",
+			spec: Spec{
+				File:   "testdata/data.csv",
+				Key:    "$this[0].firstname",
+				Value:  "NotJohn",
+				Engine: strPtr(ENGINEDASEL_V3),
+			},
+			expectedResult: false,
+		},
+		{
 			name: "Test key do not exist",
 			spec: Spec{
 				File:  "testdata/data.csv",

--- a/pkg/plugins/resources/csv/csvContent.go
+++ b/pkg/plugins/resources/csv/csvContent.go
@@ -4,6 +4,7 @@ import (
 	"encoding/csv"
 	"fmt"
 	"os"
+	"reflect"
 	"strings"
 
 	das "github.com/tomwright/dasel"
@@ -75,7 +76,30 @@ func (c *csvContent) Read(rootDir string) error {
 
 	c.DaselNode = das.New(c.csvDocument.Documents())
 
+	// dasel v2 and v3 operate on the native parsed rows. They share the same
+	// []map[string]interface{} backing slice as csvDocument.Value so that a v3
+	// in-place modification is reflected when the file is written back.
+	c.DaselV2Node = c.csvDocument.Value
+	c.DaselV3Data = c.csvDocument.Value
+
 	return nil
+}
+
+// derefValue unwraps pointer/interface indirections around a value. The dasel v3
+// engine stores modified values as *interface{}, so this resolves them to the
+// underlying value before serialization. It is a no-op for plain values (v1/v2).
+func derefValue(v interface{}) interface{} {
+	rv := reflect.ValueOf(v)
+	for rv.IsValid() && (rv.Kind() == reflect.Ptr || rv.Kind() == reflect.Interface) {
+		if rv.IsNil() {
+			return nil
+		}
+		rv = rv.Elem()
+	}
+	if !rv.IsValid() {
+		return nil
+	}
+	return rv.Interface()
 }
 
 func (c *csvContent) Write() error {
@@ -104,7 +128,7 @@ func (c *csvContent) Write() error {
 			if !ok {
 				val = ""
 			}
-			values = append(values, fmt.Sprint(val))
+			values = append(values, fmt.Sprint(derefValue(val)))
 		}
 
 		if err := writer.Write(values); err != nil {

--- a/pkg/plugins/resources/csv/main.go
+++ b/pkg/plugins/resources/csv/main.go
@@ -31,6 +31,9 @@ type CSV struct {
 	foundVersion version.Version
 	// Holds the "valid" version.filter, that might be different than the user-specified filter (Spec.VersionFilter)
 	versionFilter version.Filter
+	// engine defines the engine used to manipulate the csv file
+	// If not set, the default engine is dasel/v1
+	engine string
 }
 
 func New(spec interface{}) (*CSV, error) {
@@ -76,9 +79,24 @@ func New(spec interface{}) (*CSV, error) {
 		return nil, err
 	}
 
+	engine := ENGINEDEFAULT
+	if newSpec.Engine != nil {
+		// Resolve aliases (e.g. bare "dasel" -> latest engine) so the rest of the
+		// code only ever deals with explicit engine versions.
+		engine = resolveEngine(*newSpec.Engine)
+	}
+
+	if engine == ENGINEDASEL_V1 {
+		logrus.Warningf("Engine %q is deprecated and will be removed in a future updatecli version. Please use %q instead.",
+			ENGINEDASEL_V1,
+			ENGINEDASEL_V2,
+		)
+	}
+
 	c := CSV{
 		spec:          newSpec,
 		versionFilter: newFilter,
+		engine:        engine,
 	}
 
 	// Init currentContents
@@ -117,10 +135,11 @@ func New(spec interface{}) (*CSV, error) {
 // to identify the resource without any sensitive information or context specific data.
 func (c *CSV) ReportConfig() interface{} {
 	return Spec{
-		File:  c.spec.File,
-		Files: c.spec.Files,
-		Key:   c.spec.Key,
-		Query: c.spec.Query,
-		Value: c.spec.Value,
+		File:   c.spec.File,
+		Files:  c.spec.Files,
+		Key:    c.spec.Key,
+		Query:  c.spec.Query,
+		Value:  c.spec.Value,
+		Engine: c.spec.Engine,
 	}
 }

--- a/pkg/plugins/resources/csv/main.go
+++ b/pkg/plugins/resources/csv/main.go
@@ -89,7 +89,14 @@ func New(spec interface{}) (*CSV, error) {
 	if engine == ENGINEDASEL_V1 {
 		logrus.Warningf("Engine %q is deprecated and will be removed in a future updatecli version. Please use %q instead.",
 			ENGINEDASEL_V1,
+			ENGINEDASEL_V3,
+		)
+	}
+
+	if engine == ENGINEDASEL_V2 {
+		logrus.Warningf("Engine %q is deprecated and will be removed in a future updatecli version. Please use %q instead.",
 			ENGINEDASEL_V2,
+			ENGINEDASEL_V3,
 		)
 	}
 

--- a/pkg/plugins/resources/csv/source.go
+++ b/pkg/plugins/resources/csv/source.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/sirupsen/logrus"
 	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
@@ -19,8 +20,9 @@ func (c *CSV) Source(_ context.Context, workingDir string, resultSource *result.
 		return errors.New("source only supports one file")
 	}
 
-	if (len(c.spec.Query) > 0 && c.spec.VersionFilter.IsZero()) ||
-		(len(c.spec.Query) == 0) && !c.spec.VersionFilter.IsZero() {
+	if c.engine != ENGINEDASEL_V2 && c.engine != ENGINEDASEL_V3 &&
+		((len(c.spec.Query) > 0 && c.spec.VersionFilter.IsZero()) ||
+			(len(c.spec.Query) == 0) && !c.spec.VersionFilter.IsZero()) {
 		return ErrSpecVersionFilterRequireMultiple
 	}
 
@@ -33,13 +35,55 @@ func (c *CSV) Source(_ context.Context, workingDir string, resultSource *result.
 	}
 
 	query := ""
-	switch len(c.spec.Query) > 0 {
-	case true:
-		query = c.spec.Query
-		queryResults, err := content.MultipleQuery(query)
+	switch c.engine {
+	case ENGINEDASEL_V1:
+		logrus.Debugf("Using engine %q", c.engine)
+		switch len(c.spec.Query) > 0 {
+		case true:
+			query = c.spec.Query
+			queryResults, err := content.MultipleQuery(query)
 
+			if err != nil {
+				return fmt.Errorf("running multi query: %w", err)
+			}
+
+			c.foundVersion, err = c.versionFilter.Search(queryResults)
+			if err != nil {
+				return fmt.Errorf("filtering version: %w", err)
+			}
+			sourceOutput = c.foundVersion.GetVersion()
+
+		case false:
+			query = c.spec.Key
+			queryResult, err := content.DaselNode.Query(query)
+			if err != nil {
+				// Catch error message returned by Dasel, if it couldn't find the node
+				// This is approach is not very robust
+				// https://github.com/TomWright/dasel/blob/master/node_query.go#L58
+
+				if strings.HasPrefix(err.Error(), "could not find value:") {
+					err := fmt.Errorf("cannot find value for path %q from file %q",
+						c.spec.Key,
+						content.FilePath)
+					return err
+				}
+				return err
+			}
+
+			sourceOutput = queryResult.String()
+		}
+
+	case ENGINEDASEL_V2:
+		logrus.Debugf("Using engine %q", c.engine)
+		query = c.spec.Key
+		queryResults, err := content.QueryV2(c.spec.Key)
 		if err != nil {
-			return fmt.Errorf("running multi query: %w", err)
+			if strings.Contains(err.Error(), "property not found") {
+				return fmt.Errorf("cannot find value for path %q from file %q",
+					c.spec.Key,
+					content.FilePath)
+			}
+			return fmt.Errorf("running query %q: %w", c.spec.Key, err)
 		}
 
 		c.foundVersion, err = c.versionFilter.Search(queryResults)
@@ -48,24 +92,27 @@ func (c *CSV) Source(_ context.Context, workingDir string, resultSource *result.
 		}
 		sourceOutput = c.foundVersion.GetVersion()
 
-	case false:
+	case ENGINEDASEL_V3:
+		logrus.Debugf("Using engine %q", c.engine)
 		query = c.spec.Key
-		queryResult, err := content.DaselNode.Query(query)
+		queryResults, err := content.QueryV3(c.spec.Key)
 		if err != nil {
-			// Catch error message returned by Dasel, if it couldn't find the node
-			// This is approach is not very robust
-			// https://github.com/TomWright/dasel/blob/master/node_query.go#L58
-
-			if strings.HasPrefix(err.Error(), "could not find value:") {
-				err := fmt.Errorf("cannot find value for path %q from file %q",
+			if strings.Contains(err.Error(), "map key not found") {
+				return fmt.Errorf("cannot find value for path %q from file %q",
 					c.spec.Key,
 					content.FilePath)
-				return err
 			}
-			return err
+			return fmt.Errorf("running query %q: %w", c.spec.Key, err)
 		}
 
-		sourceOutput = queryResult.String()
+		c.foundVersion, err = c.versionFilter.Search(queryResults)
+		if err != nil {
+			return fmt.Errorf("filtering version: %w", err)
+		}
+		sourceOutput = c.foundVersion.GetVersion()
+
+	default:
+		return fmt.Errorf("engine %q not supported", c.engine)
 	}
 
 	resultSource.Result = result.SUCCESS

--- a/pkg/plugins/resources/csv/source_test.go
+++ b/pkg/plugins/resources/csv/source_test.go
@@ -12,6 +12,10 @@ import (
 	"github.com/updatecli/updatecli/pkg/plugins/utils/version"
 )
 
+func strPtr(s string) *string {
+	return &s
+}
+
 func TestSource(t *testing.T) {
 
 	testData := []struct {
@@ -71,6 +75,75 @@ func TestSource(t *testing.T) {
 			expectedResult:   "",
 			wantErr:          true,
 			expectedErrorMsg: errors.New("cannot find value for path \".doNotExist\" from file \"testdata/data.csv\""),
+		},
+		{
+			name: "Default successful workflow with Dasel v2",
+			spec: Spec{
+				File:   "testdata/data.csv",
+				Key:    ".[0].firstname",
+				Engine: strPtr(ENGINEDASEL_V2),
+			},
+			expectedResult: "John",
+		},
+		{
+			name: "Default successful workflow with Dasel v3",
+			spec: Spec{
+				File:   "testdata/data.csv",
+				Key:    "$this[0].firstname",
+				Engine: strPtr(ENGINEDASEL_V3),
+			},
+			expectedResult: "John",
+		},
+		{
+			name: "Row of a different column with Dasel v3",
+			spec: Spec{
+				File:   "testdata/data.csv",
+				Key:    "$this[2].surname",
+				Engine: strPtr(ENGINEDASEL_V3),
+			},
+			expectedResult: "Olblak",
+		},
+		{
+			name: "Empty result with Dasel v3",
+			spec: Spec{
+				File:   "testdata/data.csv",
+				Key:    "$this[0].surname",
+				Engine: strPtr(ENGINEDASEL_V3),
+			},
+			expectedResult: "",
+		},
+		{
+			name: "Test key do not exist with Dasel v3",
+			spec: Spec{
+				File:   "testdata/data.csv",
+				Key:    "$this[0].doNotExist",
+				Engine: strPtr(ENGINEDASEL_V3),
+			},
+			expectedResult:   "",
+			wantErr:          true,
+			expectedErrorMsg: errors.New("cannot find value for path \"$this[0].doNotExist\" from file \"testdata/data.csv\""),
+		},
+		{
+			name: "Version filter across rows with Dasel v3",
+			spec: Spec{
+				File:   "testdata/data.csv",
+				Key:    "map(firstname)...",
+				Engine: strPtr(ENGINEDASEL_V3),
+				VersionFilter: version.Filter{
+					Kind:    "regex",
+					Pattern: "^Jo",
+				},
+			},
+			expectedResult: "John",
+		},
+		{
+			name: "Bare dasel alias resolves to latest engine (v3)",
+			spec: Spec{
+				File:   "testdata/data.csv",
+				Key:    "$this[0].firstname",
+				Engine: strPtr(ENGINEDASEL_LATEST),
+			},
+			expectedResult: "John",
 		},
 	}
 

--- a/pkg/plugins/resources/csv/spec.go
+++ b/pkg/plugins/resources/csv/spec.go
@@ -2,12 +2,29 @@ package csv
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/sirupsen/logrus"
 	"github.com/updatecli/updatecli/pkg/plugins/utils/version"
 )
 
 type Spec struct {
+	// engine defines the engine used to manipulate the csv file.
+	//
+	// compatible:
+	//   * source
+	//   * condition
+	//   * target
+	//
+	// default:
+	//   * "dasel/v1" is the default engine used to manipulate csv files
+	//
+	// accepted values:
+	//   * "dasel/v1" for dasel v1 engine
+	//   * "dasel/v2" for dasel v2 engine
+	//   * "dasel/v3" for dasel v3 engine
+	//   * "dasel" for the latest dasel engine which is currently dasel v3
+	Engine *string `yaml:",omitempty"`
 	// [s][c][t] File specifies the csv file
 	File string `yaml:",omitempty"`
 	// [c][t] Files specifies a list of Json file to manipulate
@@ -36,6 +53,28 @@ var (
 	ErrWrongSpec error = errors.New("wrong spec content")
 )
 
+const (
+	ENGINEDASEL_V1 = "dasel/v1"
+	ENGINEDASEL_V2 = "dasel/v2"
+	ENGINEDASEL_V3 = "dasel/v3"
+	// ENGINEDASEL_LATEST is an alias resolving to the latest dasel engine.
+	ENGINEDASEL_LATEST = "dasel"
+	ENGINEDEFAULT      = ENGINEDASEL_V1
+)
+
+// resolveEngine normalizes a user-provided engine value, resolving the "dasel"
+// alias to the latest supported engine. An empty value resolves to the default.
+func resolveEngine(engine string) string {
+	switch engine {
+	case "":
+		return ENGINEDEFAULT
+	case ENGINEDASEL_LATEST:
+		return ENGINEDASEL_V3
+	default:
+		return engine
+	}
+}
+
 func (s *Spec) Validate() error {
 	var errs []error
 	if len(s.File) == 0 && len(s.Files) == 0 {
@@ -47,6 +86,16 @@ func (s *Spec) Validate() error {
 
 	if len(s.File) > 0 && len(s.Files) > 0 {
 		errs = append(errs, ErrSpecFileAndFilesDefined)
+	}
+
+	engine := ENGINEDEFAULT
+	if s.Engine != nil {
+		engine = resolveEngine(*s.Engine)
+	}
+
+	// dasel v2 and v3 deprecate the "query" parameter in favor of "key".
+	if (engine == ENGINEDASEL_V2 || engine == ENGINEDASEL_V3) && len(s.Query) > 0 && len(s.Key) == 0 {
+		errs = append(errs, fmt.Errorf("engine %q requires the parameter \"key\" over \"query\"", engine))
 	}
 
 	if len(errs) > 0 {

--- a/pkg/plugins/resources/csv/target.go
+++ b/pkg/plugins/resources/csv/target.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/sirupsen/logrus"
 	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
 	"github.com/updatecli/updatecli/pkg/core/result"
 )
@@ -42,25 +43,48 @@ func (c *CSV) Target(_ context.Context, source string, scm scm.ScmHandler, dryRu
 		var err error
 
 		query := ""
-		switch len(c.spec.Query) > 0 {
-		case true:
-			query = c.spec.Query
-			queryResults, err = c.contents[i].MultipleQuery(c.spec.Query)
+		switch c.engine {
+		case ENGINEDASEL_V1:
+			logrus.Debugf("Using engine %q", c.engine)
+			switch len(c.spec.Query) > 0 {
+			case true:
+				query = c.spec.Query
+				queryResults, err = c.contents[i].MultipleQuery(c.spec.Query)
 
-			if err != nil {
-				return err
+				if err != nil {
+					return err
+				}
+
+			case false:
+				query = c.spec.Key
+				queryResult, err := c.contents[i].Query(c.spec.Key)
+
+				if err != nil {
+					return err
+				}
+
+				queryResults = append(queryResults, queryResult)
+
 			}
 
-		case false:
+		case ENGINEDASEL_V2:
+			logrus.Debugf("Using engine %q", c.engine)
 			query = c.spec.Key
-			queryResult, err := c.contents[i].Query(c.spec.Key)
-
+			queryResults, err = c.contents[i].QueryV2(c.spec.Key)
 			if err != nil {
 				return err
 			}
 
-			queryResults = append(queryResults, queryResult)
+		case ENGINEDASEL_V3:
+			logrus.Debugf("Using engine %q", c.engine)
+			query = c.spec.Key
+			queryResults, err = c.contents[i].QueryV3(c.spec.Key)
+			if err != nil {
+				return err
+			}
 
+		default:
+			return fmt.Errorf("engine %q is not supported", c.engine)
 		}
 
 		fileChanged := false
@@ -96,20 +120,30 @@ func (c *CSV) Target(_ context.Context, source string, scm scm.ScmHandler, dryRu
 			continue
 		}
 
-		// Update the target file with the new value
-		switch len(c.spec.Query) > 0 {
-		case true:
-			err = c.contents[i].PutMultiple(c.spec.Query, c.spec.Value)
-
-			if err != nil {
+		// Update the target file with the new value.
+		// The dasel v3 engine mutates the native parsed rows in place; the CSV
+		// writer then serializes those rows. v1 and v2 use the shared v1 node.
+		switch c.engine {
+		case ENGINEDASEL_V3:
+			if err = c.contents[i].PutV3(c.spec.Key, c.spec.Value); err != nil {
 				return err
 			}
 
-		case false:
-			err = c.contents[i].Put(c.spec.Key, c.spec.Value)
+		default:
+			switch len(c.spec.Query) > 0 {
+			case true:
+				err = c.contents[i].PutMultiple(c.spec.Query, c.spec.Value)
 
-			if err != nil {
-				return err
+				if err != nil {
+					return err
+				}
+
+			case false:
+				err = c.contents[i].Put(c.spec.Key, c.spec.Value)
+
+				if err != nil {
+					return err
+				}
 			}
 		}
 

--- a/pkg/plugins/resources/csv/target_test.go
+++ b/pkg/plugins/resources/csv/target_test.go
@@ -3,6 +3,7 @@ package csv
 import (
 	"context"
 	"errors"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -61,6 +62,26 @@ func TestTarget(t *testing.T) {
 			wantErr:          true,
 			expectedErrorMsg: errors.New("could not find value for query \".[0].DoNotExist\" from file \"testdata/data.2.csv\""),
 		},
+		{
+			name: "Changed workflow with Dasel v3",
+			spec: Spec{
+				File:   "testdata/data.csv",
+				Key:    "$this[0].firstname",
+				Engine: strPtr(ENGINEDASEL_V3),
+			},
+			sourceInput:    "Tom",
+			expectedResult: true,
+		},
+		{
+			name: "Unchanged workflow with Dasel v3",
+			spec: Spec{
+				File:   "testdata/data.csv",
+				Key:    "$this[0].firstname",
+				Engine: strPtr(ENGINEDASEL_V3),
+			},
+			sourceInput:    "John",
+			expectedResult: false,
+		},
 	}
 
 	for _, tt := range testData {
@@ -82,4 +103,43 @@ func TestTarget(t *testing.T) {
 			assert.Equal(t, tt.expectedResult, gotResult.Changed)
 		})
 	}
+}
+
+// TestTargetDaselV3Write exercises the dasel v3 write path with a real (dryRun=false)
+// write to disk. The dasel v3 engine stores modified values as *interface{}, so this
+// verifies the CSV writer resolves them to plain strings (not pointer addresses) and
+// leaves the rest of the document intact.
+func TestTargetDaselV3Write(t *testing.T) {
+	initialCSV := "firstname,surname,lastname\nJohn,,Smith\nAlexis,Alex,Remi\n"
+
+	dir := t.TempDir()
+	filePath := dir + "/data.csv"
+	require.NoError(t, os.WriteFile(filePath, []byte(initialCSV), 0600))
+
+	spec := Spec{
+		File:   filePath,
+		Key:    "$this[0].firstname",
+		Value:  "Tom",
+		Engine: strPtr(ENGINEDASEL_V3),
+	}
+
+	c, err := New(spec)
+	require.NoError(t, err)
+
+	gotResult := result.Target{}
+	// dryRun=false so the file is actually written back to disk.
+	err = c.Target(context.Background(), "Tom", nil, false, &gotResult)
+	require.NoError(t, err)
+	assert.True(t, gotResult.Changed)
+
+	content, err := os.ReadFile(filePath)
+	require.NoError(t, err)
+
+	got := string(content)
+	// The updated cell must be the plain value, not a pointer address (0x...).
+	assert.Contains(t, got, "Tom,,Smith", "expected first row firstname updated to Tom, got:\n%s", got)
+	assert.NotContains(t, got, "0x", "expected no pointer address leaked into the CSV, got:\n%s", got)
+	// Untouched rows and headers survive.
+	assert.Contains(t, got, "firstname,surname,lastname", "expected header preserved, got:\n%s", got)
+	assert.Contains(t, got, "Alexis,Alex,Remi", "expected second row preserved, got:\n%s", got)
 }

--- a/pkg/plugins/resources/json/condition.go
+++ b/pkg/plugins/resources/json/condition.go
@@ -57,6 +57,13 @@ func (j *Json) Condition(_ context.Context, source string, scm scm.ScmHandler) (
 				return false, "", fmt.Errorf("querying file %q: %w", j.contents[i].FilePath, err)
 			}
 
+		case ENGINEDASEL_V3:
+			logrus.Debugf("Using engine %q", ENGINEDASEL_V3)
+			queryResults, err = j.contents[i].QueryV3(j.spec.Key)
+			if err != nil {
+				return false, "", fmt.Errorf("querying file %q: %w", j.contents[i].FilePath, err)
+			}
+
 		default:
 			return false, "", fmt.Errorf("engine %q is not supported", j.engine)
 		}

--- a/pkg/plugins/resources/json/condition_test.go
+++ b/pkg/plugins/resources/json/condition_test.go
@@ -76,6 +76,36 @@ func TestCondition(t *testing.T) {
 			expectedResult: true,
 		},
 		{
+			name: "Default scenario with Dasel v3",
+			spec: Spec{
+				File:   "testdata/data.json",
+				Key:    "firstName",
+				Value:  "Jack",
+				Engine: strPtr(ENGINEDASEL_V3),
+			},
+			expectedResult: true,
+		},
+		{
+			name: "Nested array item with Dasel v3",
+			spec: Spec{
+				File:   "testdata/data.json",
+				Key:    "phoneNumbers[0].type",
+				Value:  "home",
+				Engine: strPtr(ENGINEDASEL_V3),
+			},
+			expectedResult: true,
+		},
+		{
+			name: "Mismatching value with Dasel v3",
+			spec: Spec{
+				File:   "testdata/data.json",
+				Key:    "firstName",
+				Value:  "NotJack",
+				Engine: strPtr(ENGINEDASEL_V3),
+			},
+			expectedResult: false,
+		},
+		{
 			name: "Test key do not exist",
 			spec: Spec{
 				File:  "testdata/data.json",

--- a/pkg/plugins/resources/json/main.go
+++ b/pkg/plugins/resources/json/main.go
@@ -59,7 +59,9 @@ func New(spec interface{}) (*Json, error) {
 
 	engine := ENGINEDEFAULT
 	if newSpec.Engine != nil {
-		engine = *newSpec.Engine
+		// Resolve aliases (e.g. bare "dasel" -> latest engine) so the rest of the
+		// code only ever deals with explicit engine versions.
+		engine = resolveEngine(*newSpec.Engine)
 	}
 
 	if engine == ENGINEDASEL_V1 {

--- a/pkg/plugins/resources/json/main.go
+++ b/pkg/plugins/resources/json/main.go
@@ -67,7 +67,14 @@ func New(spec interface{}) (*Json, error) {
 	if engine == ENGINEDASEL_V1 {
 		logrus.Warningf("Engine %q is deprecated and will be removed in a future updatecli version. Please use %q instead.",
 			ENGINEDASEL_V1,
+			ENGINEDASEL_V3,
+		)
+	}
+
+	if engine == ENGINEDASEL_V2 {
+		logrus.Warningf("Engine %q is deprecated and will be removed in a future updatecli version. Please use %q instead.",
 			ENGINEDASEL_V2,
+			ENGINEDASEL_V3,
 		)
 	}
 

--- a/pkg/plugins/resources/json/source.go
+++ b/pkg/plugins/resources/json/source.go
@@ -20,7 +20,7 @@ func (j *Json) Source(_ context.Context, workingDir string, resultSource *result
 		return errors.New("source only supports one file")
 	}
 
-	if j.engine != ENGINEDASEL_V2 &&
+	if j.engine != ENGINEDASEL_V2 && j.engine != ENGINEDASEL_V3 &&
 		((len(j.spec.Query) > 0 && j.spec.VersionFilter.IsZero()) ||
 			(len(j.spec.Query) == 0 && !j.spec.VersionFilter.IsZero())) {
 		return ErrSpecVersionFilterRequireMultiple
@@ -78,6 +78,27 @@ func (j *Json) Source(_ context.Context, workingDir string, resultSource *result
 
 		if err != nil {
 			if strings.Contains(err.Error(), "property not found") {
+				err := fmt.Errorf("%s cannot find value for path %q from file %q",
+					result.FAILURE,
+					j.spec.Key,
+					content.FilePath)
+				return err
+			}
+			return fmt.Errorf("running query %q: %w", j.spec.Key, err)
+		}
+
+		j.foundVersion, err = j.versionFilter.Search(queryResults)
+		if err != nil {
+			return fmt.Errorf("filtering information: %w", err)
+		}
+		sourceOutput = j.foundVersion.GetVersion()
+
+	case ENGINEDASEL_V3:
+		logrus.Debugf("Using engine %q", j.engine)
+		queryResults, err := content.QueryV3(j.spec.Key)
+
+		if err != nil {
+			if strings.Contains(err.Error(), "map key not found") {
 				err := fmt.Errorf("%s cannot find value for path %q from file %q",
 					result.FAILURE,
 					j.spec.Key,

--- a/pkg/plugins/resources/json/source_test.go
+++ b/pkg/plugins/resources/json/source_test.go
@@ -128,6 +128,84 @@ func TestSource(t *testing.T) {
 			},
 			expectedResult: "Trevor",
 		},
+		{
+			name: "Default successful workflow with Dasel v3",
+			spec: Spec{
+				File:   "testdata/data.json",
+				Key:    "firstName",
+				Engine: strPtr(ENGINEDASEL_V3),
+			},
+			expectedResult: "Jack",
+		},
+		{
+			name: "Nested key with Dasel v3",
+			spec: Spec{
+				File:   "testdata/data.json",
+				Key:    "address.city",
+				Engine: strPtr(ENGINEDASEL_V3),
+			},
+			expectedResult: "New York",
+		},
+		{
+			name: "Array item with Dasel v3",
+			spec: Spec{
+				File:   "testdata/data.json",
+				Key:    "children[1]",
+				Engine: strPtr(ENGINEDASEL_V3),
+			},
+			expectedResult: "Thomas",
+		},
+		{
+			name: "Nested array of objects with Dasel v3",
+			spec: Spec{
+				File:   "testdata/data.json",
+				Key:    "phoneNumbers[1].type",
+				Engine: strPtr(ENGINEDASEL_V3),
+			},
+			expectedResult: "office",
+		},
+		{
+			name: "Default successful workflow with empty result using Dasel v3",
+			spec: Spec{
+				File:   "testdata/data.json",
+				Key:    "surname",
+				Engine: strPtr(ENGINEDASEL_V3),
+			},
+			expectedResult: "",
+		},
+		{
+			name: "Test key do not exist with Dasel v3",
+			spec: Spec{
+				File:   "testdata/data.json",
+				Key:    "doNotExist",
+				Value:  "",
+				Engine: strPtr(ENGINEDASEL_V3),
+			},
+			wantErr:          true,
+			expectedErrorMsg: errors.New("✗ cannot find value for path \"doNotExist\" from file \"testdata/data.json\""),
+			expectedResult:   "",
+		},
+		{
+			name: "Version filter with Dasel v3",
+			spec: Spec{
+				File:   "testdata/data.json",
+				Key:    "children...",
+				Engine: strPtr(ENGINEDASEL_V3),
+				VersionFilter: version.Filter{
+					Kind: "latest",
+				},
+			},
+			expectedResult: "Trevor",
+		},
+		{
+			name: "Bare dasel alias resolves to latest engine (v3)",
+			spec: Spec{
+				File:   "testdata/data.json",
+				Key:    "firstName",
+				Engine: strPtr(ENGINEDASEL_LATEST),
+			},
+			expectedResult: "Jack",
+		},
 	}
 
 	for _, tt := range testData {

--- a/pkg/plugins/resources/json/spec.go
+++ b/pkg/plugins/resources/json/spec.go
@@ -25,7 +25,8 @@ type Spec struct {
 	// accepted values:
 	//   * "dasel/v1" for dasel v1 engine
 	//   * "dasel/v2" for dasel v2 engine
-	//   * "dasel" for the latest dasel engine which is currently dasel v2
+	//   * "dasel/v3" for dasel v3 engine
+	//   * "dasel" for the latest dasel engine which is currently dasel v3
 	Engine *string `yaml:",omitempty"`
 	// file defines the Json file path to interact with.
 	//
@@ -119,8 +120,24 @@ var (
 const (
 	ENGINEDASEL_V1 = "dasel/v1"
 	ENGINEDASEL_V2 = "dasel/v2"
-	ENGINEDEFAULT  = ENGINEDASEL_V1
+	ENGINEDASEL_V3 = "dasel/v3"
+	// ENGINEDASEL_LATEST is an alias resolving to the latest dasel engine.
+	ENGINEDASEL_LATEST = "dasel"
+	ENGINEDEFAULT      = ENGINEDASEL_V1
 )
+
+// resolveEngine normalizes a user-provided engine value, resolving the "dasel"
+// alias to the latest supported engine. An empty value resolves to the default.
+func resolveEngine(engine string) string {
+	switch engine {
+	case "":
+		return ENGINEDEFAULT
+	case ENGINEDASEL_LATEST:
+		return ENGINEDASEL_V3
+	default:
+		return engine
+	}
+}
 
 // Validate checks if the Spec is properly defined
 func (s *Spec) Validate() error {
@@ -139,11 +156,12 @@ func (s *Spec) Validate() error {
 
 	engine := ENGINEDEFAULT
 	if s.Engine != nil {
-		engine = *s.Engine
+		engine = resolveEngine(*s.Engine)
 	}
 
-	if engine == ENGINEDASEL_V2 && len(s.Query) > 0 && len(s.Key) == 0 {
-		errs = append(errs, fmt.Errorf("engine %q requires the parameter \"key\" over \"query\"", ENGINEDASEL_V2))
+	// dasel v2 and v3 deprecate the "query" parameter in favor of "key".
+	if (engine == ENGINEDASEL_V2 || engine == ENGINEDASEL_V3) && len(s.Query) > 0 && len(s.Key) == 0 {
+		errs = append(errs, fmt.Errorf("engine %q requires the parameter \"key\" over \"query\"", engine))
 	}
 
 	for _, e := range errs {

--- a/pkg/plugins/resources/json/target.go
+++ b/pkg/plugins/resources/json/target.go
@@ -79,6 +79,13 @@ func (j *Json) Target(_ context.Context, source string, scm scm.ScmHandler, dryR
 				return fmt.Errorf("querying file %q: %w", j.contents[i].FilePath, err)
 			}
 
+		case ENGINEDASEL_V3:
+			logrus.Debugf("Using engine %q", ENGINEDASEL_V3)
+			queryResults, err = j.contents[i].QueryV3(j.spec.Key)
+			if err != nil {
+				return fmt.Errorf("querying file %q: %w", j.contents[i].FilePath, err)
+			}
+
 		default:
 			return fmt.Errorf("engine %q is not supported", j.engine)
 		}
@@ -125,26 +132,40 @@ func (j *Json) Target(_ context.Context, source string, scm scm.ScmHandler, dryR
 			continue
 		}
 
-		// Update the target file with the new value
-		switch len(j.spec.Query) > 0 {
-		case true:
-			err = j.contents[i].PutMultiple(j.spec.Query, j.spec.Value)
-
-			if err != nil {
+		// Update the target file with the new value.
+		// The dasel v3 engine operates on the native parsed data and requires its
+		// own put/write path; v1 and v2 both write through the shared v1 node.
+		switch j.engine {
+		case ENGINEDASEL_V3:
+			if err = j.contents[i].PutV3(j.spec.Key, j.spec.Value); err != nil {
 				return fmt.Errorf("updating json file %q: %w", filename, err)
 			}
 
-		case false:
-			err = j.contents[i].Put(j.spec.Key, j.spec.Value)
-
-			if err != nil {
-				return fmt.Errorf("updating json file %q: %w", filename, err)
+			if err = j.contents[i].WriteV3(); err != nil {
+				return fmt.Errorf("writing json file %q: %w", filename, err)
 			}
-		}
 
-		err = j.contents[i].Write()
-		if err != nil {
-			return fmt.Errorf("writing json file %q: %w", filename, err)
+		default:
+			switch len(j.spec.Query) > 0 {
+			case true:
+				err = j.contents[i].PutMultiple(j.spec.Query, j.spec.Value)
+
+				if err != nil {
+					return fmt.Errorf("updating json file %q: %w", filename, err)
+				}
+
+			case false:
+				err = j.contents[i].Put(j.spec.Key, j.spec.Value)
+
+				if err != nil {
+					return fmt.Errorf("updating json file %q: %w", filename, err)
+				}
+			}
+
+			err = j.contents[i].Write()
+			if err != nil {
+				return fmt.Errorf("writing json file %q: %w", filename, err)
+			}
 		}
 	}
 

--- a/pkg/plugins/resources/json/target_test.go
+++ b/pkg/plugins/resources/json/target_test.go
@@ -79,6 +79,36 @@ func TestTarget(t *testing.T) {
 			sourceInput:    "home",
 			expectedResult: false,
 		},
+		{
+			name: "Unchanged key successful workflow using Dasel v3",
+			spec: Spec{
+				File:   "testdata/data.json",
+				Key:    "firstName",
+				Engine: strPtr(ENGINEDASEL_V3),
+			},
+			sourceInput:    "Jack",
+			expectedResult: false,
+		},
+		{
+			name: "Changed key successful workflow using Dasel v3",
+			spec: Spec{
+				File:   "testdata/data.json",
+				Key:    "firstName",
+				Engine: strPtr(ENGINEDASEL_V3),
+			},
+			sourceInput:    "Tom",
+			expectedResult: true,
+		},
+		{
+			name: "Update first array item successful workflow using Dasel v3",
+			spec: Spec{
+				File:   "testdata/data.json",
+				Key:    "phoneNumbers[0].type",
+				Engine: strPtr(ENGINEDASEL_V3),
+			},
+			sourceInput:    "apartment",
+			expectedResult: true,
+		},
 	}
 
 	for _, tt := range testData {
@@ -117,9 +147,13 @@ func TestTargetPreservesSpecialCharacters(t *testing.T) {
 	engines := []struct {
 		name   string
 		engine *string
+		// key holds the selector for the "version" field. dasel v3 uses a new
+		// selector syntax that does not accept the leading dot used by v1/v2.
+		key string
 	}{
-		{name: "dasel/v1 (default)", engine: nil},
-		{name: "dasel/v2", engine: strPtr(ENGINEDASEL_V2)},
+		{name: "dasel/v1 (default)", engine: nil, key: ".version"},
+		{name: "dasel/v2", engine: strPtr(ENGINEDASEL_V2), key: ".version"},
+		{name: "dasel/v3", engine: strPtr(ENGINEDASEL_V3), key: "version"},
 	}
 
 	for _, e := range engines {
@@ -132,7 +166,7 @@ func TestTargetPreservesSpecialCharacters(t *testing.T) {
 
 			spec := Spec{
 				File:   filePath,
-				Key:    ".version",
+				Key:    e.key,
 				Engine: e.engine,
 			}
 

--- a/pkg/plugins/resources/toml/condition.go
+++ b/pkg/plugins/resources/toml/condition.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/sirupsen/logrus"
 	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
 )
 
@@ -32,20 +33,41 @@ func (t *Toml) Condition(_ context.Context, source string, scm scm.ScmHandler) (
 		var queryResults []string
 		var err error
 
-		switch len(t.spec.Query) > 0 {
-		case true:
-			queryResults, err = t.contents[i].MultipleQuery(t.spec.Query)
-			if err != nil {
-				return false, "", err
+		switch t.engine {
+		case ENGINEDASEL_V1:
+			logrus.Debugf("Using engine %q", t.engine)
+			switch len(t.spec.Query) > 0 {
+			case true:
+				queryResults, err = t.contents[i].MultipleQuery(t.spec.Query)
+				if err != nil {
+					return false, "", err
+				}
+
+			case false:
+				queryResult, err := t.contents[i].Query(t.spec.Key)
+				if err != nil {
+					return false, "", err
+				}
+
+				queryResults = []string{queryResult}
 			}
 
-		case false:
-			queryResult, err := t.contents[i].Query(t.spec.Key)
+		case ENGINEDASEL_V2:
+			logrus.Debugf("Using engine %q", t.engine)
+			queryResults, err = t.contents[i].QueryV2(t.spec.Key)
 			if err != nil {
-				return false, "", err
+				return false, "", fmt.Errorf("querying file %q: %w", t.contents[i].FilePath, err)
 			}
 
-			queryResults = []string{queryResult}
+		case ENGINEDASEL_V3:
+			logrus.Debugf("Using engine %q", t.engine)
+			queryResults, err = t.contents[i].QueryV3(t.spec.Key)
+			if err != nil {
+				return false, "", fmt.Errorf("querying file %q: %w", t.contents[i].FilePath, err)
+			}
+
+		default:
+			return false, "", fmt.Errorf("engine %q is not supported", t.engine)
 		}
 
 		for _, queryResult := range queryResults {

--- a/pkg/plugins/resources/toml/condition_test.go
+++ b/pkg/plugins/resources/toml/condition_test.go
@@ -70,6 +70,46 @@ func TestCondition(t *testing.T) {
 			expectedResult: true,
 		},
 		{
+			name: "Default scenario with Dasel v2",
+			spec: Spec{
+				File:   "testdata/data.toml",
+				Key:    ".owner.firstName",
+				Value:  "Jack",
+				Engine: strPtr(ENGINEDASEL_V2),
+			},
+			expectedResult: true,
+		},
+		{
+			name: "Default scenario with Dasel v3",
+			spec: Spec{
+				File:   "testdata/data.toml",
+				Key:    "owner.firstName",
+				Value:  "Jack",
+				Engine: strPtr(ENGINEDASEL_V3),
+			},
+			expectedResult: true,
+		},
+		{
+			name: "Nested array item with Dasel v3",
+			spec: Spec{
+				File:   "testdata/data.toml",
+				Key:    "servers.beta.role",
+				Value:  "backend",
+				Engine: strPtr(ENGINEDASEL_V3),
+			},
+			expectedResult: true,
+		},
+		{
+			name: "Mismatching value with Dasel v3",
+			spec: Spec{
+				File:   "testdata/data.toml",
+				Key:    "owner.firstName",
+				Value:  "NotJack",
+				Engine: strPtr(ENGINEDASEL_V3),
+			},
+			expectedResult: false,
+		},
+		{
 			name: "Test key do not exist",
 			spec: Spec{
 				File:  "testdata/data.toml",

--- a/pkg/plugins/resources/toml/main.go
+++ b/pkg/plugins/resources/toml/main.go
@@ -73,7 +73,14 @@ func New(spec interface{}) (*Toml, error) {
 	if engine == ENGINEDASEL_V1 {
 		logrus.Warningf("Engine %q is deprecated and will be removed in a future updatecli version. Please use %q instead.",
 			ENGINEDASEL_V1,
+			ENGINEDASEL_V3,
+		)
+	}
+
+	if engine == ENGINEDASEL_V2 {
+		logrus.Warningf("Engine %q is deprecated and will be removed in a future updatecli version. Please use %q instead.",
 			ENGINEDASEL_V2,
+			ENGINEDASEL_V3,
 		)
 	}
 

--- a/pkg/plugins/resources/toml/main.go
+++ b/pkg/plugins/resources/toml/main.go
@@ -24,6 +24,9 @@ type Toml struct {
 	foundVersion version.Version
 	// Holds the "valid" version.filter, that might be different than the user-specified filter (Spec.VersionFilter)
 	versionFilter version.Filter
+	// engine defines the engine used to manipulate the toml file
+	// If not set, the default engine is dasel/v1
+	engine string
 }
 
 func New(spec interface{}) (*Toml, error) {
@@ -60,9 +63,24 @@ func New(spec interface{}) (*Toml, error) {
 		return nil, err
 	}
 
+	engine := ENGINEDEFAULT
+	if newSpec.Engine != nil {
+		// Resolve aliases (e.g. bare "dasel" -> latest engine) so the rest of the
+		// code only ever deals with explicit engine versions.
+		engine = resolveEngine(*newSpec.Engine)
+	}
+
+	if engine == ENGINEDASEL_V1 {
+		logrus.Warningf("Engine %q is deprecated and will be removed in a future updatecli version. Please use %q instead.",
+			ENGINEDASEL_V1,
+			ENGINEDASEL_V2,
+		)
+	}
+
 	j := Toml{
 		spec:          newSpec,
 		versionFilter: newFilter,
+		engine:        engine,
 	}
 
 	// Init currentContents
@@ -101,5 +119,6 @@ func (s *Toml) ReportConfig() interface{} {
 		Multiple:         s.spec.Multiple,
 		VersionFilter:    s.spec.VersionFilter,
 		CreateMissingKey: s.spec.CreateMissingKey,
+		Engine:           s.spec.Engine,
 	}
 }

--- a/pkg/plugins/resources/toml/source.go
+++ b/pkg/plugins/resources/toml/source.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/sirupsen/logrus"
 	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
@@ -19,8 +20,9 @@ func (t *Toml) Source(_ context.Context, workingDir string, resultSource *result
 		return errors.New("source only supports one file")
 	}
 
-	if (len(t.spec.Query) > 0 && t.spec.VersionFilter.IsZero()) ||
-		(len(t.spec.Query) == 0) && !t.spec.VersionFilter.IsZero() {
+	if t.engine != ENGINEDASEL_V2 && t.engine != ENGINEDASEL_V3 &&
+		((len(t.spec.Query) > 0 && t.spec.VersionFilter.IsZero()) ||
+			(len(t.spec.Query) == 0) && !t.spec.VersionFilter.IsZero()) {
 		return ErrSpecVersionFilterRequireMultiple
 	}
 
@@ -33,13 +35,54 @@ func (t *Toml) Source(_ context.Context, workingDir string, resultSource *result
 	}
 
 	query := ""
-	switch len(t.spec.Query) > 0 {
-	case true:
-		query = t.spec.Query
-		queryResults, err := content.MultipleQuery(query)
+	switch t.engine {
+	case ENGINEDASEL_V1:
+		logrus.Debugf("Using engine %q", t.engine)
+		switch len(t.spec.Query) > 0 {
+		case true:
+			query = t.spec.Query
+			queryResults, err := content.MultipleQuery(query)
 
+			if err != nil {
+				return fmt.Errorf("running multiple query: %w", err)
+			}
+
+			t.foundVersion, err = t.versionFilter.Search(queryResults)
+			if err != nil {
+				return fmt.Errorf("filtering result: %w", err)
+			}
+			sourceOutput = t.foundVersion.GetVersion()
+
+		case false:
+			query = t.spec.Key
+			queryResult, err := content.DaselNode.Query(query)
+			if err != nil {
+				// Catch error message returned by Dasel, if it couldn't find the node
+				// This is approach is not very robust
+				// https://github.com/TomWright/dasel/blob/master/node_query.go#L58
+
+				if strings.HasPrefix(err.Error(), "could not find value:") {
+					return fmt.Errorf("cannot find value for path %q from file %q",
+						t.spec.Key,
+						content.FilePath)
+				}
+				return fmt.Errorf("running query: %w", err)
+			}
+
+			sourceOutput = queryResult.String()
+		}
+
+	case ENGINEDASEL_V2:
+		logrus.Debugf("Using engine %q", t.engine)
+		query = t.spec.Key
+		queryResults, err := content.QueryV2(t.spec.Key)
 		if err != nil {
-			return fmt.Errorf("running multiple query: %w", err)
+			if strings.Contains(err.Error(), "property not found") {
+				return fmt.Errorf("cannot find value for path %q from file %q",
+					t.spec.Key,
+					content.FilePath)
+			}
+			return fmt.Errorf("running query %q: %w", t.spec.Key, err)
 		}
 
 		t.foundVersion, err = t.versionFilter.Search(queryResults)
@@ -48,23 +91,27 @@ func (t *Toml) Source(_ context.Context, workingDir string, resultSource *result
 		}
 		sourceOutput = t.foundVersion.GetVersion()
 
-	case false:
+	case ENGINEDASEL_V3:
+		logrus.Debugf("Using engine %q", t.engine)
 		query = t.spec.Key
-		queryResult, err := content.DaselNode.Query(query)
+		queryResults, err := content.QueryV3(t.spec.Key)
 		if err != nil {
-			// Catch error message returned by Dasel, if it couldn't find the node
-			// This is approach is not very robust
-			// https://github.com/TomWright/dasel/blob/master/node_query.go#L58
-
-			if strings.HasPrefix(err.Error(), "could not find value:") {
+			if strings.Contains(err.Error(), "map key not found") {
 				return fmt.Errorf("cannot find value for path %q from file %q",
 					t.spec.Key,
 					content.FilePath)
 			}
-			return fmt.Errorf("running query: %w", err)
+			return fmt.Errorf("running query %q: %w", t.spec.Key, err)
 		}
 
-		sourceOutput = queryResult.String()
+		t.foundVersion, err = t.versionFilter.Search(queryResults)
+		if err != nil {
+			return fmt.Errorf("filtering result: %w", err)
+		}
+		sourceOutput = t.foundVersion.GetVersion()
+
+	default:
+		return fmt.Errorf("engine %q not supported", t.engine)
 	}
 
 	resultSource.Information = sourceOutput

--- a/pkg/plugins/resources/toml/source_test.go
+++ b/pkg/plugins/resources/toml/source_test.go
@@ -12,6 +12,10 @@ import (
 	"github.com/updatecli/updatecli/pkg/plugins/utils/version"
 )
 
+func strPtr(s string) *string {
+	return &s
+}
+
 func TestSource(t *testing.T) {
 
 	testData := []struct {
@@ -67,6 +71,93 @@ func TestSource(t *testing.T) {
 				},
 			},
 			expectedResult: "IC",
+		},
+		{
+			name: "Default successful workflow with Dasel v2",
+			spec: Spec{
+				File:   "testdata/data.toml",
+				Key:    ".owner.firstName",
+				Engine: strPtr(ENGINEDASEL_V2),
+			},
+			expectedResult: "Jack",
+		},
+		{
+			name: "Array item with Dasel v2",
+			spec: Spec{
+				File:   "testdata/data.toml",
+				Key:    ".database.ports.[1]",
+				Engine: strPtr(ENGINEDASEL_V2),
+			},
+			expectedResult: "8001",
+		},
+		{
+			name: "Default successful workflow with Dasel v3",
+			spec: Spec{
+				File:   "testdata/data.toml",
+				Key:    "owner.firstName",
+				Engine: strPtr(ENGINEDASEL_V3),
+			},
+			expectedResult: "Jack",
+		},
+		{
+			name: "Array item with Dasel v3",
+			spec: Spec{
+				File:   "testdata/data.toml",
+				Key:    "database.ports[1]",
+				Engine: strPtr(ENGINEDASEL_V3),
+			},
+			expectedResult: "8001",
+		},
+		{
+			name: "Nested array of objects with Dasel v3",
+			spec: Spec{
+				File:   "testdata/data.toml",
+				Key:    "employees[3].role",
+				Engine: strPtr(ENGINEDASEL_V3),
+			},
+			expectedResult: "M",
+		},
+		{
+			name: "Empty result with Dasel v3",
+			spec: Spec{
+				File:   "testdata/data.toml",
+				Key:    "owner.surname",
+				Engine: strPtr(ENGINEDASEL_V3),
+			},
+			expectedResult: "",
+		},
+		{
+			name: "Test key do not exist with Dasel v3",
+			spec: Spec{
+				File:   "testdata/data.toml",
+				Key:    "doNotExist",
+				Engine: strPtr(ENGINEDASEL_V3),
+			},
+			wantErr:          true,
+			expectedErrorMsg: errors.New("cannot find value for path \"doNotExist\" from file \"testdata/data.toml\""),
+			expectedResult:   "",
+		},
+		{
+			name: "Version filter with Dasel v3",
+			spec: Spec{
+				File:   "testdata/data.toml",
+				Key:    "employees.map(role)...",
+				Engine: strPtr(ENGINEDASEL_V3),
+				VersionFilter: version.Filter{
+					Kind:    "regex",
+					Pattern: "I(.*)",
+				},
+			},
+			expectedResult: "IC",
+		},
+		{
+			name: "Bare dasel alias resolves to latest engine (v3)",
+			spec: Spec{
+				File:   "testdata/data.toml",
+				Key:    "owner.firstName",
+				Engine: strPtr(ENGINEDASEL_LATEST),
+			},
+			expectedResult: "Jack",
 		},
 	}
 

--- a/pkg/plugins/resources/toml/spec.go
+++ b/pkg/plugins/resources/toml/spec.go
@@ -2,12 +2,29 @@ package toml
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/sirupsen/logrus"
 	"github.com/updatecli/updatecli/pkg/plugins/utils/version"
 )
 
 type Spec struct {
+	// engine defines the engine used to manipulate the toml file.
+	//
+	// compatible:
+	//   * source
+	//   * condition
+	//   * target
+	//
+	// default:
+	//   * "dasel/v1" is the default engine used to manipulate toml files
+	//
+	// accepted values:
+	//   * "dasel/v1" for dasel v1 engine
+	//   * "dasel/v2" for dasel v2 engine
+	//   * "dasel/v3" for dasel v3 engine
+	//   * "dasel" for the latest dasel engine which is currently dasel v3
+	Engine *string `yaml:",omitempty"`
 	// [s][c][t] File specifies the toml file to manipulate
 	File string `yaml:",omitempty"`
 	// [c][t] Files specifies a list of Json file to manipulate
@@ -25,7 +42,8 @@ type Spec struct {
 	/*
 	  [t] CreateMissingKey allows non-existing keys. If the key does not exist, the key is created if AllowsMissingKey
 	  is true, otherwise an error is raised (the default).
-	  Only supported if Key is used
+	  Only supported if Key is used.
+	  Not supported by the "dasel/v3" engine, which cannot create missing keys.
 	*/
 	CreateMissingKey bool `yaml:",omitempty"`
 }
@@ -41,6 +59,28 @@ var (
 	ErrWrongSpec error = errors.New("wrong spec content")
 )
 
+const (
+	ENGINEDASEL_V1 = "dasel/v1"
+	ENGINEDASEL_V2 = "dasel/v2"
+	ENGINEDASEL_V3 = "dasel/v3"
+	// ENGINEDASEL_LATEST is an alias resolving to the latest dasel engine.
+	ENGINEDASEL_LATEST = "dasel"
+	ENGINEDEFAULT      = ENGINEDASEL_V1
+)
+
+// resolveEngine normalizes a user-provided engine value, resolving the "dasel"
+// alias to the latest supported engine. An empty value resolves to the default.
+func resolveEngine(engine string) string {
+	switch engine {
+	case "":
+		return ENGINEDEFAULT
+	case ENGINEDASEL_LATEST:
+		return ENGINEDASEL_V3
+	default:
+		return engine
+	}
+}
+
 func (s *Spec) Validate() error {
 	var errs []error
 
@@ -53,6 +93,22 @@ func (s *Spec) Validate() error {
 
 	if len(s.File) > 0 && len(s.Files) > 0 {
 		errs = append(errs, ErrSpecFileAndFilesDefined)
+	}
+
+	engine := ENGINEDEFAULT
+	if s.Engine != nil {
+		engine = resolveEngine(*s.Engine)
+	}
+
+	// dasel v2 and v3 deprecate the "query" parameter in favor of "key".
+	if (engine == ENGINEDASEL_V2 || engine == ENGINEDASEL_V3) && len(s.Query) > 0 && len(s.Key) == 0 {
+		errs = append(errs, fmt.Errorf("engine %q requires the parameter \"key\" over \"query\"", engine))
+	}
+
+	// The dasel v3 engine cannot create missing keys (its API resolves the key
+	// before setting a value), so "createmissingkey" is incompatible with it.
+	if engine == ENGINEDASEL_V3 && s.CreateMissingKey {
+		errs = append(errs, fmt.Errorf("engine %q does not support the parameter \"createmissingkey\"", engine))
 	}
 
 	for _, e := range errs {

--- a/pkg/plugins/resources/toml/spec_test.go
+++ b/pkg/plugins/resources/toml/spec_test.go
@@ -1,0 +1,75 @@
+package toml
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSpecValidate(t *testing.T) {
+	testData := []struct {
+		name    string
+		spec    Spec
+		wantErr bool
+	}{
+		{
+			name: "valid default spec",
+			spec: Spec{
+				File: "testdata/data.toml",
+				Key:  ".owner.firstName",
+			},
+			wantErr: false,
+		},
+		{
+			name: "createmissingkey allowed with default engine",
+			spec: Spec{
+				File:             "testdata/data.toml",
+				Key:              ".owner.age",
+				CreateMissingKey: true,
+			},
+			wantErr: false,
+		},
+		{
+			name: "createmissingkey rejected with dasel v3",
+			spec: Spec{
+				File:             "testdata/data.toml",
+				Key:              "owner.age",
+				CreateMissingKey: true,
+				Engine:           strPtr(ENGINEDASEL_V3),
+			},
+			wantErr: true,
+		},
+		{
+			name: "createmissingkey rejected with dasel alias (latest=v3)",
+			spec: Spec{
+				File:             "testdata/data.toml",
+				Key:              "owner.age",
+				CreateMissingKey: true,
+				Engine:           strPtr(ENGINEDASEL_LATEST),
+			},
+			wantErr: true,
+		},
+		{
+			name: "createmissingkey allowed with dasel v2",
+			spec: Spec{
+				File:             "testdata/data.toml",
+				Key:              ".owner.age",
+				CreateMissingKey: true,
+				Engine:           strPtr(ENGINEDASEL_V2),
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range testData {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.spec.Validate()
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+}

--- a/pkg/plugins/resources/toml/target.go
+++ b/pkg/plugins/resources/toml/target.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/sirupsen/logrus"
 	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
 	"github.com/updatecli/updatecli/pkg/core/result"
 )
@@ -45,27 +46,48 @@ func (t *Toml) Target(_ context.Context, source string, scm scm.ScmHandler, dryR
 		var queryResults []string
 		var err error
 
-		switch len(t.spec.Query) > 0 {
-		case true:
-			queryResults, err = t.contents[i].MultipleQuery(t.spec.Query)
-			if err != nil {
-				return err
-			}
-
-		case false:
-			if t.spec.CreateMissingKey {
+		switch t.engine {
+		case ENGINEDASEL_V1:
+			logrus.Debugf("Using engine %q", t.engine)
+			switch len(t.spec.Query) > 0 {
+			case true:
 				queryResults, err = t.contents[i].MultipleQuery(t.spec.Query)
 				if err != nil {
 					return err
 				}
-			} else {
-				queryResult, err := t.contents[i].Query(t.spec.Key)
-				if err != nil {
-					return err
+
+			case false:
+				if t.spec.CreateMissingKey {
+					queryResults, err = t.contents[i].MultipleQuery(t.spec.Query)
+					if err != nil {
+						return err
+					}
+				} else {
+					queryResult, err := t.contents[i].Query(t.spec.Key)
+					if err != nil {
+						return err
+					}
+					queryResults = append(queryResults, queryResult)
 				}
-				queryResults = append(queryResults, queryResult)
+
 			}
 
+		case ENGINEDASEL_V2:
+			logrus.Debugf("Using engine %q", t.engine)
+			queryResults, err = t.contents[i].QueryV2(t.spec.Key)
+			if err != nil {
+				return fmt.Errorf("querying file %q: %w", t.contents[i].FilePath, err)
+			}
+
+		case ENGINEDASEL_V3:
+			logrus.Debugf("Using engine %q", t.engine)
+			queryResults, err = t.contents[i].QueryV3(t.spec.Key)
+			if err != nil {
+				return fmt.Errorf("querying file %q: %w", t.contents[i].FilePath, err)
+			}
+
+		default:
+			return fmt.Errorf("engine %q is not supported", t.engine)
 		}
 
 		changedFile := false
@@ -96,26 +118,40 @@ func (t *Toml) Target(_ context.Context, source string, scm scm.ScmHandler, dryR
 			continue
 		}
 
-		// Update the target file with the new value
-		switch len(t.spec.Query) > 0 {
-		case true:
-			err = t.contents[i].PutMultiple(t.spec.Query, t.spec.Value)
-
-			if err != nil {
+		// Update the target file with the new value.
+		// The dasel v3 engine operates on the native parsed data and requires its
+		// own put/write path; v1 and v2 both write through the shared v1 node.
+		switch t.engine {
+		case ENGINEDASEL_V3:
+			if err = t.contents[i].PutV3(t.spec.Key, t.spec.Value); err != nil {
 				return err
 			}
 
-		case false:
-			err = t.contents[i].Put(t.spec.Key, t.spec.Value)
+			if err = t.contents[i].WriteV3(); err != nil {
+				return err
+			}
 
+		default:
+			switch len(t.spec.Query) > 0 {
+			case true:
+				err = t.contents[i].PutMultiple(t.spec.Query, t.spec.Value)
+
+				if err != nil {
+					return err
+				}
+
+			case false:
+				err = t.contents[i].Put(t.spec.Key, t.spec.Value)
+
+				if err != nil {
+					return err
+				}
+			}
+
+			err = t.contents[i].Write()
 			if err != nil {
 				return err
 			}
-		}
-
-		err = t.contents[i].Write()
-		if err != nil {
-			return err
 		}
 
 		resultTarget.Files = append(resultTarget.Files, resourceFile)

--- a/pkg/plugins/resources/toml/target_test.go
+++ b/pkg/plugins/resources/toml/target_test.go
@@ -3,6 +3,8 @@ package toml
 import (
 	"context"
 	"errors"
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -123,6 +125,36 @@ func TestTarget(t *testing.T) {
 			sourceInput:    "50",
 			expectedResult: true,
 		},
+		{
+			name: "Successful single update workflow with Dasel v3",
+			spec: Spec{
+				File:   "testdata/data.toml",
+				Key:    "owner.firstName",
+				Engine: strPtr(ENGINEDASEL_V3),
+			},
+			sourceInput:    "Tom",
+			expectedResult: true,
+		},
+		{
+			name: "Successful no update workflow with Dasel v3",
+			spec: Spec{
+				File:   "testdata/data.toml",
+				Key:    "owner.firstName",
+				Engine: strPtr(ENGINEDASEL_V3),
+			},
+			sourceInput:    "Jack",
+			expectedResult: false,
+		},
+		{
+			name: "Update nested array item with Dasel v3",
+			spec: Spec{
+				File:   "testdata/data.toml",
+				Key:    "servers.beta.role",
+				Engine: strPtr(ENGINEDASEL_V3),
+			},
+			sourceInput:    "database",
+			expectedResult: true,
+		},
 	}
 
 	for _, tt := range testData {
@@ -145,4 +177,55 @@ func TestTarget(t *testing.T) {
 			assert.Equal(t, tt.expectedResult, gotResult.Changed)
 		})
 	}
+}
+
+// TestTargetDaselV3Write exercises the dasel v3 write path (PutV3 + WriteV3) with a
+// real (dryRun=false) write to disk, ensuring the value is updated, the rest of the
+// document (including a TOML datetime) survives the round-trip, and the output keeps
+// a 2-space indentation for nested tables.
+func TestTargetDaselV3Write(t *testing.T) {
+	initialTOML := `title = "TOML Example"
+
+[owner]
+firstName = "Jack"
+dob = 1979-05-27T07:32:00-08:00
+
+[servers]
+
+  [servers.beta]
+  ip = "10.0.0.2"
+  role = "backend"
+`
+
+	dir := t.TempDir()
+	filePath := dir + "/data.toml"
+	require.NoError(t, os.WriteFile(filePath, []byte(initialTOML), 0600))
+
+	spec := Spec{
+		File:   filePath,
+		Key:    "owner.firstName",
+		Engine: strPtr(ENGINEDASEL_V3),
+	}
+
+	j, err := New(spec)
+	require.NoError(t, err)
+
+	gotResult := result.Target{}
+	// dryRun=false so the file is actually written back to disk.
+	err = j.Target(context.Background(), "Tom", nil, false, &gotResult)
+	require.NoError(t, err)
+	assert.True(t, gotResult.Changed)
+
+	content, err := os.ReadFile(filePath)
+	require.NoError(t, err)
+
+	got := string(content)
+	assert.True(t, strings.Contains(got, `firstName = "Tom"`),
+		"expected firstName to be updated to Tom, got:\n%s", got)
+	// The datetime must survive the write cycle untouched.
+	assert.True(t, strings.Contains(got, "1979-05-27T07:32:00-08:00"),
+		"expected the TOML datetime to be preserved, got:\n%s", got)
+	// Nested tables should be indented with 2 spaces.
+	assert.True(t, strings.Contains(got, "  [servers.beta]"),
+		"expected nested table to be indented with 2 spaces, got:\n%s", got)
 }

--- a/pkg/plugins/utils/dasel/main.go
+++ b/pkg/plugins/utils/dasel/main.go
@@ -12,6 +12,13 @@ import (
 	"github.com/updatecli/updatecli/pkg/core/text"
 )
 
+const (
+	// TYPEJSON defines the json data type
+	TYPEJSON string = "json"
+	// TYPETOML defines the toml data type
+	TYPETOML string = "toml"
+)
+
 var (
 	// ErrDaselFailedParsingByteFormat is returned if dasel couldn't parse the byteData
 	ErrDaselFailedParsingByteFormat error = errors.New("failed to parse file")

--- a/pkg/plugins/utils/dasel/main.go
+++ b/pkg/plugins/utils/dasel/main.go
@@ -30,4 +30,7 @@ type FileContent struct {
 	DaselNode *dasel.Node
 	// DaselV2Node contains the dasel v2 representation of the file
 	DaselV2Node any
+	// DaselV3Data contains the native parsed data manipulated by the dasel v3 engine.
+	// dasel v3 has no stateful node object: its API operates directly on this value.
+	DaselV3Data any
 }

--- a/pkg/plugins/utils/dasel/put.go
+++ b/pkg/plugins/utils/dasel/put.go
@@ -1,9 +1,11 @@
 package dasel
 
 import (
+	"context"
 	"fmt"
 
 	daselV2 "github.com/tomwright/dasel/v2"
+	daselV3 "github.com/tomwright/dasel/v3"
 )
 
 // Put insert value in a Dasel node
@@ -43,4 +45,18 @@ func (f *FileContent) PutV2(query, value string) error {
 
 	return nil
 
+}
+
+// PutV3 sets a value in the native parsed data using the dasel v3 engine.
+// It modifies DaselV2Node in place, so a subsequent WriteV3 serializes the change.
+func (f *FileContent) PutV3(query, value string) error {
+	if f.DaselV3Data == nil {
+		return ErrEmptyDaselNode
+	}
+
+	if _, err := daselV3.Modify(context.Background(), &f.DaselV3Data, query, value); err != nil {
+		return fmt.Errorf("setting value %q with query %q: %w", value, query, err)
+	}
+
+	return nil
 }

--- a/pkg/plugins/utils/dasel/query.go
+++ b/pkg/plugins/utils/dasel/query.go
@@ -116,7 +116,7 @@ func (f *FileContent) QueryV2(query string) ([]string, error) {
 }
 
 // QueryV3 returns the value(s) for a specific query using the dasel v3 engine.
-// dasel v3 operates on the native parsed data (stored in DaselV2Node) and uses
+// dasel v3 operates on the native parsed data (stored in DaselV3Node) and uses
 // a new selector syntax, more information on https://github.com/tomwright/dasel
 func (f *FileContent) QueryV3(query string) ([]string, error) {
 	if f.DaselV3Data == nil {

--- a/pkg/plugins/utils/dasel/query.go
+++ b/pkg/plugins/utils/dasel/query.go
@@ -1,12 +1,14 @@
 package dasel
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
 	"github.com/sirupsen/logrus"
 
 	daselV2 "github.com/tomwright/dasel/v2"
+	daselV3 "github.com/tomwright/dasel/v3"
 )
 
 // MultipleQuery returns multiple query from a Dasel Node
@@ -108,6 +110,34 @@ func (f *FileContent) QueryV2(query string) ([]string, error) {
 
 	for k, v := range results {
 		stringResults[k] = fmt.Sprint(v)
+	}
+
+	return stringResults, nil
+}
+
+// QueryV3 returns the value(s) for a specific query using the dasel v3 engine.
+// dasel v3 operates on the native parsed data (stored in DaselV2Node) and uses
+// a new selector syntax, more information on https://github.com/tomwright/dasel
+func (f *FileContent) QueryV3(query string) ([]string, error) {
+	if f.DaselV3Data == nil {
+		return nil, ErrDaselFailedParsingByteFormat
+	}
+
+	queryResults, _, err := daselV3.Query(context.Background(), f.DaselV3Data, query)
+	if err != nil {
+		return nil, fmt.Errorf("querying dasel v3 node: %w", err)
+	}
+
+	if len(queryResults) == 0 {
+		err = fmt.Errorf("could not find value for query %q from file %q",
+			query,
+			f.FilePath)
+		return nil, err
+	}
+
+	stringResults := make([]string, len(queryResults))
+	for k, v := range queryResults {
+		stringResults[k] = fmt.Sprint(v.Interface())
 	}
 
 	return stringResults, nil

--- a/pkg/plugins/utils/dasel/read.go
+++ b/pkg/plugins/utils/dasel/read.go
@@ -27,13 +27,13 @@ func (f *FileContent) Read(rootDir string) error {
 	var data any
 	switch f.DataType {
 
-	case "json":
+	case TYPEJSON:
 		err = json.Unmarshal([]byte(textContent), &data)
 		if err != nil {
 			return fmt.Errorf("failed to unmarshal json content: %w", err)
 		}
 
-	case "toml":
+	case TYPETOML:
 		err := toml.Unmarshal([]byte(textContent), &data)
 
 		if err != nil {

--- a/pkg/plugins/utils/dasel/read.go
+++ b/pkg/plugins/utils/dasel/read.go
@@ -49,6 +49,8 @@ func (f *FileContent) Read(rootDir string) error {
 
 	f.DaselV2Node = data
 
+	f.DaselV3Data = data
+
 	if f.DaselNode == nil || f.DaselV2Node == nil {
 		return ErrDaselFailedParsingByteFormat
 	}

--- a/pkg/plugins/utils/dasel/write.go
+++ b/pkg/plugins/utils/dasel/write.go
@@ -34,7 +34,7 @@ func (f *FileContent) Write() error {
 	defer newFile.Close()
 
 	switch f.DataType {
-	case "json":
+	case TYPEJSON:
 		err = f.DaselNode.Write(
 			newFile,
 			f.DataType,
@@ -57,7 +57,7 @@ func (f *FileContent) Write() error {
 			return fmt.Errorf("unable to write to file %s: %w", f.FilePath, err)
 		}
 
-	case "toml":
+	case TYPETOML:
 		err = f.DaselNode.Write(
 			newFile,
 			f.DataType,
@@ -100,7 +100,7 @@ func (f *FileContent) WriteV3() error {
 	defer newFile.Close()
 
 	switch f.DataType {
-	case "json":
+	case TYPEJSON:
 		encoder := json.NewEncoder(newFile)
 		encoder.SetIndent("", "  ")
 		encoder.SetEscapeHTML(false)
@@ -109,7 +109,7 @@ func (f *FileContent) WriteV3() error {
 			return fmt.Errorf("unable to write to file %s: %w", f.FilePath, err)
 		}
 
-	case "toml":
+	case TYPETOML:
 		encoder := toml.NewEncoder(newFile)
 		encoder.Indent = "  "
 

--- a/pkg/plugins/utils/dasel/write.go
+++ b/pkg/plugins/utils/dasel/write.go
@@ -1,10 +1,12 @@
 package dasel
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/user"
 
+	"github.com/BurntSushi/toml"
 	"github.com/sirupsen/logrus"
 	"github.com/tomwright/dasel/storage"
 )
@@ -76,6 +78,47 @@ func (f *FileContent) Write() error {
 		}
 	default:
 		return fmt.Errorf("data type %q no supported", f.DataType)
+	}
+
+	return nil
+}
+
+// WriteV3 serializes the native parsed data (DaselV3Data) modified by the dasel v3
+// engine back to disk. It marshals with the standard encoders so the output format
+// matches the v1/v2 engines (2-space indentation, HTML escaping disabled for json)
+// rather than the dasel v3 native writer, keeping diffs stable across engines.
+func (f *FileContent) WriteV3() error {
+	if f.DaselV3Data == nil {
+		return ErrEmptyDaselNode
+	}
+
+	newFile, err := os.Create(f.FilePath)
+	if err != nil {
+		return fmt.Errorf("unable to write to file %s: %w", f.FilePath, err)
+	}
+
+	defer newFile.Close()
+
+	switch f.DataType {
+	case "json":
+		encoder := json.NewEncoder(newFile)
+		encoder.SetIndent("", "  ")
+		encoder.SetEscapeHTML(false)
+
+		if err := encoder.Encode(f.DaselV3Data); err != nil {
+			return fmt.Errorf("unable to write to file %s: %w", f.FilePath, err)
+		}
+
+	case "toml":
+		encoder := toml.NewEncoder(newFile)
+		encoder.Indent = "  "
+
+		if err := encoder.Encode(f.DaselV3Data); err != nil {
+			return fmt.Errorf("unable to write to file %s: %w", f.FilePath, err)
+		}
+
+	default:
+		return fmt.Errorf("data type %q not supported by the dasel v3 engine", f.DataType)
 	}
 
 	return nil


### PR DESCRIPTION
Fix #5187 

Add support for Daselv2 in toml/csv and Daselv3 for toml/csv/json

## Test

To test this pull request, you can run the following commands:

```shell
go build -o bin/updatecli
./bin/updatecli diff --config e2e/updatecli.d/success.d/json.yaml
./bin/updatecli diff --config e2e/updatecli.d/warning.d/json.yaml
cd pkg/plugins/resources/json/
go test
cd pkg/plugins/resources/csv/
go test
cd pkg/plugins/resources/toml/
go test
```

## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via pull request in [website](https://github.com/updatecli/website) repository.

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
