### PR TITLE
fix(terragrunt): support source including git username

### DIFF
--- a/pkg/plugins/autodiscovery/terragrunt/main_test.go
+++ b/pkg/plugins/autodiscovery/terragrunt/main_test.go
@@ -136,6 +136,59 @@ targets:
       path: 'terraform.source'
 `
 
+	expectedGitSSH := `name: 'Bump Terragrunt module github.com/Azure/terraform-azurerm-avm-res-network-virtualnetwork.git version'
+scms:
+  module:
+    kind: 'git'
+    spec:
+      url: 'ssh://github.com/Azure/terraform-azurerm-avm-res-network-virtualnetwork.git'
+sources:
+  latestVersion:
+    name: 'Get latest version of the github.com/Azure/terraform-azurerm-avm-res-network-virtualnetwork.git module'
+    kind: 'gittag'
+    transformers:
+      - addprefix: 'git::ssh://github.com/Azure/terraform-azurerm-avm-res-network-virtualnetwork.git?ref='
+    spec:
+      versionfilter:
+        kind: 'semver'
+        pattern: '>=0.3.0'
+    scmid: 'module'
+targets:
+  terragruntModuleFile:
+    name: 'deps: bump github.com/Azure/terraform-azurerm-avm-res-network-virtualnetwork.git to {{ source "latestVersion" }}'
+    kind: 'hcl'
+    sourceid: 'latestVersion'
+    spec:
+      file: 'git_ssh.hcl'
+      path: 'terraform.source'
+`
+	expectedGitSSHUsername := `name: 'Bump Terragrunt module git@github.com/Azure/terraform-azurerm-avm-res-network-virtualnetwork.git version'
+scms:
+  module:
+    kind: 'git'
+    spec:
+      url: 'ssh://git@github.com/Azure/terraform-azurerm-avm-res-network-virtualnetwork.git'
+sources:
+  latestVersion:
+    name: 'Get latest version of the git@github.com/Azure/terraform-azurerm-avm-res-network-virtualnetwork.git module'
+    kind: 'gittag'
+    transformers:
+      - addprefix: 'git::ssh://git@github.com/Azure/terraform-azurerm-avm-res-network-virtualnetwork.git?ref='
+    spec:
+      versionfilter:
+        kind: 'semver'
+        pattern: '>=0.3.0'
+    scmid: 'module'
+targets:
+  terragruntModuleFile:
+    name: 'deps: bump git@github.com/Azure/terraform-azurerm-avm-res-network-virtualnetwork.git to {{ source "latestVersion" }}'
+    kind: 'hcl'
+    sourceid: 'latestVersion'
+    spec:
+      file: 'git_ssh_username.hcl'
+      path: 'terraform.source'
+`
+
 	testdata := []struct {
 		name              string
 		rootDir           string
@@ -145,7 +198,9 @@ targets:
 			name:    "Terraform Version",
 			rootDir: "testdata",
 			expectedPipelines: []string{
+				expectedGitSSHUsername,
 				expectedNonTfr,
+				expectedGitSSH,
 				expectedSimpleLocalized,
 				expectedSuperComplexLocalized,
 				expectedInlined,

--- a/pkg/plugins/autodiscovery/terragrunt/testdata/git_ssh.hcl
+++ b/pkg/plugins/autodiscovery/terragrunt/testdata/git_ssh.hcl
@@ -1,0 +1,3 @@
+terraform {
+  source = "git::ssh://github.com/Azure/terraform-azurerm-avm-res-network-virtualnetwork.git?ref=v0.3.0"
+}

--- a/pkg/plugins/autodiscovery/terragrunt/testdata/git_ssh_username.hcl
+++ b/pkg/plugins/autodiscovery/terragrunt/testdata/git_ssh_username.hcl
@@ -1,0 +1,3 @@
+terraform {
+  source = "git::ssh://git@github.com/Azure/terraform-azurerm-avm-res-network-virtualnetwork.git?ref=v0.3.0"
+}

--- a/pkg/plugins/autodiscovery/terragrunt/utils.go
+++ b/pkg/plugins/autodiscovery/terragrunt/utils.go
@@ -151,7 +151,7 @@ func parseSourceUrl(evaluatedSource string, rawSource string, allowNoVersion boo
 	}
 	source.sourceType = sourceType
 	if sourceType == SourceTypeRegistry || sourceType == SourceTypeGit || sourceType == SourceTypeGithub {
-		if sourceType == SourceTypeGit && strings.HasPrefix(evaluatedSource, "git") {
+		if sourceType == SourceTypeGit && strings.HasPrefix(evaluatedSource, "git@") {
 			evaluatedSource = strings.Replace(evaluatedSource, "git@", "git::ssh://", 1)
 		}
 		u, err := url.Parse(evaluatedSource)

--- a/pkg/plugins/autodiscovery/terragrunt/utils_test.go
+++ b/pkg/plugins/autodiscovery/terragrunt/utils_test.go
@@ -22,6 +22,8 @@ func TestSearchTerragruntFiles(t *testing.T) {
 			rootDir: "testdata",
 			expectedFoundFiles: []string{
 				"testdata/complex_localized.hcl",
+				"testdata/git_ssh.hcl",
+				"testdata/git_ssh_username.hcl",
 				"testdata/inlined.hcl",
 				"testdata/more_complex_localized.hcl",
 				"testdata/non_tfr.hcl",
@@ -152,6 +154,36 @@ func TestGetTerragruntModules(t *testing.T) {
 					baseUrl:         "github.com/Azure/terraform-azurerm-avm-res-network-virtualnetwork.git",
 					rawSource:       "\"git::https://github.com/Azure/terraform-azurerm-avm-res-network-virtualnetwork.git?ref=v0.3.0\"",
 					evaluatedSource: "git::https://github.com/Azure/terraform-azurerm-avm-res-network-virtualnetwork.git?ref=v0.3.0",
+					version:         "0.3.0",
+					sourceType:      SourceTypeGit,
+				},
+			},
+		},
+		{
+			name: "Git SSH without username scenario",
+			file: "testdata/git_ssh.hcl",
+			expectedModule: &terragruntModule{
+				registryModule: nil,
+				source: terragruntModuleSource{
+					protocol:        "git::ssh",
+					baseUrl:         "github.com/Azure/terraform-azurerm-avm-res-network-virtualnetwork.git",
+					rawSource:       "\"git::ssh://github.com/Azure/terraform-azurerm-avm-res-network-virtualnetwork.git?ref=v0.3.0\"",
+					evaluatedSource: "git::ssh://github.com/Azure/terraform-azurerm-avm-res-network-virtualnetwork.git?ref=v0.3.0",
+					version:         "0.3.0",
+					sourceType:      SourceTypeGit,
+				},
+			},
+		},
+		{
+			name: "Git SSH Username scenario",
+			file: "testdata/git_ssh_username.hcl",
+			expectedModule: &terragruntModule{
+				registryModule: nil,
+				source: terragruntModuleSource{
+					protocol:        "git::ssh",
+					baseUrl:         "git@github.com/Azure/terraform-azurerm-avm-res-network-virtualnetwork.git",
+					rawSource:       "\"git::ssh://git@github.com/Azure/terraform-azurerm-avm-res-network-virtualnetwork.git?ref=v0.3.0\"",
+					evaluatedSource: "git::ssh://git@github.com/Azure/terraform-azurerm-avm-res-network-virtualnetwork.git?ref=v0.3.0",
 					version:         "0.3.0",
 					sourceType:      SourceTypeGit,
 				},


### PR DESCRIPTION
Fix #XXX

This PR will fix updatecli unable to use terragrunt autodiscovery for terraground source using git@ username Syntax.

## Test

To test this pull request, you can run the following commands:

```shell
go test -v ./pkg/plugins/autodiscovery/terragrunt
```

## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via pull request in [website](https://github.com/updatecli/website) repository.

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
