### PR TITLE
fix(github): use redirect.github.com for pull request links

### DIFF
--- a/pkg/plugins/scms/github/pullrequest.go
+++ b/pkg/plugins/scms/github/pullrequest.go
@@ -534,7 +534,10 @@ func (p *PullRequest) updatePullRequest(ctx context.Context, retry int) error {
 
 	title := p.Title
 
-	bodyPR, err := utils.GeneratePullRequestBody(p.spec.Description, p.Report)
+	bodyPR, err := utils.GeneratePullRequestBody(
+		p.spec.Description,
+		redirectGitHubPullRequestLinks(p.Report),
+	)
 	if err != nil {
 		return err
 	}
@@ -772,7 +775,10 @@ func (p *PullRequest) OpenPullRequest(ctx context.Context, retry int) error {
 
 
 	*/
-	bodyPR, err := utils.GeneratePullRequestBody(p.spec.Description, p.Report)
+	bodyPR, err := utils.GeneratePullRequestBody(
+		p.spec.Description,
+		redirectGitHubPullRequestLinks(p.Report),
+	)
 	if err != nil {
 		return err
 	}

--- a/pkg/plugins/scms/github/pullrequest_links.go
+++ b/pkg/plugins/scms/github/pullrequest_links.go
@@ -1,0 +1,14 @@
+package github
+
+import "regexp"
+
+var githubPullRequestURL = regexp.MustCompile(
+	`https://github\.com/([^/\s]+)/([^/\s]+)/pull/(\d+)`,
+)
+
+func redirectGitHubPullRequestLinks(body string) string {
+	return githubPullRequestURL.ReplaceAllString(
+		body,
+		"https://redirect.github.com/$1/$2/pull/$3",
+	)
+}

--- a/pkg/plugins/scms/github/pullrequest_links_test.go
+++ b/pkg/plugins/scms/github/pullrequest_links_test.go
@@ -1,0 +1,37 @@
+package github
+
+import "testing"
+
+func TestRedirectGitHubPullRequestLinks(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "redirects GitHub pull request URL",
+			input:    "See https://github.com/test/repo/pull/123",
+			expected: "See https://redirect.github.com/test/repo/pull/123",
+		},
+		{
+			name:     "leaves GitHub release URL unchanged",
+			input:    "See https://github.com/test/repo/releases/tag/v1.0.0",
+			expected: "See https://github.com/test/repo/releases/tag/v1.0.0",
+		},
+		{
+			name:     "leaves GitHub issue URL unchanged",
+			input:    "See https://github.com/test/repo/issues/123",
+			expected: "See https://github.com/test/repo/issues/123",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := redirectGitHubPullRequestLinks(tt.input)
+
+			if actual != tt.expected {
+				t.Fatalf("expected %q, got %q", tt.expected, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Use `redirect.github.com` for GitHub pull request links in generated GitHub pull request bodies.

This keeps referenced pull requests clickable while preventing GitHub from creating noisy backlinks on those pull requests.

## Changes

- Added GitHub-specific pull request URL rewriting.
- Applied the rewriting when creating and updating GitHub pull requests.
- Left other GitHub URLs, including issue and release URLs, unchanged.
- Added unit tests covering the URL rewriting behaviour.

## Testing

```text
go test ./pkg/core/reports ./pkg/plugins/scms/github
