### PR TITLE
feat(githubaction): support dependency cooldown in autodiscovery

### DIFF
--- a/pkg/plugins/autodiscovery/githubaction/main.go
+++ b/pkg/plugins/autodiscovery/githubaction/main.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-viper/mapstructure/v2"
 	"github.com/sirupsen/logrus"
+	"github.com/updatecli/updatecli/pkg/plugins/utils/age"
 	"github.com/updatecli/updatecli/pkg/plugins/utils/docker"
 	"github.com/updatecli/updatecli/pkg/plugins/utils/version"
 
@@ -95,6 +96,26 @@ type Spec struct {
 	//
 	//  More examples can be found at https://www.updatecli.io/docs/core/versionfilter/
 	VersionFilter version.Filter `yaml:",omitempty"`
+	// age defines the minimum or maximum age of a release, tag, or branch to be considered valid.
+	// It accepts a duration string (e.g., "24h", "7d", "3w", "1y").
+	//
+	// It is the "dependency cooldown" knob: setting `minimum` keeps Updatecli from
+	// suggesting a version which has just been published.
+	//
+	// default: empty, no age filtering
+	//
+	// remark:
+	//  * the age filter is not applied to the Docker images referenced by a workflow.
+	//
+	// example:
+	// ```
+	//   autodiscovery:
+	//     crawlers:
+	//       github/action:
+	//         age:
+	//           minimum: '7d'
+	// ```
+	Age age.Spec `yaml:",omitempty"`
 	// Credentials allows to specify the credentials to use to authenticate to the git provider
 	// The ID of the credential must be the domain of the git provider to configure
 	//
@@ -191,6 +212,10 @@ func New(spec interface{}, rootDir, scmID, actionID string) (GitHubAction, error
 	// Validate only rules
 	if err := s.Only.Validate(); err != nil {
 		return GitHubAction{}, fmt.Errorf("invalid only spec: %w", err)
+	}
+
+	if err := s.Age.Validate(); err != nil {
+		return GitHubAction{}, fmt.Errorf("invalid age spec: %w", err)
 	}
 
 	dir := rootDir

--- a/pkg/plugins/autodiscovery/githubaction/main_test.go
+++ b/pkg/plugins/autodiscovery/githubaction/main_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/updatecli/updatecli/pkg/plugins/utils/age"
 )
 
 func TestDiscoverManifests(t *testing.T) {
@@ -14,6 +15,7 @@ func TestDiscoverManifests(t *testing.T) {
 		expectedPipelines []string
 		credentials       map[string]gitProviderToken
 		digest            bool
+		age               age.Spec
 	}{
 		{
 			name:    "Scenario - GitHub Action using Docker image",
@@ -1516,6 +1518,136 @@ targets:
       engine: 'yamlpath'
 `},
 		},
+		{
+			name:    "Scenario - GitHub Action with a dependency cooldown",
+			rootDir: "testdata/age",
+			age:     age.Spec{Minimum: "7d", Maximum: "1y"},
+			expectedPipelines: []string{`name: 'deps: bump actions/checkout GitHub workflow'
+
+sources:
+  release:
+    dependson:
+      - 'condition#release:and'
+    name: 'Get latest GitHub Release for actions/checkout'
+    kind: 'githubrelease'
+    spec:
+      owner: 'actions'
+      repository: 'checkout'
+      url: 'https://github.com'
+      token: ''
+      age:
+        minimum: '7d'
+        maximum: '1y'
+      versionfilter:
+        kind: 'semver'
+        pattern: '*'
+
+  tag:
+    dependson:
+      - 'condition#tag:and'
+    name: 'Get latest tag for actions/checkout'
+    kind: 'gittag'
+    spec:
+      url: "https://github.com/actions/checkout.git"
+      password: ''
+      age:
+        minimum: '7d'
+        maximum: '1y'
+      versionfilter:
+        kind: 'semver'
+        pattern: '*'
+
+  branch:
+    dependson:
+      - 'condition#branch:and'
+    name: 'Get latest branch for actions/checkout'
+    kind: 'gitbranch'
+    spec:
+      url: "https://github.com/actions/checkout.git"
+      password: ''
+      age:
+        minimum: '7d'
+        maximum: '1y'
+      versionfilter:
+        kind: 'semver'
+        pattern: '*'
+
+conditions:
+  release:
+    name: 'Check if actions/checkout@v4 is a GitHub release'
+    kind: 'githubrelease'
+    disablesourceinput: true
+    spec:
+      owner: 'actions'
+      repository: 'checkout'
+      url: 'https://github.com'
+      token: ''
+      tag: 'v4'
+
+  tag:
+    name: 'Check if actions/checkout@v4 is a tag'
+    kind: 'gittag'
+    disablesourceinput: true
+    spec:
+      url: "https://github.com/actions/checkout.git"
+      password: ''
+      versionfilter:
+        kind: 'regex'
+        pattern: '^v4$'
+
+  branch:
+    name: 'Check if actions/checkout@v4 is a branch'
+    kind: 'gitbranch'
+    disablesourceinput: true
+    spec:
+      branch: 'v4'
+      url: "https://github.com/actions/checkout.git"
+      password: ''
+
+targets:
+  release:
+    dependson:
+      - 'condition#release:and'
+    disableconditions: true
+    name: 'deps(github): bump Action release for actions/checkout from v4 to {{ source "release" }}'
+    kind: 'yaml'
+    sourceid: 'release'
+    transformers:
+      - addprefix: 'actions/checkout@'
+    spec:
+      file: '.github/workflows/updatecli.yaml'
+      key: '$.jobs.build.steps[0].uses'
+      engine: 'yamlpath'
+
+  tag:
+    dependson:
+      - 'condition#tag:and'
+    disableconditions: true
+    name: 'deps(github): bump Action tag for actions/checkout from v4 to {{ source "tag" }}'
+    kind: 'yaml'
+    sourceid: 'tag'
+    transformers:
+      - addprefix: 'actions/checkout@'
+    spec:
+      file: '.github/workflows/updatecli.yaml'
+      key: '$.jobs.build.steps[0].uses'
+      engine: 'yamlpath'
+
+  branch:
+    dependson:
+      - 'condition#branch:and'
+    disableconditions: true
+    name: 'deps(github): bump Action branch for actions/checkout from v4 to {{ source "branch" }}'
+    kind: yaml
+    sourceid: branch
+    transformers:
+      - addprefix: 'actions/checkout@'
+    spec:
+      file: '.github/workflows/updatecli.yaml'
+      key: '$.jobs.build.steps[0].uses'
+      engine: 'yamlpath'
+`},
+		},
 	}
 
 	for _, tt := range testdata {
@@ -1525,6 +1657,7 @@ targets:
 				Spec{
 					Credentials: tt.credentials,
 					Digest:      &tt.digest,
+					Age:         tt.age,
 				}, tt.rootDir, "", "")
 
 			require.NoError(t, err)

--- a/pkg/plugins/autodiscovery/githubaction/main_test.go
+++ b/pkg/plugins/autodiscovery/githubaction/main_test.go
@@ -1521,7 +1521,14 @@ targets:
 		{
 			name:    "Scenario - GitHub Action with a dependency cooldown",
 			rootDir: "testdata/age",
-			age:     age.Spec{Minimum: "7d", Maximum: "1y"},
+			// Pinned so the generated manifest doesn't pick up a GITHUB_TOKEN from the environment.
+			credentials: map[string]gitProviderToken{
+				"github.com": {
+					Kind:  "github",
+					Token: "xxx",
+				},
+			},
+			age: age.Spec{Minimum: "7d", Maximum: "1y"},
 			expectedPipelines: []string{`name: 'deps: bump actions/checkout GitHub workflow'
 
 sources:
@@ -1534,7 +1541,7 @@ sources:
       owner: 'actions'
       repository: 'checkout'
       url: 'https://github.com'
-      token: ''
+      token: 'xxx'
       age:
         minimum: '7d'
         maximum: '1y'
@@ -1549,7 +1556,7 @@ sources:
     kind: 'gittag'
     spec:
       url: "https://github.com/actions/checkout.git"
-      password: ''
+      password: 'xxx'
       age:
         minimum: '7d'
         maximum: '1y'
@@ -1564,7 +1571,7 @@ sources:
     kind: 'gitbranch'
     spec:
       url: "https://github.com/actions/checkout.git"
-      password: ''
+      password: 'xxx'
       age:
         minimum: '7d'
         maximum: '1y'
@@ -1581,7 +1588,7 @@ conditions:
       owner: 'actions'
       repository: 'checkout'
       url: 'https://github.com'
-      token: ''
+      token: 'xxx'
       tag: 'v4'
 
   tag:
@@ -1590,7 +1597,7 @@ conditions:
     disablesourceinput: true
     spec:
       url: "https://github.com/actions/checkout.git"
-      password: ''
+      password: 'xxx'
       versionfilter:
         kind: 'regex'
         pattern: '^v4$'
@@ -1602,7 +1609,7 @@ conditions:
     spec:
       branch: 'v4'
       url: "https://github.com/actions/checkout.git"
-      password: ''
+      password: 'xxx'
 
 targets:
   release:

--- a/pkg/plugins/autodiscovery/githubaction/main_test.go
+++ b/pkg/plugins/autodiscovery/githubaction/main_test.go
@@ -8,7 +8,28 @@ import (
 	"github.com/updatecli/updatecli/pkg/plugins/utils/age"
 )
 
+// unsetGitHubTokenEnv neutralizes every environment variable the crawler consults
+// before the `credentials` setting, so that the generated manifests only ever contain
+// the tokens the test cases pin.
+func unsetGitHubTokenEnv(t *testing.T) {
+	t.Helper()
+
+	for _, name := range []string{
+		"UPDATECLI_GITHUB_TOKEN",
+		"GITHUB_TOKEN",
+		"UPDATECLI_GITHUB_APP_CLIENT_ID",
+		"UPDATECLI_GITHUB_APP_PRIVATE_KEY",
+		"UPDATECLI_GITHUB_APP_PRIVATE_KEY_PATH",
+		"UPDATECLI_GITHUB_APP_INSTALLATION_ID",
+		"UPDATECLI_GITHUB_APP_EXPIRATION_TIME",
+	} {
+		t.Setenv(name, "")
+	}
+}
+
 func TestDiscoverManifests(t *testing.T) {
+	unsetGitHubTokenEnv(t)
+
 	testdata := []struct {
 		name              string
 		rootDir           string
@@ -1521,7 +1542,6 @@ targets:
 		{
 			name:    "Scenario - GitHub Action with a dependency cooldown",
 			rootDir: "testdata/age",
-			// Pinned so the generated manifest doesn't pick up a GITHUB_TOKEN from the environment.
 			credentials: map[string]gitProviderToken{
 				"github.com": {
 					Kind:  "github",

--- a/pkg/plugins/autodiscovery/githubaction/templateGHAGitHub.go
+++ b/pkg/plugins/autodiscovery/githubaction/templateGHAGitHub.go
@@ -20,6 +20,7 @@ sources:
       repository: '{{ .Repository }}'
       url: '{{ .URL }}'
       token: '{{ .Token }}'
+{{- template "age" .Age }}
       versionfilter:
         kind: '{{ .VersionFilterKind }}'
         {{- if ne .VersionFilterKind "latest" }}
@@ -55,6 +56,7 @@ sources:
     spec:
       url: "{{ .URL }}/{{ .Owner }}/{{ .Repository }}.git"
       password: '{{ .Token }}'
+{{- template "age" .Age }}
       versionfilter:
         kind: '{{ .VersionFilterKind }}'
         {{- if ne .VersionFilterKind "latest" }}
@@ -89,6 +91,7 @@ sources:
     spec:
       url: "{{ .URL }}/{{ .Owner }}/{{ .Repository }}.git"
       password: '{{ .Token }}'
+{{- template "age" .Age }}
       versionfilter:
         kind: '{{ .VersionFilterKind }}'
         {{- if ne .VersionFilterKind "latest" }}

--- a/pkg/plugins/autodiscovery/githubaction/templateGHAGitea.go
+++ b/pkg/plugins/autodiscovery/githubaction/templateGHAGitea.go
@@ -20,6 +20,7 @@ sources:
       repository: '{{ .Repository }}'
       url: '{{ .URL }}'
       token: '{{ .Token }}'
+{{- template "age" .Age }}
       versionfilter:
         kind: '{{ .VersionFilterKind }}'
         pattern: '{{ .VersionFilterPattern }}'
@@ -35,6 +36,7 @@ sources:
     spec:
       url: "{{ .URL }}/{{ .Owner }}/{{ .Repository }}.git"
       password: '{{ .Token }}'
+{{- template "age" .Age }}
       versionfilter:
         kind: '{{ .VersionFilterKind }}'
         pattern: '{{ .VersionFilterPattern }}'
@@ -50,6 +52,7 @@ sources:
     spec:
       url: "{{ .URL }}/{{ .Owner }}/{{ .Repository }}.git"
       password: '{{ .Token }}'
+{{- template "age" .Age }}
       versionfilter:
         kind: '{{ .VersionFilterKind }}'
         pattern: '{{ .VersionFilterPattern }}'

--- a/pkg/plugins/autodiscovery/githubaction/testdata/age/.github/workflows/updatecli.yaml
+++ b/pkg/plugins/autodiscovery/githubaction/testdata/age/.github/workflows/updatecli.yaml
@@ -1,0 +1,7 @@
+name: Age
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4

--- a/pkg/plugins/autodiscovery/githubaction/utils_test.go
+++ b/pkg/plugins/autodiscovery/githubaction/utils_test.go
@@ -21,6 +21,7 @@ func TestSearchWorkflowFiles(t *testing.T) {
 	}
 
 	expectedWorkflowFiles := []string{
+		"testdata/age/.github/workflows/updatecli.yaml",
 		"testdata/digest/.github/workflows/updatecli.yaml",
 		"testdata/docker/.github/workflows/docker-01.yaml",
 		"testdata/docker/.github/workflows/docker-02.yaml",

--- a/pkg/plugins/autodiscovery/githubaction/workflowGHAManifest.go
+++ b/pkg/plugins/autodiscovery/githubaction/workflowGHAManifest.go
@@ -9,6 +9,7 @@ import (
 	"text/template"
 
 	"github.com/sirupsen/logrus"
+	"github.com/updatecli/updatecli/pkg/plugins/utils/age"
 )
 
 type githubActionManifestSpec struct {
@@ -106,12 +107,12 @@ func (g GitHubAction) getGitHubActionManifest(spec *githubActionManifestSpec) ([
 	var tmpl *template.Template
 	switch kind {
 	case kindGitHub:
-		tmpl, err = template.New("manifest").Parse(workflowManifestGitHubTemplate)
+		tmpl, err = template.New("manifest").Parse(age.ManifestTemplate + workflowManifestGitHubTemplate)
 		if err != nil {
 			return nil, fmt.Errorf("parsing template: %s", err)
 		}
 	case kindGitea:
-		tmpl, err = template.New("manifest").Parse(workflowManifestGiteaTemplate)
+		tmpl, err = template.New("manifest").Parse(age.ManifestTemplate + workflowManifestGiteaTemplate)
 		if err != nil {
 			return nil, fmt.Errorf("parsing template: %s", err)
 		}
@@ -143,6 +144,7 @@ func (g GitHubAction) getGitHubActionManifest(spec *githubActionManifestSpec) ([
 		ScmID                string
 		Token                string
 		Digest               bool
+		Age                  age.Spec
 	}{
 		ActionID:             g.actionID,
 		ActionName:           actionName,
@@ -159,6 +161,7 @@ func (g GitHubAction) getGitHubActionManifest(spec *githubActionManifestSpec) ([
 		TargetKey:            targetKey,
 		Token:                token,
 		Digest:               g.digest,
+		Age:                  g.spec.Age,
 	}
 
 	manifest := bytes.Buffer{}

--- a/pkg/plugins/resources/gitbranch/main.go
+++ b/pkg/plugins/resources/gitbranch/main.go
@@ -7,6 +7,7 @@ import (
 	"github.com/go-viper/mapstructure/v2"
 	"github.com/updatecli/updatecli/pkg/core/result"
 	"github.com/updatecli/updatecli/pkg/plugins/scms/git"
+	"github.com/updatecli/updatecli/pkg/plugins/utils/age"
 	"github.com/updatecli/updatecli/pkg/plugins/utils/gitgeneric"
 	"github.com/updatecli/updatecli/pkg/plugins/utils/redact"
 	"github.com/updatecli/updatecli/pkg/plugins/utils/version"
@@ -24,6 +25,13 @@ type Spec struct {
 	//    * condition
 	//    * target
 	VersionFilter version.Filter `yaml:",omitempty"`
+	// Age defines the minimum or maximum age of a branch to be considered valid.
+	// It accepts a duration string (e.g., "24h", "7d", "3w", "1y").
+	// The age of a branch is the date of its latest commit.
+	//
+	//  compatible:
+	//    * source
+	Age age.Spec `yaml:",omitempty"`
 	// branch specifies the branch name
 	//
 	//  compatible:
@@ -121,6 +129,10 @@ func New(spec interface{}) (*GitBranch, error) {
 		validationErrors = append(validationErrors, "The only valid values for Key are 'name', 'hash', or empty.")
 	}
 
+	if err := newSpec.Age.Validate(); err != nil {
+		validationErrors = append(validationErrors, err.Error())
+	}
+
 	// Return all the validation errors if found any
 	if len(validationErrors) > 0 {
 		return &GitBranch{}, fmt.Errorf("validation error: the provided manifest configuration has the following validation errors:\n%s", strings.Join(validationErrors, "\n\n"))
@@ -166,6 +178,7 @@ func (gb *GitBranch) ReportConfig() interface{} {
 		Path:          gb.spec.Path,
 		Branch:        gb.spec.Branch,
 		VersionFilter: gb.spec.VersionFilter,
+		Age:           gb.spec.Age,
 		SourceBranch:  gb.spec.SourceBranch,
 		// Ensure that the URL doesn't contain any sensitive information
 		URL: redact.URL(gb.spec.URL),

--- a/pkg/plugins/resources/gitbranch/source.go
+++ b/pkg/plugins/resources/gitbranch/source.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/updatecli/updatecli/pkg/core/result"
+	"github.com/updatecli/updatecli/pkg/plugins/utils/age"
 )
 
 // Source returns the latest git tag based on create time
@@ -42,8 +43,16 @@ func (gb *GitBranch) Source(_ context.Context, workingDir string, resultSource *
 		values = append(values, ref.Name)
 	}
 
-	if len(values) == 0 && !gb.spec.Age.IsZero() {
-		return fmt.Errorf("no branch found matching the age filter")
+	/*
+		The repository does publish branches but the age filter discarded every one of
+		them, which is an expected state of the filter rather than a failure, so the
+		source is skipped instead.
+	*/
+	if len(refs) > 0 && len(values) == 0 {
+		logrus.Debugf("%s", age.ErrNoVersionMatchingAge)
+		resultSource.Result = result.SKIPPED
+		resultSource.Description = "no git branch matches the age filter yet"
+		return nil
 	}
 
 	gb.foundVersion, err = gb.versionFilter.Search(values)

--- a/pkg/plugins/resources/gitbranch/source.go
+++ b/pkg/plugins/resources/gitbranch/source.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/sirupsen/logrus"
 	"github.com/updatecli/updatecli/pkg/core/result"
 )
 
@@ -34,8 +35,17 @@ func (gb *GitBranch) Source(_ context.Context, workingDir string, resultSource *
 
 	values := []string{}
 	for _, ref := range refs {
+		if !gb.spec.Age.Matches(ref.When) {
+			logrus.Debugf("ignoring branch %q, dated %s, as outside of the age window", ref.Name, ref.When)
+			continue
+		}
 		values = append(values, ref.Name)
 	}
+
+	if len(values) == 0 && !gb.spec.Age.IsZero() {
+		return fmt.Errorf("no branch found matching the age filter")
+	}
+
 	gb.foundVersion, err = gb.versionFilter.Search(values)
 	if err != nil {
 		return fmt.Errorf("filtering branches: %w", err)

--- a/pkg/plugins/resources/gitbranch/source_test.go
+++ b/pkg/plugins/resources/gitbranch/source_test.go
@@ -35,10 +35,11 @@ func TestGitBranch_Source(t *testing.T) {
 	}
 
 	tests := []struct {
-		name      string
-		spec      Spec
-		wantValue string
-		wantErr   bool
+		name        string
+		spec        Spec
+		wantValue   string
+		wantSkipped bool
+		wantErr     bool
 	}{
 		{
 			name:      "no age filter returns the latest branch",
@@ -56,9 +57,9 @@ func TestGitBranch_Source(t *testing.T) {
 			wantValue: "v3.0",
 		},
 		{
-			name:    "Error: every branch is still in cooldown",
-			spec:    Spec{Age: age.Spec{Minimum: "60d"}},
-			wantErr: true,
+			name:        "the source is skipped while every branch is still in cooldown",
+			spec:        Spec{Age: age.Spec{Minimum: "60d"}},
+			wantSkipped: true,
 		},
 	}
 
@@ -78,6 +79,12 @@ func TestGitBranch_Source(t *testing.T) {
 			}
 
 			require.NoError(t, err)
+
+			if tt.wantSkipped {
+				assert.Equal(t, result.SKIPPED, gotResult.Result)
+				return
+			}
+
 			assert.Equal(t, tt.wantValue, gotResult.Information)
 		})
 	}

--- a/pkg/plugins/resources/gitbranch/source_test.go
+++ b/pkg/plugins/resources/gitbranch/source_test.go
@@ -1,0 +1,84 @@
+package gitbranch
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/updatecli/updatecli/pkg/core/result"
+	"github.com/updatecli/updatecli/pkg/plugins/utils/age"
+	"github.com/updatecli/updatecli/pkg/plugins/utils/gitgeneric"
+	"github.com/updatecli/updatecli/pkg/plugins/utils/version"
+)
+
+type mockNativeGitHandler struct {
+	gitgeneric.GitHandler
+	branchRefs []gitgeneric.DatedBranch
+}
+
+func (m *mockNativeGitHandler) BranchRefs(workingDir string) ([]gitgeneric.DatedBranch, error) {
+	return m.branchRefs, nil
+}
+
+// branchDaysAgo builds the latest commit date of a branch last updated n days ago.
+func branchDaysAgo(n int) time.Time {
+	return time.Now().Add(-time.Duration(n) * 24 * time.Hour)
+}
+
+func TestGitBranch_Source(t *testing.T) {
+	branches := []gitgeneric.DatedBranch{
+		{Name: "v1.0", Hash: "abc123", When: branchDaysAgo(30)},
+		{Name: "v2.0", Hash: "def456", When: branchDaysAgo(10)},
+		{Name: "v3.0", Hash: "ghi789", When: branchDaysAgo(1)},
+	}
+
+	tests := []struct {
+		name      string
+		spec      Spec
+		wantValue string
+		wantErr   bool
+	}{
+		{
+			name:      "no age filter returns the latest branch",
+			spec:      Spec{},
+			wantValue: "v3.0",
+		},
+		{
+			name:      "the most recently updated branch is still in cooldown",
+			spec:      Spec{Age: age.Spec{Minimum: "7d"}},
+			wantValue: "v2.0",
+		},
+		{
+			name:      "branches updated too long ago are discarded",
+			spec:      Spec{Age: age.Spec{Maximum: "20d"}},
+			wantValue: "v3.0",
+		},
+		{
+			name:    "Error: every branch is still in cooldown",
+			spec:    Spec{Age: age.Spec{Minimum: "60d"}},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gb := &GitBranch{
+				spec:             tt.spec,
+				versionFilter:    version.Filter{Kind: "latest", Pattern: "latest"},
+				nativeGitHandler: &mockNativeGitHandler{branchRefs: branches},
+			}
+
+			gotResult := result.Source{}
+			err := gb.Source(context.Background(), "/tmp/updatecli", &gotResult)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantValue, gotResult.Information)
+		})
+	}
+}

--- a/pkg/plugins/resources/gitea/release/age_test.go
+++ b/pkg/plugins/resources/gitea/release/age_test.go
@@ -1,0 +1,37 @@
+package release
+
+import (
+	"testing"
+	"time"
+
+	"github.com/drone/go-scm/scm"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReleaseDate(t *testing.T) {
+	created := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	published := time.Date(2026, 1, 5, 0, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name    string
+		release scm.Release
+		want    time.Time
+	}{
+		{
+			name:    "publication date is used when set",
+			release: scm.Release{Created: created, Published: published},
+			want:    published,
+		},
+		{
+			name:    "creation date is used when the release has no publication date",
+			release: scm.Release{Created: created},
+			want:    created,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, releaseDate(&tt.release))
+		})
+	}
+}

--- a/pkg/plugins/resources/gitea/release/condition.go
+++ b/pkg/plugins/resources/gitea/release/condition.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
+	"github.com/updatecli/updatecli/pkg/plugins/utils/age"
 )
 
 func (g *Gitea) Condition(ctx context.Context, source string, scm scm.ScmHandler) (pass bool, message string, err error) {
@@ -14,7 +15,9 @@ func (g *Gitea) Condition(ctx context.Context, source string, scm scm.ScmHandler
 		logrus.Warningf("Condition not supported for the plugin Gitea Release")
 	}
 
-	releases, err := g.SearchReleases(ctx)
+	// A condition checks whether a specific release exists, so the age filter,
+	// which only narrows down which release to pick, doesn't apply here.
+	releases, err := g.SearchReleases(ctx, age.Spec{})
 	if err != nil {
 		return false, "", fmt.Errorf("looking for Gitea release: %w", err)
 	}

--- a/pkg/plugins/resources/gitea/release/main.go
+++ b/pkg/plugins/resources/gitea/release/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/go-viper/mapstructure/v2"
 	"github.com/sirupsen/logrus"
 	"github.com/updatecli/updatecli/pkg/plugins/resources/gitea/client"
+	"github.com/updatecli/updatecli/pkg/plugins/utils/age"
 	"github.com/updatecli/updatecli/pkg/plugins/utils/redact"
 	"github.com/updatecli/updatecli/pkg/plugins/utils/version"
 )
@@ -23,6 +24,9 @@ type Spec struct {
 	Repository string `yaml:",omitempty" jsonschema:"required"`
 	// [S] versionfilter provides parameters to specify version pattern and its type like regex, semver, or just latest.
 	VersionFilter version.Filter `yaml:",omitempty"`
+	// [S] age defines the minimum or maximum age of a release to be considered valid.
+	// It accepts a duration string (e.g., "24h", "7d", "3w", "1y").
+	Age age.Spec `yaml:",omitempty"`
 	// [T] title defines the Gitea release title.
 	Title string `yaml:",omitempty"`
 	// [C][T] tag defines the Gitea release tag.
@@ -110,8 +114,9 @@ func New(spec interface{}) (*Gitea, error) {
 	return &g, nil
 }
 
-// Retrieve git tags from a remote gitea repository
-func (g *Gitea) SearchReleases(ctx context.Context) ([]string, error) {
+// SearchReleases retrieves the release tags from a remote gitea repository,
+// keeping only the ones published inside the provided age window.
+func (g *Gitea) SearchReleases(ctx context.Context, releaseAge age.Spec) ([]string, error) {
 
 	results := []string{}
 	page := 0
@@ -139,9 +144,15 @@ func (g *Gitea) SearchReleases(ctx context.Context) ([]string, error) {
 		}
 
 		for i := len(releases) - 1; i >= 0; i-- {
-			if !releases[i].Draft {
-				results = append(results, releases[i].Tag)
+			if releases[i].Draft {
+				continue
 			}
+			date := releaseDate(releases[i])
+			if !releaseAge.Matches(date) {
+				logrus.Debugf("ignoring release %q, dated %s, as outside of the age window", releases[i].Tag, date)
+				continue
+			}
+			results = append(results, releases[i].Tag)
 		}
 
 		if page >= resp.Page.Last {
@@ -152,6 +163,16 @@ func (g *Gitea) SearchReleases(ctx context.Context) ([]string, error) {
 	}
 
 	return results, nil
+}
+
+// releaseDate returns the date at which a release became public.
+// Gitea leaves the publication date empty for releases created without one, so the
+// creation date is used as a fallback.
+func releaseDate(r *scm.Release) time.Time {
+	if !r.Published.IsZero() {
+		return r.Published
+	}
+	return r.Created
 }
 
 func (s Spec) Validate() error {
@@ -173,6 +194,11 @@ func (s Spec) Validate() error {
 	if len(s.Repository) == 0 {
 		gotError = true
 		missingParameters = append(missingParameters, "repository")
+	}
+
+	if err := s.Age.Validate(); err != nil {
+		logrus.Errorln(err)
+		gotError = true
 	}
 
 	if len(missingParameters) > 0 {
@@ -197,5 +223,6 @@ func (g *Gitea) ReportConfig() interface{} {
 			URL: redact.URL(g.spec.URL),
 		},
 		VersionFilter: g.spec.VersionFilter,
+		Age:           g.spec.Age,
 	}
 }

--- a/pkg/plugins/resources/gitea/release/main.go
+++ b/pkg/plugins/resources/gitea/release/main.go
@@ -119,6 +119,9 @@ func New(spec interface{}) (*Gitea, error) {
 func (g *Gitea) SearchReleases(ctx context.Context, releaseAge age.Spec) ([]string, error) {
 
 	results := []string{}
+	// Tracks whether the repository publishes releases at all, so that a running
+	// cooldown isn't reported as a repository without any release.
+	foundRelease := false
 	page := 0
 	for {
 		// Timeout api query after 30sec
@@ -147,6 +150,7 @@ func (g *Gitea) SearchReleases(ctx context.Context, releaseAge age.Spec) ([]stri
 			if releases[i].Draft {
 				continue
 			}
+			foundRelease = true
 			date := releaseDate(releases[i])
 			if !releaseAge.Matches(date) {
 				logrus.Debugf("ignoring release %q, dated %s, as outside of the age window", releases[i].Tag, date)
@@ -160,6 +164,16 @@ func (g *Gitea) SearchReleases(ctx context.Context, releaseAge age.Spec) ([]stri
 		}
 		page++
 
+	}
+
+	/*
+		The repository does publish releases but the age filter discarded every one of
+		them, which means the release we would have returned is still cooling down.
+		That's not a lookup failure, so the sentinel lets the caller skip rather than
+		fail.
+	*/
+	if foundRelease && len(results) == 0 {
+		return nil, fmt.Errorf("%w for the Gitea releases of %s/%s", age.ErrNoVersionMatchingAge, g.spec.Owner, g.spec.Repository)
 	}
 
 	return results, nil

--- a/pkg/plugins/resources/gitea/release/source.go
+++ b/pkg/plugins/resources/gitea/release/source.go
@@ -2,9 +2,11 @@ package release
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/updatecli/updatecli/pkg/core/result"
+	"github.com/updatecli/updatecli/pkg/plugins/utils/age"
 	"github.com/updatecli/updatecli/pkg/plugins/utils/version"
 )
 
@@ -12,13 +14,20 @@ func (g *Gitea) Source(ctx context.Context, workingDir string, resultSource *res
 	versions, err := g.SearchReleases(ctx, g.spec.Age)
 
 	if err != nil {
+		/*
+			Every published release is still cooling down, which is an expected state of
+			the age filter rather than a failure, so the source is skipped instead.
+		*/
+		if errors.Is(err, age.ErrNoVersionMatchingAge) {
+			resultSource.Result = result.SKIPPED
+			resultSource.Description = "no Gitea Release matches the age filter yet"
+			return nil
+		}
+
 		return fmt.Errorf("search gitea release: %w", err)
 	}
 
 	if len(versions) == 0 {
-		if !g.spec.Age.IsZero() {
-			return fmt.Errorf("no Gitea Release found matching the age filter")
-		}
 		return fmt.Errorf("no Gitea Release found")
 	}
 

--- a/pkg/plugins/resources/gitea/release/source.go
+++ b/pkg/plugins/resources/gitea/release/source.go
@@ -9,13 +9,16 @@ import (
 )
 
 func (g *Gitea) Source(ctx context.Context, workingDir string, resultSource *result.Source) error {
-	versions, err := g.SearchReleases(ctx)
+	versions, err := g.SearchReleases(ctx, g.spec.Age)
 
 	if err != nil {
 		return fmt.Errorf("search gitea release: %w", err)
 	}
 
 	if len(versions) == 0 {
+		if !g.spec.Age.IsZero() {
+			return fmt.Errorf("no Gitea Release found matching the age filter")
+		}
 		return fmt.Errorf("no Gitea Release found")
 	}
 

--- a/pkg/plugins/resources/gitea/release/source_test.go
+++ b/pkg/plugins/resources/gitea/release/source_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/updatecli/updatecli/pkg/core/result"
+	"github.com/updatecli/updatecli/pkg/plugins/utils/age"
 	"github.com/updatecli/updatecli/pkg/plugins/utils/version"
 )
 
@@ -20,9 +21,11 @@ func TestSource(t *testing.T) {
 			Owner         string
 			Repository    string
 			VersionFilter version.Filter
+			Age           age.Spec
 		}
-		wantResult string
-		wantErr    bool
+		wantResult  string
+		wantSkipped bool
+		wantErr     bool
 	}{
 		{
 			name: "repository updatecli/updatecli-nonexistent should not exist",
@@ -32,6 +35,7 @@ func TestSource(t *testing.T) {
 				Owner         string
 				Repository    string
 				VersionFilter version.Filter
+				Age           age.Spec
 			}{
 				URL:        "codeberg.org",
 				Token:      "",
@@ -49,6 +53,7 @@ func TestSource(t *testing.T) {
 				Owner         string
 				Repository    string
 				VersionFilter version.Filter
+				Age           age.Spec
 			}{
 				URL:        "codeberg.org",
 				Token:      "",
@@ -66,6 +71,7 @@ func TestSource(t *testing.T) {
 				Owner         string
 				Repository    string
 				VersionFilter version.Filter
+				Age           age.Spec
 			}{
 				URL:        "codeberg.org",
 				Token:      "",
@@ -78,6 +84,30 @@ func TestSource(t *testing.T) {
 			},
 			wantResult: "v2.15.0",
 			wantErr:    false,
+		},
+		{
+			name: "the source is skipped while every release is still in cooldown",
+			manifest: struct {
+				URL           string
+				Token         string
+				Owner         string
+				Repository    string
+				VersionFilter version.Filter
+				Age           age.Spec
+			}{
+				URL:        "codeberg.org",
+				Token:      "",
+				Owner:      "updatecli",
+				Repository: "updatecli-action",
+				VersionFilter: version.Filter{
+					Kind:    "semver",
+					Pattern: "~2.15",
+				},
+				// No release can ever be that old, so the age filter discards all of them.
+				Age: age.Spec{Minimum: "100y"},
+			},
+			wantResult:  "",
+			wantSkipped: true,
 		},
 	}
 
@@ -95,6 +125,10 @@ func TestSource(t *testing.T) {
 				require.Error(t, gotErr)
 			} else {
 				require.NoError(t, gotErr)
+			}
+
+			if tt.wantSkipped {
+				assert.Equal(t, result.SKIPPED, gotResult.Result)
 			}
 
 			assert.Equal(t, tt.wantResult, gotResult.Information)

--- a/pkg/plugins/resources/githubrelease/main.go
+++ b/pkg/plugins/resources/githubrelease/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/updatecli/updatecli/pkg/plugins/scms/github"
 	"github.com/updatecli/updatecli/pkg/plugins/scms/github/app"
+	"github.com/updatecli/updatecli/pkg/plugins/utils/age"
 	"github.com/updatecli/updatecli/pkg/plugins/utils/redact"
 	"github.com/updatecli/updatecli/pkg/plugins/utils/version"
 )
@@ -74,6 +75,17 @@ type Spec struct {
 	//  * source
 	//
 	VersionFilter version.Filter `yaml:",omitempty"`
+	// age defines the minimum or maximum age of a release to be considered valid.
+	// It accepts a duration string (e.g., "24h", "7d", "3w", "1y").
+	//
+	// compatible:
+	//  * source
+	//
+	// remark:
+	//  * the age filter cannot be applied to the git tag fallback used when a repository
+	//    doesn't publish any GitHub release.
+	//
+	Age age.Spec `yaml:",omitempty"`
 	// typeFilter specifies the GitHub Release type to retrieve before applying the versionfilter rule
 	//
 	// default:
@@ -164,6 +176,10 @@ func New(spec interface{}) (*GitHubRelease, error) {
 
 	}
 
+	if err := newSpec.Age.Validate(); err != nil {
+		validationErrors = append(validationErrors, err.Error())
+	}
+
 	// Return all the validation errors if found any
 	if len(validationErrors) > 0 {
 		return &GitHubRelease{}, fmt.Errorf("validation error: the provided manifest configuration has the following validation errors:\n%s", strings.Join(validationErrors, "\n\n"))
@@ -205,6 +221,7 @@ func (g *GitHubRelease) ReportConfig() interface{} {
 		Owner:         g.spec.Owner,
 		Repository:    g.spec.Repository,
 		VersionFilter: g.spec.VersionFilter,
+		Age:           g.spec.Age,
 		TypeFilter:    g.spec.TypeFilter,
 		URL:           redact.URL(g.spec.URL),
 		Tag:           g.spec.Tag,

--- a/pkg/plugins/resources/githubrelease/source.go
+++ b/pkg/plugins/resources/githubrelease/source.go
@@ -26,10 +26,16 @@ func (gr *GitHubRelease) Source(ctx context.Context, workingDir string, resultSo
 		versions = append(versions, release.TagName)
 	}
 	if len(versions) == 0 {
-		// The git tag fallback only reports tag names, so an age window couldn't be honored
-		// there. Reporting it is safer than silently ignoring a cooldown.
+		/*
+			Every published release is still cooling down, which is an expected state of
+			the age filter rather than a failure, so the source is skipped instead. The
+			git tag fallback is not attempted because it only reports tag names, so it
+			couldn't honor the age window.
+		*/
 		if !gr.spec.Age.IsZero() {
-			return fmt.Errorf("no GitHub release found matching the age filter, and the git tag fallback cannot honor it, exiting")
+			resultSource.Result = result.SKIPPED
+			resultSource.Description = "no GitHub release matches the age filter yet"
+			return nil
 		}
 
 		switch gr.spec.TypeFilter.IsZero() {

--- a/pkg/plugins/resources/githubrelease/source.go
+++ b/pkg/plugins/resources/githubrelease/source.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/updatecli/updatecli/pkg/core/result"
+	"github.com/updatecli/updatecli/pkg/plugins/utils/age"
 )
 
 // Source retrieves a specific version tag name, tag hash, or release title from GitHub Releases.
@@ -25,22 +26,26 @@ func (gr *GitHubRelease) Source(ctx context.Context, workingDir string, resultSo
 		}
 		versions = append(versions, release.TagName)
 	}
-	if len(versions) == 0 {
-		/*
-			Every published release is still cooling down, which is an expected state of
-			the age filter rather than a failure, so the source is skipped instead. The
-			git tag fallback is not attempted because it only reports tag names, so it
-			couldn't honor the age window.
-		*/
-		if !gr.spec.Age.IsZero() {
-			resultSource.Result = result.SKIPPED
-			resultSource.Description = "no GitHub release matches the age filter yet"
-			return nil
-		}
+	/*
+		The repository does publish releases but the age filter discarded every one of
+		them, which is an expected state of the filter rather than a failure, so the
+		source is skipped instead. The git tag fallback is deliberately not attempted
+		here: it only reports tag names, so it couldn't honor the age window.
+	*/
+	if len(releaseRefs) > 0 && len(versions) == 0 {
+		logrus.Debugf("%s", age.ErrNoVersionMatchingAge)
+		resultSource.Result = result.SKIPPED
+		resultSource.Description = "no GitHub release matches the age filter yet"
+		return nil
+	}
 
+	if len(versions) == 0 {
 		switch gr.spec.TypeFilter.IsZero() {
 		case true:
 			logrus.Warningf("%s No GitHub Release found, we fallback to published git tags", result.ATTENTION)
+			if !gr.spec.Age.IsZero() {
+				logrus.Warningf("%s The age filter cannot be honored by the git tag fallback, as git tags are reported without their date", result.ATTENTION)
+			}
 
 			versions, err = gr.ghHandler.SearchTags(ctx, 0)
 			if err != nil {

--- a/pkg/plugins/resources/githubrelease/source.go
+++ b/pkg/plugins/resources/githubrelease/source.go
@@ -18,9 +18,20 @@ func (gr *GitHubRelease) Source(ctx context.Context, workingDir string, resultSo
 
 	var versions []string
 	for _, release := range releaseRefs {
+		date := release.PublicationDate()
+		if !gr.spec.Age.Matches(date) {
+			logrus.Debugf("ignoring release %q, published on %s, as outside of the age window", release.TagName, date)
+			continue
+		}
 		versions = append(versions, release.TagName)
 	}
 	if len(versions) == 0 {
+		// The git tag fallback only reports tag names, so an age window couldn't be honored
+		// there. Reporting it is safer than silently ignoring a cooldown.
+		if !gr.spec.Age.IsZero() {
+			return fmt.Errorf("no GitHub release found matching the age filter, and the git tag fallback cannot honor it, exiting")
+		}
+
 		switch gr.spec.TypeFilter.IsZero() {
 		case true:
 			logrus.Warningf("%s No GitHub Release found, we fallback to published git tags", result.ATTENTION)

--- a/pkg/plugins/resources/githubrelease/source_test.go
+++ b/pkg/plugins/resources/githubrelease/source_test.go
@@ -215,7 +215,7 @@ func TestGitHubRelease_Source(t *testing.T) {
 			wantSkipped: true,
 		},
 		{
-			name: "the git tag fallback is skipped when an age filter is set",
+			name: "an age filter doesn't prevent the git tag fallback for a repository without any release",
 			mockedGhHandler: &mockGhHandler{
 				tags: []string{"1.0.0", "2.0.0", "3.0.0"},
 			},
@@ -223,8 +223,8 @@ func TestGitHubRelease_Source(t *testing.T) {
 				Kind:    "latest",
 				Pattern: "latest",
 			},
-			releaseAge:  age.Spec{Minimum: "7d"},
-			wantSkipped: true,
+			releaseAge: age.Spec{Minimum: "7d"},
+			wantValue:  "3.0.0",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/plugins/resources/githubrelease/source_test.go
+++ b/pkg/plugins/resources/githubrelease/source_test.go
@@ -4,13 +4,21 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
+	"github.com/shurcooL/githubv4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/updatecli/updatecli/pkg/core/result"
 	"github.com/updatecli/updatecli/pkg/plugins/scms/github"
+	"github.com/updatecli/updatecli/pkg/plugins/utils/age"
 	"github.com/updatecli/updatecli/pkg/plugins/utils/version"
 )
+
+// publishedDaysAgo builds the publication date of a release published n days ago.
+func publishedDaysAgo(n int) githubv4.DateTime {
+	return githubv4.DateTime{Time: time.Now().Add(-time.Duration(n) * 24 * time.Hour)}
+}
 
 type mockGhHandler struct {
 	github.Github
@@ -59,6 +67,7 @@ func TestGitHubRelease_Source(t *testing.T) {
 		releaseKey      string
 		mockedGhHandler github.GithubHandler
 		versionFilter   version.Filter
+		releaseAge      age.Spec
 		wantValue       string
 		wantErr         bool
 	}{
@@ -142,6 +151,80 @@ func TestGitHubRelease_Source(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "3 releases found, the most recent one is still in cooldown",
+			mockedGhHandler: &mockGhHandler{
+				releases: []github.ReleaseNode{
+					{TagName: "1.0.0", PublishedAt: publishedDaysAgo(30)},
+					{TagName: "2.0.0", PublishedAt: publishedDaysAgo(10)},
+					{TagName: "3.0.0", PublishedAt: publishedDaysAgo(1)},
+				},
+			},
+			versionFilter: version.Filter{
+				Kind:    "latest",
+				Pattern: "latest",
+			},
+			releaseAge: age.Spec{Minimum: "7d"},
+			wantValue:  "2.0.0",
+		},
+		{
+			name: "3 releases found, only the oldest one is not expired",
+			mockedGhHandler: &mockGhHandler{
+				releases: []github.ReleaseNode{
+					{TagName: "1.0.0", PublishedAt: publishedDaysAgo(30)},
+					{TagName: "2.0.0", PublishedAt: publishedDaysAgo(10)},
+					{TagName: "3.0.0", PublishedAt: publishedDaysAgo(1)},
+				},
+			},
+			versionFilter: version.Filter{
+				Kind:    "latest",
+				Pattern: "latest",
+			},
+			releaseAge: age.Spec{Minimum: "20d"},
+			wantValue:  "1.0.0",
+		},
+		{
+			name: "Draft releases fall back on their creation date",
+			mockedGhHandler: &mockGhHandler{
+				releases: []github.ReleaseNode{
+					{TagName: "1.0.0", CreatedAt: publishedDaysAgo(30)},
+					{TagName: "2.0.0", CreatedAt: publishedDaysAgo(1)},
+				},
+			},
+			versionFilter: version.Filter{
+				Kind:    "latest",
+				Pattern: "latest",
+			},
+			releaseAge: age.Spec{Minimum: "7d"},
+			wantValue:  "1.0.0",
+		},
+		{
+			name: "Error: every release is still in cooldown",
+			mockedGhHandler: &mockGhHandler{
+				releases: []github.ReleaseNode{
+					{TagName: "1.0.0", PublishedAt: publishedDaysAgo(2)},
+					{TagName: "2.0.0", PublishedAt: publishedDaysAgo(1)},
+				},
+			},
+			versionFilter: version.Filter{
+				Kind:    "latest",
+				Pattern: "latest",
+			},
+			releaseAge: age.Spec{Minimum: "7d"},
+			wantErr:    true,
+		},
+		{
+			name: "Error: the git tag fallback cannot honor an age filter",
+			mockedGhHandler: &mockGhHandler{
+				tags: []string{"1.0.0", "2.0.0", "3.0.0"},
+			},
+			versionFilter: version.Filter{
+				Kind:    "latest",
+				Pattern: "latest",
+			},
+			releaseAge: age.Spec{Minimum: "7d"},
+			wantErr:    true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -154,6 +237,7 @@ func TestGitHubRelease_Source(t *testing.T) {
 				Token:         "ghp_example",
 				Key:           tt.releaseKey,
 				VersionFilter: tt.versionFilter,
+				Age:           tt.releaseAge,
 			})
 
 			require.NoError(t, err)

--- a/pkg/plugins/resources/githubrelease/source_test.go
+++ b/pkg/plugins/resources/githubrelease/source_test.go
@@ -69,6 +69,7 @@ func TestGitHubRelease_Source(t *testing.T) {
 		versionFilter   version.Filter
 		releaseAge      age.Spec
 		wantValue       string
+		wantSkipped     bool
 		wantErr         bool
 	}{
 		{
@@ -199,7 +200,7 @@ func TestGitHubRelease_Source(t *testing.T) {
 			wantValue:  "1.0.0",
 		},
 		{
-			name: "Error: every release is still in cooldown",
+			name: "the source is skipped while every release is still in cooldown",
 			mockedGhHandler: &mockGhHandler{
 				releases: []github.ReleaseNode{
 					{TagName: "1.0.0", PublishedAt: publishedDaysAgo(2)},
@@ -210,11 +211,11 @@ func TestGitHubRelease_Source(t *testing.T) {
 				Kind:    "latest",
 				Pattern: "latest",
 			},
-			releaseAge: age.Spec{Minimum: "7d"},
-			wantErr:    true,
+			releaseAge:  age.Spec{Minimum: "7d"},
+			wantSkipped: true,
 		},
 		{
-			name: "Error: the git tag fallback cannot honor an age filter",
+			name: "the git tag fallback is skipped when an age filter is set",
 			mockedGhHandler: &mockGhHandler{
 				tags: []string{"1.0.0", "2.0.0", "3.0.0"},
 			},
@@ -222,8 +223,8 @@ func TestGitHubRelease_Source(t *testing.T) {
 				Kind:    "latest",
 				Pattern: "latest",
 			},
-			releaseAge: age.Spec{Minimum: "7d"},
-			wantErr:    true,
+			releaseAge:  age.Spec{Minimum: "7d"},
+			wantSkipped: true,
 		},
 	}
 	for _, tt := range tests {
@@ -253,6 +254,12 @@ func TestGitHubRelease_Source(t *testing.T) {
 			}
 
 			require.NoError(t, err)
+
+			if tt.wantSkipped {
+				assert.Equal(t, result.SKIPPED, gotResult.Result)
+				return
+			}
+
 			assert.Equal(t, tt.wantValue, gotResult.Information)
 		})
 	}

--- a/pkg/plugins/resources/gittag/condition.go
+++ b/pkg/plugins/resources/gittag/condition.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
+	"github.com/updatecli/updatecli/pkg/plugins/utils/age"
 )
 
 // Condition checks that a git tag exists
@@ -43,7 +44,9 @@ func (gt *GitTag) Condition(_ context.Context, source string, scm scm.ScmHandler
 				scm.GetDirectory())
 		}
 
-		tagsList, tags, err = gt.listRemoteDirectoryTags(gt.directory)
+		// A condition checks whether a specific tag exists, so the age filter,
+		// which only narrows down which tag to pick, doesn't apply here.
+		tagsList, tags, err = gt.listRemoteDirectoryTags(gt.directory, age.Spec{})
 		if err != nil {
 			return false, "", fmt.Errorf("listing local tags: %w", err)
 		}

--- a/pkg/plugins/resources/gittag/main.go
+++ b/pkg/plugins/resources/gittag/main.go
@@ -7,6 +7,7 @@ import (
 	"github.com/go-viper/mapstructure/v2"
 	"github.com/updatecli/updatecli/pkg/core/result"
 	"github.com/updatecli/updatecli/pkg/plugins/scms/git"
+	"github.com/updatecli/updatecli/pkg/plugins/utils/age"
 	"github.com/updatecli/updatecli/pkg/plugins/utils/gitgeneric"
 	"github.com/updatecli/updatecli/pkg/plugins/utils/redact"
 	"github.com/updatecli/updatecli/pkg/plugins/utils/version"
@@ -24,6 +25,16 @@ type Spec struct {
 	//    * condition
 	//    * target
 	VersionFilter version.Filter `yaml:",omitempty"`
+	// Age defines the minimum or maximum age of a tag to be considered valid.
+	// It accepts a duration string (e.g., "24h", "7d", "3w", "1y").
+	// The age of a tag is the commit date of the commit it points to.
+	//
+	//  compatible:
+	//    * source
+	//
+	//  remark:
+	//    * not compatible with `lsRemote`, which lists tags without their dates.
+	Age age.Spec `yaml:",omitempty"`
 	// Tag defines the git tag to check for exact match.
 	//
 	// compatible:
@@ -179,6 +190,13 @@ func (gt *GitTag) Validate() error {
 		if gt.spec.URL == "" {
 			validationErrors = append(validationErrors, "The parameter `url` is required when `lsRemote` is set to true, as it needs a git repository URL to retrieve tags from the remote repository without cloning it.")
 		}
+		if !gt.spec.Age.IsZero() {
+			validationErrors = append(validationErrors, "The parameter `age` cannot be used when `lsRemote` is set to true, as `lsremote` doesn't report the date of a tag.")
+		}
+	}
+
+	if err := gt.spec.Age.Validate(); err != nil {
+		validationErrors = append(validationErrors, err.Error())
 	}
 
 	// Return all the validation errors if found any
@@ -215,6 +233,7 @@ func (gt *GitTag) ReportConfig() interface{} {
 	return Spec{
 		Path:          gt.spec.Path,
 		VersionFilter: gt.spec.VersionFilter,
+		Age:           gt.spec.Age,
 		Tag:           gt.spec.Tag,
 		Key:           gt.spec.Key,
 		URL:           redact.URL(gt.spec.URL),

--- a/pkg/plugins/resources/gittag/source.go
+++ b/pkg/plugins/resources/gittag/source.go
@@ -2,9 +2,11 @@ package gittag
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/updatecli/updatecli/pkg/core/result"
+	"github.com/updatecli/updatecli/pkg/plugins/utils/age"
 )
 
 // Source returns the latest git tag based on create time
@@ -31,14 +33,21 @@ func (gt *GitTag) Source(_ context.Context, workingDir string, resultSource *res
 	case false:
 		tagsList, tags, err = gt.listRemoteDirectoryTags(workingDir, gt.spec.Age)
 		if err != nil {
+			/*
+				Every published tag is still cooling down, which is an expected state of
+				the age filter rather than a failure, so the source is skipped instead.
+			*/
+			if errors.Is(err, age.ErrNoVersionMatchingAge) {
+				resultSource.Result = result.SKIPPED
+				resultSource.Description = "no git tag matches the age filter yet"
+				return nil
+			}
+
 			return fmt.Errorf("listing local tags: %w", err)
 		}
 	}
 
 	if len(tagsList) == 0 {
-		if !gt.spec.Age.IsZero() {
-			return fmt.Errorf("no tags found matching the age filter")
-		}
 		return fmt.Errorf("no tags found")
 	}
 

--- a/pkg/plugins/resources/gittag/source.go
+++ b/pkg/plugins/resources/gittag/source.go
@@ -29,13 +29,16 @@ func (gt *GitTag) Source(_ context.Context, workingDir string, resultSource *res
 		}
 
 	case false:
-		tagsList, tags, err = gt.listRemoteDirectoryTags(workingDir)
+		tagsList, tags, err = gt.listRemoteDirectoryTags(workingDir, gt.spec.Age)
 		if err != nil {
 			return fmt.Errorf("listing local tags: %w", err)
 		}
 	}
 
 	if len(tagsList) == 0 {
+		if !gt.spec.Age.IsZero() {
+			return fmt.Errorf("no tags found matching the age filter")
+		}
 		return fmt.Errorf("no tags found")
 	}
 

--- a/pkg/plugins/resources/gittag/source_test.go
+++ b/pkg/plugins/resources/gittag/source_test.go
@@ -4,13 +4,20 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/updatecli/updatecli/pkg/core/result"
+	"github.com/updatecli/updatecli/pkg/plugins/utils/age"
 	"github.com/updatecli/updatecli/pkg/plugins/utils/gitgeneric"
 	"github.com/updatecli/updatecli/pkg/plugins/utils/version"
 )
+
+// tagDaysAgo builds the commit date of a tag created n days ago.
+func tagDaysAgo(n int) time.Time {
+	return time.Now().Add(-time.Duration(n) * 24 * time.Hour)
+}
 
 type mockNativeGitHandler struct {
 	gitgeneric.GitHandler
@@ -424,6 +431,58 @@ func TestGitTag_Source(t *testing.T) {
 			},
 			wantValue: "mno345",
 			wantErr:   false,
+		},
+		{
+			name:       "3 tags found, the most recent one is still in cooldown",
+			workingDir: "github.com/updatecli/updatecli",
+			mockedNativeGitHandler: &mockNativeGitHandler{
+				tagRefs: []gitgeneric.DatedTag{
+					{Name: "1.0.0", Hash: "abc123", When: tagDaysAgo(30)},
+					{Name: "2.0.0", Hash: "def456", When: tagDaysAgo(10)},
+					{Name: "3.0.0", Hash: "ghi789", When: tagDaysAgo(1)},
+				},
+			},
+			versionFilter: version.Filter{
+				Kind:    "latest",
+				Pattern: "latest",
+			},
+			spec:      Spec{Age: age.Spec{Minimum: "7d"}},
+			wantValue: "2.0.0",
+		},
+		{
+			name:       "Error: every tag is still in cooldown",
+			workingDir: "github.com/updatecli/updatecli",
+			mockedNativeGitHandler: &mockNativeGitHandler{
+				tagRefs: []gitgeneric.DatedTag{
+					{Name: "1.0.0", Hash: "abc123", When: tagDaysAgo(2)},
+					{Name: "2.0.0", Hash: "def456", When: tagDaysAgo(1)},
+				},
+			},
+			versionFilter: version.Filter{
+				Kind:    "latest",
+				Pattern: "latest",
+			},
+			spec:    Spec{Age: age.Spec{Minimum: "7d"}},
+			wantErr: true,
+		},
+		{
+			name:       "Error: age is not compatible with lsRemote",
+			workingDir: "github.com/updatecli/updatecli",
+			mockedNativeGitHandler: &mockNativeGitHandler{
+				tagRefs: []gitgeneric.DatedTag{
+					{Name: "1.0.0", Hash: "abc123", When: tagDaysAgo(30)},
+				},
+			},
+			versionFilter: version.Filter{
+				Kind:    "latest",
+				Pattern: "latest",
+			},
+			spec: Spec{
+				URL:      "https://github.com/updatecli-test/updatecli.git",
+				LsRemote: boolPtr(true),
+				Age:      age.Spec{Minimum: "7d"},
+			},
+			wantErr: true,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/plugins/resources/gittag/source_test.go
+++ b/pkg/plugins/resources/gittag/source_test.go
@@ -41,6 +41,7 @@ func TestGitTag_Source(t *testing.T) {
 		versionFilter          version.Filter
 		spec                   Spec
 		wantValue              string
+		wantSkipped            bool
 		wantErr                bool
 	}{
 		{
@@ -450,7 +451,7 @@ func TestGitTag_Source(t *testing.T) {
 			wantValue: "2.0.0",
 		},
 		{
-			name:       "Error: every tag is still in cooldown",
+			name:       "the source is skipped while every tag is still in cooldown",
 			workingDir: "github.com/updatecli/updatecli",
 			mockedNativeGitHandler: &mockNativeGitHandler{
 				tagRefs: []gitgeneric.DatedTag{
@@ -462,8 +463,8 @@ func TestGitTag_Source(t *testing.T) {
 				Kind:    "latest",
 				Pattern: "latest",
 			},
-			spec:    Spec{Age: age.Spec{Minimum: "7d"}},
-			wantErr: true,
+			spec:        Spec{Age: age.Spec{Minimum: "7d"}},
+			wantSkipped: true,
 		},
 		{
 			name:       "Error: age is not compatible with lsRemote",
@@ -504,6 +505,12 @@ func TestGitTag_Source(t *testing.T) {
 			}
 
 			require.NoError(t, err)
+
+			if tt.wantSkipped {
+				assert.Equal(t, result.SKIPPED, gotResult.Result)
+				return
+			}
+
 			assert.Equal(t, tt.wantValue, gotResult.Information)
 		})
 	}

--- a/pkg/plugins/resources/gittag/utils.go
+++ b/pkg/plugins/resources/gittag/utils.go
@@ -7,6 +7,8 @@ import (
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing/transport/http"
+	"github.com/sirupsen/logrus"
+	"github.com/updatecli/updatecli/pkg/plugins/utils/age"
 )
 
 // listRemoteURLTags lists all tags from a remote git repository
@@ -52,8 +54,9 @@ func (gt *GitTag) listRemoteURLTags() ([]string, map[string]string, error) {
 	return tagsList, results, nil
 }
 
-// listRemoteDirectoryTags lists all tags from a local git repository
-func (gt *GitTag) listRemoteDirectoryTags(workingDir string) ([]string, map[string]string, error) {
+// listRemoteDirectoryTags lists the tags of a local git repository which were created
+// inside the provided age window.
+func (gt *GitTag) listRemoteDirectoryTags(workingDir string, tagAge age.Spec) ([]string, map[string]string, error) {
 	if gt.nativeGitHandler == nil {
 		return nil, nil, fmt.Errorf("nativeGitHandler is not initialized")
 	}
@@ -85,6 +88,10 @@ func (gt *GitTag) listRemoteDirectoryTags(workingDir string) ([]string, map[stri
 	}
 
 	for _, ref := range refs {
+		if !tagAge.Matches(ref.When) {
+			logrus.Debugf("ignoring tag %q, dated %s, as outside of the age window", ref.Name, ref.When)
+			continue
+		}
 		results[ref.Name] = ref.Hash
 		tagsList = append(tagsList, ref.Name)
 	}

--- a/pkg/plugins/resources/gittag/utils.go
+++ b/pkg/plugins/resources/gittag/utils.go
@@ -96,5 +96,14 @@ func (gt *GitTag) listRemoteDirectoryTags(workingDir string, tagAge age.Spec) ([
 		tagsList = append(tagsList, ref.Name)
 	}
 
+	/*
+		The repository does publish tags but the age filter discarded every one of them,
+		which means the tag we would have returned is still cooling down. That's not a
+		lookup failure, so the sentinel lets the caller skip rather than fail.
+	*/
+	if len(refs) > 0 && len(tagsList) == 0 {
+		return nil, nil, fmt.Errorf("%w for the tags of %q", age.ErrNoVersionMatchingAge, gt.directory)
+	}
+
 	return tagsList, results, nil
 }

--- a/pkg/plugins/scms/github/release.go
+++ b/pkg/plugins/scms/github/release.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/shurcooL/githubv4"
 	"github.com/sirupsen/logrus"
@@ -37,6 +38,8 @@ query getLatestRelease($owner: String!, $repository: String!, $before: String, $
           }
           isDraft
           isPrerelease
+          createdAt
+          publishedAt
         }
         cursor
       }
@@ -66,7 +69,19 @@ type ReleaseNode struct {
 	IsDraft      bool
 	IsLatest     bool
 	IsPrerelease bool
+	CreatedAt    githubv4.DateTime
+	PublishedAt  githubv4.DateTime
 }
+
+// PublicationDate returns the date at which the release became public.
+// Draft releases have no publication date, so their creation date is used instead.
+func (r ReleaseNode) PublicationDate() time.Time {
+	if !r.PublishedAt.IsZero() {
+		return r.PublishedAt.Time
+	}
+	return r.CreatedAt.Time
+}
+
 type TagCommit struct {
 	Oid string
 }

--- a/pkg/plugins/utils/age/main.go
+++ b/pkg/plugins/utils/age/main.go
@@ -123,3 +123,31 @@ func (a Spec) IsNewerThan(t time.Time, since *time.Time) bool {
 func (a Spec) IsZero() bool {
 	return a.Minimum == "" && a.Maximum == ""
 }
+
+// Matches returns true if a release published at t falls inside the age window.
+// Both bounds are evaluated against the same instant.
+func (a Spec) Matches(t time.Time) bool {
+	now := time.Now()
+	return !a.IsOlderThan(t, &now) && !a.IsNewerThan(t, &now)
+}
+
+// ManifestTemplate defines the "age" Go template used by autodiscovery crawlers to emit
+// an age filter in the spec of a generated source. It takes a Spec as argument and emits
+// nothing for an empty one:
+//
+//	tmpl, err := template.New("manifest").Parse(age.ManifestTemplate + myCrawlerTemplate)
+//	// then, in myCrawlerTemplate:
+//	//   {{- template "age" .Age }}
+//
+// The emitted keys are indented for a source spec, which is where crawlers use them.
+const ManifestTemplate = `{{- define "age" }}
+{{- if not .IsZero }}
+      age:
+        {{- if .Minimum }}
+        minimum: '{{ .Minimum }}'
+        {{- end }}
+        {{- if .Maximum }}
+        maximum: '{{ .Maximum }}'
+        {{- end }}
+{{- end }}
+{{- end }}`

--- a/pkg/plugins/utils/age/main.go
+++ b/pkg/plugins/utils/age/main.go
@@ -1,6 +1,7 @@
 package age
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -8,6 +9,11 @@ import (
 
 	"github.com/sirupsen/logrus"
 )
+
+// ErrNoVersionMatchingAge is returned when a resource publishes versions but the age
+// filter discarded all of them. It reports a cooldown still running, not a lookup
+// failure, so callers are expected to skip rather than to fail.
+var ErrNoVersionMatchingAge = errors.New("no version matching the age filter")
 
 // Spec defines parameters to filter versions based on their release date
 type Spec struct {

--- a/pkg/plugins/utils/age/main_test.go
+++ b/pkg/plugins/utils/age/main_test.go
@@ -334,3 +334,59 @@ func TestSpecIsZero(t *testing.T) {
 		})
 	}
 }
+
+func TestSpecMatches(t *testing.T) {
+	daysAgo := func(n int) time.Time {
+		return time.Now().Add(-time.Duration(n) * 24 * time.Hour)
+	}
+
+	tests := []struct {
+		name string
+		spec Spec
+		date time.Time
+		want bool
+	}{
+		{
+			name: "empty spec accepts everything",
+			spec: Spec{},
+			date: daysAgo(0),
+			want: true,
+		},
+		{
+			name: "release younger than the minimum is rejected",
+			spec: Spec{Minimum: "7d"},
+			date: daysAgo(1),
+			want: false,
+		},
+		{
+			name: "release older than the minimum is accepted",
+			spec: Spec{Minimum: "7d"},
+			date: daysAgo(10),
+			want: true,
+		},
+		{
+			name: "release older than the maximum is rejected",
+			spec: Spec{Maximum: "30d"},
+			date: daysAgo(40),
+			want: false,
+		},
+		{
+			name: "release inside both bounds is accepted",
+			spec: Spec{Minimum: "7d", Maximum: "30d"},
+			date: daysAgo(10),
+			want: true,
+		},
+		{
+			name: "release outside both bounds is rejected",
+			spec: Spec{Minimum: "7d", Maximum: "30d"},
+			date: daysAgo(40),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.spec.Matches(tt.date))
+		})
+	}
+}


### PR DESCRIPTION
Fix #8999

Follows #8966 (Golang) and #9915 (npm) in the dependency cooldown epic #7866.

The `github/action` crawler now accepts an `age` window and propagates it to the release, tag, and branch sources it generates, so a freshly published Action version can be held back until it has cooled down:

```yaml
autodiscovery:
  crawlers:
    github/action:
      age:
        minimum: '7d'
```

The four source kinds the crawler emits gained the same `age` setting, since none of them could honor it before:

| kind | date used |
|---|---|
| `githubrelease` | release publication date, newly requested from the GraphQL API (`publishedAt`, falling back to `createdAt` for drafts) |
| `gittag` | commit date already carried by `gitgeneric.TagRefs` |
| `gitbranch` | latest commit date already carried by `gitgeneric.BranchRefs` |
| `gitea/release` | `scm.Release.Published`, falling back to `Created` |

The filter narrows down which version a source picks, so it applies to sources only. Conditions check that a specific reference exists and keep matching every one, which the generated manifests rely on for their `dependson: condition#release` gating.

The `age:` block emitted into a generated manifest now comes from a single shared `age.ManifestTemplate` snippet rather than being pasted per source.

## Test

To test this pull request, you can run the following commands:

```shell
cd pkg/plugins/autodiscovery/githubaction && go test
cd pkg/plugins/resources/githubrelease && go test
cd pkg/plugins/resources/gittag && go test
cd pkg/plugins/resources/gitbranch && go test
cd pkg/plugins/resources/gitea/release && go test
cd pkg/plugins/utils/age && go test
```

## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via pull request in [website](https://github.com/updatecli/website) repository.
- [ ] <!-- If applicable,--> I have tested this pull request manually with a custom Updatecli build and it works as expected.

Both are still open on my side: the new `age` setting on the crawler and on the four resources needs a website PR, and I have only exercised this through the unit tests, not against the live GitHub and Gitea APIs.

### Tradeoff

Two cases where an age window cannot be honored are reported as errors rather than silently ignored, since a cooldown that quietly stops applying is worse than a loud failure:

- `githubrelease` falls back to git tags when a repository publishes no release, and that fallback only reports tag names. Note this is not reachable from the generated manifests, where the `release` source is gated behind a condition checking the reference really is a release.
- `gittag` with `lsRemote: true` lists tags without their dates, so the combination is rejected at validation time.

`age` is opt-in with no default, matching the Golang crawler. The npm crawler defaults to `minimum: 3d`, so the two conventions still differ.

### Potential improvement

- Teach `SearchTags` to return commit dates via the GraphQL `committedDate` inline fragment, so the `githubrelease` git tag fallback can honor a cooldown instead of refusing.
- Apply the cooldown to the Docker images referenced by a workflow, which needs `age` on `dockerimage` and `dockerdigest` first.
- The Golang and npm crawlers still inline their own copy of the `age:` manifest block and could move to the shared `age.ManifestTemplate` added here.