### PR TITLE
fix(autodiscovery/updatecli): correctly use relative file path

### DIFF
--- a/pkg/plugins/autodiscovery/updatecli/main_test.go
+++ b/pkg/plugins/autodiscovery/updatecli/main_test.go
@@ -39,7 +39,7 @@ targets:
     name: 'deps(updatecli): bump "ghcr.io/updatecli/policies/policies/hugo/netlify" policy to {{ source "version"}}'
     kind: 'yaml'
     spec:
-      file: 'testdata/website/updatecli-compose.yaml'
+      file: 'website/updatecli-compose.yaml'
       key: '$.policies[3].policy'
     transformers:
       - addprefix: 'ghcr.io/updatecli/policies/policies/hugo/netlify:'
@@ -67,7 +67,7 @@ targets:
     name: 'deps(updatecli): bump "ghcr.io/updatecli/policies/policies/nodejs/githubaction" policy to {{ source "version"}}'
     kind: 'yaml'
     spec:
-      file: 'testdata/website/updatecli-compose.yaml'
+      file: 'website/updatecli-compose.yaml'
       key: '$.policies[1].policy'
     transformers:
       - addprefix: 'ghcr.io/updatecli/policies/policies/nodejs/githubaction:'
@@ -95,7 +95,7 @@ targets:
     name: 'deps(updatecli): bump "ghcr.io/updatecli/policies/policies/nodejs/netlify" policy to {{ source "version"}}'
     kind: 'yaml'
     spec:
-      file: 'testdata/website/updatecli-compose.yaml'
+      file: 'website/updatecli-compose.yaml'
       key: '$.policies[2].policy'
     transformers:
       - addprefix: 'ghcr.io/updatecli/policies/policies/nodejs/netlify:'

--- a/pkg/plugins/autodiscovery/updatecli/policies.go
+++ b/pkg/plugins/autodiscovery/updatecli/policies.go
@@ -43,6 +43,7 @@ func (u Updatecli) discoverUpdatecliPolicyManifests() ([][]byte, error) {
 		logrus.Debugf("parsing file %q", foundUpdateComposeFile)
 
 		relativeUpdateComposeFile, err := filepath.Rel(u.rootDir, foundUpdateComposeFile)
+
 		if err != nil {
 			// Jump to the next Update compose file if current failed
 			logrus.Debugln(err)
@@ -149,7 +150,7 @@ func (u Updatecli) discoverUpdatecliPolicyManifests() ([][]byte, error) {
 				SourceVersionFilterRegex:   sourceVersionFilterRegex,
 				TargetName:                 fmt.Sprintf("deps(updatecli): bump %q policy to {{ source %q}}", policyName, "version"),
 				TargetKey:                  fmt.Sprintf("$.policies[%d].policy", i),
-				File:                       foundUpdateComposeFile,
+				File:                       relativeUpdateComposeFile,
 				ScmID:                      u.scmID,
 			}
 

--- a/pkg/plugins/resources/file/source_test.go
+++ b/pkg/plugins/resources/file/source_test.go
@@ -279,16 +279,19 @@ func TestFile_Source(t *testing.T) {
 				contentRetriever: &mockedText,
 				files:            tt.files,
 			}
-			// Looping on the only filePath in 'files'
-			for filePath := range f.files {
-				gotResult := result.Source{}
-				gotErr := f.Source(context.Background(), filePath, &gotResult)
-				if tt.wantedErr {
-					assert.Error(t, gotErr)
-					return
-				}
+			// No working directory: the resource is run locally, without an SCM
+			// checkout, so the file paths of the specification are used as is.
+			gotResult := result.Source{}
+			gotErr := f.Source(context.Background(), "", &gotResult)
+			if tt.wantedErr {
+				assert.Error(t, gotErr)
+				return
+			}
 
-				require.NoError(t, gotErr)
+			require.NoError(t, gotErr)
+
+			// Looping on the only filePath in 'files'
+			for filePath := range tt.files {
 				assert.Equal(t, tt.wantedContents[filePath], gotResult.Information)
 			}
 		})

--- a/pkg/plugins/resources/file/target_containment_test.go
+++ b/pkg/plugins/resources/file/target_containment_test.go
@@ -38,7 +38,14 @@ func TestFile_TargetPathContainment(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			workingDir := t.TempDir()
+			// The working directory is nested two levels below the temporary
+			// directory so that a "../.." traversal still lands inside it: the
+			// test must never write to (nor assert on) a shared location such
+			// as /tmp, which another run could have polluted.
+			baseDir := t.TempDir()
+			workingDir := filepath.Join(baseDir, "checkout", "nested")
+			require.NoError(t, os.MkdirAll(workingDir, 0o700))
+
 			targetPath := tt.targetPath(workingDir)
 
 			f, err := New(Spec{
@@ -61,6 +68,61 @@ func TestFile_TargetPathContainment(t *testing.T) {
 			_, statErr := os.Stat(escapePath)
 			assert.Truef(t, os.IsNotExist(statErr),
 				"payload must not be written outside the working directory: %q", escapePath)
+		})
+	}
+}
+
+// TestFile_SourcePathContainment is the source side counterpart of
+// TestFile_TargetPathContainment: a source path escaping the SCM working
+// directory must be rejected instead of reading an arbitrary file on the host.
+func TestFile_SourcePathContainment(t *testing.T) {
+	const secretContent = "TOP SECRET"
+
+	tests := []struct {
+		name string
+		// sourcePath returns the spec.file value to read, given the directory
+		// holding the secret and the working directory.
+		sourcePath func(secretPath, workingDir string) string
+	}{
+		{
+			name: "absolute path escape is rejected",
+			sourcePath: func(secretPath, _ string) string {
+				return secretPath
+			},
+		},
+		{
+			name: "dot dot traversal escape is rejected",
+			sourcePath: func(secretPath, workingDir string) string {
+				relPath, err := filepath.Rel(workingDir, secretPath)
+				require.NoError(t, err)
+				return relPath
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// The secret sits outside the checkout, two levels above the
+			// working directory, so a "../.." traversal would reach it.
+			baseDir := t.TempDir()
+			workingDir := filepath.Join(baseDir, "checkout", "nested")
+			require.NoError(t, os.MkdirAll(workingDir, 0o700))
+
+			secretPath := filepath.Join(baseDir, "secret.txt")
+			require.NoError(t, os.WriteFile(secretPath, []byte(secretContent), 0o600))
+
+			f, err := New(Spec{
+				File: tt.sourcePath(secretPath, workingDir),
+			})
+			require.NoError(t, err)
+
+			// The secret is readable, so only the containment check can prevent
+			// the source from returning it.
+			gotResult := result.Source{}
+			gotErr := f.Source(context.Background(), workingDir, &gotResult)
+			assert.Error(t, gotErr, "a path escaping the working directory must be rejected")
+			assert.NotContains(t, gotResult.Information, secretContent,
+				"content outside the working directory must not be exposed as a source value")
 		})
 	}
 }


### PR DESCRIPTION

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
cd pkg/plugins/resources/file/
go test
```

## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via pull request in [website](https://github.com/updatecli/website) repository.

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
