### PR TITLE
fix: add username/password auth to helm/argocd autodiscovery

### DIFF
--- a/pkg/plugins/autodiscovery/argocd/application.go
+++ b/pkg/plugins/autodiscovery/argocd/application.go
@@ -216,13 +216,17 @@ func (f ArgoCD) generateManifestBySource(data ApplicationSourceSpec, file string
 		}
 	}
 
+	username := ""
+	password := ""
 	token := ""
 	repoURL, err := url.Parse(data.RepoURL) // to validate URL format
 	switch err {
 	case nil:
 		if _, ok := f.spec.Auths[repoURL.Host]; ok {
+			username = f.spec.Auths[repoURL.Host].Username
+			password = f.spec.Auths[repoURL.Host].Password
 			token = f.spec.Auths[repoURL.Host].Token
-			logrus.Debugf("found token for repository %q", data.RepoURL)
+			logrus.Debugf("found credentials for repository %q", data.RepoURL)
 		}
 	default:
 		logrus.Debugf("Ignoring auth configuration due to invalid Helm repository URL: %s", err)
@@ -258,6 +262,8 @@ func (f ArgoCD) generateManifestBySource(data ApplicationSourceSpec, file string
 		TargetID                   string
 		TargetKey                  string
 		TargetYamlDocument         int
+		Username                   string
+		Password                   string
 		Token                      string
 		File                       string
 		ScmID                      string
@@ -280,6 +286,8 @@ func (f ArgoCD) generateManifestBySource(data ApplicationSourceSpec, file string
 		TargetYamlDocument:         yamlDocument,
 		File:                       file,
 		ScmID:                      f.scmID,
+		Username:                   username,
+		Password:                   password,
 		Token:                      token,
 	}
 

--- a/pkg/plugins/autodiscovery/argocd/main.go
+++ b/pkg/plugins/autodiscovery/argocd/main.go
@@ -47,7 +47,7 @@ type Spec struct {
 	//  More examples can be found at https://www.updatecli.io/docs/core/versionfilter/
 
 	VersionFilter version.Filter `yaml:",omitempty"`
-	// Auths holds a map of string to string where the key is the registry URL and the value the token used for authentication
+	// Auths holds a map of registry credentials where the key is the registry URL without scheme.
 	//
 	// Please be aware that only the host part of the URL is used to lookup for authentication token.
 	//
@@ -55,12 +55,18 @@ type Spec struct {
 	//
 	// ```
 	// auths:
-	//   "my-helm-repo.com": "my-secret-token"
+	//   "my-helm-repo.com": 
+	//     token: "my-secret-token"
+	//   "my-second-helm-repo.com": 
+	//     username: "username"
+	//     password: "my-secret-password"
 	// ```
 	Auths map[string]auth `yaml:",omitempty"`
 }
 
 type auth struct {
+	Username string `yaml:",omitempty"`
+	Password string `yaml:",omitempty"`
 	Token string `yaml:",omitempty"`
 }
 

--- a/pkg/plugins/autodiscovery/argocd/main.go
+++ b/pkg/plugins/autodiscovery/argocd/main.go
@@ -47,9 +47,9 @@ type Spec struct {
 	//  More examples can be found at https://www.updatecli.io/docs/core/versionfilter/
 
 	VersionFilter version.Filter `yaml:",omitempty"`
-	// Auths holds a map of registry credentials where the key is the registry URL without scheme.
+	// Auths holds a map of registry credentials where the key is the registry host (domain[:port]) without scheme.
 	//
-	// Please be aware that only the host part of the URL is used to lookup for authentication token.
+	// Please be aware that only the host part of the URL is used to lookup for authentication credentials.
 	//
 	// Example:
 	//

--- a/pkg/plugins/autodiscovery/argocd/main.go
+++ b/pkg/plugins/autodiscovery/argocd/main.go
@@ -55,9 +55,9 @@ type Spec struct {
 	//
 	// ```
 	// auths:
-	//   "my-helm-repo.com": 
+	//   "my-helm-repo.com":
 	//     token: "my-secret-token"
-	//   "my-second-helm-repo.com": 
+	//   "my-second-helm-repo.com":
 	//     username: "username"
 	//     password: "my-secret-password"
 	// ```
@@ -67,7 +67,7 @@ type Spec struct {
 type auth struct {
 	Username string `yaml:",omitempty"`
 	Password string `yaml:",omitempty"`
-	Token string `yaml:",omitempty"`
+	Token    string `yaml:",omitempty"`
 }
 
 // ArgoCD holds all information needed to generate argocd pipelines.

--- a/pkg/plugins/autodiscovery/argocd/manifestTemplate.go
+++ b/pkg/plugins/autodiscovery/argocd/manifestTemplate.go
@@ -15,6 +15,12 @@ sources:
     spec:
       name: '{{ .ChartName }}'
       url: '{{ .SourceChartRepository }}'
+      {{- if .Username }}
+      username: '{{ .Username }}'
+      {{- end }}
+      {{- if .Password }}
+      password: '{{ .Password }}'
+      {{- end }}
       {{- if .Token }}
       token: '{{ .Token }}'
       {{- end }}

--- a/pkg/plugins/autodiscovery/helm/dependencies.go
+++ b/pkg/plugins/autodiscovery/helm/dependencies.go
@@ -115,13 +115,17 @@ func (h Helm) discoverHelmDependenciesManifests() ([][]byte, error) {
 				}
 			}
 
+			username := ""
+			password := ""
 			token := ""
 			repoURL, err := url.Parse(dependency.Repository)
 			switch err {
 			case nil:
 				if _, ok := h.spec.Auths[repoURL.Host]; ok {
+					username = h.spec.Auths[repoURL.Host].Username
+					password = h.spec.Auths[repoURL.Host].Password
 					token = h.spec.Auths[repoURL.Host].Token
-					logrus.Debugf("found token for repository %q", dependency.Repository)
+					logrus.Debugf("found credentials for repository %q", dependency.Repository)
 				}
 			default:
 				logrus.Debugf("Ignoring auth configuration due to invalid Helm repository URL: %s", err)
@@ -155,6 +159,8 @@ func (h Helm) discoverHelmDependenciesManifests() ([][]byte, error) {
 				TargetChartSkipPackaging    bool
 				TargetChartVersionIncrement string
 				TargetFile                  string
+				Username                    string
+				Password                    string
 				Token                       string
 				File                        string
 				ScmID                       string
@@ -178,6 +184,8 @@ func (h Helm) discoverHelmDependenciesManifests() ([][]byte, error) {
 				TargetChartVersionIncrement: h.spec.VersionIncrement,
 				TargetFile:                  filepath.Base(foundChartFile),
 				File:                        relativeFoundChartFile,
+				Username:                    username,
+				Password:                    password,
 				Token:                       token,
 				ScmID:                       h.scmID,
 			}

--- a/pkg/plugins/autodiscovery/helm/dependencyManifest.go
+++ b/pkg/plugins/autodiscovery/helm/dependencyManifest.go
@@ -16,6 +16,12 @@ sources:
     spec:
       name: '{{ .DependencyName }}'
       url: '{{ .DependencyRepository }}'
+      {{- if .Username }}
+      username: '{{ .Username }}'
+      {{- end }}
+      {{- if .Password }}
+      password: '{{ .Password }}'
+      {{- end }}
       {{- if .Token }}
       token: '{{ .Token }}'
       {{- end }}


### PR DESCRIPTION
Hi! First of all, thanks for creating this great tool! 😃 It has become a big cornerstone of my update strategy.

While using it, I stumbled across an issue with some Autodiscovery plugins.

Both the Helm and ArgoCD Autodiscovery documentation mention support for `username/password` authentication in the auth section. However, it looks like only `token` is currently passed through by the code. This pull request adds support for passing both to the generated manifests as well.

I also fixed a small documentation issue where the ArgoCD auth example used `<registry>: my-token` instead of `<registry>.token: my-token` as I was already adding the other options anyway 😄 

## Test

To test this pull request, you can run the following commands:

```shell
go test ./pkg/plugins/autodiscovery/helm
go test ./pkg/plugins/autodiscovery/argocd
```

I didn't add any additional tests because passing the `token` field through to the generated manifests was already covered by existing tests, and the new functionality follows the same code path. Adding separate tests for `username/password` felt somewhat redundant, but I'm happy to add them if you think they would be valuable. 🙂

## Additional Information

### Checklist

- [ ] <s>I have updated the documentation via pull request in [website](https://github.com/updatecli/website) repository.</s> Not applicable

### Tradeoff

None that i can think of.

### Potential improvement

First of all, it's absolutely possible that I misunderstood part of the code. I only looked at a small portion of the codebase while investigating this issue, so apologies if that's the case. 🙂

I think it could be worth separating the Helm Autodiscovery auth section/handling  for Helm registries and container registries a bit more. The current implementation uses `docker.InlineKeyChain` for both container registries and Helm registries. That makes sense for OCI registries, but it feels a little less intuitive for non-OCI Helm registries (see the [Helm autodiscovery auth handling](https://github.com/updatecli/updatecli/blob/main/pkg/plugins/autodiscovery/helm/main.go#L30), which is used for both container manifests and Helm dependency manifests).

I can also imagine situations where different credentials are needed for container images and Helm charts. One example is GitLab, which provides both a Container Registry and a Package Registry on the same domain. They support fine-grained credentials, so you might want separate credentials with access to only one of those registries.

Additionally, the type itself appears to be primarily intended for OCI registries (see the [`InlineKeyChain` type documentation](https://pkg.go.dev/github.com/updatecli/updatecli/pkg/plugins/utils/docker#InlineKeyChain)). At the same time, it seems to be used for non-OCI registries as well.

I don't think this is a major issue - the `InlineKeyChain` type works well as a catch-all since it supports `username`, `password`, and `token`. It just felt a little confusing while I was tracking down this bug.