### PR TITLE
fix(terraform/lock): record h1 for all platforms on OpenTofu registry (#9213)

### DIFF
--- a/pkg/plugins/resources/terraform/lock/main.go
+++ b/pkg/plugins/resources/terraform/lock/main.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/go-viper/mapstructure/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
@@ -185,15 +186,11 @@ func (t *TerraformLock) Changelog(from, to string) *result.Changelogs {
 }
 
 func (t *TerraformLock) getProviderHashes(version string) ([]string, error) {
-	// For OpenTofu registry, the provider package metadata API returns
-	// per-platform h1 hashes for *all* published platforms in the
-	// `packages` field without requiring per-platform zip downloads.
-	// Terraform registry does not expose h1 for all platforms this way, so
-	// h1 must be computed per requested platform via download.
-	// To match `tofu init` (which records h1 for every published platform
-	// on OpenTofu), expand to all platforms when registry is opentofu.
+	// For OpenTofu registry, use bounded timeout to avoid hanging on stalled registry
 	if t.provider.Hostname == "registry.opentofu.org" {
-		if hashes, err := t.getOpenTofuAllHashes(context.Background(), version); err == nil && len(hashes) > 0 {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		if hashes, err := t.getOpenTofuAllHashes(ctx, version); err == nil && len(hashes) > 0 {
 			return hashes, nil
 		} else if err != nil {
 			logrus.Debugf("opentofu all-hashes fetch failed, falling back to per-platform: %v", err)
@@ -218,7 +215,7 @@ func (t *TerraformLock) getProviderHashes(version string) ([]string, error) {
 // and returns hashes for all published platforms. It uses the `packages` map
 // returned by the provider package metadata endpoint, which contains both
 // zh and h1 hashes per platform without requiring zip downloads.
-// Falls back to caller on any error so default registry path is unaffected.
+// Uses a timeout-bounded client to avoid stalling.
 func (t *TerraformLock) getOpenTofuAllHashes(ctx context.Context, version string) ([]string, error) {
 	if len(t.spec.Platforms) == 0 {
 		return nil, fmt.Errorf("platforms required")
@@ -239,7 +236,8 @@ func (t *TerraformLock) getOpenTofuAllHashes(ctx context.Context, version string
 	if err != nil {
 		return nil, err
 	}
-	resp, err := http.DefaultClient.Do(req)
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/plugins/resources/terraform/lock/main.go
+++ b/pkg/plugins/resources/terraform/lock/main.go
@@ -2,7 +2,11 @@ package lock
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/url"
+	"slices"
 	"strings"
 
 	"github.com/go-viper/mapstructure/v2"
@@ -181,6 +185,21 @@ func (t *TerraformLock) Changelog(from, to string) *result.Changelogs {
 }
 
 func (t *TerraformLock) getProviderHashes(version string) ([]string, error) {
+	// For OpenTofu registry, the provider package metadata API returns
+	// per-platform h1 hashes for *all* published platforms in the
+	// `packages` field without requiring per-platform zip downloads.
+	// Terraform registry does not expose h1 for all platforms this way, so
+	// h1 must be computed per requested platform via download.
+	// To match `tofu init` (which records h1 for every published platform
+	// on OpenTofu), expand to all platforms when registry is opentofu.
+	if t.provider.Hostname == "registry.opentofu.org" {
+		if hashes, err := t.getOpenTofuAllHashes(context.Background(), version); err == nil && len(hashes) > 0 {
+			return hashes, nil
+		} else if err != nil {
+			logrus.Debugf("opentofu all-hashes fetch failed, falling back to per-platform: %v", err)
+		}
+	}
+
 	pv, err := t.lockIndex.GetOrCreateProviderVersion(context.Background(), t.provider.ForDisplay(), version, t.spec.Platforms)
 	if err != nil {
 		return nil, fmt.Errorf("%s failed to query provider locks for provider: %q, version: %q, platforms: %q: %s",
@@ -193,6 +212,59 @@ func (t *TerraformLock) getProviderHashes(version string) ([]string, error) {
 	}
 
 	return pv.AllHashes(), nil
+}
+
+// getOpenTofuAllHashes fetches provider metadata from registry.opentofu.org
+// and returns hashes for all published platforms. It uses the `packages` map
+// returned by the provider package metadata endpoint, which contains both
+// zh and h1 hashes per platform without requiring zip downloads.
+// Falls back to caller on any error so default registry path is unaffected.
+func (t *TerraformLock) getOpenTofuAllHashes(ctx context.Context, version string) ([]string, error) {
+	if len(t.spec.Platforms) == 0 {
+		return nil, fmt.Errorf("platforms required")
+	}
+	platform := t.spec.Platforms[0]
+	parts := strings.Split(platform, "_")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid platform %q", platform)
+	}
+	osName, arch := parts[0], parts[1]
+	baseURL := fmt.Sprintf("https://%s/", t.provider.Hostname)
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		return nil, err
+	}
+	u.Path = fmt.Sprintf("/v1/providers/%s/%s/%s/download/%s/%s", t.provider.Namespace, t.provider.Type, version, osName, arch)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("opentofu registry unexpected status %s for %s", resp.Status, u.String())
+	}
+	var body struct {
+		Packages map[string]struct {
+			Hashes []string `json:"hashes"`
+		} `json:"packages"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return nil, err
+	}
+	if len(body.Packages) == 0 {
+		return nil, fmt.Errorf("no packages in opentofu response")
+	}
+	var hashes []string
+	for _, pkg := range body.Packages {
+		hashes = append(hashes, pkg.Hashes...)
+	}
+	slices.Sort(hashes)
+	hashes = slices.Compact(hashes)
+	return hashes, nil
 }
 
 // ReportConfig returns a new configuration object with only the necessary fields


### PR DESCRIPTION
Closes #9213

**Problem:** `terraform/lock` only recorded `h1:` hashes for requested `spec.platforms` (e.g. 1-2), but `zh:` via `SHA256SUMS` was for all platforms. `tofu init` against `registry.opentofu.org` always writes `h1` for *every* published platform (e.g. `hashicorp/null` 3.2.1 → 10 `h1` + 10 `zh`), so the lock file was perpetually dirty.

**Root cause:** `getProviderHashes()` → `lockIndex.GetOrCreateProviderVersion(..., t.spec.Platforms)` → `minamijoyo/tfupdate/lock/index.go` loops only over requested platforms to compute `h1` via zip download+dirhash. OpenTofu registry actually exposes all `h1` in the provider package metadata API (`GET /v1/providers/<ns>/<type>/<ver>/download/<os>/<arch>` → `packages` map), unlike Terraform registry.

**Fix:**
- If `provider.Hostname == "registry.opentofu.org"`, fetch `packages` metadata and return all `h1`+`zh` hashes sorted/compacted without per-platform downloads
- Falls back to existing per-platform path on error; `registry.terraform.io` path unchanged
- Backwards compatible, no spec change

**Tests:** `go test ./pkg/plugins/resources/terraform/lock/... -v` — PASS (except pre-existing `TestUpdateAbsoluteFilePath` /tmp vs \tmp on Windows — also on main). Verified `curl https://registry.opentofu.org/v1/providers/hashicorp/null/3.2.1/download/linux/amd64 | jq .packages` returns 10 entries each with `["zh:...","h1:..."]`.

cc @olblak

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a 10-second limit when retrieving OpenTofu provider metadata, preventing lockfile generation from waiting indefinitely.
  * Preserved fallback behavior when provider metadata is unavailable or cannot be retrieved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->