### PR TITLE
fix(npm/age): When no version matching age found, skipping instead of error

### DIFF
--- a/pkg/plugins/autodiscovery/npm/dependency.go
+++ b/pkg/plugins/autodiscovery/npm/dependency.go
@@ -9,6 +9,7 @@ import (
 	"text/template"
 
 	"github.com/sirupsen/logrus"
+	"github.com/updatecli/updatecli/pkg/plugins/utils/age"
 )
 
 type lockFileSupport struct {
@@ -182,7 +183,7 @@ func (n Npm) discoverDependencyManifests() ([][]byte, error) {
 					}
 				}
 
-				tmpl, err := template.New("manifest").Parse(manifestTemplate)
+				tmpl, err := template.New("manifest").Parse(age.ManifestTemplate + manifestTemplate)
 				if err != nil {
 					logrus.Debugln(err)
 					continue

--- a/pkg/plugins/autodiscovery/npm/manifestTemplate.go
+++ b/pkg/plugins/autodiscovery/npm/manifestTemplate.go
@@ -20,15 +20,7 @@ sources:
 {{- if .SourceRegistryToken }}
       registrytoken: '{{ .SourceRegistryToken }}'
 {{- end }}
-{{- if or .SourceAge.Minimum .SourceAge.Maximum }}
-      age:
-        {{- if .SourceAge.Minimum }}
-        minimum: '{{ .SourceAge.Minimum }}'
-        {{- end }}
-        {{- if .SourceAge.Maximum }}
-        maximum: '{{ .SourceAge.Maximum }}'
-        {{- end }}
-{{- end }}
+{{- template "age" .SourceAge }}
       versionfilter:
         kind: '{{ .SourceVersionFilterKind }}'
         pattern: '{{ .SourceVersionFilterPattern }}'

--- a/pkg/plugins/resources/npm/condition.go
+++ b/pkg/plugins/resources/npm/condition.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/updatecli/updatecli/pkg/core/pipeline/scm"
+	"github.com/updatecli/updatecli/pkg/plugins/utils/age"
 )
 
 // Condition checks that an Npm package version exist
@@ -25,7 +26,11 @@ func (n Npm) Condition(ctx context.Context, source string, scm scm.ScmHandler) (
 	}
 
 	_, versions, err := n.getVersions(ctx)
-	if err != nil {
+	/*
+		A cooldown still running means no published version is usable yet, which the loop
+		below already reports as an unmet condition, so it isn't surfaced as an error.
+	*/
+	if err != nil && !errors.Is(err, age.ErrNoVersionMatchingAge) {
 		return false, "", err
 	}
 

--- a/pkg/plugins/resources/npm/main.go
+++ b/pkg/plugins/resources/npm/main.go
@@ -224,19 +224,34 @@ func (n *Npm) getVersions(ctx context.Context) (v string, versions []string, err
 		return "", nil, err
 	}
 
+	publishedVersions := []string{}
 	for _, value := range n.data.Versions {
-		versions = append(versions, value.Version)
+		publishedVersions = append(publishedVersions, value.Version)
 	}
 
 	// Discard the versions published outside of the age window, if any is defined.
-	versions = filterVersionsByAge(versions, n.data.Time, n.spec.Age)
+	versions = filterVersionsByAge(publishedVersions, n.data.Time, n.spec.Age)
+
+	/*
+		The package does publish versions but the age filter discarded every one of them,
+		which reports a cooldown still running rather than a lookup failure, so callers are
+		expected to skip rather than to fail.
+	*/
+	if len(publishedVersions) > 0 && len(versions) == 0 {
+		return "", versions, fmt.Errorf("%w for the npm package %q", age.ErrNoVersionMatchingAge, n.spec.Name)
+	}
 
 	if n.versionFilter.Kind == version.LATESTVERSIONKIND {
 		if n.spec.Age.IsZero() {
 			return n.data.DistTags.Latest, versions, nil
 		}
 
-		return latestVersionMatchingAge(n.data.DistTags.Latest, n.data.orderedVersions, versions), versions, nil
+		latestVersion := latestVersionMatchingAge(n.data.DistTags.Latest, n.data.orderedVersions, versions)
+		if latestVersion == "" {
+			return "", versions, fmt.Errorf("%w for the npm package %q", age.ErrNoVersionMatchingAge, n.spec.Name)
+		}
+
+		return latestVersion, versions, nil
 	}
 
 	sort.Strings(versions)

--- a/pkg/plugins/resources/npm/source.go
+++ b/pkg/plugins/resources/npm/source.go
@@ -2,15 +2,27 @@ package npm
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/updatecli/updatecli/pkg/core/result"
+	"github.com/updatecli/updatecli/pkg/plugins/utils/age"
 )
 
 // Source returns the latest npm package version
 func (n Npm) Source(ctx context.Context, workingDir string, resultSource *result.Source) error {
 	version, _, err := n.getVersions(ctx)
 	if err != nil {
+		/*
+			Every published version is still cooling down, which is an expected state of
+			the age filter rather than a failure, so the source is skipped instead.
+		*/
+		if errors.Is(err, age.ErrNoVersionMatchingAge) {
+			resultSource.Result = result.SKIPPED
+			resultSource.Description = fmt.Sprintf("no version of the npm package %q matches the age filter yet", n.spec.Name)
+			return nil
+		}
+
 		return err
 	}
 

--- a/pkg/plugins/resources/npm/source_test.go
+++ b/pkg/plugins/resources/npm/source_test.go
@@ -25,6 +25,7 @@ func TestSource(t *testing.T) {
 		spec                 Spec
 		expectedResult       string
 		expectedError        bool
+		expectedSkipped      bool
 		expectedNewError     bool
 		mockedResponse       bool
 		mockedBody           string
@@ -135,7 +136,7 @@ func TestSource(t *testing.T) {
 			expectedResult:       "0.2.0",
 		},
 		{
-			name: "Failing case of retrieving axios version with an unrealistic minimum age",
+			name: "Skipped case of retrieving axios version with an unrealistic minimum age",
 			spec: Spec{
 				Name: "axios",
 				VersionFilter: version.Filter{
@@ -151,7 +152,7 @@ func TestSource(t *testing.T) {
 			mockedHTTPStatusCode: 200,
 			mockedToken:          "mytoken",
 			mockedUrl:            "https://mycustomregistry.updatecli.io",
-			expectedError:        true,
+			expectedSkipped:      true,
 		},
 		{
 			name: "Passing case of retrieving axios version with a maximum age",
@@ -173,7 +174,7 @@ func TestSource(t *testing.T) {
 			expectedResult:       "0.2.0",
 		},
 		{
-			name: "Failing case of retrieving axios version with an unrealistic maximum age",
+			name: "Skipped case of retrieving axios version with an unrealistic maximum age",
 			spec: Spec{
 				Name: "axios",
 				VersionFilter: version.Filter{
@@ -189,7 +190,7 @@ func TestSource(t *testing.T) {
 			mockedHTTPStatusCode: 200,
 			mockedToken:          "mytoken",
 			mockedUrl:            "https://mycustomregistry.updatecli.io",
-			expectedError:        true,
+			expectedSkipped:      true,
 		},
 		{
 			name: "Passing case of retrieving axios version with a minimum age and the default latest versionfilter",
@@ -208,7 +209,7 @@ func TestSource(t *testing.T) {
 			expectedResult: "0.1.0",
 		},
 		{
-			name: "Failing case of retrieving axios version with an unrealistic minimum age and the default latest versionfilter",
+			name: "Skipped case of retrieving axios version with an unrealistic minimum age and the default latest versionfilter",
 			spec: Spec{
 				Name:          "axios",
 				Age:           age.Spec{Minimum: "100y"},
@@ -220,7 +221,7 @@ func TestSource(t *testing.T) {
 			mockedHTTPStatusCode: 200,
 			mockedToken:          "mytoken",
 			mockedUrl:            "https://mycustomregistry.updatecli.io",
-			expectedError:        true,
+			expectedSkipped:      true,
 		},
 		{
 			name: "Failing case of an invalid age spec",
@@ -249,6 +250,13 @@ func TestSource(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
+
+			// A cooldown discarding every published version skips the source, it doesn't fail it.
+			if tt.expectedSkipped {
+				assert.Equal(t, result.SKIPPED, gotResult.Result)
+				return
+			}
+
 			assert.Equal(t, tt.expectedResult, gotResult.Information)
 		})
 	}


### PR DESCRIPTION
* When no version matching age found, skipping instead of error
* The npm autodiscovery uses the share age template

## Test

To test this pull request, you can run the following commands:

```shell
cd pkg/plugins/autodiscovery/npm/
go test .
cd pkg/plugins/resources/npm
go test .
```

## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via pull request in [website](https://github.com/updatecli/website) repository.
- [ ] <!-- If applicable,--> I have tested this pull request manually with a custom Updatecli build and it works as expected.

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
