### PR TITLE
fix: go module cooldown with pseudo version

### DIFF
--- a/pkg/plugins/resources/go/module/condition.go
+++ b/pkg/plugins/resources/go/module/condition.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
@@ -47,18 +46,8 @@ func (g *GoModule) Condition(ctx context.Context, source string, scm scm.ScmHand
 				return true, fmt.Sprintf("version %q available", versionToCheck), nil
 			}
 		case false:
-			releaseDate, err := time.Parse(time.RFC3339, versionInfo.Time)
-			if err != nil {
-				logrus.Debugf("failed to parse release date for version %q from proxy %q: %v\n", versionToCheck, proxy, err)
-				continue
-			}
-			if g.Spec.Age.Minimum != "" && g.Spec.Age.IsOlderThan(releaseDate, nil) {
-				logrus.Debugf("ignoring	version %q from proxy %q because its age is below %q (released on %s)\n", versionToCheck, proxy, g.Spec.Age.Minimum, releaseDate)
-				continue
-			}
-
-			if g.Spec.Age.Maximum != "" && g.Spec.Age.IsNewerThan(releaseDate, nil) {
-				logrus.Debugf("ignoring version %q from proxy %q because its age is above %q (released on %s)\n", versionToCheck, proxy, g.Spec.Age.Maximum, releaseDate)
+			if !isVersionMatchingAge(versionInfo, g.Spec.Age) {
+				logrus.Debugf("ignoring version %q from proxy %q because it doesn't match the age filter\n", versionToCheck, proxy)
 				continue
 			}
 

--- a/pkg/plugins/resources/go/module/main.go
+++ b/pkg/plugins/resources/go/module/main.go
@@ -45,6 +45,17 @@ func New(spec interface{}) (*GoModule, error) {
 		newFilter.Pattern = "*"
 	}
 
+	/*
+		Init must run after the fallback above, as it defaults an empty kind to "latest"
+		which would silently override the semantic versioning default of that resource.
+		It also provides the default pattern of a partially specified filter, such as
+		"latest" for a filter only setting `kind: latest`.
+	*/
+	newFilter, err = newFilter.Init()
+	if err != nil {
+		return nil, err
+	}
+
 	if err = newSpec.Age.Validate(); err != nil {
 		return nil, fmt.Errorf("wrong age spec %v", err)
 	}

--- a/pkg/plugins/resources/go/module/source.go
+++ b/pkg/plugins/resources/go/module/source.go
@@ -10,7 +10,7 @@ import (
 
 // Source returns the latest go module version
 func (g *GoModule) Source(ctx context.Context, workingDir string, resultSource *result.Source) error {
-	version, _, err := g.versions(ctx)
+	version, err := g.versions(ctx)
 	if err != nil {
 		/*
 			Every published version is still cooling down, which is an expected state of

--- a/pkg/plugins/resources/go/module/source.go
+++ b/pkg/plugins/resources/go/module/source.go
@@ -2,6 +2,7 @@ package gomodule
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/updatecli/updatecli/pkg/core/result"
@@ -11,6 +12,16 @@ import (
 func (g *GoModule) Source(ctx context.Context, workingDir string, resultSource *result.Source) error {
 	version, _, err := g.versions(ctx)
 	if err != nil {
+		/*
+			Every published version is still cooling down, which is an expected state of
+			the age filter rather than a failure, so the source is skipped instead.
+		*/
+		if errors.Is(err, ErrNoVersionMatchingAge) {
+			resultSource.Result = result.SKIPPED
+			resultSource.Description = fmt.Sprintf("no version of the GO module %q matches the age filter yet", g.Spec.Module)
+			return nil
+		}
+
 		return fmt.Errorf("searching go module version: %w", err)
 	}
 

--- a/pkg/plugins/resources/go/module/source_test.go
+++ b/pkg/plugins/resources/go/module/source_test.go
@@ -13,10 +13,11 @@ import (
 
 func TestSource(t *testing.T) {
 	tests := []struct {
-		name           string
-		spec           Spec
-		expectedResult string
-		expectedError  bool
+		name            string
+		spec            Spec
+		expectedResult  string
+		expectedError   bool
+		expectedSkipped bool
 	}{
 		{
 			spec: Spec{
@@ -84,7 +85,8 @@ func TestSource(t *testing.T) {
 					Minimum: "100y",
 				},
 			},
-			expectedError: true,
+			// Every published version is still cooling down, which is a skip and not a failure
+			expectedSkipped: true,
 		},
 		{
 			spec: Spec{
@@ -110,7 +112,8 @@ func TestSource(t *testing.T) {
 					Maximum: "1s",
 				},
 			},
-			expectedError: true,
+			// Every published version is too old, which is a skip and not a failure
+			expectedSkipped: true,
 		},
 	}
 	for _, tt := range tests {
@@ -124,6 +127,12 @@ func TestSource(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
+			if tt.expectedSkipped {
+				assert.Equal(t, result.SKIPPED, gotResult.Result)
+				assert.Empty(t, gotResult.Information)
+				return
+			}
+			assert.Equal(t, result.SUCCESS, gotResult.Result)
 			assert.Equal(t, tt.expectedResult, gotResult.Information)
 		})
 	}

--- a/pkg/plugins/resources/go/module/version.go
+++ b/pkg/plugins/resources/go/module/version.go
@@ -3,6 +3,7 @@ package gomodule
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -18,6 +19,11 @@ import (
 	"github.com/updatecli/updatecli/pkg/plugins/utils/age"
 	"github.com/updatecli/updatecli/pkg/plugins/utils/version"
 )
+
+// ErrNoVersionMatchingAge is returned when a Golang module publishes versions but the age
+// filter discarded all of them. It reports a cooldown still running, not a lookup failure,
+// so callers are expected to skip rather than to fail.
+var ErrNoVersionMatchingAge = errors.New("no version matching the age filter")
 
 // versionInfo represents the structure of the version information returned by the Go proxy API.
 type versionInfo struct {
@@ -37,45 +43,87 @@ func (g *GoModule) versions(ctx context.Context) (v string, versions []string, e
 		GOPROXY = goModuleDefaultProxy
 	}
 
+	// Tracks proxies which do publish versions for that module but none matching the age
+	// filter, so that a running cooldown isn't reported as a missing module.
+	heldBackByAge := false
+
 	for _, proxy := range strings.Split(GOPROXY, ",") {
 		proxy = strings.TrimSpace(proxy)
 		if !isSupportedGoProxy(proxy) {
 			continue
 		}
 
-		proxyVersions, err := getVersionsFromProxy(ctx, g.webClient, proxy, g.Spec.Module, g.Spec.Age)
+		publishedVersions, matchingVersions, err := getVersionsFromProxy(ctx, g.webClient, proxy, g.Spec.Module, g.Spec.Age)
 		if err != nil {
 			logrus.Debugf("skipping proxy %q due to %v\n", proxy, err)
 			continue
 		}
 
-		if proxyVersions == nil && isLatestVersionFilter(g.versionFilter) {
-			pseudoVersion, err := getLatestVersionFromProxy(ctx, g.webClient, proxy, g.Spec.Module)
+		/*
+			The module doesn't publish any version, so the only thing a Go proxy can report
+			is the pseudo version of its latest commit.
+			as explained on https://go.dev/ref/mod#goproxy-protocol
+		*/
+		if len(publishedVersions) == 0 {
+			if !isLatestVersionFilter(g.versionFilter) {
+				logrus.Debugf("no version published for module %q on proxy %q\n", g.Spec.Module, proxy)
+				continue
+			}
+
+			latestVersion, err := getLatestVersionFromProxy(ctx, g.webClient, proxy, g.Spec.Module)
 			if err != nil {
 				logrus.Debugf("skipping proxy %q due to %v\n", proxy, err)
 				continue
 			}
 
-			if pseudoVersion != "" {
-
-				if !isPseudoVersionMatchingAge(pseudoVersion, g.Spec.Age) {
-					logrus.Debugf("ignoring pseudo version %q from proxy %q because it doesn't match the age filter\n", pseudoVersion, proxy)
-					continue
-				}
-
-				versions = append(versions, pseudoVersion)
+			if latestVersion.Version == "" {
+				logrus.Debugf("no version published for module %q on proxy %q\n", g.Spec.Module, proxy)
+				continue
 			}
 
-			logrus.Debugf("no version published for module %q on proxy %q, fallback to pseudo version %q\n", g.Spec.Module, proxy, pseudoVersion)
+			if !isVersionMatchingAge(latestVersion, g.Spec.Age) {
+				logrus.Debugf("ignoring version %q from proxy %q because it doesn't match the age filter\n", latestVersion.Version, proxy)
+				heldBackByAge = true
+				continue
+			}
 
-			return pseudoVersion, versions, nil
+			logrus.Debugf("no version published for module %q on proxy %q, fallback to version %q\n", g.Spec.Module, proxy, latestVersion.Version)
+
+			g.Version = version.Version{
+				ParsedVersion:   latestVersion.Version,
+				OriginalVersion: latestVersion.Version,
+			}
+
+			return latestVersion.Version, []string{latestVersion.Version}, nil
 		}
 
+		// The module publishes versions but the age filter discarded every one of them,
+		// which means the version we would have returned is still cooling down.
+		if len(matchingVersions) == 0 {
+			logrus.Debugf("every version published for module %q on proxy %q is filtered out by the age filter\n", g.Spec.Module, proxy)
+			heldBackByAge = true
+			continue
+		}
+
+		versions = versionNames(matchingVersions)
+
 		/*
-			The response should be a list of version separated by \n
-			as explained on https://go.dev/ref/mod#goproxy-protocol
+			A "latest" filter asks for the most recently published version, which the
+			lexicographic sort below can't identify since "v1.9.0" sorts after "v1.10.0".
+			Release dates are known whenever the age filter ran, so use them to fall back
+			on the most recent version that isn't cooling down anymore.
 		*/
-		versions = append(versions, proxyVersions...)
+		if isNewestVersionFilter(g.versionFilter) && !g.Spec.Age.IsZero() {
+			newestVersion := newestPublishedVersion(matchingVersions)
+			if newestVersion != "" {
+				g.Version = version.Version{
+					ParsedVersion:   newestVersion,
+					OriginalVersion: newestVersion,
+				}
+
+				return newestVersion, versions, nil
+			}
+		}
 
 		sort.Strings(versions)
 		g.Version, err = g.versionFilter.Search(versions)
@@ -87,40 +135,47 @@ func (g *GoModule) versions(ctx context.Context) (v string, versions []string, e
 
 	}
 
+	if heldBackByAge {
+		return "", nil, fmt.Errorf("%w for GO module %q", ErrNoVersionMatchingAge, g.Spec.Module)
+	}
+
 	return "", nil, fmt.Errorf("GO module %q not found on proxy %q", g.Spec.Module, GOPROXY)
 }
 
-// getVersionsFromProxy returns all versions of a Golang module from a proxy
-func getVersionsFromProxy(ctx context.Context, client httpclient.HTTPClient, proxy, module string, releaseAge age.Spec) ([]string, error) {
+// getFromProxy queries a Go module proxy endpoint and returns its raw response body.
+// The endpoint is built by appending elems to the module path, as described on
+// https://go.dev/ref/mod#goproxy-protocol
+func getFromProxy(ctx context.Context, client httpclient.HTTPClient, proxy, module string, elems ...string) ([]byte, error) {
 	URL, err := url.JoinPath(
 		sanitizeGoProxy(proxy),
-		sanitizeGoModuleNameForProxy(module),
-		"@v", "list")
+		append([]string{sanitizeGoModuleNameForProxy(module)}, elems...)...)
 	if err != nil {
-		logrus.Errorf("something went wrong while getting go module api data %q\n", err)
-		return nil, err
+		return nil, fmt.Errorf("building go module proxy url: %w", err)
 	}
 
 	// #nosec G704
 	req, err := http.NewRequestWithContext(ctx, "GET", URL, nil)
 	if err != nil {
-		logrus.Errorf("something went wrong while getting go module api data %q\n", err)
-		return nil, err
+		return nil, fmt.Errorf("building go module proxy request: %w", err)
 	}
 
 	res, err := client.Do(req)
 	if err != nil {
-		logrus.Errorf("something went wrong while getting go module api data %q\n", err)
-		return nil, err
+		return nil, fmt.Errorf("querying go module proxy: %w", err)
 	}
 
 	defer res.Body.Close()
 	if res.StatusCode >= 400 {
-		logrus.Errorf("something went wrong while getting golang module data: proxy %q returned HTTP %d (%s)\n", proxy, res.StatusCode, res.Status)
-		logrus.Debugf("skipping proxy %q due to HTTP %d (%s)\n", proxy, res.StatusCode, res.Status)
+		/*
+			A proxy answering with an error status isn't necessarily a problem, GOPROXY may
+			list several proxies and the next one is expected to serve the module, so the
+			details are only reported at debug level.
+		*/
+		logrus.Debugf("proxy %q returned HTTP %d (%s) for module %q\n", proxy, res.StatusCode, res.Status, module)
+
 		body, err := httputil.DumpResponse(res, false)
 		if err != nil {
-			logrus.Debugf("failed to dump proxy response for %q: %q\n", proxy, err)
+			logrus.Debugf("failed to dump proxy response for %q: %v\n", proxy, err)
 		} else {
 			logrus.Debugf("\n%v\n", string(body))
 		}
@@ -130,159 +185,85 @@ func getVersionsFromProxy(ctx context.Context, client httpclient.HTTPClient, pro
 
 	data, err := io.ReadAll(res.Body)
 	if err != nil {
-		logrus.Errorf("something went wrong while getting golang module api data%q\n", err)
-		return nil, err
+		return nil, fmt.Errorf("reading go module proxy response: %w", err)
+	}
+
+	return data, nil
+}
+
+// getVersionsFromProxy returns the versions of a Golang module published on a proxy.
+//
+// It returns both every published version and the subset matching the age filter, as
+// telling "this module doesn't publish any version" from "every published version is
+// still cooling down" requires very different handling from the caller.
+// The matching subset carries release dates because the goproxy protocol doesn't
+// guarantee any ordering of the published versions.
+func getVersionsFromProxy(ctx context.Context, client httpclient.HTTPClient, proxy, module string, releaseAge age.Spec) (publishedVersions []string, matchingVersions []versionInfo, err error) {
+	data, err := getFromProxy(ctx, client, proxy, module, "@v", "list")
+	if err != nil {
+		return nil, nil, err
 	}
 
 	// The response should be a list of version separated by \n
 	// as explained on https://go.dev/ref/mod#goproxy-protocol
-
 	dataStr := strings.TrimSpace(string(data))
-	versions := strings.Split(dataStr, "\n")
+	if dataStr == "" {
+		return nil, nil, nil
+	}
 
-	// Sanitize versions by filtering out versions that are too recent based on the MinimumReleaseAge filter
-	if !releaseAge.IsZero() {
-		sanitizedVersions := []string{}
+	publishedVersions = strings.Split(dataStr, "\n")
 
-		for v := range versions {
-			getVersionInfo, err := getVersionInfoFromProxy(ctx, client, proxy, module, versions[v])
-			if err != nil {
-				logrus.Debugf("ignoring version %q from proxy %q due to %q\n", versions[v], proxy, err)
-				continue
-			}
-
-			releaseDate, err := time.Parse(time.RFC3339, getVersionInfo.Time)
-			if err != nil {
-				logrus.Debugf("ignoring version %q from proxy %q due to invalid release date format: %q\n", versions[v], proxy, err)
-				continue
-			}
-
-			if releaseAge.Minimum != "" && releaseAge.IsOlderThan(releaseDate, nil) {
-				logrus.Debugf("ignoring	version %q from proxy %q because its age is below %q (released on %s)\n", versions[v], proxy, releaseAge.Minimum, releaseDate)
-				continue
-			}
-
-			if releaseAge.Maximum != "" && releaseAge.IsNewerThan(releaseDate, nil) {
-				logrus.Debugf("ignoring version %q from proxy %q because its age is above %q (released on %s)\n", versions[v], proxy, releaseAge.Maximum, releaseDate)
-				continue
-			}
-
-			sanitizedVersions = append(sanitizedVersions, versions[v])
+	// Without an age filter there is no reason to pay for one request per version.
+	if releaseAge.IsZero() {
+		matchingVersions = make([]versionInfo, 0, len(publishedVersions))
+		for _, v := range publishedVersions {
+			matchingVersions = append(matchingVersions, versionInfo{Version: v})
 		}
-		versions = sanitizedVersions
+
+		return publishedVersions, matchingVersions, nil
 	}
 
-	if len(versions) == 0 {
-		return nil, nil
+	for _, v := range publishedVersions {
+		vInfo, err := getVersionInfoFromProxy(ctx, client, proxy, module, v)
+		if err != nil {
+			logrus.Debugf("ignoring version %q from proxy %q due to %v\n", v, proxy, err)
+			continue
+		}
+
+		if !isVersionMatchingAge(vInfo, releaseAge) {
+			continue
+		}
+
+		matchingVersions = append(matchingVersions, vInfo)
 	}
 
-	if len(versions) == 1 && versions[0] == "" {
-		return nil, nil
-	}
-
-	return versions, nil
+	return publishedVersions, matchingVersions, nil
 }
 
 // getLatestVersionFromProxy returns the latest version of a Golang module from a proxy
-func getLatestVersionFromProxy(ctx context.Context, client httpclient.HTTPClient, proxy, module string) (string, error) {
-	URL, err := url.JoinPath(
-		sanitizeGoProxy(proxy),
-		sanitizeGoModuleNameForProxy(module),
-		"@latest")
-
+func getLatestVersionFromProxy(ctx context.Context, client httpclient.HTTPClient, proxy, module string) (versionInfo, error) {
+	data, err := getFromProxy(ctx, client, proxy, module, "@latest")
 	if err != nil {
-		logrus.Errorf("something went wrong while getting go module api data %q\n", err)
-		return "", err
-	}
-
-	// #nosec G704
-	req, err := http.NewRequestWithContext(ctx, "GET", URL, nil)
-	if err != nil {
-		logrus.Errorf("something went wrong while getting go module api data %q\n", err)
-		return "", err
-	}
-
-	res, err := client.Do(req)
-	if err != nil {
-		logrus.Errorf("something went wrong while getting go module api data %q\n", err)
-		return "", err
-	}
-
-	defer res.Body.Close()
-	if res.StatusCode >= 400 {
-		body, err := httputil.DumpResponse(res, false)
-		logrus.Errorf("something went wrong while getting golang module data %q\n", err)
-		logrus.Debugf("skipping proxy %q due to %q\n", proxy, err)
-		logrus.Debugf("\n%v\n", string(body))
-
-		return "", fmt.Errorf("GO module %q not found on proxy %q", module, proxy)
-	}
-
-	data, err := io.ReadAll(res.Body)
-	if err != nil {
-		logrus.Errorf("something went wrong while getting npm api data%q\n", err)
-		return "", err
-	}
-
-	type JSONData struct {
-		Version string `json:"Version"`
-		Time    string `json:"Time"`
-	}
-
-	jsonData := JSONData{}
-	err = json.Unmarshal(data, &jsonData)
-	if err != nil {
-		return "", fmt.Errorf("something went wrong while parsing go module api data %q", err)
-	}
-
-	return jsonData.Version, nil
-}
-
-// getVersionInfoFromProxy returns the version information of a Golang module from a proxy
-func getVersionInfoFromProxy(ctx context.Context, client httpclient.HTTPClient, proxy, module, version string) (versionInfo, error) {
-	URL, err := url.JoinPath(
-		sanitizeGoProxy(proxy),
-		sanitizeGoModuleNameForProxy(module),
-		"@v",
-		version+".info")
-
-	if err != nil {
-		logrus.Errorf("something went wrong while getting go module api data %q\n", err)
-		return versionInfo{}, err
-	}
-
-	// #nosec G704
-	req, err := http.NewRequestWithContext(ctx, "GET", URL, nil)
-	if err != nil {
-		logrus.Errorf("something went wrong while getting go module api data %q\n", err)
-		return versionInfo{}, err
-	}
-
-	res, err := client.Do(req)
-	if err != nil {
-		logrus.Errorf("something went wrong while getting go module api data %q\n", err)
-		return versionInfo{}, err
-	}
-
-	defer res.Body.Close()
-	if res.StatusCode >= 400 {
-		body, err := httputil.DumpResponse(res, false)
-		logrus.Errorf("something went wrong while getting golang module data %q\n", err)
-		logrus.Debugf("skipping proxy %q due to %q\n", proxy, err)
-		logrus.Debugf("\n%v\n", string(body))
-
-		return versionInfo{}, fmt.Errorf("GO module %q not found on proxy %q", module, proxy)
-	}
-
-	data, err := io.ReadAll(res.Body)
-	if err != nil {
-		logrus.Errorf("something went wrong while getting go module proxy response data%q\n", err)
 		return versionInfo{}, err
 	}
 
 	vInfo := versionInfo{}
-	err = json.Unmarshal(data, &vInfo)
+	if err = json.Unmarshal(data, &vInfo); err != nil {
+		return versionInfo{}, fmt.Errorf("something went wrong while parsing go module api data %q", err)
+	}
+
+	return vInfo, nil
+}
+
+// getVersionInfoFromProxy returns the version information of a Golang module from a proxy
+func getVersionInfoFromProxy(ctx context.Context, client httpclient.HTTPClient, proxy, module, version string) (versionInfo, error) {
+	data, err := getFromProxy(ctx, client, proxy, module, "@v", version+".info")
 	if err != nil {
+		return versionInfo{}, err
+	}
+
+	vInfo := versionInfo{}
+	if err = json.Unmarshal(data, &vInfo); err != nil {
 		return versionInfo{}, fmt.Errorf("something went wrong while parsing go module api data %q", err)
 	}
 
@@ -311,30 +292,66 @@ func isLatestVersionFilter(versionfilter version.Filter) bool {
 	return false
 }
 
-func isPseudoVersionMatchingAge(pseudoVersion string, releaseAge age.Spec) bool {
-	// Pseudo versions have the format vX.0.0-yyyymmddhhmmss-abcdefabcdef
-	parts := strings.Split(pseudoVersion, "-")
-	if len(parts) < 3 {
-		logrus.Debugf("invalid pseudo version format: %q\n", pseudoVersion)
-		return false
+// isNewestVersionFilter returns true if the version filter asks for the most recently
+// published version rather than for a version matching a pattern.
+func isNewestVersionFilter(versionfilter version.Filter) bool {
+	return versionfilter.Kind == version.LATESTVERSIONKIND &&
+		versionfilter.Pattern == version.LATESTVERSIONKIND
+}
+
+// isVersionMatchingAge returns true if a version falls inside the age window.
+// Versions without a parsable release date are never considered as matching.
+func isVersionMatchingAge(v versionInfo, releaseAge age.Spec) bool {
+	if releaseAge.IsZero() {
+		return true
 	}
 
-	timestamp := parts[len(parts)-2]
-	releaseDate, err := time.Parse("20060102150405", timestamp)
+	releaseDate, err := time.Parse(time.RFC3339, v.Time)
 	if err != nil {
-		logrus.Debugf("failed to parse release date from pseudo version %q: %q\n", pseudoVersion, err)
+		logrus.Debugf("ignoring version %q due to invalid release date %q: %v\n", v.Version, v.Time, err)
 		return false
 	}
 
 	if releaseAge.Minimum != "" && releaseAge.IsOlderThan(releaseDate, nil) {
-		logrus.Debugf("ignoring pseudo version %q because its age is below %q (released on %s)\n", pseudoVersion, releaseAge.Minimum, releaseDate)
+		logrus.Debugf("ignoring version %q because its age is below %q (released on %s)\n", v.Version, releaseAge.Minimum, releaseDate)
 		return false
 	}
 
 	if releaseAge.Maximum != "" && releaseAge.IsNewerThan(releaseDate, nil) {
-		logrus.Debugf("ignoring pseudo version %q because its age is above %q (released on %s)\n", pseudoVersion, releaseAge.Maximum, releaseDate)
+		logrus.Debugf("ignoring version %q because its age is above %q (released on %s)\n", v.Version, releaseAge.Maximum, releaseDate)
 		return false
 	}
 
 	return true
+}
+
+// newestPublishedVersion returns the most recently published version among the provided
+// ones, or an empty string when none of them carries a parsable release date.
+func newestPublishedVersion(versions []versionInfo) string {
+	newestVersion := ""
+	newestReleaseDate := time.Time{}
+
+	for _, v := range versions {
+		releaseDate, err := time.Parse(time.RFC3339, v.Time)
+		if err != nil {
+			continue
+		}
+
+		if newestVersion == "" || releaseDate.After(newestReleaseDate) {
+			newestVersion = v.Version
+			newestReleaseDate = releaseDate
+		}
+	}
+
+	return newestVersion
+}
+
+// versionNames returns the version strings of the provided version information.
+func versionNames(versions []versionInfo) []string {
+	names := make([]string, 0, len(versions))
+	for _, v := range versions {
+		names = append(names, v.Version)
+	}
+
+	return names
 }

--- a/pkg/plugins/resources/go/module/version.go
+++ b/pkg/plugins/resources/go/module/version.go
@@ -32,7 +32,7 @@ type versionInfo struct {
 }
 
 // GetVersions fetch all versions of a Golang module
-func (g *GoModule) versions(ctx context.Context) (v string, versions []string, err error) {
+func (g *GoModule) versions(ctx context.Context) (v string, err error) {
 
 	var GOPROXY string
 	if g.Spec.Proxy != "" {
@@ -94,7 +94,7 @@ func (g *GoModule) versions(ctx context.Context) (v string, versions []string, e
 				OriginalVersion: latestVersion.Version,
 			}
 
-			return latestVersion.Version, []string{latestVersion.Version}, nil
+			return latestVersion.Version, nil
 		}
 
 		// The module publishes versions but the age filter discarded every one of them,
@@ -105,7 +105,7 @@ func (g *GoModule) versions(ctx context.Context) (v string, versions []string, e
 			continue
 		}
 
-		versions = versionNames(matchingVersions)
+		versions := versionNames(matchingVersions)
 
 		/*
 			A "latest" filter asks for the most recently published version, which the
@@ -121,25 +121,25 @@ func (g *GoModule) versions(ctx context.Context) (v string, versions []string, e
 					OriginalVersion: newestVersion,
 				}
 
-				return newestVersion, versions, nil
+				return newestVersion, nil
 			}
 		}
 
 		sort.Strings(versions)
 		g.Version, err = g.versionFilter.Search(versions)
 		if err != nil {
-			return "", nil, err
+			return "", err
 		}
 
-		return g.Version.GetVersion(), versions, nil
+		return g.Version.GetVersion(), nil
 
 	}
 
 	if heldBackByAge {
-		return "", nil, fmt.Errorf("%w for GO module %q", ErrNoVersionMatchingAge, g.Spec.Module)
+		return "", fmt.Errorf("%w for GO module %q", ErrNoVersionMatchingAge, g.Spec.Module)
 	}
 
-	return "", nil, fmt.Errorf("GO module %q not found on proxy %q", g.Spec.Module, GOPROXY)
+	return "", fmt.Errorf("GO module %q not found on proxy %q", g.Spec.Module, GOPROXY)
 }
 
 // getFromProxy queries a Go module proxy endpoint and returns its raw response body.

--- a/pkg/plugins/resources/go/module/version_test.go
+++ b/pkg/plugins/resources/go/module/version_test.go
@@ -239,30 +239,30 @@ func TestVersions(t *testing.T) {
 
 func TestNewVersionFilter(t *testing.T) {
 	tests := []struct {
-		name            string
-		versionFilter   version.Filter
-		expectedFilter  version.Filter
-		expectedNewErr  bool
-		expectedIsLatst bool
+		name             string
+		versionFilter    version.Filter
+		expectedFilter   version.Filter
+		expectedNewErr   bool
+		expectedIsLatest bool
 	}{
 		{
-			name:            "no filter falls back to semantic versioning",
-			expectedFilter:  version.Filter{Kind: version.SEMVERVERSIONKIND, Pattern: "*"},
-			expectedIsLatst: true,
+			name:             "no filter falls back to semantic versioning",
+			expectedFilter:   version.Filter{Kind: version.SEMVERVERSIONKIND, Pattern: "*"},
+			expectedIsLatest: true,
 		},
 		{
 			// A "latest" kind without any pattern used to be searched as the literal
 			// pattern "" and never matched anything.
-			name:            "latest kind without pattern gets its default pattern",
-			versionFilter:   version.Filter{Kind: version.LATESTVERSIONKIND},
-			expectedFilter:  version.Filter{Kind: version.LATESTVERSIONKIND, Pattern: version.LATESTVERSIONKIND},
-			expectedIsLatst: true,
+			name:             "latest kind without pattern gets its default pattern",
+			versionFilter:    version.Filter{Kind: version.LATESTVERSIONKIND},
+			expectedFilter:   version.Filter{Kind: version.LATESTVERSIONKIND, Pattern: version.LATESTVERSIONKIND},
+			expectedIsLatest: true,
 		},
 		{
-			name:            "semver kind without pattern gets its default pattern",
-			versionFilter:   version.Filter{Kind: version.SEMVERVERSIONKIND},
-			expectedFilter:  version.Filter{Kind: version.SEMVERVERSIONKIND, Pattern: "*"},
-			expectedIsLatst: true,
+			name:             "semver kind without pattern gets its default pattern",
+			versionFilter:    version.Filter{Kind: version.SEMVERVERSIONKIND},
+			expectedFilter:   version.Filter{Kind: version.SEMVERVERSIONKIND, Pattern: "*"},
+			expectedIsLatest: true,
 		},
 		{
 			name:           "explicit filter is left untouched",
@@ -286,7 +286,7 @@ func TestNewVersionFilter(t *testing.T) {
 
 			require.NoError(t, err)
 			assert.Equal(t, tt.expectedFilter, got.versionFilter)
-			assert.Equal(t, tt.expectedIsLatst, isLatestVersionFilter(got.versionFilter))
+			assert.Equal(t, tt.expectedIsLatest, isLatestVersionFilter(got.versionFilter))
 		})
 	}
 }

--- a/pkg/plugins/resources/go/module/version_test.go
+++ b/pkg/plugins/resources/go/module/version_test.go
@@ -1,0 +1,292 @@
+package gomodule
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"path"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/updatecli/updatecli/pkg/plugins/utils/age"
+	"github.com/updatecli/updatecli/pkg/plugins/utils/version"
+)
+
+const testModule string = "example.com/mymodule"
+
+// daysAgo returns a release date as reported by a Go module proxy.
+func daysAgo(days int) string {
+	return time.Now().Add(-time.Duration(days) * 24 * time.Hour).Format(time.RFC3339)
+}
+
+// goProxyStub serves the subset of the goproxy protocol used by that resource, as
+// described on https://go.dev/ref/mod#goproxy-protocol
+type goProxyStub struct {
+	// publishedVersions is served by the "@v/list" endpoint.
+	publishedVersions []string
+	// releaseDates maps a version to its release date, served by "@v/<version>.info".
+	releaseDates map[string]string
+	// latestVersion is served by the "@latest" endpoint.
+	latestVersion versionInfo
+	// requestedPaths records every requested path, to assert on the requests really sent.
+	requestedPaths []string
+}
+
+// start returns a GoModule querying that stub instead of a real Go module proxy.
+func (s *goProxyStub) start(t *testing.T, spec Spec) *GoModule {
+	t.Helper()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		s.requestedPaths = append(s.requestedPaths, r.URL.Path)
+
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/@v/list"):
+			fmt.Fprint(w, strings.Join(s.publishedVersions, "\n"))
+
+		case strings.HasSuffix(r.URL.Path, "/@latest"):
+			if s.latestVersion.Version == "" {
+				http.NotFound(w, r)
+				return
+			}
+			assert.NoError(t, json.NewEncoder(w).Encode(s.latestVersion))
+
+		case strings.HasSuffix(r.URL.Path, ".info"):
+			requestedVersion := strings.TrimSuffix(path.Base(r.URL.Path), ".info")
+			releaseDate, ok := s.releaseDates[requestedVersion]
+			if !ok {
+				http.NotFound(w, r)
+				return
+			}
+			assert.NoError(t, json.NewEncoder(w).Encode(versionInfo{
+				Version: requestedVersion,
+				Time:    releaseDate,
+			}))
+
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	spec.Proxy = server.URL
+	spec.Module = testModule
+
+	got, err := New(spec)
+	require.NoError(t, err)
+	got.webClient = http.DefaultClient
+
+	return got
+}
+
+// infoRequests returns the ".info" paths requested to the stub.
+func (s *goProxyStub) infoRequests() []string {
+	requests := []string{}
+	for _, p := range s.requestedPaths {
+		if strings.HasSuffix(p, ".info") {
+			requests = append(requests, p)
+		}
+	}
+
+	return requests
+}
+
+func TestVersions(t *testing.T) {
+	tests := []struct {
+		name string
+		spec Spec
+		stub goProxyStub
+		// expectedVersion is the version returned by versions()
+		expectedVersion string
+		// expectedHeldBackByAge is true when the age filter is expected to discard every version
+		expectedHeldBackByAge bool
+		// expectedInfoRequests is the number of ".info" requests expected on the proxy
+		expectedInfoRequests int
+	}{
+		{
+			name: "module without any published version falls back to its latest commit",
+			spec: Spec{
+				VersionFilter: version.Filter{Kind: version.LATESTVERSIONKIND},
+				Age:           age.Spec{Minimum: "7d"},
+			},
+			stub: goProxyStub{
+				latestVersion: versionInfo{
+					Version: "v0.0.0-20260101120000-abcdefabcdef",
+					Time:    daysAgo(60),
+				},
+			},
+			expectedVersion: "v0.0.0-20260101120000-abcdefabcdef",
+			// An empty "@v/list" must not be turned into a request for "@v/.info"
+			expectedInfoRequests: 0,
+		},
+		{
+			name: "cooldown holds back the only commit of a module without any published version",
+			spec: Spec{
+				VersionFilter: version.Filter{Kind: version.LATESTVERSIONKIND},
+				Age:           age.Spec{Minimum: "7d"},
+			},
+			stub: goProxyStub{
+				latestVersion: versionInfo{
+					Version: "v0.0.0-20260101120000-abcdefabcdef",
+					Time:    daysAgo(1),
+				},
+			},
+			expectedHeldBackByAge: true,
+			expectedInfoRequests:  0,
+		},
+		{
+			name: "latest endpoint answering a tagged version is accepted without any age filter",
+			spec: Spec{
+				VersionFilter: version.Filter{Kind: version.LATESTVERSIONKIND},
+			},
+			stub: goProxyStub{
+				latestVersion: versionInfo{Version: "v1.2.3", Time: daysAgo(60)},
+			},
+			expectedVersion:      "v1.2.3",
+			expectedInfoRequests: 0,
+		},
+		{
+			name: "cooldown holds back every published version instead of using the latest commit",
+			spec: Spec{
+				VersionFilter: version.Filter{Kind: version.LATESTVERSIONKIND},
+				Age:           age.Spec{Minimum: "7d"},
+			},
+			stub: goProxyStub{
+				publishedVersions: []string{"v1.0.0", "v1.1.0"},
+				releaseDates: map[string]string{
+					"v1.0.0": daysAgo(2),
+					"v1.1.0": daysAgo(1),
+				},
+				// A module publishing versions must never fall back to a pseudo version
+				latestVersion: versionInfo{
+					Version: "v0.0.0-20260101120000-abcdefabcdef",
+					Time:    daysAgo(60),
+				},
+			},
+			expectedHeldBackByAge: true,
+			expectedInfoRequests:  2,
+		},
+		{
+			name: "latest filter falls back to the most recently published version out of cooldown",
+			spec: Spec{
+				VersionFilter: version.Filter{Kind: version.LATESTVERSIONKIND},
+				Age:           age.Spec{Minimum: "7d"},
+			},
+			stub: goProxyStub{
+				publishedVersions: []string{"v1.9.0", "v1.10.0", "v1.11.0"},
+				releaseDates: map[string]string{
+					"v1.9.0":  daysAgo(50),
+					"v1.10.0": daysAgo(10),
+					"v1.11.0": daysAgo(1),
+				},
+			},
+			// "v1.9.0" is the lexicographic maximum, "v1.10.0" the most recently published
+			expectedVersion:      "v1.10.0",
+			expectedInfoRequests: 3,
+		},
+		{
+			name: "semver filter keeps ordering versions semantically",
+			spec: Spec{
+				VersionFilter: version.Filter{Kind: version.SEMVERVERSIONKIND, Pattern: "*"},
+				Age:           age.Spec{Minimum: "7d"},
+			},
+			stub: goProxyStub{
+				publishedVersions: []string{"v1.9.0", "v1.10.0", "v1.11.0"},
+				releaseDates: map[string]string{
+					"v1.9.0":  daysAgo(50),
+					"v1.10.0": daysAgo(10),
+					"v1.11.0": daysAgo(1),
+				},
+			},
+			expectedVersion:      "v1.10.0",
+			expectedInfoRequests: 3,
+		},
+		{
+			name: "no age filter means no release date lookup",
+			spec: Spec{
+				VersionFilter: version.Filter{Kind: version.SEMVERVERSIONKIND, Pattern: "*"},
+			},
+			stub: goProxyStub{
+				publishedVersions: []string{"v1.9.0", "v1.10.0"},
+			},
+			expectedVersion:      "v1.10.0",
+			expectedInfoRequests: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.stub.start(t, tt.spec)
+
+			gotVersion, _, err := got.versions(context.Background())
+
+			if tt.expectedHeldBackByAge {
+				require.ErrorIs(t, err, ErrNoVersionMatchingAge)
+				assert.Empty(t, gotVersion)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expectedVersion, gotVersion)
+			}
+
+			assert.Len(t, tt.stub.infoRequests(), tt.expectedInfoRequests)
+		})
+	}
+}
+
+func TestNewVersionFilter(t *testing.T) {
+	tests := []struct {
+		name            string
+		versionFilter   version.Filter
+		expectedFilter  version.Filter
+		expectedNewErr  bool
+		expectedIsLatst bool
+	}{
+		{
+			name:            "no filter falls back to semantic versioning",
+			expectedFilter:  version.Filter{Kind: version.SEMVERVERSIONKIND, Pattern: "*"},
+			expectedIsLatst: true,
+		},
+		{
+			// A "latest" kind without any pattern used to be searched as the literal
+			// pattern "" and never matched anything.
+			name:            "latest kind without pattern gets its default pattern",
+			versionFilter:   version.Filter{Kind: version.LATESTVERSIONKIND},
+			expectedFilter:  version.Filter{Kind: version.LATESTVERSIONKIND, Pattern: version.LATESTVERSIONKIND},
+			expectedIsLatst: true,
+		},
+		{
+			name:            "semver kind without pattern gets its default pattern",
+			versionFilter:   version.Filter{Kind: version.SEMVERVERSIONKIND},
+			expectedFilter:  version.Filter{Kind: version.SEMVERVERSIONKIND, Pattern: "*"},
+			expectedIsLatst: true,
+		},
+		{
+			name:           "explicit filter is left untouched",
+			versionFilter:  version.Filter{Kind: version.SEMVERVERSIONKIND, Pattern: "1.0.x"},
+			expectedFilter: version.Filter{Kind: version.SEMVERVERSIONKIND, Pattern: "1.0.x"},
+		},
+		{
+			name:           "unsupported kind is rejected",
+			versionFilter:  version.Filter{Kind: "notakind"},
+			expectedNewErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := New(Spec{Module: testModule, VersionFilter: tt.versionFilter})
+			if tt.expectedNewErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedFilter, got.versionFilter)
+			assert.Equal(t, tt.expectedIsLatst, isLatestVersionFilter(got.versionFilter))
+		})
+	}
+}

--- a/pkg/plugins/resources/go/module/version_test.go
+++ b/pkg/plugins/resources/go/module/version_test.go
@@ -222,7 +222,7 @@ func TestVersions(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := tt.stub.start(t, tt.spec)
 
-			gotVersion, _, err := got.versions(context.Background())
+			gotVersion, err := got.versions(context.Background())
 
 			if tt.expectedHeldBackByAge {
 				require.ErrorIs(t, err, ErrNoVersionMatchingAge)


### PR DESCRIPTION
Don't return an error if Updatecli can't find a pseudo version matching the age definition

## Test

To test this pull request, you can run the following commands:

```shell
cd pkg/plugins/resources/go/module
go test
```

## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via pull request in [website](https://github.com/updatecli/website) repository.
- [ ] <!-- If applicable,--> I have tested this pull request manually with a custom Updatecli build and it works as expected.

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
