### PR TITLE
feat(gitcommit): support age filtering

### DIFF
--- a/e2e/updatecli.d/success.d/gitCommit.yaml
+++ b/e2e/updatecli.d/success.d/gitCommit.yaml
@@ -21,6 +21,14 @@ sources:
       branch: main
       depth: 1
       url: https://github.com/updatecli-test/updatecli-submodules.git
+  from-scm-with-age:
+    name: Get the latest commit settled for at least one hour from an SCM working directory
+    kind: gitcommit
+    scmid: git-repository
+    spec:
+      branch: main
+      age:
+        minimum: "1h"
   from-path:
     name: Get the latest commit from the current working directory
     kind: gitcommit

--- a/pkg/plugins/resources/gitcommit/main.go
+++ b/pkg/plugins/resources/gitcommit/main.go
@@ -1,9 +1,14 @@
 package gitcommit
 
 import (
+	"fmt"
+	"strings"
+	"time"
+
 	"github.com/go-viper/mapstructure/v2"
 	"github.com/updatecli/updatecli/pkg/core/result"
 	"github.com/updatecli/updatecli/pkg/plugins/scms/git"
+	"github.com/updatecli/updatecli/pkg/plugins/utils/age"
 	"github.com/updatecli/updatecli/pkg/plugins/utils/gitgeneric"
 	"github.com/updatecli/updatecli/pkg/plugins/utils/redact"
 )
@@ -27,6 +32,18 @@ type Spec struct {
 	// default:
 	//   The repository's current HEAD branch.
 	Branch string `yaml:",omitempty"`
+	// Age defines the minimum or maximum age of a commit to be considered valid.
+	// It accepts a duration string (e.g., "24h", "7d", "3w", "1y").
+	// The age of a commit is its committer date, and the newest commit of the branch
+	// falling inside that window is returned.
+	//
+	// compatible:
+	//   * source
+	//
+	// remarks:
+	//   * The branch history is walked from its tip until a commit matches, so Depth
+	//     must be large enough to reach it.
+	Age age.Spec `yaml:",omitempty"`
 	// Hash specifies the commit hash checked by the condition.
 	//
 	// compatible:
@@ -81,6 +98,7 @@ type GitCommit struct {
 type commitHandler interface {
 	GetCommitHash(workingDir, branch string) (string, error)
 	IsCommitExist(workingDir, commit string) (bool, error)
+	SearchCommit(workingDir, branch string, match func(when time.Time) bool) (gitgeneric.DatedCommit, error)
 }
 
 // New returns a newly initialized GitCommit resource.
@@ -88,6 +106,17 @@ func New(spec interface{}) (*GitCommit, error) {
 	newSpec := Spec{}
 	if err := mapstructure.Decode(spec, &newSpec); err != nil {
 		return nil, err
+	}
+
+	validationErrors := []string{}
+
+	if err := newSpec.Age.Validate(); err != nil {
+		validationErrors = append(validationErrors, err.Error())
+	}
+
+	// Return all the validation errors if found any
+	if len(validationErrors) > 0 {
+		return nil, fmt.Errorf("validation error: the provided manifest configuration has the following validation errors:\n%s", strings.Join(validationErrors, "\n\n"))
 	}
 
 	return &GitCommit{
@@ -119,6 +148,7 @@ func (gc *GitCommit) ReportConfig() interface{} {
 	return Spec{
 		Path:   gc.spec.Path,
 		Branch: gc.spec.Branch,
+		Age:    gc.spec.Age,
 		Hash:   gc.spec.Hash,
 		Depth:  gc.spec.Depth,
 		URL:    redact.URL(gc.spec.URL),

--- a/pkg/plugins/resources/gitcommit/main_test.go
+++ b/pkg/plugins/resources/gitcommit/main_test.go
@@ -5,16 +5,61 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/updatecli/updatecli/pkg/plugins/utils/age"
 )
 
 func TestNew(t *testing.T) {
-	resource, err := New(map[string]interface{}{
-		"path":   "/tmp/repository",
-		"branch": "main",
-	})
-	require.NoError(t, err)
-	assert.Equal(t, "/tmp/repository", resource.spec.Path)
-	assert.Equal(t, "main", resource.spec.Branch)
+	tests := []struct {
+		name    string
+		spec    map[string]interface{}
+		wantAge age.Spec
+		wantErr []string
+	}{
+		{
+			name: "path and branch",
+			spec: map[string]interface{}{
+				"path":   "/tmp/repository",
+				"branch": "main",
+			},
+		},
+		{
+			name: "age filter",
+			spec: map[string]interface{}{
+				"path":   "/tmp/repository",
+				"branch": "main",
+				"age":    map[string]interface{}{"minimum": "7d", "maximum": "30d"},
+			},
+			wantAge: age.Spec{Minimum: "7d", Maximum: "30d"},
+		},
+		{
+			name: "invalid age filter",
+			spec: map[string]interface{}{
+				"path":   "/tmp/repository",
+				"branch": "main",
+				"age":    map[string]interface{}{"minimum": "7 days"},
+			},
+			wantErr: []string{"validation error", `invalid MinimumReleaseAge "7 days"`},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resource, err := New(tt.spec)
+
+			if len(tt.wantErr) > 0 {
+				require.Error(t, err)
+				for _, want := range tt.wantErr {
+					assert.Contains(t, err.Error(), want)
+				}
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, "/tmp/repository", resource.spec.Path)
+			assert.Equal(t, "main", resource.spec.Branch)
+			assert.Equal(t, tt.wantAge, resource.spec.Age)
+		})
+	}
 }
 
 func TestReportConfig(t *testing.T) {
@@ -22,6 +67,7 @@ func TestReportConfig(t *testing.T) {
 	resource := &GitCommit{spec: Spec{
 		Path:     "/tmp/repository",
 		Branch:   "main",
+		Age:      age.Spec{Minimum: "7d", Maximum: "30d"},
 		Hash:     "abc123",
 		Depth:    &depth,
 		URL:      "https://user:secret@example.com/owner/repository.git",
@@ -32,6 +78,7 @@ func TestReportConfig(t *testing.T) {
 	assert.Equal(t, Spec{
 		Path:   "/tmp/repository",
 		Branch: "main",
+		Age:    age.Spec{Minimum: "7d", Maximum: "30d"},
 		Hash:   "abc123",
 		Depth:  &depth,
 		URL:    "https://****:****@example.com/owner/repository.git",

--- a/pkg/plugins/resources/gitcommit/source.go
+++ b/pkg/plugins/resources/gitcommit/source.go
@@ -2,9 +2,14 @@ package gitcommit
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"time"
 
+	"github.com/sirupsen/logrus"
 	"github.com/updatecli/updatecli/pkg/core/result"
+	"github.com/updatecli/updatecli/pkg/plugins/utils/age"
+	"github.com/updatecli/updatecli/pkg/plugins/utils/gitgeneric"
 )
 
 // Source returns the latest commit hash for the configured Git branch.
@@ -25,19 +30,65 @@ func (gc *GitCommit) Source(_ context.Context, workingDir string, resultSource *
 		return fmt.Errorf("unknown Git working directory. Did you specify one of `spec.URL`, `scmid` or `spec.path`?")
 	}
 
-	hash, err := gc.nativeGitHandler.GetCommitHash(gc.directory, gc.spec.Branch)
-	if err != nil {
-		return fmt.Errorf("retrieving latest Git commit: %w", err)
-	}
-
 	branch := gc.spec.Branch
 	if branch == "" {
 		branch = "HEAD"
 	}
 
+	// Without an age filter the branch tip is the answer, so the history is left alone.
+	if gc.spec.Age.IsZero() {
+		hash, err := gc.nativeGitHandler.GetCommitHash(gc.directory, gc.spec.Branch)
+		if err != nil {
+			return fmt.Errorf("retrieving latest Git commit: %w", err)
+		}
+
+		resultSource.Result = result.SUCCESS
+		resultSource.Information = hash
+		resultSource.Description = fmt.Sprintf("Git commit %q found for branch %q", hash, branch)
+
+		return nil
+	}
+
+	commit, err := gc.nativeGitHandler.SearchCommit(gc.directory, gc.spec.Branch, gc.spec.Age.Matches)
+	if err != nil {
+		/*
+			The branch does have a history but the age filter discarded every commit of
+			it, which means the commit we would have returned is still cooling down.
+			That's an expected state of the filter rather than a lookup failure, so the
+			source is skipped instead. A history truncated by `depth` ends up here too,
+			hence the reminder.
+		*/
+		if errors.Is(err, gitgeneric.ErrNoCommitFound) {
+			logrus.Debugf("%s", age.ErrNoVersionMatchingAge)
+			logrus.Warningf("no commit of branch %q matched the age filter %s", branch, endOfHistory(err, gc.spec.Depth))
+
+			resultSource.Result = result.SKIPPED
+			resultSource.Description = "no git commit matches the age filter yet"
+
+			return nil
+		}
+
+		return fmt.Errorf("retrieving latest Git commit: %w", err)
+	}
+
 	resultSource.Result = result.SUCCESS
-	resultSource.Information = hash
-	resultSource.Description = fmt.Sprintf("Git commit %q found for branch %q", hash, branch)
+	resultSource.Information = commit.Hash
+	resultSource.Description = fmt.Sprintf("Git commit %q found for branch %q, committed on %s and matching the age filter",
+		commit.Hash, branch, commit.When.Format(time.RFC3339))
 
 	return nil
+}
+
+// endOfHistory explains why a history walk ran out of commits, telling a branch which
+// genuinely holds no matching commit from one whose older commits were never fetched.
+func endOfHistory(err error, depth *int) string {
+	if !errors.Is(err, gitgeneric.ErrTruncatedHistory) {
+		return "anywhere in its history"
+	}
+
+	if depth == nil || *depth == 0 {
+		return "before the end of the shallow history available. A matching commit may exist further back, in commits which were never fetched"
+	}
+
+	return fmt.Sprintf("before the end of the %d commit(s) fetched by `spec.depth`. A matching commit may exist further back, consider raising it", *depth)
 }

--- a/pkg/plugins/resources/gitcommit/source_test.go
+++ b/pkg/plugins/resources/gitcommit/source_test.go
@@ -3,20 +3,52 @@ package gitcommit
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/updatecli/updatecli/pkg/core/result"
+	"github.com/updatecli/updatecli/pkg/plugins/utils/age"
+	"github.com/updatecli/updatecli/pkg/plugins/utils/gitgeneric"
 )
 
 type mockGitHandler struct {
-	hash         string
-	exists       bool
-	err          error
+	hash   string
+	exists bool
+	err    error
+	// commits holds the branch history, newest first.
+	commits      []gitgeneric.DatedCommit
 	gotDirectory string
 	gotBranch    string
 	gotCommit    string
+	gotSearch    bool
+}
+
+// SearchCommit reproduces the newest-first, stop-on-first-match contract of the real
+// handler so that the age filtering itself is exercised rather than a canned answer.
+func (m *mockGitHandler) SearchCommit(workingDir, branch string, match func(when time.Time) bool) (gitgeneric.DatedCommit, error) {
+	m.gotDirectory = workingDir
+	m.gotBranch = branch
+	m.gotSearch = true
+
+	if m.err != nil {
+		return gitgeneric.DatedCommit{}, m.err
+	}
+
+	for _, commit := range m.commits {
+		if match(commit.When) {
+			return commit, nil
+		}
+	}
+
+	return gitgeneric.DatedCommit{}, fmt.Errorf("%w in the history of %q", gitgeneric.ErrNoCommitFound, branch)
+}
+
+// commitDaysAgo builds the committer date of a commit created n days ago.
+func commitDaysAgo(n int) time.Time {
+	return time.Now().Add(-time.Duration(n) * 24 * time.Hour)
 }
 
 func (m *mockGitHandler) GetCommitHash(workingDir, branch string) (string, error) {
@@ -32,16 +64,25 @@ func (m *mockGitHandler) IsCommitExist(workingDir, commit string) (bool, error) 
 }
 
 func TestSource(t *testing.T) {
+	// A branch history, newest first, as the mocked handler walks it.
+	commits := []gitgeneric.DatedCommit{
+		{Hash: "ghi789", When: commitDaysAgo(1)},
+		{Hash: "def456", When: commitDaysAgo(10)},
+		{Hash: "abc123", When: commitDaysAgo(30)},
+	}
+
 	tests := []struct {
-		name       string
-		workingDir string
-		spec       Spec
-		handler    *mockGitHandler
-		wantHash   string
-		wantDir    string
-		wantBranch string
-		wantDesc   string
-		wantErr    string
+		name        string
+		workingDir  string
+		spec        Spec
+		handler     *mockGitHandler
+		wantHash    string
+		wantDir     string
+		wantBranch  string
+		wantDesc    string
+		wantSkipped bool
+		wantSearch  bool
+		wantErr     string
 	}{
 		{
 			name:       "SCM working directory HEAD",
@@ -75,6 +116,52 @@ func TestSource(t *testing.T) {
 			wantBranch: "missing",
 			wantErr:    "retrieving latest Git commit: branch not found",
 		},
+		{
+			name:       "the branch tip is still in cooldown",
+			workingDir: "/tmp/scm",
+			spec:       Spec{Age: age.Spec{Minimum: "7d"}},
+			handler:    &mockGitHandler{commits: commits},
+			wantHash:   "def456",
+			wantDir:    "/tmp/scm",
+			wantSearch: true,
+		},
+		{
+			name:       "commits older than the maximum are discarded",
+			workingDir: "/tmp/scm",
+			spec:       Spec{Age: age.Spec{Maximum: "20d"}},
+			handler:    &mockGitHandler{commits: commits},
+			wantHash:   "ghi789",
+			wantDir:    "/tmp/scm",
+			wantSearch: true,
+		},
+		{
+			name:        "the source is skipped while every commit is still in cooldown",
+			workingDir:  "/tmp/scm",
+			spec:        Spec{Age: age.Spec{Minimum: "60d"}},
+			handler:     &mockGitHandler{commits: commits},
+			wantDir:     "/tmp/scm",
+			wantSkipped: true,
+			wantSearch:  true,
+		},
+		{
+			name:        "the source is skipped when the age window falls between two commits",
+			workingDir:  "/tmp/scm",
+			spec:        Spec{Age: age.Spec{Minimum: "12d", Maximum: "20d"}},
+			handler:     &mockGitHandler{commits: commits},
+			wantDir:     "/tmp/scm",
+			wantSkipped: true,
+			wantSearch:  true,
+		},
+		{
+			name:       "a Git lookup error is not mistaken for a running cooldown",
+			workingDir: "/tmp/scm",
+			spec:       Spec{Branch: "missing", Age: age.Spec{Minimum: "7d"}},
+			handler:    &mockGitHandler{err: errors.New("branch not found")},
+			wantDir:    "/tmp/scm",
+			wantBranch: "missing",
+			wantSearch: true,
+			wantErr:    "retrieving latest Git commit: branch not found",
+		},
 	}
 
 	for _, tt := range tests {
@@ -87,12 +174,24 @@ func TestSource(t *testing.T) {
 				assert.Contains(t, err.Error(), tt.wantErr)
 			} else {
 				require.NoError(t, err)
-				assert.Equal(t, result.SUCCESS, got.Result)
-				assert.Equal(t, tt.wantHash, got.Information)
-				assert.Equal(t, tt.wantDesc, got.Description)
+
+				switch tt.wantSkipped {
+				case true:
+					assert.Equal(t, result.SKIPPED, got.Result)
+					assert.Equal(t, "no git commit matches the age filter yet", got.Description)
+					assert.Empty(t, got.Information)
+				case false:
+					assert.Equal(t, result.SUCCESS, got.Result)
+					assert.Equal(t, tt.wantHash, got.Information)
+					if tt.wantDesc != "" {
+						assert.Equal(t, tt.wantDesc, got.Description)
+					}
+				}
 			}
 			assert.Equal(t, tt.wantDir, tt.handler.gotDirectory)
 			assert.Equal(t, tt.wantBranch, tt.handler.gotBranch)
+			// Without an age filter the history must never be walked.
+			assert.Equal(t, tt.wantSearch, tt.handler.gotSearch)
 		})
 	}
 }

--- a/pkg/plugins/utils/gitgeneric/commit.go
+++ b/pkg/plugins/utils/gitgeneric/commit.go
@@ -1,0 +1,160 @@
+package gitgeneric
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/sirupsen/logrus"
+)
+
+// ErrNoCommitFound is returned when the history of a branch ends without any
+// commit accepted by the caller's matcher.
+var ErrNoCommitFound = errors.New("no commit found")
+
+// ErrTruncatedHistory reports a history which ended on a commit whose parents were
+// never fetched, as a shallow clone does. It accompanies ErrNoCommitFound so that a
+// caller can tell "this branch has no matching commit" from "the commits which could
+// have matched were never fetched".
+var ErrTruncatedHistory = errors.New("truncated history")
+
+// DatedCommit represents a git commit with its committer date.
+type DatedCommit struct {
+	When time.Time
+	Hash string
+}
+
+// resolveBranchHash returns the hash referenced by a local or remote branch.
+// An empty branch resolves the repository HEAD.
+func resolveBranchHash(gitRepository *git.Repository, branch string) (plumbing.Hash, error) {
+	if branch == "" {
+		head, err := gitRepository.Head()
+		if err != nil {
+			return plumbing.ZeroHash, fmt.Errorf("getting HEAD: %s", err)
+		}
+		return head.Hash(), nil
+	}
+
+	references := []plumbing.ReferenceName{
+		plumbing.NewBranchReferenceName(branch),
+		plumbing.NewRemoteReferenceName(DefaultRemoteReferenceName, branch),
+	}
+	for _, referenceName := range references {
+		reference, err := gitRepository.Reference(referenceName, true)
+		if err == nil {
+			return reference.Hash(), nil
+		}
+		if err != plumbing.ErrReferenceNotFound {
+			return plumbing.ZeroHash, fmt.Errorf("getting branch %q: %s", branch, err)
+		}
+	}
+
+	return plumbing.ZeroHash, fmt.Errorf("branch %q not found", branch)
+}
+
+// insertByCommitterTime inserts a commit into a list kept ordered by committer date,
+// newest first.
+func insertByCommitterTime(commits []*object.Commit, commit *object.Commit) []*object.Commit {
+	index := sort.Search(len(commits), func(i int) bool {
+		return commits[i].Committer.When.Before(commit.Committer.When)
+	})
+
+	commits = append(commits, nil)
+	copy(commits[index+1:], commits[index:])
+	commits[index] = commit
+
+	return commits
+}
+
+/*
+SearchCommit walks the history of a branch, newest committer date first, and returns
+the first commit accepted by match.
+
+The walk is lazy: it only loads the parents of the commits it visits, so a branch whose
+tip already matches costs a single commit object rather than a full history read.
+
+The history is walked by committer date rather than by the depth-first order which
+go-git traverses by default: on a history containing merges, a depth-first walk yields
+commits of a side branch before more recent ones of the mainline, so stopping on the
+first match would not return the newest matching commit.
+
+The history of a shallow repository ends on a commit whose parents were never fetched.
+That truncation is indistinguishable from the end of a complete history here, so the
+walk stops and reports ErrNoCommitFound wrapping ErrTruncatedHistory, leaving the
+caller to explain it. Note that the boundary commit itself is matched before its
+missing parents are looked up, which is why the walk is driven here rather than
+through Repository.Log: the go-git iterators load the parents of a commit before
+handing it over, so they would drop the oldest commit of a shallow clone.
+*/
+func (g GoGit) SearchCommit(workingDir, branch string, match func(when time.Time) bool) (DatedCommit, error) {
+	gitRepository, err := git.PlainOpen(workingDir)
+	if err != nil {
+		return DatedCommit{}, fmt.Errorf("opening %q git directory: %s", workingDir, err)
+	}
+
+	hash, err := resolveBranchHash(gitRepository, branch)
+	if err != nil {
+		return DatedCommit{}, err
+	}
+
+	tip, err := object.GetCommit(gitRepository.Storer, hash)
+	if err != nil {
+		return DatedCommit{}, fmt.Errorf("getting commit %q: %s", hash, err)
+	}
+
+	// pending holds the commits left to visit, newest committer date first.
+	pending := []*object.Commit{tip}
+	seen := map[plumbing.Hash]bool{tip.Hash: true}
+	truncated := false
+
+	for len(pending) > 0 {
+		commit := pending[0]
+		pending = pending[1:]
+
+		if match(commit.Committer.When) {
+			return DatedCommit{
+				Hash: commit.Hash.String(),
+				When: commit.Committer.When,
+			}, nil
+		}
+
+		logrus.Debugf("ignoring commit %q, dated %s, as rejected by the commit filter",
+			commit.Hash.String(), commit.Committer.When)
+
+		for _, parentHash := range commit.ParentHashes {
+			if seen[parentHash] {
+				continue
+			}
+
+			parent, err := object.GetCommit(gitRepository.Storer, parentHash)
+			if err != nil {
+				/*
+					A missing parent means the history is truncated, which a shallow clone
+					does on purpose, so this branch of the walk ends here instead of
+					failing the whole lookup.
+				*/
+				if errors.Is(err, plumbing.ErrObjectNotFound) {
+					logrus.Debugf("history of %q in %q is truncated at commit %q",
+						branch, workingDir, commit.Hash.String())
+					truncated = true
+					continue
+				}
+
+				return DatedCommit{}, fmt.Errorf("getting commit %q: %s", parentHash, err)
+			}
+
+			seen[parentHash] = true
+			pending = insertByCommitterTime(pending, parent)
+		}
+	}
+
+	if truncated {
+		return DatedCommit{}, fmt.Errorf("%w in the %w of %q", ErrNoCommitFound, ErrTruncatedHistory, branch)
+	}
+
+	return DatedCommit{}, fmt.Errorf("%w in the history of %q", ErrNoCommitFound, branch)
+}

--- a/pkg/plugins/utils/gitgeneric/commit_test.go
+++ b/pkg/plugins/utils/gitgeneric/commit_test.go
@@ -124,3 +124,220 @@ func TestIsCommitExist(t *testing.T) {
 		})
 	}
 }
+
+// commitDaysAgo builds the committer date of a commit created n days ago.
+func commitDaysAgo(n int) time.Time {
+	return time.Now().Add(-time.Duration(n) * 24 * time.Hour)
+}
+
+// olderThan builds a matcher accepting the commits which are at least n days old.
+func olderThan(n int) func(time.Time) bool {
+	return func(when time.Time) bool {
+		return when.Before(commitDaysAgo(n))
+	}
+}
+
+func TestSearchCommit(t *testing.T) {
+	directory := t.TempDir()
+	repository, err := git.PlainInit(directory, false)
+	require.NoError(t, err)
+
+	worktree, err := repository.Worktree()
+	require.NoError(t, err)
+
+	commit := func(content, message string, when time.Time) plumbing.Hash {
+		require.NoError(t, os.WriteFile(directory+"/file.txt", []byte(content), 0o600))
+		_, err = worktree.Add("file.txt")
+		require.NoError(t, err)
+		hash, commitErr := worktree.Commit(message, &git.CommitOptions{
+			AllowEmptyCommits: true,
+			Author: &object.Signature{
+				Name:  "Updatecli Test",
+				Email: "test@updatecli.io",
+				When:  when,
+			},
+		})
+		require.NoError(t, commitErr)
+		return hash
+	}
+
+	/*
+		A history with a merge, so that the walk order is actually exercised:
+
+		  master  30d --- 10d ------------- merge (0d)
+		                     \             /
+		  feature             `--- 5d ----'
+
+		A depth-first walk reaches the 5 days old feature commit before the 10 days old
+		master one, so a matcher accepting anything older than 3 days only returns the
+		right commit when the history is walked by committer time.
+	*/
+	oldest := commit("oldest", "oldest commit", commitDaysAgo(30))
+	mainline := commit("mainline", "mainline commit", commitDaysAgo(10))
+
+	featureReference := plumbing.NewHashReference(plumbing.NewBranchReferenceName("feature"), mainline)
+	require.NoError(t, repository.Storer.SetReference(featureReference))
+	require.NoError(t, worktree.Checkout(&git.CheckoutOptions{Branch: featureReference.Name()}))
+	feature := commit("feature", "feature commit", commitDaysAgo(5))
+
+	require.NoError(t, worktree.Checkout(&git.CheckoutOptions{Branch: plumbing.NewBranchReferenceName("master")}))
+	merge := commit("merge", "merge commit", commitDaysAgo(0))
+	mergeCommit, err := repository.CommitObject(merge)
+	require.NoError(t, err)
+	mergeCommit.ParentHashes = []plumbing.Hash{mainline, feature}
+	mergeObject := repository.Storer.NewEncodedObject()
+	require.NoError(t, mergeCommit.Encode(mergeObject))
+	merge, err = repository.Storer.SetEncodedObject(mergeObject)
+	require.NoError(t, err)
+	require.NoError(t, repository.Storer.SetReference(
+		plumbing.NewHashReference(plumbing.NewBranchReferenceName("master"), merge)))
+	require.NoError(t, worktree.Reset(&git.ResetOptions{Commit: merge, Mode: git.HardReset}))
+
+	remoteReference := plumbing.NewHashReference(
+		plumbing.NewRemoteReferenceName(DefaultRemoteReferenceName, "remote-only"),
+		mainline,
+	)
+	require.NoError(t, repository.Storer.SetReference(remoteReference))
+
+	handler := GoGit{}
+
+	t.Run("a matching tip stops the walk immediately", func(t *testing.T) {
+		visited := 0
+		got, err := handler.SearchCommit(directory, "", func(time.Time) bool {
+			visited++
+			return true
+		})
+		require.NoError(t, err)
+		assert.Equal(t, merge.String(), got.Hash)
+		// The laziness of the walk is the point: a matching tip must cost one commit.
+		assert.Equal(t, 1, visited)
+	})
+
+	t.Run("the newest matching commit wins across a merge", func(t *testing.T) {
+		got, err := handler.SearchCommit(directory, "", olderThan(3))
+		require.NoError(t, err)
+		assert.Equal(t, feature.String(), got.Hash)
+	})
+
+	t.Run("the history is walked by committer time, not depth first", func(t *testing.T) {
+		got, err := handler.SearchCommit(directory, "", olderThan(7))
+		require.NoError(t, err)
+		assert.Equal(t, mainline.String(), got.Hash)
+	})
+
+	t.Run("the oldest commit is reachable", func(t *testing.T) {
+		got, err := handler.SearchCommit(directory, "", olderThan(20))
+		require.NoError(t, err)
+		assert.Equal(t, oldest.String(), got.Hash)
+		// The committer date is what the matcher was given.
+		assert.WithinDuration(t, commitDaysAgo(30), got.When, time.Minute)
+	})
+
+	t.Run("an exhausted history reports no commit found", func(t *testing.T) {
+		_, err := handler.SearchCommit(directory, "", olderThan(365))
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrNoCommitFound)
+	})
+
+	t.Run("a local branch is resolved", func(t *testing.T) {
+		got, err := handler.SearchCommit(directory, "feature", func(time.Time) bool { return true })
+		require.NoError(t, err)
+		assert.Equal(t, feature.String(), got.Hash)
+	})
+
+	t.Run("a remote branch is resolved", func(t *testing.T) {
+		got, err := handler.SearchCommit(directory, "remote-only", func(time.Time) bool { return true })
+		require.NoError(t, err)
+		assert.Equal(t, mainline.String(), got.Hash)
+	})
+
+	t.Run("a missing branch errors", func(t *testing.T) {
+		_, err := handler.SearchCommit(directory, "missing", func(time.Time) bool { return true })
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `branch "missing" not found`)
+	})
+
+	t.Run("an invalid repository errors", func(t *testing.T) {
+		_, err := handler.SearchCommit(directory+"/missing", "", func(time.Time) bool { return true })
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "opening")
+	})
+}
+
+// TestSearchCommitTruncatedHistory covers the boundary of a shallow repository, whose
+// oldest commit references parents which were never fetched.
+func TestSearchCommitTruncatedHistory(t *testing.T) {
+	directory := t.TempDir()
+	repository, err := git.PlainInit(directory, false)
+	require.NoError(t, err)
+
+	worktree, err := repository.Worktree()
+	require.NoError(t, err)
+
+	commit := func(content, message string, when time.Time) plumbing.Hash {
+		require.NoError(t, os.WriteFile(directory+"/file.txt", []byte(content), 0o600))
+		_, err = worktree.Add("file.txt")
+		require.NoError(t, err)
+		hash, commitErr := worktree.Commit(message, &git.CommitOptions{
+			Author: &object.Signature{
+				Name:  "Updatecli Test",
+				Email: "test@updatecli.io",
+				When:  when,
+			},
+		})
+		require.NoError(t, commitErr)
+		return hash
+	}
+
+	boundaryHash := commit("boundary", "boundary commit", commitDaysAgo(10))
+	tip := commit("tip", "tip commit", commitDaysAgo(1))
+
+	// Point the oldest commit at a parent absent from the object store, exactly as the
+	// oldest commit of a shallow clone does.
+	boundary, err := repository.CommitObject(boundaryHash)
+	require.NoError(t, err)
+	boundary.ParentHashes = []plumbing.Hash{plumbing.NewHash("0123456789abcdef0123456789abcdef01234567")}
+
+	encoded := repository.Storer.NewEncodedObject()
+	require.NoError(t, boundary.Encode(encoded))
+	truncatedBoundary, err := repository.Storer.SetEncodedObject(encoded)
+	require.NoError(t, err)
+
+	// Re-parent the tip onto the rewritten boundary commit.
+	tipCommit, err := repository.CommitObject(tip)
+	require.NoError(t, err)
+	tipCommit.ParentHashes = []plumbing.Hash{truncatedBoundary}
+	encodedTip := repository.Storer.NewEncodedObject()
+	require.NoError(t, tipCommit.Encode(encodedTip))
+	truncatedTip, err := repository.Storer.SetEncodedObject(encodedTip)
+	require.NoError(t, err)
+	require.NoError(t, repository.Storer.SetReference(
+		plumbing.NewHashReference(plumbing.NewBranchReferenceName("master"), truncatedTip)))
+
+	handler := GoGit{}
+
+	/*
+		The commit on the shallow boundary must be matched before its missing parents are
+		looked up. The go-git iterators load the parents of a commit before handing it
+		over, so they drop this commit entirely -- which is the one a `depth` limited
+		clone is the most likely to want.
+	*/
+	t.Run("the commit on the boundary is still matched", func(t *testing.T) {
+		got, err := handler.SearchCommit(directory, "", olderThan(5))
+		require.NoError(t, err)
+		assert.Equal(t, truncatedBoundary.String(), got.Hash)
+	})
+
+	t.Run("a newer commit is preferred over the boundary", func(t *testing.T) {
+		got, err := handler.SearchCommit(directory, "", func(time.Time) bool { return true })
+		require.NoError(t, err)
+		assert.Equal(t, truncatedTip.String(), got.Hash)
+	})
+
+	t.Run("walking past the boundary reports a truncated history rather than failing", func(t *testing.T) {
+		_, err := handler.SearchCommit(directory, "", olderThan(365))
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrNoCommitFound)
+		assert.ErrorIs(t, err, ErrTruncatedHistory)
+	})
+}

--- a/pkg/plugins/utils/gitgeneric/main.go
+++ b/pkg/plugins/utils/gitgeneric/main.go
@@ -341,29 +341,12 @@ func (g GoGit) GetCommitHash(workingDir, branch string) (string, error) {
 		return "", fmt.Errorf("opening %q git directory: %s", workingDir, err)
 	}
 
-	if branch == "" {
-		head, err := gitRepository.Head()
-		if err != nil {
-			return "", fmt.Errorf("getting HEAD: %s", err)
-		}
-		return head.Hash().String(), nil
+	hash, err := resolveBranchHash(gitRepository, branch)
+	if err != nil {
+		return "", err
 	}
 
-	references := []plumbing.ReferenceName{
-		plumbing.NewBranchReferenceName(branch),
-		plumbing.NewRemoteReferenceName(DefaultRemoteReferenceName, branch),
-	}
-	for _, referenceName := range references {
-		reference, err := gitRepository.Reference(referenceName, true)
-		if err == nil {
-			return reference.Hash().String(), nil
-		}
-		if err != plumbing.ErrReferenceNotFound {
-			return "", fmt.Errorf("getting branch %q: %s", branch, err)
-		}
-	}
-
-	return "", fmt.Errorf("branch %q not found", branch)
+	return hash.String(), nil
 }
 
 // GetLatestCommitHash returns the latest commit hash from the working directory


### PR DESCRIPTION
Add age filtering to git commit plugin
Similar to the other plugins that already support cooldown.

Here is an example of manifest

```
sources:
  from-scm-with-age:
    name: Get the latest commit settled for at least one hour from an SCM working directory
    kind: gitcommit
    scmid: git-repository
    spec:
      branch: main
      age:
        minimum: "1h"
```

## Test

To test this pull request, you can run the following commands:

```shell
cd pkg/plugins/resources/gitcommit
go test
cd  pkg/plugins/utils/gitgeneric
go test
```

## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via pull request in [website](https://github.com/updatecli/website) repository.
- [ ] <!-- If applicable,--> I have tested this pull request manually with a custom Updatecli build and it works as expected.

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
