### PR TITLE
chore(go): use age shared error message

### DIFF
--- a/pkg/plugins/resources/go/module/source.go
+++ b/pkg/plugins/resources/go/module/source.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/updatecli/updatecli/pkg/core/result"
+	"github.com/updatecli/updatecli/pkg/plugins/utils/age"
 )
 
 // Source returns the latest go module version
@@ -16,7 +17,7 @@ func (g *GoModule) Source(ctx context.Context, workingDir string, resultSource *
 			Every published version is still cooling down, which is an expected state of
 			the age filter rather than a failure, so the source is skipped instead.
 		*/
-		if errors.Is(err, ErrNoVersionMatchingAge) {
+		if errors.Is(err, age.ErrNoVersionMatchingAge) {
 			resultSource.Result = result.SKIPPED
 			resultSource.Description = fmt.Sprintf("no version of the GO module %q matches the age filter yet", g.Spec.Module)
 			return nil

--- a/pkg/plugins/resources/go/module/version.go
+++ b/pkg/plugins/resources/go/module/version.go
@@ -3,7 +3,6 @@ package gomodule
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -19,11 +18,6 @@ import (
 	"github.com/updatecli/updatecli/pkg/plugins/utils/age"
 	"github.com/updatecli/updatecli/pkg/plugins/utils/version"
 )
-
-// ErrNoVersionMatchingAge is returned when a Golang module publishes versions but the age
-// filter discarded all of them. It reports a cooldown still running, not a lookup failure,
-// so callers are expected to skip rather than to fail.
-var ErrNoVersionMatchingAge = errors.New("no version matching the age filter")
 
 // versionInfo represents the structure of the version information returned by the Go proxy API.
 type versionInfo struct {
@@ -136,7 +130,7 @@ func (g *GoModule) versions(ctx context.Context) (v string, err error) {
 	}
 
 	if heldBackByAge {
-		return "", fmt.Errorf("%w for GO module %q", ErrNoVersionMatchingAge, g.Spec.Module)
+		return "", fmt.Errorf("%w for GO module %q", age.ErrNoVersionMatchingAge, g.Spec.Module)
 	}
 
 	return "", fmt.Errorf("GO module %q not found on proxy %q", g.Spec.Module, GOPROXY)

--- a/pkg/plugins/resources/go/module/version_test.go
+++ b/pkg/plugins/resources/go/module/version_test.go
@@ -225,7 +225,7 @@ func TestVersions(t *testing.T) {
 			gotVersion, err := got.versions(context.Background())
 
 			if tt.expectedHeldBackByAge {
-				require.ErrorIs(t, err, ErrNoVersionMatchingAge)
+				require.ErrorIs(t, err, age.ErrNoVersionMatchingAge)
 				assert.Empty(t, gotVersion)
 			} else {
 				require.NoError(t, err)


### PR DESCRIPTION
Minor code cleanup to use shared age error message

## Test

To test this pull request, you can run the following commands:

```shell
cd <to_package_directory>
go test
```

## Additional Information

### Checklist

- [ ] <!-- If applicable,--> I have updated the documentation via pull request in [website](https://github.com/updatecli/website) repository.
- [ ] <!-- If applicable,--> I have tested this pull request manually with a custom Updatecli build and it works as expected.

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
