### PR TITLE
fix(autodiscovery/helmfile): use relative file path in generated manifests

### DIFF
--- a/pkg/plugins/autodiscovery/helmfile/main_test.go
+++ b/pkg/plugins/autodiscovery/helmfile/main_test.go
@@ -42,7 +42,7 @@ conditions:
     name: 'Ensure release "datadog" is specified for Helmfile "helmfile.d/cik8s.yaml"'
     kind: 'yaml'
     spec:
-      file: 'testdata/helmfile.d/cik8s.yaml'
+      file: 'helmfile.d/cik8s.yaml'
       key: '$.releases[0].chart'
       value: 'datadog/datadog'
     disablesourceinput: true
@@ -51,7 +51,7 @@ targets:
     name: 'deps(helmfile): update "datadog" Helm Chart version to {{ source "datadog"}}'
     kind: 'yaml'
     spec:
-      file: 'testdata/helmfile.d/cik8s.yaml'
+      file: 'helmfile.d/cik8s.yaml'
       key: '$.releases[0].version'
     sourceid: 'datadog'
 `, `name: 'Bump "docker-registry-secrets" Helm Chart version for Helmfile "helmfile.d/cik8s.yaml"'
@@ -70,7 +70,7 @@ conditions:
     name: 'Ensure release "docker-registry-secrets" is specified for Helmfile "helmfile.d/cik8s.yaml"'
     kind: 'yaml'
     spec:
-      file: 'testdata/helmfile.d/cik8s.yaml'
+      file: 'helmfile.d/cik8s.yaml'
       key: '$.releases[1].chart'
       value: 'jenkins-infra/docker-registry-secrets'
     disablesourceinput: true
@@ -79,7 +79,7 @@ targets:
     name: 'deps(helmfile): update "docker-registry-secrets" Helm Chart version to {{ source "docker-registry-secrets"}}'
     kind: 'yaml'
     spec:
-      file: 'testdata/helmfile.d/cik8s.yaml'
+      file: 'helmfile.d/cik8s.yaml'
       key: '$.releases[1].version'
     sourceid: 'docker-registry-secrets'
 `, `name: 'Bump "myOCIChart" Helm Chart version for Helmfile "helmfile.d/cik8s.yaml"'
@@ -98,7 +98,7 @@ conditions:
     name: 'Ensure release "myOCIChart" is specified for Helmfile "helmfile.d/cik8s.yaml"'
     kind: 'yaml'
     spec:
-      file: 'testdata/helmfile.d/cik8s.yaml'
+      file: 'helmfile.d/cik8s.yaml'
       key: '$.releases[3].chart'
       value: 'myOCIRegistry/myOCIChart'
     disablesourceinput: true
@@ -107,7 +107,7 @@ targets:
     name: 'deps(helmfile): update "myOCIChart" Helm Chart version to {{ source "myOCIChart"}}'
     kind: 'yaml'
     spec:
-      file: 'testdata/helmfile.d/cik8s.yaml'
+      file: 'helmfile.d/cik8s.yaml'
       key: '$.releases[3].version'
     sourceid: 'myOCIChart'
 `,

--- a/pkg/plugins/autodiscovery/helmfile/releases.go
+++ b/pkg/plugins/autodiscovery/helmfile/releases.go
@@ -226,7 +226,7 @@ func (h Helmfile) discoverHelmfileReleaseManifests() ([][]byte, error) {
 				TargetID:                   release.Name,
 				TargetName:                 fmt.Sprintf("deps(helmfile): update %q Helm Chart version to {{ source %q}}", release.Name, release.Name),
 				TargetKey:                  fmt.Sprintf("$.releases[%d].version", i),
-				File:                       foundHelmfile,
+				File:                       relativeFoundChartFile,
 				ScmID:                      h.scmID,
 				Token:                      token,
 			}


### PR DESCRIPTION
## Summary

Fixes #10108.

The `File` field in the generated condition and target was set to `foundHelmfile` (absolute path within the SCM clone) instead of `relativeFoundChartFile`. This caused every helmfile-derived pipeline to fail at the condition step when an `scmid` is configured.

`ManifestName` and `ConditionName` already used `relativeFoundChartFile` correctly — `File` was the only field that did not.

This is the same bug fixed for the `updatecli` autodiscovery plugin in #9759; the helmfile plugin was not updated at the same time.

## Before

All helmfile-derived condition steps fail with:

```
✗ Something went wrong:
	init yaml files: absolute path "/tmp/updatecli/.../helmfile.yaml" is not allowed:
	files must stay within the working directory "/tmp/updatecli/..."
```

The target is skipped due to `dependsOn conditions`, silently preventing any helmfile release from being updated.

## After

Conditions resolve correctly against the SCM clone and targets apply as expected:

```
✔ key "$.releases[22].chart" is correctly set to "vaultwarden/vaultwarden"
⚠ - change detected:
	* key "$.releases[22].version" updated from "0.44.0" to "0.46.1", in file "helmfile.yaml"
```

Tested locally by building from this branch and running `updatecli pipeline apply` against a real helmfile repository — 6 version-bump PRs were opened correctly where previously 0 were.

## Checklist

- [ ] I have updated the documentation via pull request in [website](https://github.com/updatecli/website) repository.