### PR TITLE
fix(version): use original version string instead of re-formatted date for lookup

### DIFF
--- a/pkg/plugins/utils/version/time.go
+++ b/pkg/plugins/utils/version/time.go
@@ -21,6 +21,7 @@ type Time struct {
 	// Day of the month: "2" "_2" "02"
 	layout       string
 	versions     []time.Time
+	originals    []string
 	FoundVersion Version
 }
 
@@ -35,6 +36,7 @@ func (d *Time) Init(versions []string) error {
 		}
 
 		d.versions = append(d.versions, t)
+		d.originals = append(d.originals, version)
 	}
 
 	if len(d.versions) == 0 {
@@ -60,7 +62,7 @@ func (d *Time) Search(rawversions map[string]string) error {
 	}
 	d.Sort()
 
-	id := d.versions[len(d.versions)-1].Format(d.layout)
+	id := d.originals[len(d.originals)-1]
 
 	d.FoundVersion.ParsedVersion = rawversions[id]
 	d.FoundVersion.OriginalVersion = d.FoundVersion.ParsedVersion


### PR DESCRIPTION
Search formats parsed time values back to strings using the layout, then uses those formatted strings as map keys into rawversions. The map is keyed by the original version strings, so after formatting loses precision or changes format, the lookup silently returns an empty string.

Track the original version string alongside each parsed time during Init, so Search can look up the correct key in rawversions.