### PR TITLE
fix(yaml): stop retrying an unrecoverable decode error in condition

### DIFF
--- a/pkg/plugins/resources/yaml/condition.go
+++ b/pkg/plugins/resources/yaml/condition.go
@@ -108,9 +108,12 @@ func (y *Yaml) Condition(_ context.Context, source string, scm scm.ScmHandler) (
 					if derr == io.EOF {
 						break
 					}
+					// The decoder does not advance past a syntax error, so it would
+					// return the same error on every subsequent call. Stop reading
+					// this file instead of looping on it.
 					errorMessages = append(errorMessages, fmt.Errorf(
-						"%q - parsing yaml file: %w", originalFilePath, err))
-					continue
+						"%q - parsing yaml file: %w", originalFilePath, derr))
+					break
 				}
 				docs = append(docs, &doc)
 			}

--- a/pkg/plugins/resources/yaml/condition_test.go
+++ b/pkg/plugins/resources/yaml/condition_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -805,5 +806,55 @@ name: github
 			require.NoError(t, gotErr)
 			assert.Equal(t, tt.isResultWanted, gotResult)
 		})
+	}
+}
+
+// Test_Condition_yamlpathUndecodableFile guards against a decode loop that never
+// terminates. yaml.v3 does not advance past a syntax error, so a file whose first
+// document parses and whose remainder does not (a Markdown file dropped in a
+// workflows directory, say) makes the decoder return the same non-EOF error
+// forever. Retrying instead of stopping grew errorMessages until the process was
+// OOM-killed.
+func Test_Condition_yamlpathUndecodableFile(t *testing.T) {
+	spec := Spec{
+		File:   "README.md",
+		Key:    "$.name",
+		Engine: "yamlpath",
+	}
+
+	y, err := New(spec)
+	require.NoError(t, err)
+
+	y.contentRetriever = &text.MockTextRetriever{
+		Contents: map[string]string{
+			"README.md": `# OpenAPI Breaking Changes Detection
+
+## Overview
+
+This workflow detects breaking changes in the OpenAPI specification.
+
+## How It Works
+
+1. **Automatic Detection**: On every PR, the workflow:
+   - compares the spec against the base branch
+`,
+		},
+	}
+	y.files = map[string]file{
+		"README.md": {originalFilePath: "README.md", filePath: "README.md"},
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		_, _, condErr := y.Condition(context.Background(), "", nil)
+		done <- condErr
+	}()
+
+	select {
+	case condErr := <-done:
+		require.Error(t, condErr)
+		assert.Contains(t, condErr.Error(), "parsing yaml file")
+	case <-time.After(10 * time.Second):
+		t.Fatal("Condition did not return: the decoder loop is spinning on a non-EOF error")
 	}
 }


### PR DESCRIPTION
The yamlpath engine retries a decode error it cannot recover from, so a single
unparseable file makes `Condition` allocate until the process is OOM-killed.

`yaml.v3` does not advance past a syntax error: once `Decode` fails, every
subsequent call returns the same non-EOF error. The loop appends an error and
`continue`s, so it spins forever:

```go
if derr := dec.Decode(&doc); derr != nil {
    if derr == io.EOF { break }
    errorMessages = append(errorMessages, fmt.Errorf(
        "%q - parsing yaml file: %w", originalFilePath, err))
    continue
}
```

A heap profile of an org-wide GitHub Action autodiscovery run (45 repositories
via a `githubsearch` scm) shows where it goes:

```
Showing nodes accounting for 14.62GB, 99.35% of 14.71GB total
      flat  flat%   sum%        cum   cum%
   11.16GB 75.83% 75.83%    11.22GB 76.29%  fmt.errorf
    2.49GB 16.93% 92.76%    14.69GB 99.81%  ...resources/yaml.(*Yaml).Condition

    1.80GB    12.67GB    111:  errorMessages = append(errorMessages, fmt.Errorf(
```

The trigger in our case was a Markdown file sitting in a `.github/workflows`
directory. Its first document parses as a scalar; the remainder then yields a
sticky `yaml: line 8: did not find expected <document start>`. Any file that
parses partially will do it.

This stops reading the file on such an error, which is what `source.go` and
`target_yamlpath.go` already do for the same case — `condition.go` was the only
one retrying. It also wraps `derr` rather than `err`, which is nil at that
point, so the message reported `%!w(<nil>)` instead of the parse failure.

## Test

```shell
cd pkg/plugins/resources/yaml
go test
```

`Test_Condition_yamlpathUndecodableFile` fails (10s guard, "the decoder loop is
spinning on a non-EOF error") with `continue` restored, and passes with `break`.

Verified against the real workload that surfaced it — same policy set, same 45
repositories: **15.4 GB peak, dying after 13 repositories → 886 MB peak across
547 pipelines**.

## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via pull request in [website](https://github.com/updatecli/website) repository.
- [x] I have tested this pull request manually with a custom Updatecli build and it works as expected.

### Tradeoff

Stopping at the first undecodable document means later documents in that file
are not inspected. They are unreachable anyway: the decoder cannot get past the
syntax error, so the previous behaviour never reached them either — it just
spun. The condition still reports the file as failing.

### Potential improvement

`derr == io.EOF` could be `errors.Is(derr, io.EOF)` here and in the two sibling
files. Left alone to keep this diff to the bug.
