### PR TITLE
fix: skip resource depends on skipped source

### DIFF
--- a/pkg/core/pipeline/utils.go
+++ b/pkg/core/pipeline/utils.go
@@ -51,6 +51,11 @@ func (p *Pipeline) shouldSkipResource(leaf *Node, depsResults map[string]*Node) 
 				if dependencyResult.Category == conditionCategory && dependencyResult.Result != result.SUCCESS {
 					return true
 				}
+				// A skipped source doesn't provide any value, so running its dependents
+				// would have them consume an empty source input.
+				if dependencyResult.Category == sourceCategory && dependencyResult.Result == result.SKIPPED {
+					return true
+				}
 				if dependencyResult.Result == result.FAILURE {
 					// And operator but dep is failed
 					return true

--- a/pkg/core/pipeline/utils_test.go
+++ b/pkg/core/pipeline/utils_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
 func TestExtractDepsFromTemplate(t *testing.T) {
@@ -43,6 +44,96 @@ func TestExtractDepsFromTemplate(t *testing.T) {
 			sort.Strings(data.ExpectedResult)
 			sort.Strings(got)
 			require.Equal(t, data.ExpectedResult, got)
+		})
+	}
+}
+
+func TestShouldSkipResource(t *testing.T) {
+	testdata := []struct {
+		Name           string
+		Leaf           Node
+		DepsResults    map[string]*Node
+		ExpectedResult bool
+	}{
+		{
+			Name: "target depending on a successful source runs",
+			Leaf: Node{
+				ID:        "target#mytarget",
+				Category:  targetCategory,
+				DependsOn: []Dependency{{ID: "source#mysource", Operator: andBooleanOperator}},
+			},
+			DepsResults: map[string]*Node{
+				"source#mysource": {ID: "source#mysource", Category: sourceCategory, Result: result.SUCCESS},
+			},
+			ExpectedResult: false,
+		},
+		{
+			// A skipped source has no value to provide, so its dependents would otherwise
+			// consume an empty source input.
+			Name: "target depending on a skipped source is skipped",
+			Leaf: Node{
+				ID:        "target#mytarget",
+				Category:  targetCategory,
+				DependsOn: []Dependency{{ID: "source#mysource", Operator: andBooleanOperator}},
+			},
+			DepsResults: map[string]*Node{
+				"source#mysource": {ID: "source#mysource", Category: sourceCategory, Result: result.SKIPPED},
+			},
+			ExpectedResult: true,
+		},
+		{
+			Name: "condition depending on a skipped source is skipped",
+			Leaf: Node{
+				ID:        "condition#mycondition",
+				Category:  conditionCategory,
+				DependsOn: []Dependency{{ID: "source#mysource", Operator: andBooleanOperator}},
+			},
+			DepsResults: map[string]*Node{
+				"source#mysource": {ID: "source#mysource", Category: sourceCategory, Result: result.SKIPPED},
+			},
+			ExpectedResult: true,
+		},
+		{
+			Name: "target depending on a failed source is skipped",
+			Leaf: Node{
+				ID:        "target#mytarget",
+				Category:  targetCategory,
+				DependsOn: []Dependency{{ID: "source#mysource", Operator: andBooleanOperator}},
+			},
+			DepsResults: map[string]*Node{
+				"source#mysource": {ID: "source#mysource", Category: sourceCategory, Result: result.FAILURE},
+			},
+			ExpectedResult: true,
+		},
+		{
+			// A skipped target only means it had nothing to change, which mustn't stop
+			// the resources depending on it.
+			Name: "target depending on a skipped target runs",
+			Leaf: Node{
+				ID:        "target#mytarget",
+				Category:  targetCategory,
+				DependsOn: []Dependency{{ID: "target#myothertarget", Operator: andBooleanOperator}},
+			},
+			DepsResults: map[string]*Node{
+				"target#myothertarget": {ID: "target#myothertarget", Category: targetCategory, Result: result.SKIPPED},
+			},
+			ExpectedResult: false,
+		},
+		{
+			Name: "resource without any dependency runs",
+			Leaf: Node{
+				ID:       "target#mytarget",
+				Category: targetCategory,
+			},
+			ExpectedResult: false,
+		},
+	}
+
+	p := Pipeline{}
+
+	for _, tt := range testdata {
+		t.Run(tt.Name, func(t *testing.T) {
+			require.Equal(t, tt.ExpectedResult, p.shouldSkipResource(&tt.Leaf, tt.DepsResults))
 		})
 	}
 }


### PR DESCRIPTION
No need to run resources that depends on a skipped source

## Test

To test this pull request, you can run the following commands:

```shell
cd pkg/core/pipeline/
go test
```

## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via pull request in [website](https://github.com/updatecli/website) repository.
- [ ] <!-- If applicable,--> I have tested this pull request manually with a custom Updatecli build and it works as expected.

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
