### PR TITLE
feat(yaml)!: add createmissingkey and appendtoarray to the yaml resource

### DIFF
--- a/e2e/testdata/yaml/values.yaml
+++ b/e2e/testdata/yaml/values.yaml
@@ -1,0 +1,7 @@
+# Test data used by the yaml createmissingkey/appendtoarray e2e manifest.
+# It is only ever read in dry run, so it stays unmodified.
+image:
+  name: nginx
+  tag: v1.0.0
+allowedTags:
+  - v1.0.0

--- a/e2e/updatecli.d/success.d/yaml/createandappend.yaml
+++ b/e2e/updatecli.d/success.d/yaml/createandappend.yaml
@@ -1,0 +1,58 @@
+name: Test YAML resource createmissingkey and appendtoarray
+
+sources:
+  tag:
+    name: Get the existing image tag
+    kind: yaml
+    spec:
+      file: e2e/testdata/yaml/values.yaml
+      key: $.image.tag
+
+targets:
+  createMissingKey:
+    name: Create a key that does not exist yet
+    kind: yaml
+    sourceid: tag
+    spec:
+      file: e2e/testdata/yaml/values.yaml
+      key: $.image.registry.tag
+      createmissingkey: true
+
+  createMissingKeys:
+    name: Create several keys sharing the same value
+    kind: yaml
+    sourceid: tag
+    spec:
+      file: e2e/testdata/yaml/values.yaml
+      keys:
+        - $.image.mirror.tag
+        - $.image.fallback.tag
+      createmissingkey: true
+
+  appendToArray:
+    name: Append a new entry to an existing array
+    kind: yaml
+    spec:
+      file: e2e/testdata/yaml/values.yaml
+      key: $.allowedTags
+      appendtoarray: true
+      value: v1.1.0
+
+  appendToArrayIdempotent:
+    name: Appending an entry already present reports no change
+    kind: yaml
+    spec:
+      file: e2e/testdata/yaml/values.yaml
+      key: $.allowedTags
+      appendtoarray: true
+      value: v1.0.0
+
+  appendToMissingArray:
+    name: Create a missing array holding the value
+    kind: yaml
+    spec:
+      file: e2e/testdata/yaml/values.yaml
+      key: $.deniedTags
+      appendtoarray: true
+      createmissingkey: true
+      value: v0.1.0

--- a/pkg/plugins/resources/yaml/create.go
+++ b/pkg/plugins/resources/yaml/create.go
@@ -1,0 +1,358 @@
+package yaml
+
+import (
+	"fmt"
+	"strings"
+
+	goyaml "github.com/goccy/go-yaml"
+	"github.com/goccy/go-yaml/ast"
+)
+
+// defaultYamlIndent is the indentation width used when a document gives no hint.
+const defaultYamlIndent = 2
+
+// pathElement is a single step of a yaml key path, as produced by splitYamlPathKey.
+type pathElement struct {
+	// raw is the element as it appears in the key, including its leading
+	// separator (".name", ".'a.b'", "[0]", "[*]", "..name"). Concatenating the
+	// raw form of the leading elements after "$" rebuilds a valid path prefix.
+	raw string
+	// name is the map key this element selects. Only meaningful when isKey is true.
+	name string
+	// isKey reports whether the element selects a map key, as opposed to a
+	// sequence index ("[0]", "[*]") or a recursive descent ("..name").
+	isKey bool
+}
+
+// splitYamlPathKey splits a sanitized yaml key (see sanitizeYamlPathKey) into its
+// successive elements. It mirrors the grammar implemented by goccy's PathString so
+// that a prefix rebuilt from these elements is always a path goccy can parse.
+func splitYamlPathKey(key string) ([]pathElement, error) {
+	buf := []rune(key)
+	if len(buf) == 0 || buf[0] != '$' {
+		return nil, fmt.Errorf("path %q must start with %q", key, "$")
+	}
+
+	var elements []pathElement
+	cursor := 1
+
+	for cursor < len(buf) {
+		switch buf[cursor] {
+		case '.':
+			// "..name" is a recursive descent, which we cannot create through.
+			if cursor+1 < len(buf) && buf[cursor+1] == '.' {
+				start := cursor
+				cursor += 2
+				for cursor < len(buf) && buf[cursor] != '.' && buf[cursor] != '[' {
+					cursor++
+				}
+				elements = append(elements, pathElement{raw: string(buf[start:cursor])})
+				continue
+			}
+
+			start := cursor
+			cursor++ // skip '.'
+
+			// A quoted key runs until the closing quote, with '\' escaping.
+			if cursor < len(buf) && buf[cursor] == '\'' {
+				cursor++ // skip opening quote
+				var name strings.Builder
+				closed := false
+				for cursor < len(buf) {
+					if buf[cursor] == '\\' && cursor+1 < len(buf) {
+						cursor++
+						name.WriteRune(buf[cursor])
+						cursor++
+						continue
+					}
+					if buf[cursor] == '\'' {
+						cursor++ // skip closing quote
+						closed = true
+						break
+					}
+					name.WriteRune(buf[cursor])
+					cursor++
+				}
+				if !closed {
+					return nil, fmt.Errorf("could not find end delimiter for key in path %q", key)
+				}
+				elements = append(elements, pathElement{
+					raw:   string(buf[start:cursor]),
+					name:  name.String(),
+					isKey: true,
+				})
+				continue
+			}
+
+			nameStart := cursor
+			for cursor < len(buf) && buf[cursor] != '.' && buf[cursor] != '[' {
+				cursor++
+			}
+			if nameStart == cursor {
+				return nil, fmt.Errorf("could not find key by empty name in path %q", key)
+			}
+			elements = append(elements, pathElement{
+				raw:   string(buf[start:cursor]),
+				name:  string(buf[nameStart:cursor]),
+				isKey: true,
+			})
+
+		case '[':
+			start := cursor
+			for cursor < len(buf) && buf[cursor] != ']' {
+				cursor++
+			}
+			if cursor >= len(buf) {
+				return nil, fmt.Errorf("could not find closing %q in path %q", "]", key)
+			}
+			cursor++ // skip ']'
+			elements = append(elements, pathElement{raw: string(buf[start:cursor])})
+
+		default:
+			return nil, fmt.Errorf("invalid character %q at %d in path %q", string(buf[cursor]), cursor, key)
+		}
+	}
+
+	return elements, nil
+}
+
+// pathPrefix rebuilds the path addressing the first n elements.
+func pathPrefix(elements []pathElement, n int) string {
+	var sb strings.Builder
+	sb.WriteString("$")
+	for i := 0; i < n; i++ {
+		sb.WriteString(elements[i].raw)
+	}
+	return sb.String()
+}
+
+// deepestExistingNode walks key element by element and returns the node addressed by
+// the longest prefix that resolves, together with the number of elements it consumed.
+// A nil node with depth 0 means the document itself is empty.
+func deepestExistingNode(body ast.Node, elements []pathElement) (ast.Node, int, error) {
+	// An empty document has nothing to walk.
+	if body == nil {
+		return nil, 0, nil
+	}
+
+	node := body
+	depth := 0
+
+	for i := 1; i <= len(elements); i++ {
+		prefix := pathPrefix(elements, i)
+
+		path, err := goyaml.PathString(prefix)
+		if err != nil {
+			return nil, 0, fmt.Errorf("crafting yamlpath query for key %q: %w", prefix, err)
+		}
+
+		found, err := path.FilterNode(body)
+		if err != nil {
+			// goccy reports descending into a scalar as an invalid query.
+			return nil, 0, fmt.Errorf("searching for key %q: %w", prefix, err)
+		}
+
+		if found == nil {
+			break
+		}
+
+		// An explicit null ("key:", "key: ~") carries no mapping to merge onto.
+		// Stopping here leaves the null as part of the missing path so that its
+		// parent mapping adopts the generated subtree in its place.
+		if _, isNull := found.(*ast.NullNode); isNull {
+			break
+		}
+
+		node = found
+		depth = i
+	}
+
+	return node, depth, nil
+}
+
+// buildMissingSubtree renders the missing elements as a nested mapping ending on
+// leafValue. Letting goccy encode the Go value keeps the token positions coherent,
+// which is what ast.Merge relies on to re-indent the subtree onto its new parent.
+func buildMissingSubtree(missing []pathElement, leafValue interface{}, indent int) (ast.Node, error) {
+	value := leafValue
+	for i := len(missing) - 1; i >= 0; i-- {
+		value = map[string]interface{}{missing[i].name: value}
+	}
+
+	node, err := goyaml.ValueToNode(value, goyaml.Indent(indent), goyaml.IndentSequence(true))
+	if err != nil {
+		return nil, fmt.Errorf("crafting yaml node: %w", err)
+	}
+
+	return node, nil
+}
+
+// detectIndent reports the indentation width used by the block mappings of a
+// document, so that a generated subtree matches the surrounding style. It falls
+// back to defaultYamlIndent when the document holds no nested block mapping.
+func detectIndent(node ast.Node) int {
+	mapping, ok := node.(*ast.MappingNode)
+	if !ok || mapping.IsFlowStyle {
+		return defaultYamlIndent
+	}
+
+	for _, value := range mapping.Values {
+		child, ok := value.Value.(*ast.MappingNode)
+		if !ok || child.IsFlowStyle || len(child.Values) == 0 {
+			continue
+		}
+
+		indent := child.Values[0].Key.GetToken().Position.Column - value.Key.GetToken().Position.Column
+		if indent > 0 {
+			return indent
+		}
+
+		// Keep looking deeper when this level is inconclusive.
+		if indent := detectIndent(child); indent != defaultYamlIndent {
+			return indent
+		}
+	}
+
+	return defaultYamlIndent
+}
+
+// subtreeLeaf descends depth levels into a subtree built by buildMissingSubtree and
+// returns the leaf node holding the value.
+func subtreeLeaf(node ast.Node, depth int) ast.Node {
+	current := node
+	for i := 0; i < depth; i++ {
+		mapping, ok := current.(*ast.MappingNode)
+		if !ok || len(mapping.Values) != 1 {
+			return nil
+		}
+		current = mapping.Values[0].Value
+	}
+	return current
+}
+
+// isNullNode reports whether node is an explicit yaml null ("key:", "key: ~").
+// Such a node exists but holds nothing to descend into, so key creation treats it
+// as an absent key and overwrites it.
+func isNullNode(node ast.Node) bool {
+	_, ok := node.(*ast.NullNode)
+	return ok
+}
+
+// mergeable normalizes a node so that ast.Merge accepts it as a destination. goccy
+// currently always exposes maps as *ast.MappingNode, but a single mapping pair can
+// surface as *ast.MappingValueNode, which ast.Merge rejects.
+func mergeable(node ast.Node) (ast.Node, bool) {
+	if mappingValue, ok := node.(*ast.MappingValueNode); ok {
+		return ast.Mapping(mappingValue.GetToken(), false, mappingValue), true
+	}
+	return node, false
+}
+
+// createMissingKey creates the key addressed by elements inside doc and sets it to
+// leafValue. It returns the newly inserted leaf node so that a comment can be
+// attached to it. The caller is responsible for checking that the key is absent.
+func createMissingKey(doc *ast.DocumentNode, key string, elements []pathElement, leafValue interface{}) (ast.Node, error) {
+	parent, depth, err := deepestExistingNode(doc.Body, elements)
+	if err != nil {
+		return nil, err
+	}
+
+	missing := elements[depth:]
+	if len(missing) == 0 {
+		return nil, fmt.Errorf("key %q already exists", key)
+	}
+
+	// Creating through a sequence index is ambiguous: there is no sensible way to
+	// materialize element N of a sequence that does not have one.
+	for _, element := range missing {
+		if !element.isKey {
+			return nil, fmt.Errorf("cannot create key %q: unsupported element %q in a missing path", key, element.raw)
+		}
+	}
+
+	subtree, err := buildMissingSubtree(missing, leafValue, detectIndent(doc.Body))
+	if err != nil {
+		return nil, err
+	}
+
+	leaf := subtreeLeaf(subtree, len(missing))
+	if leaf == nil {
+		return nil, fmt.Errorf("cannot create key %q: unexpected generated yaml node", key)
+	}
+
+	// An empty document has no node to merge onto, so the subtree becomes the body.
+	if parent == nil {
+		doc.Body = subtree
+		return leaf, nil
+	}
+
+	target, wrapped := mergeable(parent)
+	if err := ast.Merge(target, subtree); err != nil {
+		return nil, fmt.Errorf("creating key %q: %w", key, err)
+	}
+
+	if wrapped {
+		if err := replaceNode(doc, elements, depth, target); err != nil {
+			return nil, fmt.Errorf("creating key %q: %w", key, err)
+		}
+	}
+
+	return leaf, nil
+}
+
+// replaceNode re-attaches node at the position addressed by the first depth elements.
+func replaceNode(doc *ast.DocumentNode, elements []pathElement, depth int, node ast.Node) error {
+	if depth == 0 {
+		doc.Body = node
+		return nil
+	}
+
+	path, err := goyaml.PathString(pathPrefix(elements, depth))
+	if err != nil {
+		return err
+	}
+
+	file := &ast.File{Docs: []*ast.DocumentNode{doc}}
+
+	return path.ReplaceWithNode(file, node)
+}
+
+// appendToSequence appends valueNode to seq unless the sequence already holds value.
+// It reports whether the sequence was modified.
+func appendToSequence(seq *ast.SequenceNode, value string, comment string) (bool, error) {
+	for _, element := range seq.Values {
+		// Compare the decoded value so that quoted and folded scalars are not
+		// mistaken for a different entry.
+		var decoded string
+		if err := goyaml.NodeToValue(element, &decoded); err != nil {
+			continue
+		}
+		if decoded == value {
+			return false, nil
+		}
+	}
+
+	appended, err := goyaml.ValueToNode([]interface{}{value}, goyaml.IndentSequence(true))
+	if err != nil {
+		return false, fmt.Errorf("crafting yaml node: %w", err)
+	}
+
+	appendedSeq, ok := appended.(*ast.SequenceNode)
+	if !ok {
+		return false, fmt.Errorf("unexpected generated yaml node of type %s", appended.Type())
+	}
+
+	if comment != "" {
+		if err := setNodeComment(appendedSeq.Values[0], comment); err != nil {
+			return false, err
+		}
+	}
+
+	// Merging keeps SequenceNode.ValueHeadComments in sync with Values, which a
+	// direct append to Values would not.
+	if err := ast.Merge(seq, appendedSeq); err != nil {
+		return false, fmt.Errorf("appending to sequence: %w", err)
+	}
+
+	return true, nil
+}

--- a/pkg/plugins/resources/yaml/create.go
+++ b/pkg/plugins/resources/yaml/create.go
@@ -356,3 +356,62 @@ func appendToSequence(seq *ast.SequenceNode, value string, comment string) (bool
 
 	return true, nil
 }
+
+// multiMatchKey reports whether key can address more than one node. goccy answers
+// such a query with a synthetic sequence wrapping the matched nodes rather than
+// with a matched node itself, so callers that mutate the returned node in place
+// must unwrap it first. A recursive descent always wraps, while "[*]" only wraps
+// when it is not the last element of the path.
+func multiMatchKey(key string) (bool, error) {
+	elements, err := splitYamlPathKey(key)
+	if err != nil {
+		return false, err
+	}
+
+	for i, element := range elements {
+		switch {
+		case strings.HasPrefix(element.raw, ".."):
+			return true, nil
+		case element.raw == "[*]" && i < len(elements)-1:
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+// appendTargetSequences returns the sequences that an appendtoarray target must
+// append to. node is the node goccy matched for key: for a key matching several
+// nodes ("$.agents[*].tags", "$..tags") that node is a detached wrapper, and
+// appending to it would mutate a copy while leaving the document untouched, so its
+// matched entries are unwrapped and returned instead.
+func appendTargetSequences(node ast.Node, key, originFilePath string) ([]*ast.SequenceNode, error) {
+	multiMatch, err := multiMatchKey(key)
+	if err != nil {
+		return nil, fmt.Errorf("cannot append to key %q: %w", key, err)
+	}
+
+	sequence, ok := node.(*ast.SequenceNode)
+	if !ok {
+		return nil, fmt.Errorf("cannot append to key %q from file %q: expected a yaml sequence but got %s", key, originFilePath, node.Type())
+	}
+
+	if !multiMatch {
+		return []*ast.SequenceNode{sequence}, nil
+	}
+
+	if len(sequence.Values) == 0 {
+		return nil, fmt.Errorf("cannot append to key %q from file %q: no yaml sequence matched", key, originFilePath)
+	}
+
+	sequences := make([]*ast.SequenceNode, 0, len(sequence.Values))
+	for _, matched := range sequence.Values {
+		matchedSequence, ok := matched.(*ast.SequenceNode)
+		if !ok {
+			return nil, fmt.Errorf("cannot append to key %q from file %q: expected a yaml sequence but got %s", key, originFilePath, matched.Type())
+		}
+		sequences = append(sequences, matchedSequence)
+	}
+
+	return sequences, nil
+}

--- a/pkg/plugins/resources/yaml/create.go
+++ b/pkg/plugins/resources/yaml/create.go
@@ -380,37 +380,58 @@ func multiMatchKey(key string) (bool, error) {
 	return false, nil
 }
 
-// appendTargetSequences returns the sequences that an appendtoarray target must
-// append to. node is the node goccy matched for key: for a key matching several
-// nodes ("$.agents[*].tags", "$..tags") that node is a detached wrapper, and
-// appending to it would mutate a copy while leaving the document untouched, so its
-// matched entries are unwrapped and returned instead.
-func appendTargetSequences(node ast.Node, key, originFilePath string) ([]*ast.SequenceNode, error) {
+// matchedNodes unwraps the node goccy returned for key into the nodes it actually
+// matched, and reports how many of the selected positions hold no node at all.
+//
+// A key addressing several nodes ("$.agents[*].tag", "$..tag") never resolves to
+// the matched node itself: goccy answers with a detached sequence holding one entry
+// per selected position, and that entry is nil where the key is absent. A non-nil
+// node is therefore no proof that the key exists, and mutating it in place mutates
+// a copy. An empty wrapper, or one holding only nil entries, means the key is
+// absent everywhere.
+func matchedNodes(node ast.Node, key string) (matched []ast.Node, missing int, err error) {
 	multiMatch, err := multiMatchKey(key)
 	if err != nil {
-		return nil, fmt.Errorf("cannot append to key %q: %w", key, err)
+		return nil, 0, fmt.Errorf("cannot evaluate key %q: %w", key, err)
 	}
 
-	sequence, ok := node.(*ast.SequenceNode)
-	if !ok {
-		return nil, fmt.Errorf("cannot append to key %q from file %q: expected a yaml sequence but got %s", key, originFilePath, node.Type())
+	// goccy answers a path that resolves nowhere at all with a nil node, whether or
+	// not it holds a multi match selector.
+	if node == nil {
+		return nil, 0, nil
 	}
 
 	if !multiMatch {
-		return []*ast.SequenceNode{sequence}, nil
+		return []ast.Node{node}, 0, nil
 	}
 
-	if len(sequence.Values) == 0 {
-		return nil, fmt.Errorf("cannot append to key %q from file %q: no yaml sequence matched", key, originFilePath)
+	wrapper, ok := node.(*ast.SequenceNode)
+	if !ok {
+		return nil, 0, fmt.Errorf("evaluating key %q: expected a yaml sequence of matches but got %s", key, node.Type())
 	}
 
-	sequences := make([]*ast.SequenceNode, 0, len(sequence.Values))
-	for _, matched := range sequence.Values {
-		matchedSequence, ok := matched.(*ast.SequenceNode)
-		if !ok {
-			return nil, fmt.Errorf("cannot append to key %q from file %q: expected a yaml sequence but got %s", key, originFilePath, matched.Type())
+	for _, value := range wrapper.Values {
+		if value == nil {
+			missing++
+			continue
 		}
-		sequences = append(sequences, matchedSequence)
+		matched = append(matched, value)
+	}
+
+	return matched, missing, nil
+}
+
+// appendTargetSequences returns the sequences that an appendtoarray target must
+// append to, one per node matched by its key.
+func appendTargetSequences(matched []ast.Node, key, originFilePath string) ([]*ast.SequenceNode, error) {
+	sequences := make([]*ast.SequenceNode, 0, len(matched))
+
+	for _, node := range matched {
+		sequence, ok := node.(*ast.SequenceNode)
+		if !ok {
+			return nil, fmt.Errorf("cannot append to key %q from file %q: expected a yaml sequence but got %s", key, originFilePath, node.Type())
+		}
+		sequences = append(sequences, sequence)
 	}
 
 	return sequences, nil

--- a/pkg/plugins/resources/yaml/create_test.go
+++ b/pkg/plugins/resources/yaml/create_test.go
@@ -1,0 +1,142 @@
+package yaml
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_splitYamlPathKey(t *testing.T) {
+	tests := []struct {
+		name        string
+		key         string
+		wantedNames []string
+		wantedRaws  []string
+		wantedKeys  []bool
+		wantedError bool
+	}{
+		{
+			name:        "single key",
+			key:         "$.a",
+			wantedNames: []string{"a"},
+			wantedRaws:  []string{".a"},
+			wantedKeys:  []bool{true},
+		},
+		{
+			name:        "nested keys",
+			key:         "$.a.b.c",
+			wantedNames: []string{"a", "b", "c"},
+			wantedRaws:  []string{".a", ".b", ".c"},
+			wantedKeys:  []bool{true, true, true},
+		},
+		{
+			name:        "key with an index",
+			key:         "$.a[0].b",
+			wantedNames: []string{"a", "", "b"},
+			wantedRaws:  []string{".a", "[0]", ".b"},
+			wantedKeys:  []bool{true, false, true},
+		},
+		{
+			name:        "key with a wildcard index",
+			key:         "$.a[*].b",
+			wantedNames: []string{"a", "", "b"},
+			wantedRaws:  []string{".a", "[*]", ".b"},
+			wantedKeys:  []bool{true, false, true},
+		},
+		{
+			name:        "quoted key holding a dot",
+			key:         "$.'a.b'.c",
+			wantedNames: []string{"a.b", "c"},
+			wantedRaws:  []string{".'a.b'", ".c"},
+			wantedKeys:  []bool{true, true},
+		},
+		{
+			name:        "quoted key holding an escaped quote",
+			key:         `$.'a\'b'`,
+			wantedNames: []string{"a'b"},
+			wantedRaws:  []string{`.'a\'b'`},
+			wantedKeys:  []bool{true},
+		},
+		{
+			name:        "recursive descent is not a key",
+			key:         "$..a",
+			wantedNames: []string{""},
+			wantedRaws:  []string{"..a"},
+			wantedKeys:  []bool{false},
+		},
+		{
+			name:        "root only",
+			key:         "$",
+			wantedNames: []string{},
+			wantedRaws:  []string{},
+			wantedKeys:  []bool{},
+		},
+		{
+			name:        "missing root",
+			key:         "a.b",
+			wantedError: true,
+		},
+		{
+			name:        "empty key",
+			key:         "",
+			wantedError: true,
+		},
+		{
+			name:        "trailing dot",
+			key:         "$.a.",
+			wantedError: true,
+		},
+		{
+			name:        "trailing recursive descent is parsed as a non creatable element",
+			key:         "$.a..",
+			wantedNames: []string{"a", ""},
+			wantedRaws:  []string{".a", ".."},
+			wantedKeys:  []bool{true, false},
+		},
+		{
+			name:        "unterminated quote",
+			key:         "$.'a",
+			wantedError: true,
+		},
+		{
+			name:        "unterminated index",
+			key:         "$.a[0",
+			wantedError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := splitYamlPathKey(tt.key)
+
+			if tt.wantedError {
+				assert.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Len(t, got, len(tt.wantedNames))
+
+			for i := range got {
+				assert.Equal(t, tt.wantedNames[i], got[i].name, "name of element %d", i)
+				assert.Equal(t, tt.wantedRaws[i], got[i].raw, "raw of element %d", i)
+				assert.Equal(t, tt.wantedKeys[i], got[i].isKey, "isKey of element %d", i)
+			}
+
+			// Concatenating the raw elements after "$" must rebuild the key, which
+			// is what lets the walker query prefixes with goccy.
+			assert.Equal(t, tt.key, pathPrefix(got, len(got)))
+		})
+	}
+}
+
+func Test_pathPrefix(t *testing.T) {
+	elements, err := splitYamlPathKey("$.a[0].'b.c'")
+	require.NoError(t, err)
+
+	assert.Equal(t, "$", pathPrefix(elements, 0))
+	assert.Equal(t, "$.a", pathPrefix(elements, 1))
+	assert.Equal(t, "$.a[0]", pathPrefix(elements, 2))
+	assert.Equal(t, "$.a[0].'b.c'", pathPrefix(elements, 3))
+}

--- a/pkg/plugins/resources/yaml/main.go
+++ b/pkg/plugins/resources/yaml/main.go
@@ -156,6 +156,45 @@ type Spec struct {
 	//```
 	//
 	SearchPattern bool `yaml:",omitempty"`
+	//"createmissingkey" allows creating the key when it does not exist yet in the yaml document.
+	//
+	//compatible:
+	//  * target
+	//
+	//default:
+	//	false
+	//
+	//remark:
+	//  * missing intermediate keys are created as nested maps.
+	//  * the key is only created, never removed, and existing keys are left untouched.
+	//  * a missing sequence index such as `$.agents[0].name` cannot be created.
+	//  * not supported by the "yamlpath" engine.
+	//  * the yaml file itself must already exist.
+	//
+	//example:
+	//  * key: $.image.tag
+	//    createmissingkey: true
+	//
+	CreateMissingKey bool `yaml:",omitempty"`
+	//"appendtoarray" appends the value as a new entry of the yaml sequence targeted by "key".
+	//
+	//compatible:
+	//  * target
+	//
+	//default:
+	//	false
+	//
+	//remark:
+	//  * the operation is idempotent, appending is skipped when the sequence already contains the value.
+	//  * combined with "createmissingkey", a missing sequence is created holding the value as its sole entry.
+	//  * "key" must target the sequence itself, not one of its entries.
+	//  * not supported by the "yamlpath" engine.
+	//
+	//example:
+	//  * key: $.allowedTags
+	//    appendtoarray: true
+	//
+	AppendToArray bool `yaml:",omitempty"`
 	//comment defines a comment to add after the value.
 	//
 	//default: empty
@@ -271,6 +310,9 @@ func (s *Spec) Validate() error {
 	}
 	if len(s.Keys) > 1 && hasDuplicates(s.Keys) {
 		validationErrors = append(validationErrors, "Validation error in target of type 'yaml': the attribute `spec.keys` contains duplicated values")
+	}
+	if s.Engine == EngineYamlPath && (s.CreateMissingKey || s.AppendToArray) {
+		validationErrors = append(validationErrors, fmt.Sprintf("Validation error in target of type 'yaml': engine %q does not support the attributes `spec.createmissingkey` and `spec.appendtoarray`", s.Engine))
 	}
 
 	// Return all the validation errors if found any
@@ -397,13 +439,15 @@ func (y *Yaml) UpdateAbsoluteFilePath(workDir string) error {
 // to identify the resource without any sensitive information or context specific data.
 func (y *Yaml) ReportConfig() interface{} {
 	return Spec{
-		File:          y.spec.File,
-		Files:         y.spec.Files,
-		Key:           y.spec.Key,
-		Keys:          y.spec.Keys,
-		Value:         y.spec.Value,
-		Engine:        y.spec.Engine,
-		KeyOnly:       y.spec.KeyOnly,
-		SearchPattern: y.spec.SearchPattern,
+		File:             y.spec.File,
+		Files:            y.spec.Files,
+		Key:              y.spec.Key,
+		Keys:             y.spec.Keys,
+		Value:            y.spec.Value,
+		Engine:           y.spec.Engine,
+		KeyOnly:          y.spec.KeyOnly,
+		SearchPattern:    y.spec.SearchPattern,
+		CreateMissingKey: y.spec.CreateMissingKey,
+		AppendToArray:    y.spec.AppendToArray,
 	}
 }

--- a/pkg/plugins/resources/yaml/main.go
+++ b/pkg/plugins/resources/yaml/main.go
@@ -77,6 +77,15 @@ type Spec struct {
 	//
 	//remark:
 	//  * key is a simpler version of yamlpath accepts keys.
+	//  * as a target, a key that a document does not hold is an error, so that a
+	//    manifest never reports a success for an update it did not make. The same
+	//    rule applies to a wildcard such as `$.agents[*].name`: every position it
+	//    selects must hold the key, otherwise the target fails rather than updating
+	//    only some of them. Set "searchpattern" to update the positions holding the
+	//    key and tolerate the others.
+	//  * a recursive selector such as `$..name` cannot report a partial match: it
+	//    searches for the key itself, so it only ever selects the positions already
+	//    holding it, and never fails on the ones that do not.
 	//
 	//example using default engine:
 	//  * key: $.name
@@ -154,6 +163,12 @@ type Spec struct {
 	//        '\\' c      matches character c
 	//        lo '-' hi   matches character c for lo <= c <= hi
 	//```
+	//
+	//remark:
+	//  * as a target, it also relaxes the requirement that the key exists: a file
+	//    that does not hold it is ignored instead of failing the target, and a
+	//    wildcard key updates the positions holding it rather than failing on the
+	//    ones that do not.
 	//
 	SearchPattern bool `yaml:",omitempty"`
 	//"createmissingkey" allows creating the key when it does not exist yet in the yaml document.

--- a/pkg/plugins/resources/yaml/main.go
+++ b/pkg/plugins/resources/yaml/main.go
@@ -168,6 +168,8 @@ type Spec struct {
 	//  * missing intermediate keys are created as nested maps.
 	//  * the key is only created, never removed, and existing keys are left untouched.
 	//  * a missing sequence index such as `$.agents[0].name` cannot be created.
+	//  * a key selecting several nodes, such as `$.agents[*].tag` or `$..tag`,
+	//    is rejected: the key cannot be created under each selected node.
 	//  * not supported by the "yamlpath" engine.
 	//  * the yaml file itself must already exist.
 	//
@@ -317,6 +319,20 @@ func (s *Spec) Validate() error {
 
 	if s.Engine == EngineYamlPath && s.AppendToArray {
 		validationErrors = append(validationErrors, fmt.Sprintf("Validation error in target of type 'yaml': engine %q does not support the attributes `spec.appendtoarray`", s.Engine))
+	}
+
+	// A wildcard or a recursive selector addresses one node per selected position,
+	// and there is no way to create a key under each of them: goccy's selector
+	// replacement only rewrites the positions that already hold the key, so
+	// creating through such a key would silently write nothing.
+	if s.CreateMissingKey {
+		for _, key := range s.getKeys() {
+			// A key that does not parse is reported when it is evaluated, with a
+			// message naming the offending character.
+			if multiMatch, err := multiMatchKey(key); err == nil && multiMatch {
+				validationErrors = append(validationErrors, fmt.Sprintf("Validation error in target of type 'yaml': the attribute `spec.createmissingkey` does not support the wildcard or recursive selector of key %q", key))
+			}
+		}
 	}
 
 	// Return all the validation errors if found any

--- a/pkg/plugins/resources/yaml/main.go
+++ b/pkg/plugins/resources/yaml/main.go
@@ -311,8 +311,12 @@ func (s *Spec) Validate() error {
 	if len(s.Keys) > 1 && hasDuplicates(s.Keys) {
 		validationErrors = append(validationErrors, "Validation error in target of type 'yaml': the attribute `spec.keys` contains duplicated values")
 	}
-	if s.Engine == EngineYamlPath && (s.CreateMissingKey || s.AppendToArray) {
-		validationErrors = append(validationErrors, fmt.Sprintf("Validation error in target of type 'yaml': engine %q does not support the attributes `spec.createmissingkey` and `spec.appendtoarray`", s.Engine))
+	if s.Engine == EngineYamlPath && s.CreateMissingKey {
+		validationErrors = append(validationErrors, fmt.Sprintf("Validation error in target of type 'yaml': engine %q does not support the attributes `spec.createmissingkey`", s.Engine))
+	}
+
+	if s.Engine == EngineYamlPath && s.AppendToArray {
+		validationErrors = append(validationErrors, fmt.Sprintf("Validation error in target of type 'yaml': engine %q does not support the attributes `spec.appendtoarray`", s.Engine))
 	}
 
 	// Return all the validation errors if found any

--- a/pkg/plugins/resources/yaml/main_test.go
+++ b/pkg/plugins/resources/yaml/main_test.go
@@ -14,6 +14,45 @@ func Test_Validate(t *testing.T) {
 		isErrorWanted bool
 	}{
 		{
+			name: "Validation error when 'createmissingkey' is used with the yamlpath engine",
+			spec: Spec{
+				File:             "/tmp/test.yaml",
+				Key:              "foo.bar",
+				Engine:           EngineYamlPath,
+				CreateMissingKey: true,
+			},
+			isErrorWanted: true,
+		},
+		{
+			name: "Validation error when 'appendtoarray' is used with the yamlpath engine",
+			spec: Spec{
+				File:          "/tmp/test.yaml",
+				Key:           "foo.bar",
+				Engine:        EngineYamlPath,
+				AppendToArray: true,
+			},
+			isErrorWanted: true,
+		},
+		{
+			name: "Normal case with 'createmissingkey' and the go-yaml engine",
+			spec: Spec{
+				File:             "/tmp/test.yaml",
+				Key:              "foo.bar",
+				Engine:           EngineGoYaml,
+				CreateMissingKey: true,
+			},
+			isErrorWanted: false,
+		},
+		{
+			name: "Normal case with 'appendtoarray' and the default engine",
+			spec: Spec{
+				File:          "/tmp/test.yaml",
+				Key:           "foo.bar",
+				AppendToArray: true,
+			},
+			isErrorWanted: false,
+		},
+		{
 			name: "Normal case with 'File'",
 			spec: Spec{
 				File: "/tmp/test.yaml",

--- a/pkg/plugins/resources/yaml/target_create_test.go
+++ b/pkg/plugins/resources/yaml/target_create_test.go
@@ -704,3 +704,179 @@ func Test_TargetYamlPathPartialDocumentMatch(t *testing.T) {
 	assert.False(t, gotResult.Changed)
 	assert.Equal(t, result.SUCCESS, gotResult.Result)
 }
+
+// Test_TargetWildcardKey covers keys selecting several nodes. goccy answers such a
+// query with a detached sequence holding one entry per selected position, and a nil
+// entry where the key is absent, so a non-nil node used to be mistaken for a key
+// that exists everywhere: the target then reported a change that ReplaceWithNode
+// had not made.
+func Test_TargetWildcardKey(t *testing.T) {
+	tests := []struct {
+		name             string
+		spec             Spec
+		inputSourceValue string
+		mockedContent    string
+		wantedContent    string
+		wantedResult     bool
+		wantedError      bool
+		dryRun           bool
+	}{
+		{
+			name:             "Update every node selected by a wildcard",
+			spec:             Spec{File: "test.yaml", Key: "$.agents[*].tag"},
+			inputSourceValue: "v2",
+			mockedContent: `agents:
+  - name: first
+    tag: v1
+  - name: second
+    tag: v1
+`,
+			wantedContent: `agents:
+  - name: first
+    tag: v2
+  - name: second
+    tag: v2
+`,
+			wantedResult: true,
+		},
+		{
+			name:             "Updating a wildcard reports no change when every selected node already holds the value",
+			spec:             Spec{File: "test.yaml", Key: "$.agents[*].tag"},
+			inputSourceValue: "v2",
+			mockedContent: `agents:
+  - name: first
+    tag: v2
+  - name: second
+    tag: v2
+`,
+			wantedContent: `agents:
+  - name: first
+    tag: v2
+  - name: second
+    tag: v2
+`,
+			wantedResult: false,
+		},
+		{
+			name:             "Updating a wildcard reports a change when only some selected nodes hold the value",
+			spec:             Spec{File: "test.yaml", Key: "$.agents[*].tag"},
+			inputSourceValue: "v2",
+			mockedContent: `agents:
+  - name: first
+    tag: v2
+  - name: second
+    tag: v1
+`,
+			wantedContent: `agents:
+  - name: first
+    tag: v2
+  - name: second
+    tag: v2
+`,
+			wantedResult: true,
+		},
+		{
+			name:             "A key missing from every node selected by a wildcard is not found",
+			spec:             Spec{File: "test.yaml", Key: "$.agents[*].tag"},
+			inputSourceValue: "v2",
+			mockedContent: `agents:
+  - name: first
+  - name: second
+`,
+			wantedError: true,
+		},
+		{
+			name:             "A key missing from some of the nodes selected by a wildcard fails",
+			spec:             Spec{File: "test.yaml", Key: "$.agents[*].tag"},
+			inputSourceValue: "v2",
+			mockedContent: `agents:
+  - name: first
+    tag: v1
+  - name: second
+`,
+			wantedError: true,
+		},
+		{
+			name:             "A recursive selector matching nothing is not found",
+			spec:             Spec{File: "test.yaml", Key: "$..tag"},
+			inputSourceValue: "v2",
+			mockedContent:    "foo: bar\n",
+			wantedError:      true,
+		},
+		{
+			name:             "Update every node selected by a recursive selector",
+			spec:             Spec{File: "test.yaml", Key: "$..tag"},
+			inputSourceValue: "v2",
+			mockedContent: `spec:
+  tag: v1
+status:
+  tag: v1
+`,
+			wantedContent: `spec:
+  tag: v2
+status:
+  tag: v2
+`,
+			wantedResult: true,
+		},
+		{
+			name:             "Appending to a sequence missing from every node selected by a wildcard is not found",
+			spec:             Spec{File: "test.yaml", Key: "$.agents[*].tags", AppendToArray: true},
+			inputSourceValue: "b",
+			mockedContent: `agents:
+  - name: first
+  - name: second
+`,
+			wantedError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runTargetTestCase(t, tt.spec, tt.inputSourceValue, tt.mockedContent, tt.wantedContent, tt.wantedResult, tt.wantedError, tt.dryRun)
+		})
+	}
+}
+
+// Test_CreateMissingKeyRejectsMultiMatchKey covers createmissingkey refusing a key
+// that selects several nodes: goccy's selector replacement only rewrites the
+// positions already holding the key, so creating through such a key writes nothing.
+func Test_CreateMissingKeyRejectsMultiMatchKey(t *testing.T) {
+	for _, key := range []string{"$.agents[*].tag", "$..tag", "$.agents[*].spec.tag"} {
+		t.Run(key, func(t *testing.T) {
+			_, err := New(Spec{File: "test.yaml", Key: key, CreateMissingKey: true})
+			require.ErrorContains(t, err, "`spec.createmissingkey` does not support the wildcard or recursive selector")
+		})
+	}
+
+	// A trailing "[*]" addresses the sequence itself, which goccy resolves to the
+	// live node, so it stays supported.
+	_, err := New(Spec{File: "test.yaml", Key: "$.tags[*]", CreateMissingKey: true})
+	require.NoError(t, err)
+}
+
+// Test_TargetSearchPatternIgnoresMissingWildcardKey covers spec.searchpattern being
+// honored when a wildcard selects nodes that do not hold the key, which used to be
+// unreachable because the detached wrapper goccy returns is not nil.
+func Test_TargetSearchPatternIgnoresMissingWildcardKey(t *testing.T) {
+	content := "agents:\n  - name: first\n  - name: second\n"
+
+	t.Chdir(t.TempDir())
+	require.NoError(t, os.WriteFile("test.yaml", []byte(content), 0600))
+
+	mockedText := text.MockTextRetriever{
+		Contents: map[string]string{"test.yaml": content},
+	}
+
+	y, err := New(Spec{File: "test.yaml", Key: "$.agents[*].tag", SearchPattern: true})
+	require.NoError(t, err)
+
+	y.contentRetriever = &mockedText
+
+	gotResult := result.Target{}
+	require.NoError(t, y.Target(context.Background(), "v2", nil, false, &gotResult))
+
+	assert.False(t, gotResult.Changed)
+	assert.Equal(t, result.SKIPPED, gotResult.Result)
+	assert.Equal(t, content, mockedText.Contents["test.yaml"])
+}

--- a/pkg/plugins/resources/yaml/target_create_test.go
+++ b/pkg/plugins/resources/yaml/target_create_test.go
@@ -908,3 +908,57 @@ func Test_TargetSearchPatternUpdatesPartialWildcardKey(t *testing.T) {
 	assert.Equal(t, result.ATTENTION, gotResult.Result)
 	assert.Equal(t, "agents:\n  - name: first\n    tag: v2\n  - name: second\n", mockedText.Contents["test.yaml"])
 }
+
+// Test_TargetDocumentIndexOutOfRange covers a documentindex addressing no document
+// of the file: the keys loop then evaluates nothing, which used to leave the target
+// reporting a success it had not made. The yamlpath engine and the source both
+// report this as a missing key.
+func Test_TargetDocumentIndexOutOfRange(t *testing.T) {
+	documentIndex := 5
+
+	mockedText := text.MockTextRetriever{
+		Contents: map[string]string{"test.yaml": "image:\n  tag: v1\n"},
+	}
+
+	y, err := New(Spec{File: "test.yaml", Key: "$.image.tag", DocumentIndex: &documentIndex})
+	require.NoError(t, err)
+
+	y.contentRetriever = &mockedText
+	y.files = map[string]file{
+		"test.yaml": {filePath: "test.yaml", originalFilePath: "test.yaml"},
+	}
+
+	gotResult := result.Target{}
+	gotErr := y.Target(context.Background(), "v2", nil, false, &gotResult)
+
+	require.ErrorContains(t, gotErr, "documentindex 5 addresses no document of file")
+	assert.False(t, gotResult.Changed)
+	assert.Equal(t, "image:\n  tag: v1\n", mockedText.Contents["test.yaml"])
+}
+
+// Test_TargetSearchPatternIgnoresDocumentIndexOutOfRange covers spec.searchpattern
+// relaxing that check, as the matched files need not all hold the same number of
+// documents.
+func Test_TargetSearchPatternIgnoresDocumentIndexOutOfRange(t *testing.T) {
+	content := "image:\n  tag: v1\n"
+	documentIndex := 5
+
+	t.Chdir(t.TempDir())
+	require.NoError(t, os.WriteFile("test.yaml", []byte(content), 0600))
+
+	mockedText := text.MockTextRetriever{
+		Contents: map[string]string{"test.yaml": content},
+	}
+
+	y, err := New(Spec{File: "test.yaml", Key: "$.image.tag", DocumentIndex: &documentIndex, SearchPattern: true})
+	require.NoError(t, err)
+
+	y.contentRetriever = &mockedText
+
+	gotResult := result.Target{}
+	require.NoError(t, y.Target(context.Background(), "v2", nil, false, &gotResult))
+
+	assert.False(t, gotResult.Changed)
+	assert.Equal(t, result.SKIPPED, gotResult.Result)
+	assert.Equal(t, content, mockedText.Contents["test.yaml"])
+}

--- a/pkg/plugins/resources/yaml/target_create_test.go
+++ b/pkg/plugins/resources/yaml/target_create_test.go
@@ -481,6 +481,119 @@ tags:
 			mockedContent:    "foo: bar\n",
 			wantedError:      true,
 		},
+		{
+			// goccy answers a wildcard query with a detached sequence wrapping the
+			// matched nodes, so appending to it used to report a change while
+			// leaving the file untouched.
+			name:             "Append a value to every sequence matched by a wildcard",
+			spec:             Spec{File: "test.yaml", Key: "$.agents[*].tags", AppendToArray: true},
+			inputSourceValue: "b",
+			mockedContent: `agents:
+  - name: first
+    tags:
+      - a
+  - name: second
+    tags:
+      - a
+`,
+			wantedContent: `agents:
+  - name: first
+    tags:
+      - a
+      - b
+  - name: second
+    tags:
+      - a
+      - b
+`,
+			wantedResult: true,
+		},
+		{
+			name:             "Append to a wildcard skips the sequences already holding the value",
+			spec:             Spec{File: "test.yaml", Key: "$.agents[*].tags", AppendToArray: true},
+			inputSourceValue: "b",
+			mockedContent: `agents:
+  - name: first
+    tags:
+      - a
+      - b
+  - name: second
+    tags:
+      - a
+`,
+			wantedContent: `agents:
+  - name: first
+    tags:
+      - a
+      - b
+  - name: second
+    tags:
+      - a
+      - b
+`,
+			wantedResult: true,
+		},
+		{
+			name:             "Append to a wildcard reports no change when every sequence holds the value",
+			spec:             Spec{File: "test.yaml", Key: "$.agents[*].tags", AppendToArray: true},
+			inputSourceValue: "b",
+			mockedContent: `agents:
+  - name: first
+    tags:
+      - b
+  - name: second
+    tags:
+      - b
+`,
+			wantedContent: `agents:
+  - name: first
+    tags:
+      - b
+  - name: second
+    tags:
+      - b
+`,
+			wantedResult: false,
+		},
+		{
+			name:             "Append a value to every sequence matched by a recursive descent",
+			spec:             Spec{File: "test.yaml", Key: "$..tags", AppendToArray: true},
+			inputSourceValue: "b",
+			mockedContent: `spec:
+  tags:
+    - a
+status:
+  tags:
+    - a
+`,
+			wantedContent: `spec:
+  tags:
+    - a
+    - b
+status:
+  tags:
+    - a
+    - b
+`,
+			wantedResult: true,
+		},
+		{
+			name:             "Appending to a wildcard matching a value that is not a sequence fails",
+			spec:             Spec{File: "test.yaml", Key: "$.agents[*].tags", AppendToArray: true},
+			inputSourceValue: "b",
+			mockedContent: `agents:
+  - name: first
+    tags: a
+`,
+			wantedError: true,
+		},
+		{
+			name:             "Appending to a recursive descent matching nothing fails",
+			spec:             Spec{File: "test.yaml", Key: "$..tags", AppendToArray: true},
+			inputSourceValue: "b",
+			mockedContent:    "foo: bar\n",
+			wantedError:      true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/plugins/resources/yaml/target_create_test.go
+++ b/pkg/plugins/resources/yaml/target_create_test.go
@@ -880,3 +880,31 @@ func Test_TargetSearchPatternIgnoresMissingWildcardKey(t *testing.T) {
 	assert.Equal(t, result.SKIPPED, gotResult.Result)
 	assert.Equal(t, content, mockedText.Contents["test.yaml"])
 }
+
+// Test_TargetSearchPatternUpdatesPartialWildcardKey covers spec.searchpattern
+// relaxing the requirement that every position selected by a wildcard holds the
+// key: the ones holding it are updated instead of failing the target. A wildcard
+// selecting nothing at all is skipped, so failing on a wildcard selecting some
+// would be incoherent.
+func Test_TargetSearchPatternUpdatesPartialWildcardKey(t *testing.T) {
+	content := "agents:\n  - name: first\n    tag: v1\n  - name: second\n"
+
+	t.Chdir(t.TempDir())
+	require.NoError(t, os.WriteFile("test.yaml", []byte(content), 0600))
+
+	mockedText := text.MockTextRetriever{
+		Contents: map[string]string{"test.yaml": content},
+	}
+
+	y, err := New(Spec{File: "test.yaml", Key: "$.agents[*].tag", SearchPattern: true})
+	require.NoError(t, err)
+
+	y.contentRetriever = &mockedText
+
+	gotResult := result.Target{}
+	require.NoError(t, y.Target(context.Background(), "v2", nil, false, &gotResult))
+
+	assert.True(t, gotResult.Changed)
+	assert.Equal(t, result.ATTENTION, gotResult.Result)
+	assert.Equal(t, "agents:\n  - name: first\n    tag: v2\n  - name: second\n", mockedText.Contents["test.yaml"])
+}

--- a/pkg/plugins/resources/yaml/target_create_test.go
+++ b/pkg/plugins/resources/yaml/target_create_test.go
@@ -1,0 +1,593 @@
+package yaml
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/updatecli/updatecli/pkg/core/result"
+	"github.com/updatecli/updatecli/pkg/core/text"
+)
+
+func Test_TargetCreateMissingKey(t *testing.T) {
+	tests := []struct {
+		name             string
+		spec             Spec
+		inputSourceValue string
+		mockedContent    string
+		wantedContent    string
+		wantedResult     bool
+		wantedError      bool
+		dryRun           bool
+	}{
+		{
+			name:             "Create a missing key at the root of the document",
+			spec:             Spec{File: "test.yaml", Key: "$.newkey", CreateMissingKey: true},
+			inputSourceValue: "v1",
+			mockedContent: `image:
+  name: nginx
+foo: bar
+`,
+			wantedContent: `image:
+  name: nginx
+foo: bar
+newkey: v1
+`,
+			wantedResult: true,
+		},
+		{
+			name:             "Create a missing key under an existing mapping",
+			spec:             Spec{File: "test.yaml", Key: "$.image.tag", CreateMissingKey: true},
+			inputSourceValue: "v1",
+			mockedContent: `image:
+  name: nginx
+foo: bar
+`,
+			wantedContent: `image:
+  name: nginx
+  tag: v1
+foo: bar
+`,
+			wantedResult: true,
+		},
+		{
+			name:             "Create a full missing branch",
+			spec:             Spec{File: "test.yaml", Key: "$.a.b.c", CreateMissingKey: true},
+			inputSourceValue: "v1",
+			mockedContent: `image:
+  name: nginx
+`,
+			wantedContent: `image:
+  name: nginx
+a:
+  b:
+    c: v1
+`,
+			wantedResult: true,
+		},
+		{
+			name:             "Create a key under a null parent",
+			spec:             Spec{File: "test.yaml", Key: "$.github.owner", CreateMissingKey: true},
+			inputSourceValue: "olblak",
+			mockedContent: `github:
+foo: bar
+`,
+			wantedContent: `github:
+  owner: olblak
+foo: bar
+`,
+			wantedResult: true,
+		},
+		{
+			name:             "Create a key inside an empty flow mapping",
+			spec:             Spec{File: "test.yaml", Key: "$.github.owner", CreateMissingKey: true},
+			inputSourceValue: "olblak",
+			mockedContent:    "github: {}\n",
+			wantedContent:    "github: {owner: olblak}\n",
+			wantedResult:     true,
+		},
+		{
+			name:             "Create a nested key matching a four spaces indentation",
+			spec:             Spec{File: "test.yaml", Key: "$.root.a.b", CreateMissingKey: true},
+			inputSourceValue: "v1",
+			mockedContent: `root:
+    child: 1
+`,
+			wantedContent: `root:
+    child: 1
+    a:
+        b: v1
+`,
+			wantedResult: true,
+		},
+		{
+			name:             "Create a key with a comment",
+			spec:             Spec{File: "test.yaml", Key: "$.image.tag", CreateMissingKey: true, Comment: "updated by updatecli"},
+			inputSourceValue: "v1",
+			mockedContent: `image:
+  name: nginx
+`,
+			wantedContent: `image:
+  name: nginx
+  tag: v1 # updated by updatecli
+`,
+			wantedResult: true,
+		},
+		{
+			name:             "Create a key while preserving the surrounding comments",
+			spec:             Spec{File: "test.yaml", Key: "$.image.tag", CreateMissingKey: true},
+			inputSourceValue: "v1",
+			mockedContent: `# head comment
+image:
+  name: nginx # trailing comment
+foo: bar
+`,
+			wantedContent: `# head comment
+image:
+  name: nginx # trailing comment
+  tag: v1
+foo: bar
+`,
+			wantedResult: true,
+		},
+		{
+			name:             "Creating an already existing key set to the same value reports no change",
+			spec:             Spec{File: "test.yaml", Key: "$.image.tag", CreateMissingKey: true},
+			inputSourceValue: "v1",
+			mockedContent: `image:
+  name: nginx
+  tag: v1
+`,
+			wantedContent: `image:
+  name: nginx
+  tag: v1
+`,
+			wantedResult: false,
+		},
+		{
+			name:             "Creating an already existing key set to another value updates it",
+			spec:             Spec{File: "test.yaml", Key: "$.image.tag", CreateMissingKey: true},
+			inputSourceValue: "v2",
+			mockedContent: `image:
+  name: nginx
+  tag: v1
+`,
+			wantedContent: `image:
+  name: nginx
+  tag: v2
+`,
+			wantedResult: true,
+		},
+		{
+			name:             "Create a key in an empty document",
+			spec:             Spec{File: "test.yaml", Key: "$.a.b", CreateMissingKey: true},
+			inputSourceValue: "v1",
+			mockedContent:    "",
+			wantedContent: `a:
+  b: v1
+`,
+			wantedResult: true,
+		},
+		{
+			name:             "Create a key holding a dot in its name",
+			spec:             Spec{File: "test.yaml", Key: `versions.1\.2`, CreateMissingKey: true},
+			inputSourceValue: "v1",
+			mockedContent: `versions:
+  a: 1
+`,
+			wantedContent: `versions:
+  a: 1
+  "1.2": v1
+`,
+			wantedResult: true,
+		},
+		{
+			name:             "Create a key in every document of a multi documents file",
+			spec:             Spec{File: "test.yaml", Key: "$.newkey", CreateMissingKey: true},
+			inputSourceValue: "v1",
+			mockedContent: `a: 1
+---
+b: 2
+`,
+			wantedContent: `a: 1
+newkey: v1
+---
+b: 2
+newkey: v1
+`,
+			wantedResult: true,
+		},
+		{
+			name:             "Create a key in a single document of a multi documents file",
+			spec:             Spec{File: "test.yaml", Key: "$.newkey", CreateMissingKey: true, DocumentIndex: ptrInt(1)},
+			inputSourceValue: "v1",
+			mockedContent: `a: 1
+---
+b: 2
+`,
+			wantedContent: `a: 1
+---
+b: 2
+newkey: v1
+`,
+			wantedResult: true,
+		},
+		{
+			name:             "Create multiple keys sharing the same value",
+			spec:             Spec{File: "test.yaml", Keys: []string{"$.x.a", "$.z.b"}, CreateMissingKey: true},
+			inputSourceValue: "v1",
+			mockedContent:    "foo: bar\n",
+			wantedContent: `foo: bar
+x:
+  a: v1
+z:
+  b: v1
+`,
+			wantedResult: true,
+		},
+		{
+			name:             "Creating a key in dry run mode does not write the file",
+			spec:             Spec{File: "test.yaml", Key: "$.image.tag", CreateMissingKey: true},
+			inputSourceValue: "v1",
+			dryRun:           true,
+			mockedContent: `image:
+  name: nginx
+`,
+			wantedContent: `image:
+  name: nginx
+`,
+			wantedResult: true,
+		},
+		{
+			name:             "A missing key without createmissingkey still fails",
+			spec:             Spec{File: "test.yaml", Key: "$.image.tag"},
+			inputSourceValue: "v1",
+			mockedContent: `image:
+  name: nginx
+`,
+			wantedError: true,
+		},
+		{
+			name:             "Creating a key through a scalar fails",
+			spec:             Spec{File: "test.yaml", Key: "$.image.name.sub", CreateMissingKey: true},
+			inputSourceValue: "v1",
+			mockedContent: `image:
+  name: nginx
+`,
+			wantedError: true,
+		},
+		{
+			name:             "Creating a key through a missing array index fails",
+			spec:             Spec{File: "test.yaml", Key: "$.missing[0].name", CreateMissingKey: true},
+			inputSourceValue: "v1",
+			mockedContent: `image:
+  name: nginx
+`,
+			wantedError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runTargetTestCase(t, tt.spec, tt.inputSourceValue, tt.mockedContent, tt.wantedContent, tt.wantedResult, tt.wantedError, tt.dryRun)
+		})
+	}
+}
+
+func Test_TargetAppendToArray(t *testing.T) {
+	tests := []struct {
+		name             string
+		spec             Spec
+		inputSourceValue string
+		mockedContent    string
+		wantedContent    string
+		wantedResult     bool
+		wantedError      bool
+		dryRun           bool
+	}{
+		{
+			name:             "Append a value to a block sequence",
+			spec:             Spec{File: "test.yaml", Key: "$.tags", AppendToArray: true},
+			inputSourceValue: "v1.2.3",
+			mockedContent: `tags:
+  - v1.0.0
+  - v1.1.0
+`,
+			wantedContent: `tags:
+  - v1.0.0
+  - v1.1.0
+  - v1.2.3
+`,
+			wantedResult: true,
+		},
+		{
+			name:             "Appending a value already present reports no change",
+			spec:             Spec{File: "test.yaml", Key: "$.tags", AppendToArray: true},
+			inputSourceValue: "v1.2.3",
+			mockedContent: `tags:
+  - v1.0.0
+  - v1.2.3
+`,
+			wantedContent: `tags:
+  - v1.0.0
+  - v1.2.3
+`,
+			wantedResult: false,
+		},
+		{
+			name:             "Appending a value already present as a folded scalar reports no change",
+			spec:             Spec{File: "test.yaml", Key: "$.tags", AppendToArray: true},
+			inputSourceValue: "v1.2.3",
+			mockedContent: `tags:
+  - >-
+      v1.2.3
+`,
+			wantedContent: `tags:
+  - >-
+      v1.2.3
+`,
+			wantedResult: false,
+		},
+		{
+			name:             "Appending a value already present as a quoted scalar reports no change",
+			spec:             Spec{File: "test.yaml", Key: "$.tags", AppendToArray: true},
+			inputSourceValue: "v1.2.3",
+			mockedContent: `tags:
+  - "v1.2.3"
+`,
+			wantedContent: `tags:
+  - "v1.2.3"
+`,
+			wantedResult: false,
+		},
+		{
+			name:             "Append a value to a flow sequence",
+			spec:             Spec{File: "test.yaml", Key: "$.tags", AppendToArray: true},
+			inputSourceValue: "v1.2.3",
+			mockedContent:    "tags: [v1.0.0]\n",
+			wantedContent:    "tags: [v1.0.0, v1.2.3]\n",
+			wantedResult:     true,
+		},
+		{
+			name:             "Append a value to an empty flow sequence",
+			spec:             Spec{File: "test.yaml", Key: "$.tags", AppendToArray: true},
+			inputSourceValue: "v1.2.3",
+			mockedContent:    "tags: []\n",
+			wantedContent:    "tags: [v1.2.3]\n",
+			wantedResult:     true,
+		},
+		{
+			name:             "Append a value preserving an unusual sequence indentation",
+			spec:             Spec{File: "test.yaml", Key: "$.tags", AppendToArray: true},
+			inputSourceValue: "b",
+			mockedContent: `tags:
+   - a
+`,
+			wantedContent: `tags:
+   - a
+   - b
+`,
+			wantedResult: true,
+		},
+		{
+			name:             "Append a value to a nested sequence",
+			spec:             Spec{File: "test.yaml", Key: "$.spec.tags", AppendToArray: true},
+			inputSourceValue: "b",
+			mockedContent: `spec:
+  tags:
+    - a
+`,
+			wantedContent: `spec:
+  tags:
+    - a
+    - b
+`,
+			wantedResult: true,
+		},
+		{
+			name:             "Append a value with a comment",
+			spec:             Spec{File: "test.yaml", Key: "$.tags", AppendToArray: true, Comment: "added by updatecli"},
+			inputSourceValue: "b",
+			mockedContent: `tags:
+  - a
+`,
+			wantedContent: `tags:
+  - a
+  - b # added by updatecli
+`,
+			wantedResult: true,
+		},
+		{
+			name:             "Append creates the missing sequence when allowed",
+			spec:             Spec{File: "test.yaml", Key: "$.tags", AppendToArray: true, CreateMissingKey: true},
+			inputSourceValue: "v1.2.3",
+			mockedContent:    "foo: bar\n",
+			wantedContent: `foo: bar
+tags:
+  - v1.2.3
+`,
+			wantedResult: true,
+		},
+		{
+			name:             "Append creates a missing branch ending on a sequence",
+			spec:             Spec{File: "test.yaml", Key: "$.a.tags", AppendToArray: true, CreateMissingKey: true},
+			inputSourceValue: "v1.2.3",
+			mockedContent:    "foo: bar\n",
+			wantedContent: `foo: bar
+a:
+  tags:
+    - v1.2.3
+`,
+			wantedResult: true,
+		},
+		{
+			name:             "Append replaces a null value with a sequence when allowed",
+			spec:             Spec{File: "test.yaml", Key: "$.tags", AppendToArray: true, CreateMissingKey: true},
+			inputSourceValue: "v1.2.3",
+			mockedContent: `tags:
+foo: bar
+`,
+			wantedContent: `tags:
+  - v1.2.3
+foo: bar
+`,
+			wantedResult: true,
+		},
+		{
+			name:             "Append to a single document of a multi documents file",
+			spec:             Spec{File: "test.yaml", Key: "$.tags", AppendToArray: true, DocumentIndex: ptrInt(0)},
+			inputSourceValue: "b",
+			mockedContent: `tags:
+  - a
+---
+tags:
+  - a
+`,
+			wantedContent: `tags:
+  - a
+  - b
+---
+tags:
+  - a
+`,
+			wantedResult: true,
+		},
+		{
+			name:             "Appending in dry run mode does not write the file",
+			spec:             Spec{File: "test.yaml", Key: "$.tags", AppendToArray: true},
+			inputSourceValue: "b",
+			dryRun:           true,
+			mockedContent: `tags:
+  - a
+`,
+			wantedContent: `tags:
+  - a
+`,
+			wantedResult: true,
+		},
+		{
+			name:             "Appending to a key that is not a sequence fails",
+			spec:             Spec{File: "test.yaml", Key: "$.image", AppendToArray: true},
+			inputSourceValue: "v1",
+			mockedContent:    "image: nginx\n",
+			wantedError:      true,
+		},
+		{
+			name:             "Appending to a missing key without createmissingkey fails",
+			spec:             Spec{File: "test.yaml", Key: "$.tags", AppendToArray: true},
+			inputSourceValue: "v1",
+			mockedContent:    "foo: bar\n",
+			wantedError:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runTargetTestCase(t, tt.spec, tt.inputSourceValue, tt.mockedContent, tt.wantedContent, tt.wantedResult, tt.wantedError, tt.dryRun)
+		})
+	}
+}
+
+// Test_TargetSearchPatternIgnoresMissingKey covers the go-yaml engine honoring
+// spec.searchpattern when the key is absent, which used to be unreachable because
+// goccy reports a missing key as a nil node rather than as ErrNotFoundNode.
+func Test_TargetSearchPatternIgnoresMissingKey(t *testing.T) {
+	// searchpattern resolves the file against the filesystem, and matches the
+	// pattern on paths relative to the working directory, so the test runs from a
+	// temporary directory holding the file.
+	t.Chdir(t.TempDir())
+	require.NoError(t, os.WriteFile("test.yaml", []byte("foo: bar\n"), 0600))
+
+	mockedText := text.MockTextRetriever{
+		Contents: map[string]string{"test.yaml": "foo: bar\n"},
+	}
+
+	y, err := New(Spec{File: "test.yaml", Key: "$.image.tag", SearchPattern: true})
+	require.NoError(t, err)
+
+	y.contentRetriever = &mockedText
+
+	gotResult := result.Target{}
+	require.NoError(t, y.Target(context.Background(), "v1", nil, false, &gotResult))
+
+	assert.False(t, gotResult.Changed)
+	assert.Equal(t, result.SKIPPED, gotResult.Result)
+	assert.Equal(t, "foo: bar\n", mockedText.Contents["test.yaml"])
+}
+
+// Test_TargetYamlPathMissingKeyErrors covers the yamlpath engine reporting a key
+// missing from every document, which used to be silently skipped because the check
+// sat inside the document loop.
+func Test_TargetYamlPathMissingKeyErrors(t *testing.T) {
+	mockedText := text.MockTextRetriever{
+		Contents: map[string]string{"test.yaml": "foo: bar\n---\nbar: foo\n"},
+	}
+
+	y, err := New(Spec{File: "test.yaml", Key: "$.image.tag", Engine: EngineYamlPath})
+	require.NoError(t, err)
+
+	y.contentRetriever = &mockedText
+	y.files = map[string]file{
+		"test.yaml": {filePath: "test.yaml", originalFilePath: "test.yaml"},
+	}
+
+	gotResult := result.Target{}
+	assert.Error(t, y.Target(context.Background(), "v1", nil, false, &gotResult))
+}
+
+func runTargetTestCase(t *testing.T, spec Spec, inputSourceValue, mockedContent, wantedContent string, wantedResult, wantedError, dryRun bool) {
+	t.Helper()
+
+	mockedText := text.MockTextRetriever{
+		Contents: map[string]string{"test.yaml": mockedContent},
+	}
+
+	y, err := New(spec)
+	require.NoError(t, err)
+
+	y.contentRetriever = &mockedText
+	y.files = map[string]file{
+		"test.yaml": {filePath: "test.yaml", originalFilePath: "test.yaml"},
+	}
+
+	gotResult := result.Target{}
+	gotErr := y.Target(context.Background(), inputSourceValue, nil, dryRun, &gotResult)
+
+	if wantedError {
+		assert.Error(t, gotErr)
+		return
+	}
+
+	require.NoError(t, gotErr)
+	assert.Equal(t, wantedResult, gotResult.Changed)
+
+	defer os.Remove("test.yaml")
+	assert.Equal(t, wantedContent, mockedText.Contents["test.yaml"])
+}
+
+// Test_TargetYamlPathPartialDocumentMatch covers a key present in only some of the
+// documents of a file: the documents carrying it are already up to date, so the
+// file must be reported as unchanged.
+func Test_TargetYamlPathPartialDocumentMatch(t *testing.T) {
+	content := "tags: v1\n---\nother: foo\n"
+
+	mockedText := text.MockTextRetriever{
+		Contents: map[string]string{"test.yaml": content},
+	}
+
+	y, err := New(Spec{File: "test.yaml", Key: "$.tags", Engine: EngineYamlPath})
+	require.NoError(t, err)
+
+	y.contentRetriever = &mockedText
+	y.files = map[string]file{
+		"test.yaml": {filePath: "test.yaml", originalFilePath: "test.yaml"},
+	}
+
+	gotResult := result.Target{}
+	require.NoError(t, y.Target(context.Background(), "v1", nil, false, &gotResult))
+
+	assert.False(t, gotResult.Changed)
+	assert.Equal(t, result.SUCCESS, gotResult.Result)
+}

--- a/pkg/plugins/resources/yaml/target_goyaml.go
+++ b/pkg/plugins/resources/yaml/target_goyaml.go
@@ -84,13 +84,18 @@ func (y Yaml) goYamlTarget(valueToWrite string, resultTarget *result.Target, dry
 				// goccy's selector replacement only rewrites the positions that
 				// already hold the key, and createmissingkey cannot create the
 				// others either, so a partial match would quietly write less than
-				// the manifest asks for.
-				case filterErr == nil && len(matched) > 0 && missing > 0:
+				// the manifest asks for. spec.searchpattern asks for that
+				// tolerance explicitly, so it updates what it found instead.
+				case filterErr == nil && len(matched) > 0 && missing > 0 && !y.spec.SearchPattern:
 					errMsg = append(errMsg, fmt.Sprintf("key %q from file %q is missing from %d of the %d nodes it selects in document index %d", key, originFilePath, missing, missing+len(matched), index))
 
 				// A null value is an existing node that holds nothing, so when we
 				// may create the key we overwrite it instead of updating it.
 				case filterErr == nil && len(matched) > 0 && (!y.spec.CreateMissingKey || !isNullNode(node)):
+					if missing > 0 {
+						logrus.Debugf("key %q from file %q is missing from %d of the %d nodes it selects in document %d, updating the %d nodes holding it", key, originFilePath, missing, missing+len(matched), index, len(matched))
+					}
+
 					changed, err := y.updateNode(yamlFile, index, doc, urlPath, matched, key, valueToWrite, nodeToWrite, resultTarget, originFilePath, dryRun)
 					if err != nil {
 						return 0, ignoredFiles, err

--- a/pkg/plugins/resources/yaml/target_goyaml.go
+++ b/pkg/plugins/resources/yaml/target_goyaml.go
@@ -67,11 +67,31 @@ func (y Yaml) goYamlTarget(valueToWrite string, resultTarget *result.Target, dry
 				// create it we let our own walker decide rather than FilterNode.
 				node, filterErr := urlPath.FilterNode(doc.Body)
 
+				// A key selecting several nodes ("$.agents[*].tag", "$..tag")
+				// resolves to a detached wrapper holding one entry per selected
+				// position, so a non-nil node is not by itself proof that the key
+				// exists anywhere. Unwrap it before deciding what to do.
+				var matched []ast.Node
+				var missing int
+				if filterErr == nil {
+					matched, missing, err = matchedNodes(node, key)
+					if err != nil {
+						return 0, ignoredFiles, err
+					}
+				}
+
 				switch {
+				// goccy's selector replacement only rewrites the positions that
+				// already hold the key, and createmissingkey cannot create the
+				// others either, so a partial match would quietly write less than
+				// the manifest asks for.
+				case filterErr == nil && len(matched) > 0 && missing > 0:
+					errMsg = append(errMsg, fmt.Sprintf("key %q from file %q is missing from %d of the %d nodes it selects in document index %d", key, originFilePath, missing, missing+len(matched), index))
+
 				// A null value is an existing node that holds nothing, so when we
 				// may create the key we overwrite it instead of updating it.
-				case filterErr == nil && node != nil && (!y.spec.CreateMissingKey || !isNullNode(node)):
-					changed, err := y.updateNode(yamlFile, index, doc, urlPath, node, key, valueToWrite, nodeToWrite, resultTarget, originFilePath, dryRun)
+				case filterErr == nil && len(matched) > 0 && (!y.spec.CreateMissingKey || !isNullNode(node)):
+					changed, err := y.updateNode(yamlFile, index, doc, urlPath, matched, key, valueToWrite, nodeToWrite, resultTarget, originFilePath, dryRun)
 					if err != nil {
 						return 0, ignoredFiles, err
 					}
@@ -205,13 +225,13 @@ func (y Yaml) createKey(doc *ast.DocumentNode, key, valueToWrite string, resultT
 	return true, nil
 }
 
-// updateNode either appends to the sequence addressed by key, or replaces the value
-// of the node it addresses. It reports whether the document was modified.
-func (y Yaml) updateNode(yamlFile *ast.File, index int, doc *ast.DocumentNode, urlPath *goyaml.Path, node ast.Node, key, valueToWrite string, nodeToWrite ast.Node, resultTarget *result.Target, originFilePath string, dryRun bool) (bool, error) {
+// updateNode either appends to the sequences addressed by key, or replaces the value
+// of the nodes it addresses. matched holds every node the key selected, which is more
+// than one for a wildcard or a recursive selector. It reports whether the document
+// was modified.
+func (y Yaml) updateNode(yamlFile *ast.File, index int, doc *ast.DocumentNode, urlPath *goyaml.Path, matched []ast.Node, key, valueToWrite string, nodeToWrite ast.Node, resultTarget *result.Target, originFilePath string, dryRun bool) (bool, error) {
 	if y.spec.AppendToArray {
-		// A key matching several nodes resolves to a detached wrapper, so append to
-		// each matched sequence rather than to the node goccy returned.
-		sequences, err := appendTargetSequences(node, key, originFilePath)
+		sequences, err := appendTargetSequences(matched, key, originFilePath)
 		if err != nil {
 			return false, err
 		}
@@ -244,13 +264,12 @@ func (y Yaml) updateNode(yamlFile *ast.File, index int, doc *ast.DocumentNode, u
 		return true, nil
 	}
 
-	oldVersion := node.String()
+	oldVersion := matchedValues(matched)
 	resultTarget.Information = oldVersion
 
-	// Compare decoded value so folded/literal scalars (>-, |) aren't
-	// flagged as changed by their formatting markers. See issue #8295.
-	var decoded string
-	if err := goyaml.NodeToValue(node, &decoded); err == nil && decoded == valueToWrite {
+	// Every selected node must already hold the value for the target to be a no-op,
+	// as ReplaceWithNode rewrites all of them at once.
+	if alreadySet(matched, valueToWrite) {
 		resultTarget.Description = fmt.Sprintf("%s\nkey %q already set to %q, from file %q",
 			resultTarget.Description,
 			key,
@@ -286,4 +305,33 @@ func shouldMessage(dryRun bool) string {
 		return " should be "
 	}
 	return " "
+}
+
+// matchedValues renders the value(s) held by the matched nodes, for the target
+// description and information.
+func matchedValues(matched []ast.Node) string {
+	if len(matched) == 1 {
+		return matched[0].String()
+	}
+
+	values := make([]string, 0, len(matched))
+	for _, node := range matched {
+		values = append(values, strings.TrimSpace(node.String()))
+	}
+
+	return strings.Join(values, ", ")
+}
+
+// alreadySet reports whether every matched node already holds valueToWrite. The
+// decoded value is compared so that folded and literal scalars (">-", "|") are not
+// flagged as changed by their formatting markers. See issue #8295.
+func alreadySet(matched []ast.Node, valueToWrite string) bool {
+	for _, node := range matched {
+		var decoded string
+		if err := goyaml.NodeToValue(node, &decoded); err != nil || decoded != valueToWrite {
+			return false
+		}
+	}
+
+	return len(matched) > 0
 }

--- a/pkg/plugins/resources/yaml/target_goyaml.go
+++ b/pkg/plugins/resources/yaml/target_goyaml.go
@@ -209,14 +209,20 @@ func (y Yaml) createKey(doc *ast.DocumentNode, key, valueToWrite string, resultT
 // of the node it addresses. It reports whether the document was modified.
 func (y Yaml) updateNode(yamlFile *ast.File, index int, doc *ast.DocumentNode, urlPath *goyaml.Path, node ast.Node, key, valueToWrite string, nodeToWrite ast.Node, resultTarget *result.Target, originFilePath string, dryRun bool) (bool, error) {
 	if y.spec.AppendToArray {
-		sequence, ok := node.(*ast.SequenceNode)
-		if !ok {
-			return false, fmt.Errorf("cannot append to key %q from file %q: expected a yaml sequence but got %s", key, originFilePath, node.Type())
+		// A key matching several nodes resolves to a detached wrapper, so append to
+		// each matched sequence rather than to the node goccy returned.
+		sequences, err := appendTargetSequences(node, key, originFilePath)
+		if err != nil {
+			return false, err
 		}
 
-		appended, err := appendToSequence(sequence, valueToWrite, y.spec.Comment)
-		if err != nil {
-			return false, fmt.Errorf("appending to key %q from file %q: %w", key, originFilePath, err)
+		appended := false
+		for _, sequence := range sequences {
+			sequenceAppended, err := appendToSequence(sequence, valueToWrite, y.spec.Comment)
+			if err != nil {
+				return false, fmt.Errorf("appending to key %q from file %q: %w", key, originFilePath, err)
+			}
+			appended = appended || sequenceAppended
 		}
 
 		if !appended {

--- a/pkg/plugins/resources/yaml/target_goyaml.go
+++ b/pkg/plugins/resources/yaml/target_goyaml.go
@@ -1,7 +1,6 @@
 package yaml
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -13,33 +12,18 @@ import (
 	goyaml "github.com/goccy/go-yaml"
 	"github.com/goccy/go-yaml/ast"
 	"github.com/goccy/go-yaml/parser"
-	"github.com/goccy/go-yaml/token"
 )
 
 func (y Yaml) goYamlTarget(valueToWrite string, resultTarget *result.Target, dryRun bool) (notChanged int, ignoredFiles int, err error) {
 	nodeToWrite, err := goyaml.ValueToNode(valueToWrite)
-
-	if y.spec.Comment != "" {
-		commentGroup := &ast.CommentGroupNode{
-			Comments: []*ast.CommentNode{
-				{
-					Token: &token.Token{
-						Type: token.CommentType,
-						// Add a space before the comment
-						Value: " " + y.spec.Comment,
-					},
-				},
-			},
-		}
-
-		err = nodeToWrite.SetComment(commentGroup)
-		if err != nil {
-			logrus.Errorf("error setting comment: %s", err)
-		}
-	}
-
 	if err != nil {
 		return 0, ignoredFiles, fmt.Errorf("parsing value to write: %w", err)
+	}
+
+	if y.spec.Comment != "" {
+		if err := setNodeComment(nodeToWrite, y.spec.Comment); err != nil {
+			logrus.Errorf("error setting comment: %s", err)
+		}
 	}
 
 	keys := y.spec.getKeys()
@@ -63,48 +47,55 @@ func (y Yaml) goYamlTarget(valueToWrite string, resultTarget *result.Target, dry
 				return 0, ignoredFiles, fmt.Errorf("crafting yamlpath query for key %q: %w", key, err)
 			}
 
-			oldVersion := ""
 			keyNotFound := []string{}
 			errMsg := []string{}
-			contentChanged := false
+			// keyProcessed reports whether the key was resolved, or created, in at
+			// least one of the evaluated documents.
+			keyProcessed := false
+			keyChanged := false
 
 			for index, doc := range yamlFile.Docs {
-				var node ast.Node
-
 				if y.spec.DocumentIndex != nil {
 					if index != *y.spec.DocumentIndex {
 						continue
 					}
 				}
 
-				node, err = urlPath.FilterNode(doc.Body)
-				if err != nil {
-					if errors.Is(err, goyaml.ErrNotFoundNode) {
-						if y.spec.SearchPattern {
-							// If search pattern is true then we don't want to return an error
-							// as we are probably trying to identify a file matching the key
-							logrus.Debugf("ignoring key %q from file %q in document %d: %s", key, originFilePath, index, err)
-							continue
-						}
-						keyNotFound = append(keyNotFound, fmt.Sprintf("couldn't find key %q from file %q in document %d", key, originFilePath, index))
+				// goccy reports a missing key as a nil node rather than an error,
+				// but reports an intermediate null value ("key:") as an invalid
+				// query. Both mean the key is absent, so when we are allowed to
+				// create it we let our own walker decide rather than FilterNode.
+				node, filterErr := urlPath.FilterNode(doc.Body)
+
+				switch {
+				// A null value is an existing node that holds nothing, so when we
+				// may create the key we overwrite it instead of updating it.
+				case filterErr == nil && node != nil && (!y.spec.CreateMissingKey || !isNullNode(node)):
+					changed, err := y.updateNode(yamlFile, index, doc, urlPath, node, key, valueToWrite, nodeToWrite, resultTarget, originFilePath, dryRun)
+					if err != nil {
+						return 0, ignoredFiles, err
 					}
+					keyProcessed = true
+					keyChanged = keyChanged || changed
 
-					errMsg = append(errMsg, fmt.Sprintf("searching for key %q in document index %d: %s", key, index, err.Error()))
-					continue
-				}
+				case y.spec.CreateMissingKey:
+					changed, err := y.createKey(doc, key, valueToWrite, resultTarget, originFilePath, dryRun)
+					if err != nil {
+						return 0, ignoredFiles, err
+					}
+					keyProcessed = true
+					keyChanged = keyChanged || changed
 
-				if node == nil {
-					keyNotFound = append(keyNotFound, fmt.Sprintf("couldn't find key %s from file %q", key, originFilePath))
-					continue
-				}
+				case filterErr != nil:
+					errMsg = append(errMsg, fmt.Sprintf("searching for key %q in document index %d: %s", key, index, filterErr.Error()))
 
-				oldVersion = node.String()
+				case y.spec.SearchPattern:
+					// If search pattern is true then we don't want to return an error
+					// as we are probably trying to identify a file matching the key
+					logrus.Debugf("ignoring key %q from file %q in document %d as it does not exist", key, originFilePath, index)
 
-				// Compare decoded value so folded/literal scalars (>-, |) aren't
-				// flagged as changed by their formatting markers. See issue #8295.
-				var decoded string
-				if err := goyaml.NodeToValue(node, &decoded); err != nil || decoded != valueToWrite {
-					contentChanged = true
+				default:
+					keyNotFound = append(keyNotFound, fmt.Sprintf("couldn't find key %q from file %q in document %d", key, originFilePath, index))
 				}
 			}
 
@@ -119,34 +110,15 @@ func (y Yaml) goYamlTarget(valueToWrite string, resultTarget *result.Target, dry
 				return 0, ignoredFiles, fmt.Errorf("key not found from file %q", originFilePath)
 			}
 
-			fileKeysProcessed++
-			resultTarget.Information = oldVersion
-
-			if !contentChanged {
-				resultTarget.Description = fmt.Sprintf("%s\nkey %q already set to %q, from file %q",
-					resultTarget.Description,
-					key,
-					valueToWrite,
-					originFilePath)
-				fileNotChanged++
+			if !keyProcessed {
 				continue
 			}
 
-			for index, doc := range yamlFile.Docs {
-				if y.spec.DocumentIndex != nil {
-					if index != *y.spec.DocumentIndex {
-						continue
-					}
-				}
+			fileKeysProcessed++
 
-				tmpYAMLFile := ast.File{
-					Name: yamlFile.Name,
-				}
-				tmpYAMLFile.Docs = append(tmpYAMLFile.Docs, doc)
-				if err := urlPath.ReplaceWithNode(&tmpYAMLFile, nodeToWrite); err != nil {
-					return 0, ignoredFiles, fmt.Errorf("replacing yaml key %q: %w", key, err)
-				}
-				yamlFile.Docs[index].Body = tmpYAMLFile.Docs[0].Body
+			if !keyChanged {
+				fileNotChanged++
+				continue
 			}
 
 			if _, ok := resultTargetFilesMap[filePath]; !ok {
@@ -156,20 +128,6 @@ func (y Yaml) goYamlTarget(valueToWrite string, resultTarget *result.Target, dry
 
 			resultTarget.Changed = true
 			resultTarget.Result = result.ATTENTION
-
-			shouldMsg := " "
-			if dryRun {
-				// Use to craft message depending if we run Updatecli in dryrun mode or not
-				shouldMsg = " should be "
-			}
-
-			resultTarget.Description = fmt.Sprintf("%s\nkey %q%supdated from %q to %q, in file %q",
-				resultTarget.Description,
-				key,
-				shouldMsg,
-				oldVersion,
-				valueToWrite,
-				originFilePath)
 		}
 
 		// If no keys were processed for this file (all were ignored), count as ignored
@@ -205,4 +163,121 @@ func (y Yaml) goYamlTarget(valueToWrite string, resultTarget *result.Target, dry
 	}
 
 	return notChanged, ignoredFiles, nil
+}
+
+// createKey inserts a key that does not exist yet in doc. When the target also
+// appends to an array, the key is created holding the value as its sole entry.
+func (y Yaml) createKey(doc *ast.DocumentNode, key, valueToWrite string, resultTarget *result.Target, originFilePath string, dryRun bool) (bool, error) {
+	elements, err := splitYamlPathKey(key)
+	if err != nil {
+		return false, fmt.Errorf("cannot create key %q: %w", key, err)
+	}
+
+	var leafValue interface{} = valueToWrite
+	if y.spec.AppendToArray {
+		leafValue = []interface{}{valueToWrite}
+	}
+
+	leaf, err := createMissingKey(doc, key, elements, leafValue)
+	if err != nil {
+		return false, err
+	}
+
+	if y.spec.Comment != "" {
+		if y.spec.AppendToArray {
+			// The comment belongs to the sole entry of the created sequence.
+			if sequence, ok := leaf.(*ast.SequenceNode); ok && len(sequence.Values) == 1 {
+				leaf = sequence.Values[0]
+			}
+		}
+		if err := setNodeComment(leaf, y.spec.Comment); err != nil {
+			logrus.Errorf("error setting comment: %s", err)
+		}
+	}
+
+	resultTarget.Description = fmt.Sprintf("%s\nkey %q%screated in file %q with value %q",
+		resultTarget.Description,
+		key,
+		shouldMessage(dryRun),
+		originFilePath,
+		valueToWrite)
+
+	return true, nil
+}
+
+// updateNode either appends to the sequence addressed by key, or replaces the value
+// of the node it addresses. It reports whether the document was modified.
+func (y Yaml) updateNode(yamlFile *ast.File, index int, doc *ast.DocumentNode, urlPath *goyaml.Path, node ast.Node, key, valueToWrite string, nodeToWrite ast.Node, resultTarget *result.Target, originFilePath string, dryRun bool) (bool, error) {
+	if y.spec.AppendToArray {
+		sequence, ok := node.(*ast.SequenceNode)
+		if !ok {
+			return false, fmt.Errorf("cannot append to key %q from file %q: expected a yaml sequence but got %s", key, originFilePath, node.Type())
+		}
+
+		appended, err := appendToSequence(sequence, valueToWrite, y.spec.Comment)
+		if err != nil {
+			return false, fmt.Errorf("appending to key %q from file %q: %w", key, originFilePath, err)
+		}
+
+		if !appended {
+			resultTarget.Description = fmt.Sprintf("%s\nkey %q already contains %q, from file %q",
+				resultTarget.Description,
+				key,
+				valueToWrite,
+				originFilePath)
+			return false, nil
+		}
+
+		resultTarget.Description = fmt.Sprintf("%s\nvalue %q%sappended to key %q, in file %q",
+			resultTarget.Description,
+			valueToWrite,
+			shouldMessage(dryRun),
+			key,
+			originFilePath)
+
+		return true, nil
+	}
+
+	oldVersion := node.String()
+	resultTarget.Information = oldVersion
+
+	// Compare decoded value so folded/literal scalars (>-, |) aren't
+	// flagged as changed by their formatting markers. See issue #8295.
+	var decoded string
+	if err := goyaml.NodeToValue(node, &decoded); err == nil && decoded == valueToWrite {
+		resultTarget.Description = fmt.Sprintf("%s\nkey %q already set to %q, from file %q",
+			resultTarget.Description,
+			key,
+			valueToWrite,
+			originFilePath)
+		return false, nil
+	}
+
+	tmpYAMLFile := ast.File{
+		Name: yamlFile.Name,
+	}
+	tmpYAMLFile.Docs = append(tmpYAMLFile.Docs, doc)
+	if err := urlPath.ReplaceWithNode(&tmpYAMLFile, nodeToWrite); err != nil {
+		return false, fmt.Errorf("replacing yaml key %q: %w", key, err)
+	}
+	yamlFile.Docs[index].Body = tmpYAMLFile.Docs[0].Body
+
+	resultTarget.Description = fmt.Sprintf("%s\nkey %q%supdated from %q to %q, in file %q",
+		resultTarget.Description,
+		key,
+		shouldMessage(dryRun),
+		oldVersion,
+		valueToWrite,
+		originFilePath)
+
+	return true, nil
+}
+
+// shouldMessage crafts the message fragment depending on whether Updatecli runs in
+// dry run mode or not.
+func shouldMessage(dryRun bool) string {
+	if dryRun {
+		return " should be "
+	}
+	return " "
 }

--- a/pkg/plugins/resources/yaml/target_goyaml.go
+++ b/pkg/plugins/resources/yaml/target_goyaml.go
@@ -40,6 +40,21 @@ func (y Yaml) goYamlTarget(valueToWrite string, resultTarget *result.Target, dry
 			return 0, ignoredFiles, fmt.Errorf("parsing yaml file: %w", err)
 		}
 
+		// A documentindex addressing no document of the file leaves the keys loop
+		// below evaluating nothing at all, reporting neither a match nor a miss, so
+		// the file would be silently ignored and the target would succeed without
+		// having updated anything. The yamlpath engine and the source both report
+		// this as a missing key.
+		if y.spec.DocumentIndex != nil && (*y.spec.DocumentIndex < 0 || *y.spec.DocumentIndex >= len(yamlFile.Docs)) {
+			if y.spec.SearchPattern {
+				logrus.Debugf("ignoring file %q as it holds %d document(s) and documentindex is %d", originFilePath, len(yamlFile.Docs), *y.spec.DocumentIndex)
+				ignoredFiles++
+				continue
+			}
+
+			return 0, ignoredFiles, fmt.Errorf("documentindex %d addresses no document of file %q, which holds %d document(s)", *y.spec.DocumentIndex, originFilePath, len(yamlFile.Docs))
+		}
+
 		// Process each key for this file
 		for _, key := range keys {
 			urlPath, err := goyaml.PathString(key)

--- a/pkg/plugins/resources/yaml/target_yamlpath.go
+++ b/pkg/plugins/resources/yaml/target_yamlpath.go
@@ -62,6 +62,10 @@ func (y *Yaml) goYamlPathTarget(valueToWrite string, resultTarget *result.Target
 			// No DocumentIndex: search across all documents and process each doc that matches
 			foundAny := false
 			var docNotChangedCount int
+			// docsMatched counts the documents in which the key was found, which is
+			// the only meaningful denominator: len(docs) ignores both DocumentIndex
+			// and the documents that simply do not carry the key.
+			var docsMatched int
 
 			for index, doc := range docs {
 
@@ -80,7 +84,7 @@ func (y *Yaml) goYamlPathTarget(valueToWrite string, resultTarget *result.Target
 				}
 
 				foundAny = true
-				fileKeysProcessed++
+				docsMatched++
 				var oldVersion string
 				var notChangedNode int
 				for _, node := range nodes {
@@ -128,18 +132,23 @@ func (y *Yaml) goYamlPathTarget(valueToWrite string, resultTarget *result.Target
 				if notChangedNode == len(nodes) {
 					docNotChangedCount++
 				}
+			}
 
-				if !foundAny {
-					if y.spec.SearchPattern {
-						logrus.Debugf("ignoring key %q in file %q as we couldn't find it in any document", key, originFilePath)
-						continue
-					}
-					return 0, ignoredFiles, fmt.Errorf("couldn't find key %q from file %q", key, originFilePath)
+			// Whether the key was found has to be decided once every document has
+			// been evaluated, not while iterating over them.
+			if !foundAny {
+				if y.spec.SearchPattern {
+					logrus.Debugf("ignoring key %q in file %q as we couldn't find it in any document", key, originFilePath)
+					continue
 				}
-				if docNotChangedCount == len(docs) {
-					// if every matching document had only unchanged nodes, consider file not changed for this key
-					fileNotChanged++
-				}
+				return 0, ignoredFiles, fmt.Errorf("couldn't find key %q from file %q", key, originFilePath)
+			}
+
+			fileKeysProcessed++
+
+			if docNotChangedCount == docsMatched {
+				// if every matching document had only unchanged nodes, consider file not changed for this key
+				fileNotChanged++
 			}
 		} // end keys loop
 

--- a/pkg/plugins/resources/yaml/utils.go
+++ b/pkg/plugins/resources/yaml/utils.go
@@ -5,6 +5,7 @@ import (
 
 	goyaml "github.com/goccy/go-yaml"
 	"github.com/goccy/go-yaml/ast"
+	"github.com/goccy/go-yaml/token"
 	"github.com/sirupsen/logrus"
 )
 
@@ -60,4 +61,21 @@ func nodeValue(node ast.Node) string {
 	}
 
 	return node.String()
+}
+
+// setNodeComment attaches comment as a trailing comment of node.
+func setNodeComment(node ast.Node, comment string) error {
+	commentGroup := &ast.CommentGroupNode{
+		Comments: []*ast.CommentNode{
+			{
+				Token: &token.Token{
+					Type: token.CommentType,
+					// Add a space before the comment
+					Value: " " + comment,
+				},
+			},
+		},
+	}
+
+	return node.SetComment(commentGroup)
 }


### PR DESCRIPTION
Fix #60

Add two attributes to the `yaml` resource, so that a target can write a key that
does not exist yet, and can grow a sequence instead of replacing it.

**`createmissingkey`** creates the key when the document does not hold it,
building the missing intermediate keys as nested maps and matching the
indentation of the surrounding document.

```yaml
targets:
  tag:
    kind: yaml
    spec:
      file: values.yaml
      key: $.image.tag
      createmissingkey: true
```
appendtoarray appends the value as a new entry of the sequence addressed by
key. It is idempotent: appending a value the sequence already holds reports no
change. Combined with createmissingkey, a missing sequence is created holding
the value as its sole entry.

```yaml
targets:
  allowedTags:
    kind: yaml
    spec:
      file: values.yaml
      key: $.allowedTags
      appendtoarray: true
```

Both are supported by the default go-yaml engine only, and are rejected at
validation time when engine: yamlpath is set. createmissingkey also rejects a
key holding a wildcard or a recursive selector ($.agents[*].tag, $..tag),
since there is no way to create the key under each selected position.

Getting there surfaced a handful of pre-existing defects in the shared code
paths, fixed in their own commits: a key selecting several nodes resolves to a
detached wrapper rather than to the matched node itself, which was mistaken for a
key present everywhere; and the yamlpath engine counted processed keys per
document, which left its missing-key check unreachable.

⚠️ Breaking changes

Both affect the yaml resource used as a target, and both apply to manifests
that do not use the new attributes.

1. A wildcard key must now be held by every position it selects.

A key such as $.agents[*].tag used to update the entries carrying tag and
report a success, silently leaving the others untouched:

```yaml
agents:
  - name: first
    tag: v1       # updated
  - name: second  # ignored, target reported success
```
It now fails instead, so a target never reports a success for an update it only
partially made. This matches the rule already applied to documents: a key missing
from one document of a multi-document file has always been an error.

Set searchpattern: true to keep the previous behaviour and update the positions
holding the key.

A recursive selector ($..tag) is unaffected: it searches for the key itself, so
it only ever selects positions already holding it and cannot match partially.

2. engine: yamlpath now fails when the key is missing from every document.

The check existed but was unreachable, so the target was silently reported as
skipped. It now errors, as the default go-yaml engine already did. Set
searchpattern: true to ignore files that do not carry the key.

Test

To test this pull request, you can run the following commands:

```bash
cd pkg/plugins/resources/yaml
go test
```
An end to end manifest covering both attributes is added in
e2e/updatecli.d/success.d/yaml/createandappend.yaml.

Additional Information

Checklist

- <!-- If applicable,--> I have updated the documentation via pull request om/updatecli/website) repository.
- <!-- If applicable,--> I have tested this pull request manually with a cuorks as expected.

Tradeoff

createmissingkey creates the key in every document of a multi-document file
when documentindex is not set, and in every file matched by file/files when
searchpattern is set. This follows the existing rule that a target evaluate
documents, but it means a key can land on documents that were never meant t
it. Set documentindex to narrow it down.

A missing sequence index ($.agents[0].name) is not created: materialising e
N of a sequence that does not have one has no sensible answer.

Potential improvement

Rejecting createmissingkey combined with searchpattern at validation time,
since the combination turns every glob match into a write rather than a sea