### PR TITLE
fix: updatecli policies

### DIFF
--- a/updatecli/updatecli-compose.d/golang/major.yaml
+++ b/updatecli/updatecli-compose.d/golang/major.yaml
@@ -30,6 +30,7 @@ policies:
               "github.com/Masterminds/*": ""
               "github.com/shurcooL/*": ""
               "github.com/aws/*": ""
+              "go.opentelemetry.io/*": ""
 
   - name: Module from golang.org
     id: golang_major_golang.org

--- a/updatecli/updatecli-compose.d/golang/minor.yaml
+++ b/updatecli/updatecli-compose.d/golang/minor.yaml
@@ -30,6 +30,7 @@ policies:
               "github.com/Masterminds/*": ""
               "github.com/shurcooL/*": ""
               "github.com/aws/*": ""
+              "go.opentelemetry.io/*": ""
 
   - name: Module from golang.org
     id: golang_minor_golang_org

--- a/updatecli/updatecli.d/devcontainer.yaml
+++ b/updatecli/updatecli.d/devcontainer.yaml
@@ -8,7 +8,7 @@ labels:
 actions:
   default:
     kind: github/pullrequest
-    title: 'deps: Bump Golang version to {{ source "golang" }}'
+    title: 'deps: Bump Golang version to {{ source "golangfullversion" }}'
     spec:
       automerge: true
       labels:
@@ -39,10 +39,15 @@ sources:
           pattern: '(\d+\.\d+)'
       - addprefix: "dev-"
 
+  golangfullversion:
+    name: Get latest golang version
+    kind: golang
+
 conditions:
   docker:
     name: 'Check if mcr.microsoft.com/devcontainers/go:{{ source "golang" }} exist'
     kind: dockerimage
+    sourceid: golang
     spec:
       image: mcr.microsoft.com/devcontainers/go
 
@@ -51,6 +56,7 @@ targets:
   # so we can't use the json plugin
   devcontainer:
     name: 'update devcontainer to golang {{ source "golang" }}'
+    disablesourceinput: true
     kind: file
     scmid: default
     spec:

--- a/updatecli/updatecli.d/devcontainer.yaml
+++ b/updatecli/updatecli.d/devcontainer.yaml
@@ -1,4 +1,4 @@
-name: "docs: bump updatecli version"
+name: "deps: Bump Golang version"
 pipelineid: "golang/version"
 
 labels:
@@ -8,6 +8,7 @@ labels:
 actions:
   default:
     kind: github/pullrequest
+    title: 'deps: Bump Golang version to {{ source "golang" }}'
     spec:
       automerge: true
       labels:
@@ -42,7 +43,6 @@ conditions:
   docker:
     name: 'Check if mcr.microsoft.com/devcontainers/go:{{ source "golang" }} exist'
     kind: dockerimage
-    disablesourceinput: true
     spec:
       image: mcr.microsoft.com/devcontainers/go
 


### PR DESCRIPTION
Fix various updatecli pipelines

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Update automation now excludes OpenTelemetry Go modules from automatic major and minor version bumps.
  * Go version update pull requests now display the complete resolved Go version in their titles.
  * Improved update detection for Docker and devcontainer-related files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->