### PR TITLE
fix(yaml): preserve unicode chars instead of escaping to \U (#10192)

### DIFF
--- a/pkg/plugins/resources/yaml/target_yamlpath.go
+++ b/pkg/plugins/resources/yaml/target_yamlpath.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/sirupsen/logrus"
@@ -15,19 +17,46 @@ import (
 	"go.yaml.in/yaml/v3"
 )
 
+var (
+	yamlUnicodeEscape8 = regexp.MustCompile(`\\U[0-9A-Fa-f]{8}`)
+	yamlUnicodeEscape4 = regexp.MustCompile(`\\u[0-9A-Fa-f]{4}`)
+)
+
+// decodeYAMLEscapedUnicode converts YAML double-quoted escape sequences
+// \U0001F308 and \uXXXX back to literal utf8. go.yaml.in/yaml escapes
+// emoji because its is_printable check follows YAML 1.1 (only up to U+FFFD),
+// so plain scalars with 4-byte utf8 are emitted as double-quoted \U escapes.
+// Preserving the literal keeps GitHub Actions workflow names like
+// "Run zizmor 🌈" unchanged. See issues #522 and #10192.
+func decodeYAMLEscapedUnicode(s string) string {
+	if !strings.Contains(s, `\u`) && !strings.Contains(s, `\U`) {
+		return s
+	}
+	s = yamlUnicodeEscape8.ReplaceAllStringFunc(s, func(m string) string {
+		hex := m[2:]
+		v, err := strconv.ParseUint(hex, 16, 32)
+		if err != nil {
+			return m
+		}
+		return string(rune(v))
+	})
+	s = yamlUnicodeEscape4.ReplaceAllStringFunc(s, func(m string) string {
+		hex := m[2:]
+		v, err := strconv.ParseUint(hex, 16, 16)
+		if err != nil {
+			return m
+		}
+		return string(rune(v))
+	})
+	return s
+}
+
 func (y *Yaml) goYamlPathTarget(valueToWrite string, resultTarget *result.Target, dryRun bool) (notChanged int, ignoredFiles int, err error) {
-	var buf bytes.Buffer
-	e := yaml.NewEncoder(&buf)
-	defer e.Close()
-
-	e.SetIndent(2)
-
 	keys := y.spec.getKeys()
 
 	resultTargetFilesMap := map[string]bool{}
 
 	for filePath := range y.files {
-		buf = bytes.Buffer{}
 		originFilePath := y.files[filePath].originalFilePath
 		fileNotChanged := 0
 		fileKeysProcessed := 0
@@ -164,15 +193,19 @@ func (y *Yaml) goYamlPathTarget(valueToWrite string, resultTarget *result.Target
 		}
 
 		// Re-encode all documents back into buffer
-		buf = bytes.Buffer{}
+		var buf bytes.Buffer
+		enc := yaml.NewEncoder(&buf)
+		enc.SetIndent(2)
 		for _, doc := range docs {
-			if err := e.Encode(doc); err != nil {
+			if err := enc.Encode(doc); err != nil {
+				_ = enc.Close()
 				return 0, ignoredFiles, fmt.Errorf("unable to marshal the yaml file: %w", err)
 			}
 		}
+		_ = enc.Close()
 
 		f := y.files[filePath]
-		f.content = buf.String()
+		f.content = decodeYAMLEscapedUnicode(buf.String())
 		// preserve leading document marker if it was present originally
 		if strings.HasPrefix(y.files[filePath].content, "---\n") && !strings.HasPrefix(f.content, "---\n") {
 			f.content = "---\n" + f.content

--- a/pkg/plugins/resources/yaml/target_yamlpath.go
+++ b/pkg/plugins/resources/yaml/target_yamlpath.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"regexp"
 	"strconv"
 	"strings"
 
@@ -17,38 +16,66 @@ import (
 	"go.yaml.in/yaml/v3"
 )
 
-var (
-	yamlUnicodeEscape8 = regexp.MustCompile(`\\U[0-9A-Fa-f]{8}`)
-	yamlUnicodeEscape4 = regexp.MustCompile(`\\u[0-9A-Fa-f]{4}`)
-)
-
 // decodeYAMLEscapedUnicode converts YAML double-quoted escape sequences
-// \U0001F308 and \uXXXX back to literal utf8. go.yaml.in/yaml escapes
-// emoji because its is_printable check follows YAML 1.1 (only up to U+FFFD),
-// so plain scalars with 4-byte utf8 are emitted as double-quoted \U escapes.
-// Preserving the literal keeps GitHub Actions workflow names like
-// "Run zizmor 🌈" unchanged. See issues #522 and #10192.
+// \U0001F308 and \uXXXX back to literal utf8, but only inside double-quoted
+// scalars and honoring escaped backslashes (e.g. "\\u0041" stays literal).
+// go.yaml.in/yaml escapes emoji because its is_printable follows YAML 1.1
+// (only up to U+FFFD), so 4-byte utf8 is emitted as double-quoted \U escapes.
 func decodeYAMLEscapedUnicode(s string) string {
-	if !strings.Contains(s, `\u`) && !strings.Contains(s, `\U`) {
-		return s
+	var out bytes.Buffer
+	inDQ := false
+	escaped := false
+	for i := 0; i < len(s); {
+		c := s[i]
+		if c == '"' && !escaped {
+			inDQ = !inDQ
+			out.WriteByte(c)
+			i++
+			continue
+		}
+		if inDQ && c == '\\' && !escaped && i+1 < len(s) {
+			// Check for \UXXXXXXXX (8 hex) and \uXXXX (4 hex)
+			if s[i+1] == 'U' && i+10 <= len(s) && isHex(s[i+2:i+10]) {
+				hex := s[i+2 : i+10]
+				v, err := strconv.ParseUint(hex, 16, 32)
+				if err == nil {
+					out.WriteRune(rune(v))
+					i += 10
+					escaped = false
+					continue
+				}
+			}
+			if s[i+1] == 'u' && i+6 <= len(s) && isHex(s[i+2:i+6]) {
+				hex := s[i+2 : i+6]
+				v, err := strconv.ParseUint(hex, 16, 16)
+				if err == nil {
+					out.WriteRune(rune(v))
+					i += 6
+					escaped = false
+					continue
+				}
+			}
+		}
+		// track escaped state for next char (\ escapes next char)
+		if c == '\\' && !escaped {
+			escaped = true
+		} else {
+			escaped = false
+		}
+		out.WriteByte(c)
+		i++
 	}
-	s = yamlUnicodeEscape8.ReplaceAllStringFunc(s, func(m string) string {
-		hex := m[2:]
-		v, err := strconv.ParseUint(hex, 16, 32)
-		if err != nil {
-			return m
+	return out.String()
+}
+
+func isHex(s string) bool {
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')) {
+			return false
 		}
-		return string(rune(v))
-	})
-	s = yamlUnicodeEscape4.ReplaceAllStringFunc(s, func(m string) string {
-		hex := m[2:]
-		v, err := strconv.ParseUint(hex, 16, 16)
-		if err != nil {
-			return m
-		}
-		return string(rune(v))
-	})
-	return s
+	}
+	return true
 }
 
 func (y *Yaml) goYamlPathTarget(valueToWrite string, resultTarget *result.Target, dryRun bool) (notChanged int, ignoredFiles int, err error) {


### PR DESCRIPTION
Closes #10192

**Problem:** `pkg/plugins/resources/yaml` using `go.yaml.in/yaml/v3` escapes emoji/non-ASCII beyond U+FFFD to `\U0001F308` (YAML 1.1 `is_printable` limit). Result: `name: Run zizmor 🌈` → `name: "Run zizmor \U0001F308"` causing noisy diffs in GitHub Actions workflows (see also #522).

**Root cause:** `target_yamlpath.go` re-serializes via `go.yaml.in/yaml/v3` where `yaml_emitter_set_unicode(true)` still forces double-quoted `\U` for 4-byte UTF-8. `goccy/go-yaml` path (`target_goyaml.go` via `yamlFile.String()`) preserves literals.

**Fix:**
- Use per-file `yaml.Encoder` (avoid shared encoder reuse)
- Post-process `buf.String()` with `decodeYAMLEscapedUnicode` to convert `\U0001F308`/`\uXXXX` back to literal UTF-8
- Preserves `🔧 🌈 🔍` etc. unchanged

**Tests:** `go test ./pkg/plugins/resources/yaml/... -v` — all PASS (0.34s). `go vet` clean. Single file changed.

**Repro:**
```bash
go run repro.go # before: "Run zizmor \\U0001F308", after: "Run zizmor 🌈"
```

cc @olblak

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * YAML Unicode escapes are now decoded only within double-quoted values, while literal escape text in other scalar styles remains unchanged.
  * YAML output generation now handles per-file encoding and cleanup more reliably, including when errors occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->